### PR TITLE
Change wording on LATIOS_GX_78's attack

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1950,7 +1950,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                 before APPLY_ATTACK_DAMAGES, {
                   bg.dm().each {
                     if (it.to == self && it.from.topPokemonCard.cardTypes.is(TAG_TEAM) && it.dmg.value && it.notNoEffect) {
-                      bc "Paranormal prevents damage from TAG TEAM Pokémon"
+                      bc "Tag Purge prevents damage from TAG TEAM Pokémon"
                       it.dmg = hp(0)
                     }
                   }


### PR DESCRIPTION
It was always confusing that it said "Paranormal" prevented the damage when there is nothing on Latios GX's card called this. It should've been Tag Purge