### PR TITLE
Altaria EX check fix

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1902,9 +1902,9 @@ public enum DragonFrontiers implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert my.hand.filterByType(BASIC_ENERGY) : "No Basic Energy in Hand"
-            assert my.all.findAll { it.ex && it.STAGE2 } : "No Stage 2 Pokemon-ex in play"
+            assert my.all.findAll { it.EX && it.STAGE2 } : "No Stage 2 Pokemon-ex in play"
             powerUsed()
-            def tar = my.all.findAll { it.ex && it.STAGE2 }.select()
+            def tar = my.all.findAll { it.EX && it.STAGE2 }.select()
             attachEnergyFrom(basic: true, my.hand, tar)
           }
         }


### PR DESCRIPTION
it.EX is for pokemon ex it.POKEMON_EX is for pokemon EX. Dont you love the naming conventions?