### PR TITLE
Unown shuffle pokepower can only be used once per turn

### DIFF
--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2976,7 +2976,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3026,7 +3028,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3063,7 +3067,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3096,7 +3102,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3135,7 +3143,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3178,7 +3188,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3223,7 +3235,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3266,7 +3280,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3299,7 +3315,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3344,7 +3362,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3382,7 +3402,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3415,7 +3437,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3448,7 +3472,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3483,7 +3509,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3527,7 +3555,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3560,7 +3590,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3597,7 +3629,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3632,7 +3666,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3674,7 +3710,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3711,7 +3749,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3760,7 +3800,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3793,7 +3835,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3827,7 +3871,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3862,7 +3908,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3901,7 +3949,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3934,7 +3984,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -3968,7 +4020,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard
@@ -4004,7 +4058,9 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn (before your attack), you may search your deck for another Unown and switch it with Unown. (Any cards attached to Unown, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Unown on top of your deck. Shuffle your deck afterward. You can't use more than 1 Shuffle Poké-Power each turn."
           actionA {
             checkLastTurn()
+            assert bg.em().retrieveObject("Unown_Shuffle") != bg.turnCount : "You can't use more than 1 Shuffle Poké-Power each turn."
             assert my.deck : "Deck is empty"
+            bg.em().storeObject("Unown_Shuffle", bg.turnCount)
             powerUsed()
 
             def oldUnown = self.topPokemonCard


### PR DESCRIPTION
This was annoying to do without find/replace. 