### PR TITLE
Fix Oranguru UPR-114 Resource Managment card order

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2809,7 +2809,9 @@ public enum UltraPrism implements LogicCardInfo {
               assert my.discard.notEmpty
             }
             onAttack {
-              my.discard.select(count : 3).moveTo(my.deck)
+              def list = my.discard.select(count:3)
+              def rearrangedCards = rearrange(list)
+              rearrangedCards.moveTo(my.deck)
             }
           }
           move "Profound Knowledge", {


### PR DESCRIPTION
Should allow the player to choose the order the cards are placed on the bottom of the deck as the attack states.