### PR TITLE
Unified Minds Fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2848,7 +2848,7 @@ public enum UnifiedMinds implements CardInfo {
 					attackRequirement {}
 					onAttack {
             damage 20
-						flip { damage 20 }
+						flip 2, { damage 20 }
 					}
 				}
 			};

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3891,10 +3891,7 @@ public enum UnifiedMinds implements CardInfo {
 				move "Call for Family", {
 					text " Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."
 					energyCost C
-					attackRequirement {}
-					onAttack {
-						callForFamily(basic:true, 1, delegate)
-					}
+					callForFamily(basic:true, 1, delegate)
 				}
 				move "Berserker Tackle", {
 					text "60 damage. This Pokémon does 10 damage to itself."

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3697,13 +3697,11 @@ public enum UnifiedMinds implements CardInfo {
             powerUsed()
             if (confirm("Would you like to discard stadium in play (${bg.stadiumInfoStruct.stadiumCard})?")) {
               discard bg.stadiumInfoStruct.stadiumCard
-              def card = 0
-              def attach = 0
-              while (attach < 3 && (my.hand.filterByEnergyType(R) || my.hand.filterByEnergyType(M))) {
-                card = my.hand.findAll {it.filterByEnergyType(R) || it.filterByEnergyType(M)}.select("Select a Fire or Metal Energy")
-                if(!card) break;
-                attachEnergyFrom(card, my.all)
-                attach++
+
+              my.hand.findAll{
+                it.cardTypes.isEnergy() && (it.asEnergyCard().containsTypePlain(M) || it.asEnergyCard().containsTypePlain(R))
+              }.select(min: 0, max: 3, "Attach a [R] or [M] card to Haxorus.").each{
+                attachEnergy(self, it)
               }
             }
 					}
@@ -3713,8 +3711,7 @@ public enum UnifiedMinds implements CardInfo {
 					energyCost R, M
 					attackRequirement {}
 					onAttack {
-						damage 10
-            damage 40*self.cards.filterByType(BASIC_ENERGY).size()
+            damage 10+40*self.cards.filterByType(BASIC_ENERGY).size()
 					}
 				}
 

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3339,7 +3339,9 @@ public enum UnifiedMinds implements CardInfo {
           onActivate {
 						if (it == PLAY_FROM_HAND && confirm("Use Captivating Wink?")) {
 							opp.hand.showToMe("Opponent's hand")
-              opp.hand.findAll { it.basic }.select(max: opp.bench.freeBenchCount).moveTo(opp.bench)
+              def basicPokemon = opp.hand.findAll{ it.basic }
+              def maximumAllowed = Math.min(basicPokemon.size(), opp.bench.freeBenchCount)
+              basicPokemon.select(min: 0, max: maximumAllowed).moveTo(opp.bench)
 						}
 					}
 				}

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3464,7 +3464,7 @@ public enum UnifiedMinds implements CardInfo {
 					onAttack {
 						gxPerform()
             def discardCount = 1
-            if (self.cards.energySufficient(thisMove.energyCost + F, F, F)) {
+            if (self.cards.energySufficient(thisMove.energyCost + [F, F, F])) {
                 discardCount = 2
             }
             opp.all.select(count:discardCount, "Select $discardCount Pokemon to discard").discard()

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2786,7 +2786,7 @@ public enum UnifiedMinds implements CardInfo {
 					delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
-                if(it.to.owner == self.owner && it.dmg.value && it.notNoEffect && it.to.cardTypes.is(TAG_TEAM)) {
+                if(it.to.owner == self.owner && it.dmg.value && it.notNoEffect && it.to.topPokemonCard.cardTypes.is(TAG_TEAM)) {
                   bc "Tag Coach -20"
                   it.dmg -= hp(20)
                 }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3326,7 +3326,7 @@ public enum UnifiedMinds implements CardInfo {
 					energyCost C, C, C
 					attackRequirement {}
 					onAttack {
-						noWrDamage 80
+						noWrDamage 80, defending
 					}
 				}
 			};

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2675,13 +2675,14 @@ public enum UnifiedMinds implements CardInfo {
 			return basic (this, hp:HP090, type:F, retreatCost:1) {
 				weakness G
 				move "Deep Sea Boring", {
-					text " Search your deck for a Trainer card, reveal it, and put it into your hand. Then, shuffle your deck."
+					text "Search your deck for a Trainer card, reveal it, and put it into your hand. Then, shuffle your deck."
 					energyCost C
 					attackRequirement {
-						assert deck
+						assert deck.notEmpty : "Empty deck"
 					}
 					onAttack {
-            deck.search(count:1, cardTypeFilter(TRAINER_CARD)).moveTo(hand)
+            my.deck.search(count:1, "Choose a Trainer card", cardTypeFilter(TRAINER_CARD)).showToOpponent("Chosen card").moveTo(my.hand)
+            shuffleDeck()
 					}
 				}
 				move "Water Pulse", {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3206,14 +3206,14 @@ public enum UnifiedMinds implements CardInfo {
 				weakness F
 				resistance P, MINUS20
 				move "Cleaning Up", {
-					text " Discard a Pokémon Tool card from 1 of your opponent's Pokémon."
+					text "Discard a Pokémon Tool card from 1 of your opponent's Pokémon."
 					energyCost C
 					attackRequirement {
-            assert opp.all.filterByType(POKEMON_TOOL) : "There are no Pokemon Tool cards attached to your opponent's Pokemon."
+            assert opp.all.findAll{it.cards.filterByType(POKEMON_TOOL)} : "There are no Pokemon Tool cards attached to your opponent's Pokemon."
           }
 					onAttack {
 						def target = opp.all.findAll{ it.cards.filterByType(POKEMON_TOOL) }.select("Choose the pokémon from which discard a Pokémon Tool card")
-            target.cards.filterByType(POKEMON_TOOL).select("Choose the Tool card to discard").discard()
+            target.select("Choose the Pokémon Tool card to discard").cards.filterByType(POKEMON_TOOL).discard()
 					}
 				}
 			};

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3953,16 +3953,16 @@ public enum UnifiedMinds implements CardInfo {
 					energyCost C
 					attackRequirement {}
 					onAttack {
-            delayed {
-              before ATTACH_ENERGY, defending {
-                if (ef.reason == PLAY_FROM_HAND && bg.currentTurn == self.owner.opposite) {
-                  wcu "Lazy Howl ends the turn"
-                  bg.gm().betweenTurns()
+            targeted (defending) {
+              delayed {
+                before ATTACH_ENERGY, defending {
+                  if (ef.reason == PLAY_FROM_HAND && bg.currentTurn == self.owner.opposite) {
+                    wcu "Lazy Howl ends the turn"
+                    bg.gm().betweenTurns()
+                  }
                 }
+                unregisterAfter 2
               }
-              unregisterAfter 2
-              after SWITCH, defending, {unregister()}
-              after EVOLVE, defending, {unregister()}
             }
 					}
 				}

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -786,10 +786,7 @@ public enum UnifiedMinds implements CardInfo {
 				move "Sea Creeper Net", {
 					text " Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."
 					energyCost C
-					attackRequirement {}
-					onAttack {
-						callForFamily(basic:true, 1, delegate)
-					}
+					callForFamily(basic:true, 1, delegate)
 				}
 				move "Spinning Attack", {
 					text "40 damage. "

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3127,7 +3127,7 @@ public enum UnifiedMinds implements CardInfo {
 					}
 				}
 				move "Claw Slash", {
-					text "130 damage. "
+					text "130 damage."
 					energyCost D, D, C
 					attackRequirement {}
 					onAttack {
@@ -3135,12 +3135,12 @@ public enum UnifiedMinds implements CardInfo {
 					}
 				}
 				move "Nocturnal Maneuvers GX", {
-					text " Search your deck for any number of Basic Pokémon and put them onto your Bench. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
+					text "Search your deck for any number of Basic Pokémon and put them onto your Bench. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)"
 					energyCost C
 					attackRequirement { gxCheck() }
+          callForFamily(basic:true, my.bench.freeBenchCount, delegate)
 					onAttack {
 						gxPerform()
-            callForFamily(basic:true, my.bench.freeBenchCount, delegate)
 					}
 				}
 			};


### PR DESCRIPTION
This PR includes more fixes to the list of initial issues for the UNM set implementation.

The fixes include:

- Fix SLAKOTH_167 Lazy Howl
- Fix DHELMISE_20 Sea Creeper Net
- Fix TAUROS_164 Call for Family
- Fix HAXORUS_156 Powerful Axe and Grind Up ability
- Fix GARCHOMP_GIRATINA_GX_146 GG End GX
- Fix MAWILE_GX_141 Captivating Wink
- Fix HOOPA_140 Mind Shock
- Fix PURRLOIN_135 Cleaning Up
- Fix WEAVILE_GX_132 Nocturnal Maneuvers GX
- Fix LUCARIO_117 Tag Coach ability
- Fix RELICANTH_111 Deep Sea Boring
- Fix ARCHEN_120 Endeavor