### PR TITLE
Mark as basic - a different approach to not staying basic when removed from play

### DIFF
--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2295,12 +2295,9 @@ public enum HolonPhantoms implements LogicCardInfo {
                 my.deck.remove(it)
                 it.cardTypes.add(BASIC)
                 it.cardTypes.remove(EVOLUTION)
-                delayed {
-                  after REMOVE_FROM_PLAY, it {
-                    it.cardTypes.remove(BASIC)
-                    it.cardTypes.add(EVOLUTION)
-                    unregister()
-                  }
+                it.onRemoveFromPlay {
+                  it.cardTypes.remove(BASIC)
+                  it.cardTypes.add(EVOLUTION)
                 }
                 benchPCS(it)
               }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2411,12 +2411,9 @@ public enum LegendMaker implements LogicCardInfo {
               hand.remove(it)
               it.cardTypes.add(BASIC)
               it.cardTypes.remove(EVOLUTION)
-              delayed {
-                after REMOVE_FROM_PLAY, it {
-                  it.cardTypes.remove(BASIC)
-                  it.cardTypes.add(EVOLUTION)
-                  unregister()
-                }
+              it.onRemoveFromPlay {
+                it.cardTypes.remove(BASIC)
+                it.cardTypes.add(EVOLUTION)
               }
               benchPCS(it)
             }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1214,12 +1214,9 @@ public enum LegendMaker implements LogicCardInfo {
               my.deck.remove(it)
               it.cardTypes.add(BASIC)
               it.cardTypes.remove(EVOLUTION)
-              delayed {
-                after REMOVE_FROM_PLAY, it {
-                  it.cardTypes.remove(BASIC)
-                  it.cardTypes.add(EVOLUTION)
-                  unregister()
-                }
+              it.onRemoveFromPlay {
+                it.cardTypes.remove(BASIC)
+                it.cardTypes.add(EVOLUTION)
               }
               benchPCS(it)
             }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1613,12 +1613,9 @@ public enum PowerKeepers implements LogicCardInfo {
                 my.deck.remove(it)
                 it.cardTypes.add(BASIC)
                 it.cardTypes.remove(EVOLUTION)
-                delayed {
-                  after REMOVE_FROM_PLAY, it {
-                    it.cardTypes.remove(BASIC)
-                    it.cardTypes.add(EVOLUTION)
-                    unregister()
-                  }
+                it.onRemoveFromPlay {
+                  it.cardTypes.remove(BASIC)
+                  it.cardTypes.add(EVOLUTION)
                 }
                 benchPCS(it)
               }


### PR DESCRIPTION
I'm pretty sure I'm trying to add a `onRemoveFromPlay` closure directly to the card similar to how I'm directly manipulating the `cardTypes`. This is feeling more wrong the further I go down this rabbit hole, but I'm still curious if it works.