### PR TITLE
Fixed top entry benching on the opponent’s bench

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -471,7 +471,7 @@ public enum RebelClash implements LogicCardInfo {
                       if(bg.currentTurn == thisCard.player){
                         bc"It is your turn"
                         thisCard.player.pbg.deck.remove(0)
-                        benchPCS(thisCard)
+                        benchPCS(thisCard, OTHER, thisCard.player)
                         prevent()// Top Entry activates instead of drawing the card
                       } else {
                         bc"It is not your turn"


### PR DESCRIPTION
Code stolen from pokeflute from gen 1
If this doesn’t work ill put the card on the opponent’s bench