### PR TITLE
Mark as basic - card still considered basic after discard

### DIFF
--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2295,6 +2295,13 @@ public enum HolonPhantoms implements LogicCardInfo {
                 my.deck.remove(it)
                 it.cardTypes.add(BASIC)
                 it.cardTypes.remove(EVOLUTION)
+                delayed {
+                  after REMOVE_FROM_PLAY, it {
+                    it.cardTypes.remove(BASIC)
+                    it.cardTypes.add(EVOLUTION)
+                    unregister()
+                  }
+                }
                 benchPCS(it)
               }
               shuffleDeck()

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2414,6 +2414,13 @@ public enum LegendMaker implements LogicCardInfo {
               hand.remove(it)
               it.cardTypes.add(BASIC)
               it.cardTypes.remove(EVOLUTION)
+              delayed {
+                after REMOVE_FROM_PLAY, it {
+                  it.cardTypes.remove(BASIC)
+                  it.cardTypes.add(EVOLUTION)
+                  unregister()
+                }
+              }
               benchPCS(it)
             }
           }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1214,6 +1214,13 @@ public enum LegendMaker implements LogicCardInfo {
               my.deck.remove(it)
               it.cardTypes.add(BASIC)
               it.cardTypes.remove(EVOLUTION)
+              delayed {
+                after REMOVE_FROM_PLAY, it {
+                  it.cardTypes.remove(BASIC)
+                  it.cardTypes.add(EVOLUTION)
+                  unregister()
+                }
+              }
               benchPCS(it)
             }
             shuffleDeck()

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1613,6 +1613,13 @@ public enum PowerKeepers implements LogicCardInfo {
                 my.deck.remove(it)
                 it.cardTypes.add(BASIC)
                 it.cardTypes.remove(EVOLUTION)
+                delayed {
+                  after REMOVE_FROM_PLAY, it {
+                    it.cardTypes.remove(BASIC)
+                    it.cardTypes.add(EVOLUTION)
+                    unregister()
+                  }
+                }
                 benchPCS(it)
               }
               shuffleDeck()


### PR DESCRIPTION
Cards are still considered basic after discard. Attempt to revert the changes with a delayed effect on the affected card being removed from play.