### PR TITLE
Falinks V ability fix

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2721,7 +2721,7 @@ public enum RebelClash implements LogicCardInfo {
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
-                if (it.to.name.contains("Falinks")&& it.dmg.value && it.notNoEffect) {
+                if (it.to.owner == self.owner && it.to.name.contains("Falinks") && it.dmg.value && it.notNoEffect) {
                   bc "Iron Defense Formation -20"
                   it.dmg -= hp(20)
                 }


### PR DESCRIPTION
Falinks V no longer decreases damage to your opponents’ falinks
https://forum.tcgone.net/t/br-falinks-v-rcl-110-the-ability-should-not-affect-both-side/9719?u=mt.gufo