### PR TITLE
Added method isPokemonDelta

### DIFF
--- a/src/tcgwars/logic/util/PokemonCardSet.java
+++ b/src/tcgwars/logic/util/PokemonCardSet.java
@@ -285,6 +285,11 @@ public class PokemonCardSet implements PokemonStack, Serializable {
   public boolean isEX() {
     return getTopPokemonCard().getCardTypes().is(CardType.EX);
   }
+  
+  public boolean isPokemonDelta() {
+    List<PlayerType> Holon_Veil = TcgStatics.bg().em().retrieveObject("Holon_Veil")
+    return getCardTypes().is(CardType.DELTA) || (getCardTypes().is(CardType.POKEMON) && Holon_Veil.contains(this.player));
+  }
 
   public boolean isPokemonEX(){
     return getTopPokemonCard().getCardTypes().is(CardType.POKEMON_EX);


### PR DESCRIPTION
If this works as I intend, whenever a card would normally use .cardTypes.is(DELTA) instead it would call the created method and if ampheros delta is in play it would return true. I have very little understanding of how things work outside of implementation so I would greatly appreciate it if @axpendix could look it over and/or tell me what I did obviously wrong.