### PR TITLE
Polteageist V (SWSH21)'s Ability; plus some minor fixes on SMP, UPR and CIN

### DIFF
--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -423,10 +423,10 @@ public enum CrimsonInvasion implements LogicCardInfo {
           move "Dance of Flames", {
             text "For each Energy attached to your opponent's Pokémon, attach a [R] Energy card from your discard pile to your Pokémon in any way you like."
             onAttack {
-              //TODO : more efecient way?
-              opp.active.cards.filterByType(ENERGY).each{
-                attachEnergyFrom(type:R,my.discard,my.all)
-              }
+              opp.all.each{
+                it.active.cards.filterByType(ENERGY).each{
+                  attachEnergyFrom(type:R,my.discard,my.all)
+                }
             }
           }
           move "Burning Bonemerang", {
@@ -570,7 +570,6 @@ public enum CrimsonInvasion implements LogicCardInfo {
             onAttack {
               gxPerform()
               opp.all.each{
-                //TODO : check if the pokemon has energy attached?
                 if(it.cards.filterByType(ENERGY))
                   it.cards.filterByType(ENERGY).select("Discard").discard()
               }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1093,7 +1093,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               assert my.deck : "There is no more cards in your deck"
             }
             onAttack{
-              my.deck.search(count:1,"Choose an Item card",cardTypeFilter(ITEM)).showToOpponent("The choosen Item card.").moveTo(my.hand)
+              my.deck.search(count:1,"Choose an Item card",cardTypeFilter(ITEM)).showToOpponent("The chosen Item card.").moveTo(my.hand)
             }
           }
           move "X-Scissor" , {
@@ -2979,7 +2979,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               afterDamage {
                 def number = Math.min(2, opp.hand.size())
                 if (number > 0) {
-                  opp.hand.select(hidden: true, count:number).showToMe("Choosen cards").moveTo(opp.deck)
+                  opp.hand.select(hidden: true, count:number).showToMe("Chosen cards").moveTo(opp.deck)
                   shuffleDeck(null, TargetPlayer.OPPONENT)
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -1806,8 +1806,7 @@ public enum UltraPrism implements LogicCardInfo {
             text "You can use this attack only if you go second, and only on your first turn. Discard an Energy from 1 of your opponent’s Pokémon."
             energyCost C
             attackRequirement {
-              //TODO : is second turn 1 or 2?
-              assert bg.turnCount==2
+              assert bg.turnCount == 2 : "You can use this attack only on your first turn"
             }
             onAttack {
               def tar = opp.all.findAll {it.cards.energyCount(C)}

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -312,8 +312,19 @@ public enum SwordShieldPromos implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Teapot of Surprises", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent's attack (even if it is Knocked Out), choose a random card from your opponent's hand. Your opponent reveals that card and puts it on the bottom of their deck."
-          actionA {
-            // TODO
+          delayedA (priority: LAST) {
+            before APPLY_ATTACK_DAMAGES, {
+              PokemonCardSet pcs = ef.attacker
+              if (pcs.owner != self.owner) {
+                bg.dm().each{
+                  if (it.to == self && self.active && it.dmg.value) {
+                    if (opp.hand.size() > 0) {
+                      opp.hand.select(hidden: true, count:1).showToMe("Chosen card").showToOpponent("Teapot of Surprises: this card will be put on the bottom of your deck").moveTo(opp.deck)
+                    }
+                  }
+                }
+              }
+            }
           }
         }
         move "Mind Bend", {


### PR DESCRIPTION
Fixes
* Alolan Marowak (CIN 12) now counts energy attached to all of the opponent's Pokémon, not only the Active one.
* Two typos on SM Promo cards.
* Added a missing warning on Murkrow (UPR)'s attack.
* Removed an outdated typo on Gyarados-GX (CIN).