### PR TITLE
Properly unregister’s jolteon’s effect.

### DIFF
--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2345,8 +2345,19 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
             onAttack{
               gxPerform()
-              damage 110
-              preventAllEffectsNextTurn()
+              damage 110              
+              delayed {
+                before null, null, Source.ATTACK, {
+                  if (ef instanceof TargetedEffect) {
+                    def tar = (ef as TargetedEffect).getResolvedTarget(bg, e)
+                    if (tar != null && bg.currentTurn==self.owner.opposite && tar==self) {
+                      bc "Swift Run GX prevents this effect"
+                      prevent()
+                    }
+                  }
+                }
+                unregisterAfter 2
+              }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2357,6 +2357,8 @@ public enum SunMoonPromos implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
+                after EVOLVE,self, {unregister()}
+                after SWITCH,self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2358,7 +2358,7 @@ public enum SunMoonPromos implements LogicCardInfo {
                 }
                 before APPLY_ATTACK_DAMAGES, {
                   bg.dm().each {
-                    if(it.notNoEffect && it.to.self && it.dmg.value){
+                    if(it.notNoEffect && it.to == self && it.dmg.value){
                       it.dmg = hp(0)
                       bc "Swift run GX prevents damage"
                     }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2356,6 +2356,14 @@ public enum SunMoonPromos implements LogicCardInfo {
                     }
                   }
                 }
+                before APPLY_ATTACK_DAMAGES, {
+                  bg.dm().each {
+                    if(it.notNoEffect && it.to.self && it.dmg.value){
+                      it.dmg = hp(0)
+                      bc "Swift run GX prevents damage"
+                    }
+                  }
+                }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
                 after SWITCH,self, {unregister()}


### PR DESCRIPTION
Previous implementation blocked trainer cards