### PR TITLE
Implement unified minds pokemon

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -980,29 +980,47 @@ class TcgStatics {
     }
   }
 
-  static void defendingAttacksCostsMore (PokemonCardSet pcs, List<Type> energies) {
-    targeted(pcs) {
-      delayed {
-        def eff
-        register {
-          eff = getter (GET_MOVE_LIST, NORMAL, pcs) {h->
-            def list=[]
-            for(move in h.object){
-              def copy=move.shallowCopy()
-              copy.energyCost.addAll(energies)
-              list.add(copy)
-            }
-            h.object=list
-          }
-          bc "Attacks of $pcs will cost $energies more during next turn"
-        }
-        unregister {
-          eff.unregister()
-        }
-        unregisterAfter 2
-      }
-    }
-  }
+	static void defendingAttacksCostsMore (PokemonCardSet pcs, List<Type> energies) {
+		targeted(pcs) {
+			delayed {
+				def eff
+				register {
+					eff = getter (GET_MOVE_LIST, NORMAL, pcs) {h->
+						def list=[]
+						for(move in h.object){
+							def copy=move.shallowCopy()
+							copy.energyCost.addAll(energies)
+							list.add(copy)
+						}
+						h.object=list
+					}
+					bc "Attacks of $pcs will cost $energies more during next turn"
+				}
+				unregister {
+					eff.unregister()
+				}
+				unregisterAfter 2
+			}
+		}
+	}
+
+	static void defendingRetreatsCostsMore (PokemonCardSet pcs, List<Type> energies) {
+		targeted(pcs) {
+			delayed {
+				def eff
+				register {
+					eff = getter (GET_RETREAT_COST, NORMAL, pcs) {h->
+						h.object += 1
+					}
+					bc "Retreat cost of $pcs will cost 1 more energy during the next turn."
+				}
+				unregister {
+					eff.unregister()
+				}
+				unregisterAfter 2
+			}
+		}
+	}
 
   static void increasedDamageDoneToDefending (PokemonCardSet self, PokemonCardSet pcs, int value, String atkName=""){
     targeted(pcs){


### PR DESCRIPTION
This PR introduces the first implementation for the Pokemon Unified Minds set.

There are about 162 Pokemon Cards being implemented with their abilities and moves.  There are 13 moves/abilities that have not been written yet because they need require further discussion on how best to complete them.  

This needs to be tested on the dev server.