### PR TITLE
Unown 127

### DIFF
--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -3391,7 +3391,8 @@ public enum UnseenForces implements LogicCardInfo {
               target = opp.bench.select("Select the new active")
               sw defending, target
             }
-            damage 30, target
+            apply BURNED
+            apply CONFUSED
           }
         }
       };


### PR DESCRIPTION
Status effects are applied, not damage

Will `apply` correctly target the new defending Pokemon? Or will it try to apply to the old one? I'm assuming `sw` will have set opp().active to the new one already.

rant: Also, I know this is accurate to what is on the card, but this card text is confusing, since when is there more than one defending Pokemon in the TCG? Either there is a mechanic I was never aware of, or Nintendo was bad at writing card text.