### PR TITLE
Fixed caterpie_1 and Metapod_2 Adaptive Evolution

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -308,7 +308,7 @@ public enum RebelClash implements LogicCardInfo {
           text "This Pokemon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-              if (bg.turnCount == 2) prevent()
+              prevent()
             }
           }
         }
@@ -328,7 +328,7 @@ public enum RebelClash implements LogicCardInfo {
           text "This Pokemon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-              if (bg.turnCount == 2) prevent()
+              prevent()
             }
           }
         }


### PR DESCRIPTION
Adaptive evolution allows catterpie and metapod to evolve on both the player’s first turn and on the turn it was put into play. The previous implementation only allowed them to evolve on the first turn if the player went second.