### PR TITLE
Mark as basic

### DIFF
--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2293,9 +2293,8 @@ public enum HolonPhantoms implements LogicCardInfo {
             if(my.deck){
               my.deck.search(min:0, max:1, "Search your deck for a card named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Aerodactyl ex" || it.name == "Lileep" || it.name == "Anorith"}).each {
                 my.deck.remove(it)
-                it.cardTypes.add(BASIC)
-                it.cardTypes.remove(EVOLUTION)
                 benchPCS(it)
+                //TODO Mark as basic
               }
               shuffleDeck()
             }
@@ -2304,8 +2303,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             if(eligible){
               eligible.select("Select which Pokemon to bench").each {
                 hand.remove(it)
-                it.cardTypes.add(BASIC)
-                it.cardTypes.remove(EVOLUTION)
+                // TODO How to mark it as a Basic Pokemon?
                 benchPCS(it)
               }
             }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2403,9 +2403,8 @@ public enum LegendMaker implements LogicCardInfo {
             def eligible = my.hand.findAll { it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Aerodactyl ex" || it.name == "Lileep" || it.name == "Anorith"}
             eligible.select("Select which Pokemon to bench").each {
               hand.remove(it)
+
               // TODO How to mark it as a Basic Pokemon?
-              it.cardTypes.add(BASIC)
-              it.cardTypes.remove(EVOLUTION)
               benchPCS(it)
             }
           }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1212,8 +1212,6 @@ public enum LegendMaker implements LogicCardInfo {
             def maxSpace = Math.min(my.bench.freeBenchCount, 2)
             my.deck.search(min:0, max:maxSpace, "Search your deck for up to 2 cards named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Lileep" || it.name == "Anorith"}).each {
               my.deck.remove(it)
-              it.cardTypes.add(BASIC)
-              it.cardTypes.remove(EVOLUTION)
               benchPCS(it)
             }
             shuffleDeck()
@@ -2405,6 +2403,7 @@ public enum LegendMaker implements LogicCardInfo {
             def eligible = my.hand.findAll { it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Aerodactyl ex" || it.name == "Lileep" || it.name == "Anorith"}
             eligible.select("Select which Pokemon to bench").each {
               hand.remove(it)
+              // TODO How to mark it as a Basic Pokemon?
               it.cardTypes.add(BASIC)
               it.cardTypes.remove(EVOLUTION)
               benchPCS(it)

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1608,15 +1608,7 @@ public enum PowerKeepers implements LogicCardInfo {
           energyCost W
           attackRequirement {}
           onAttack {
-            if(my.deck){
-              my.deck.search(min:0, max:2, "Search your deck for a card named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Lileep" || it.name == "Anorith"}).each {
-                my.deck.remove(it)
-                it.cardTypes.add(BASIC)
-                it.cardTypes.remove(EVOLUTION)
-                benchPCS(it)
-              }
-              shuffleDeck()
-            }
+            // TODO
           }
         }
         move "Mud Shot", {

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1608,7 +1608,13 @@ public enum PowerKeepers implements LogicCardInfo {
           energyCost W
           attackRequirement {}
           onAttack {
-            // TODO
+            if(my.deck) {
+              my.deck.search(min:0, max:2, "Search your deck for a card named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Lileep" || it.name == "Anorith"}).each {
+                my.deck.remove(it)
+                benchPCS(it)
+              }
+              shuffleDeck()
+            }
           }
         }
         move "Mud Shot", {

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1606,15 +1606,16 @@ public enum PowerKeepers implements LogicCardInfo {
         move "Influence", {
           text "Search your deck for Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith and put up to 2 of them onto your Bench. Shuffle your deck afterward. Treat the new Benched Pokémon as Basic Pokémon."
           energyCost W
-          attackRequirement {}
+          attackRequirement {
+            assert my.bench.notFull : "Bench is full"
+            assert my.deck : "Deck is empty"
+          }
           onAttack {
-            if(my.deck) {
-              my.deck.search(min:0, max:2, "Search your deck for a card named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Lileep" || it.name == "Anorith"}).each {
-                my.deck.remove(it)
-                benchPCS(it)
-              }
-              shuffleDeck()
+            my.deck.search(min:0, max:2, "Search your deck for a card named Omanyte, Kabuto, Aerodactyl, Lileep, or Anorith", {it.name == "Omanyte" || it.name == "Kabuto" || it.name == "Aerodactyl" || it.name == "Lileep" || it.name == "Anorith"}).each {
+              my.deck.remove(it)
+              benchPCS(it)
             }
+            shuffleDeck()
           }
         }
         move "Mud Shot", {


### PR DESCRIPTION
This reverts the changes I've made so far. According to @axpendix this is not the correct way to go about having the Pokemon cards put into play by these effects be considered a Basic Pokemon. Apparently, a Pokemon card in play without another card under it should already be considered basic. However, the way other cards check if a Pokemon card is basic doesn't seem to line up with this. I'm going to need to figure out what the best way to handle this actually is.