### PR TITLE
Clefable 74 RCL - Prankish not only once per turn

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1910,7 +1910,7 @@ public enum RebelClash implements LogicCardInfo {
         }
       };
       case CLEFABLE_75:
-      return evolution (this, from:"Clefairy", hp:HP110, type:P, retreatCost:1) {
+      return evolution (this, from:"Clefairy", hp:HP110, type:P, retreatCost:2) {
         weakness M
         bwAbility "Prankish", {
           text "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put an Energy attached to your opponent’s Active Pokémon on top of their deck."

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1913,7 +1913,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Clefairy", hp:HP110, type:P, retreatCost:1) {
         weakness M
         bwAbility "Prankish", {
-          text "Once during your turn, when you play this card from your hand to evolve a Pokemon, you may choose an Energy attached to your opponent’s Active Pokemon and return it to the top of your opponent’s deck."
+          text "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put an Energy attached to your opponent’s Active Pokémon on top of their deck."
           onActivate {r->
             if (r==PLAY_FROM_HAND && opp.active.cards.energyCount(C) && confirm("Use Prankish?")) {
               opp.active.cards.filterByType(ENERGY).select(count:1).moveTo(addToTop: true, opp.deck)

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1915,9 +1915,7 @@ public enum RebelClash implements LogicCardInfo {
         bwAbility "Prankish", {
           text "Once during your turn, when you play this card from your hand to evolve a Pokemon, you may choose an Energy attached to your opponent’s Active Pokemon and return it to the top of your opponent’s deck."
           onActivate {r->
-            if (r==PLAY_FROM_HAND && opp.active.cards.energyCount(C) && bg.em().retrieveObject("Prankish")!=bg.turnCount && confirm("Use Prankish?")) {
-              powerUsed()
-              bg.em().storeObject("Prankish", bg.turnCount)
+            if (r==PLAY_FROM_HAND && opp.active.cards.energyCount(C) && confirm("Use Prankish?")) {
               opp.active.cards.filterByType(ENERGY).select(count:1).moveTo(addToTop: true, opp.deck)
             }
           }


### PR DESCRIPTION
Prankish should not be limited to only once per turn. It should trigger
every time the Clefable is played from the hand to evolve a Pokemon.

This should fix
https://forum.tcgone.net/t/br-clefable-rcl-75-you-should-be-able-to-use-more-than-one-p/9930

Note: The text attribute for the ability states "Once during your turn," but [the actual card does not](https://tcgone.net/cards/clefable-rcl-75). Should this be corrected as well?