### PR TITLE
Clefable RCL 75 - Correct ability text in log

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1920,6 +1920,7 @@ public enum RebelClash implements LogicCardInfo {
           text "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put an Energy attached to your opponent’s Active Pokémon on top of their deck."
           onActivate {r->
             if (r==PLAY_FROM_HAND && opp.active.cards.energyCount(C) && confirm("Use Prankish?")) {
+              powerUsed()
               opp.active.cards.filterByType(ENERGY).select(count:1).moveTo(addToTop: true, opp.deck)
             }
           }


### PR DESCRIPTION
I over-removed when fixing the ability. Without powerUsed the "used
ability" text doesn't seem to appear in the game log, which is certainly
problematic.

Whoops.