### PR TITLE
Reverted Ninetales V

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -844,20 +844,6 @@ public enum RebelClash implements LogicCardInfo {
       case NINETALES_V_26:
       return basic (this, hp:HP200, type:R, retreatCost:2) {
         weakness W
-        bwAbility "Dark Oath", {
-          text "As long as this Pokemon is your Active Pokemon, your opponent’s Active Pokemon pays [C] more to use its attacks."
-          getterA GET_MOVE_LIST, { h ->
-            if (self.active && h.effect.target.active && h.effect.target.owner == self.owner.opposite) {
-              def list = []
-              for (move in h.object) {
-                def copy = move.shallowCopy()
-                copy.energyCost.add(C)
-                list.add(copy)
-              }
-              h.object=list
-            }
-          }
-        }
         move "Nine-Tailed Shapeshifter", {
           text "Choose 1 of your opponent’s Active Pokemon’s attacks and use it as this attack."
           energyCost R, C, C
@@ -868,7 +854,7 @@ public enum RebelClash implements LogicCardInfo {
             def list = defending.topPokemonCard.moves
             def selected = choose(list, "Choose an attack to use.")
             bc "$selected was chosen"
-            def bef = blockingEffect(BETWEEN_TURNS)
+            def bef = blockingEffect(ENERGY_COST_CALCULATOR, BETWEEN_TURNS)
             attack (selected as Move)
             bef.unregisterItself(bg().em())
           }


### PR DESCRIPTION
I think getters cant get attacks from pokemon that dont belong to the active player? The previous attempt correctly added C to the defending pokemon’s attack cost but when Nine Temptations copied it.