### PR TITLE
Holon Circle

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -1895,11 +1895,20 @@ public enum CrystalGuardians implements LogicCardInfo {
         onPlay {
           boolean flag = false
           eff = delayed {
-            before CHECK_ATTACK_REQUIREMENTS, {
+            before null, null, Source.ATTACK, {
               bc "Holon Circle prevents the attack"
-              prevent()
               flag = true
               bg.gm().betweenTurns()
+              prevent()
+            }
+            before APPLY_ATTACK_DAMAGES, {
+              flag = true
+              bg.dm().each {
+                if(it.notNoEffect && it.dmg.value){
+                  it.dmg = hp(0)
+                  bc "Holon Circle prevents damage"
+                }
+              }
             }
             before BETWEEN_TURNS, {
               if(flag){


### PR DESCRIPTION
Reverted changes as they allowed pokemon to break holon circle without having the energy to attack. Testing different timing on changing phase vs preventing effects. Added preventing attack damage as previous versions did not.