### PR TITLE
Oricorio Gx ability

### DIFF
--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -2328,7 +2328,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           globalAbility {Card thisCard->
             delayed {
               before KNOCKOUT, {
-                if(ef.pokemonToBeKnockedOut.owner == thisCard.player){
+                if(ef.pokemonToBeKnockedOut.owner == thisCard.player && bg.currentTurn == thisCard.player.opposite){
                   bg.em().storeObject("Dance_of_Tribute", bg.turnCount)
                 }
               }


### PR DESCRIPTION
The ability didn’t function if a pokemon was knocked out on the opponent’s previous turn and then another one was knocked out by between turns effects.