### PR TITLE
Trainer fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen1/BaseSet.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSet.groovy
@@ -2112,7 +2112,7 @@ public enum BaseSet implements CardInfo {
           onPlay {
             def pcs = opp.bench.select("New active")
             targeted (pcs, TRAINER_CARD) {
-              sw opp.active, pcs
+              sw opp.active, pcs, TRAINER_CARD
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2654,7 +2654,7 @@ public enum BurningShadows implements CardInfo {
           onPlay {
             def pcs = opp.bench.select("New active")
             targeted (pcs, TRAINER_CARD) {
-              sw opp.active, pcs
+              sw opp.active, pcs, TRAINER_CARD
               if(my.bench) {
                 sw my.active, my.bench.select("New active"), TRAINER_CARD
               }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -330,7 +330,7 @@ public enum CelestialStorm implements CardInfo {
               assert opp.bench
               powerUsed()
               flip {
-                sw opp.active, opp.bench.select("New active.")
+                sw opp.active, opp.bench.select("New active."), SRC_ABILITY
               }
             }
           }
@@ -640,7 +640,7 @@ public enum CelestialStorm implements CardInfo {
               before APPLY_ATTACK_DAMAGES, {
                 if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet)
+                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
                 }
               }
               after SWITCH, self, {unregister()}
@@ -663,7 +663,7 @@ public enum CelestialStorm implements CardInfo {
               before APPLY_ATTACK_DAMAGES, {
                 if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet)
+                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
                 }
               }
               after SWITCH, self, {unregister()}
@@ -2659,7 +2659,7 @@ public enum CelestialStorm implements CardInfo {
               assert self.active : "$self is not your active pokémon"
               assert opp.bench : "There is no pokémon on your opponent's bench to switch"
               powerUsed()
-              sw self.owner.opposite.pbg.active, self.owner.opposite.pbg.bench.select("Choose the new active")
+              sw self.owner.opposite.pbg.active, self.owner.opposite.pbg.bench.select("Choose the new active"), SRC_ABILITY
             }
           }
           move "Dragon Claw" , {

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2283,7 +2283,7 @@ public enum CrimsonInvasion implements CardInfo {
           onPlay {
             if(opp.bench){
               def pcs = opp.bench.select("Switch")
-              sw opp.active, pcs
+              sw opp.active, pcs, TRAINER_CARD
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1090,7 +1090,7 @@ public enum DragonMajesty implements CardInfo {
               before APPLY_ATTACK_DAMAGES, {
                 if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Rough Skin activates"
-                  directDamage(30, ef.attacker)
+                  directDamage(30, ef.attacker, SRC_ABILITY)
                 }
               }
             }
@@ -1378,7 +1378,7 @@ public enum DragonMajesty implements CardInfo {
               before APPLY_ATTACK_DAMAGES, {
                 if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value}) && self.active && self.types.contains(N)){
                   bc "Dragon Talon activates"
-                  directDamage(30, ef.attacker)
+                  directDamage(30, ef.attacker, TRAINER_CARD)
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -554,7 +554,7 @@ public enum ForbiddenLight implements CardInfo {
             actionA {
               checkLastTurn()
               powerUsed()
-              apply BURNED, opp.active
+              apply BURNED, opp.active, SRC_ABILITY
             }
           }
           move "Fire Spin", {
@@ -695,7 +695,7 @@ public enum ForbiddenLight implements CardInfo {
             onActivate {reason ->
               if(reason == PLAY_FROM_HAND && confirm("Gale Shuriken")){
                 powerUsed()
-                directDamage 20,opp.all.select()
+                directDamage 20, opp.all.select(), SRC_ABILITY
               }
             }
           }
@@ -716,7 +716,7 @@ public enum ForbiddenLight implements CardInfo {
             onActivate {reason ->
               if(reason == PLAY_FROM_HAND && confirm("Shuriken Flurry")){
                 powerUsed()
-                directDamage 30,opp.all.select()
+                directDamage 30, opp.all.select(), SRC_ABILITY
               }
             }
           }
@@ -888,7 +888,7 @@ public enum ForbiddenLight implements CardInfo {
               assert my.hand.filterByEnergyType(W) : "There is no [W] energy in your hand"
               powerUsed()
               my.hand.filterByEnergyType(W).select().discard()
-              if(opp.bench) sw opp.active, opp.bench.oppSelect("New active")
+              if(opp.bench) sw opp.active, opp.bench.oppSelect("New active"), SRC_ABILITY
             }
           }
           move "Sauna Blast", {
@@ -1219,7 +1219,7 @@ public enum ForbiddenLight implements CardInfo {
               before (KNOCKOUT,self) {
                 if(self.active && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite) {
                   def pcs = self.owner.opposite.pbg.all.oppSelect("choose the Pokémon to put 3 damage counters on")
-                  directDamage 30, pcs
+                  directDamage 30, pcs, SRC_ABILITY
                 }
               }
             }
@@ -1351,7 +1351,7 @@ public enum ForbiddenLight implements CardInfo {
               before APPLY_ATTACK_DAMAGES, {
                 if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet)
+                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
                 }
               }
               after SWITCH, self, {unregister()}

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -1902,7 +1902,7 @@ public enum GuardiansRising implements CardInfo {
               if(r==PLAY_FROM_HAND && opp.bench.notEmpty && confirm('Use Bloodthirsty Eyes?')) {
                 powerUsed()
                 def pcs = opp.bench.select('New defending')
-                sw opp.active, pcs
+                sw opp.active, pcs, SRC_ABILITY
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -4048,7 +4048,7 @@ public enum LostThunder implements CardInfo {
             if(opp.bench && my.hand.findAll({it.name=="Custom Catcher"}).size()>=2) {
               if(confirm("Use another Custom Catcher and switch your opponent active?") || toDraw == 0){
                 my.hand.findAll({it.name=="Custom Catcher" && it!= thisCard}).subList(0,1).discard()
-                sw opp.active, opp.bench.select("Choose the new active")
+                sw opp.active, opp.bench.select("Choose the new active"), TRAINER_CARD
                 return
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -904,9 +904,9 @@ public enum LostThunder implements CardInfo {
             onActivate{r->
               if(r==PLAY_FROM_HAND) {
                 if(confirm("Use Hazardous Evolution?")) {
-                  apply POISONED, opp.active
+                  apply POISONED, opp.active, SRC_ABILITY
                   extraPoison 2
-                  apply PARALYZED, opp.active
+                  apply PARALYZED, opp.active, SRC_ABILITY
                 }
               }
 
@@ -1572,7 +1572,7 @@ public enum LostThunder implements CardInfo {
               assert self.active : "$self is not your active"
               assert opp.bench : "No opponent bench"
               powerUsed()
-              sw opp.active, opp.bench.oppSelect("Select the new active.")
+              sw opp.active, opp.bench.oppSelect("Select the new active."), SRC_ABILITY
             }
           }
           move "Aurora Gain" , {
@@ -2402,7 +2402,7 @@ public enum LostThunder implements CardInfo {
               benchPCS(thisCard)
               if(thisCard.player.opposite.pbg.bench){
                 multiSelect(thisCard.player.opposite.pbg.bench,2).each{
-                  directDamage 10, it
+                  directDamage 10, it, SRC_ABILITY
                 }
               }
             }
@@ -4397,7 +4397,7 @@ public enum LostThunder implements CardInfo {
                 if(self.types.contains(P) && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite) {
                   bc "Spell Tag activates"
                   for(int i=0;i<4;i++){
-                    if(self.owner.opposite.pbg.all) directDamage 10, self.owner.opposite.pbg.all.select("Put 1 damage counter to", true, self.owner)
+                    if(self.owner.opposite.pbg.all) directDamage 10, self.owner.opposite.pbg.all.select("Put 1 damage counter to", true, self.owner), TRAINER_CARD
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -2084,7 +2084,7 @@ public enum UnbrokenBonds implements CardInfo {
                 all.each {
                   if(self.active && it.owner != self.owner && it.basic) {
                     if(flag) {bc "Detention Gas activates"; flag = 0}
-                    directDamage 10, it
+                    directDamage 10, it, SRC_ABILITY
                   }
                 }
               }
@@ -2688,7 +2688,7 @@ public enum UnbrokenBonds implements CardInfo {
               checkLastTurn()
               powerUsed()
               flip {
-                directDamage 30, opp.all.select()
+                directDamage 30, opp.all.select(), SRC_ABILITY
               }
               bg().gm().betweenTurns()
             }


### PR DESCRIPTION
Added sources to many trainers and abilities. This is meant to address bugs where effects like Safeguard or preventAllEffectsNextTurn stop trainers and abilities from targeting them. Adding sources prevents them from being categorized as effects from attacks.