### PR TITLE
Heatran ability fix

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -839,7 +839,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "Once during your turn, when this Pokémon moves from your Bench to become your Active Pokémon, you may move any number of [R] Energy from your other Pokémon to it."
             delayedA{
               after SWITCH, {
-                if(bg.em().retrieveObject("Burning_Road") != bg.turnCount && self.active && bg.currentTurn == self.owner && confirm("Use Burning Road?")){
+                if(bg.em().retrieveObject("Burning_Road") != bg.turnCount && self.active && bg.currentTurn == self.owner && ef.pcs==self && confirm("Use Burning Road?")){
                   bg.em().storeObject("Burning_Road", bg.turnCount)
                   while(1){
                     def pl=(my.all.findAll {it.cards.filterByEnergyType(R) && it!=self})


### PR DESCRIPTION
Heatran’s ability currently activates when the opponent’s pokemon is knocked out and the select a new active at the beginning of the next turn. If this works I wll copy it to xernias prism star and cinderace