### PR TITLE
ariados_10

### DIFF
--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -502,9 +502,7 @@ public enum LostThunder implements LogicCardInfo {
                     prevent()
                   }
                 }
-                after SWITCH, self, {unregister()}
                 after SWITCH, defending, {unregister()}
-                after EVOLVE, self, {unregister()}
                 after EVOLVE, defending, {unregister()}
                 unregisterAfter 2
               }


### PR DESCRIPTION
Effect shouldn’t unregister when ariados is switched or evolved. 
https://forum.tcgone.net/t/br-switch-cls-147-ariados-lot-10-switch-was-used-despite/9779/2?u=mt.gufo