### PR TITLE
Hardcode Holon_Veil into is

### DIFF
--- a/src/tcgwars/logic/util/CardTypeSet.java
+++ b/src/tcgwars/logic/util/CardTypeSet.java
@@ -34,7 +34,7 @@ public class CardTypeSet extends TreeSet<CardType>{
   }
   public boolean is(CardType o){
     List<PlayerType> Holon_Veil = TcgStatics.bg().em().retrieveObject("Holon_Veil");
-    return (contains(o) || (contains(CardType.POKEMON) && Holon_Veil.contains(player)));
+    return (contains(o) || (o == CardType.DELTA && contains(CardType.POKEMON) && Holon_Veil.contains(player)));
   }
   public boolean isNot(CardType o){
     return !contains(o);

--- a/src/tcgwars/logic/util/CardTypeSet.java
+++ b/src/tcgwars/logic/util/CardTypeSet.java
@@ -9,6 +9,8 @@ import gnu.trove.set.hash.THashSet;
 import tcgwars.logic.card.CardType;
 import tcgwars.logic.card.CardType.CardTypeComparator;
 import tcgwars.logic.card.Type;
+import tcgwars.logic.Battleground;
+import tcgwars.logic.PlayerType;
 
 /**
  * @author axpendix@hotmail.com
@@ -31,7 +33,8 @@ public class CardTypeSet extends TreeSet<CardType>{
     }
   }
   public boolean is(CardType o){
-    return contains(o);
+    List<PlayerType> Holon_Veil = TcgStatics.bg().em().retrieveObject("Holon_Veil");
+    return (contains(o) || (contains(CardType.POKEMON) && Holon_Veil.contains(player)));
   }
   public boolean isNot(CardType o){
     return !contains(o);


### PR DESCRIPTION
This feels like way to deep of a fix for a single card. Still hoping for a review from @axpendix . 
The goal of this change is that the delta check will return true even if the card isn’t a delta card as long as ampharos delta’s ability is active. I store the list of playerTypes for whom Holon Veil is active in the stored object Holon_Veil.
Marking as a draft so it doesn’t get merged by accident again.