### PR TITLE
Multiple card fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -313,7 +313,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before you attack), if Claydol is your Active Pokémon, you may shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent’s hand. This power can’t be used if Claydol is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert self.active : "$self is not your Active Pokémon"
               powerUsed()
               my.hand.moveTo(my.deck)
@@ -814,7 +814,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before your attack), you may search your deck for a card. Shuffle your deck, then put that card on top of your deck. This power can’t be used if Magcargo is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert my.deck : "There is no card in your deck"
               powerUsed()
               def tar = my.deck.search(max:1,"Select 1 card",{true}).each{my.deck.remove(it)}
@@ -911,7 +911,8 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before you attack), if Sableye is your Active Pokémon, you may look at your opponent’s hand. This power can’t be used if Sableye is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
+              assert self.active : "$self is not your active Pokémon."
               assert opp.hand : "There is no card in your opponent hand"
               powerUsed()
               opp.hand.showToMe("Opponent's hand")
@@ -977,7 +978,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before your attack), you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. You opponent chooses the Benched Pokémon to switch. This power can’t be used if Shiftry is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert opp.bench : "There is no benched Pokemon"
               powerUsed()
 
@@ -1438,9 +1439,9 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before your attack), if Nosepass is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can’t be used if Nosepass is affected by a Special Condition."
             actionA {
               checkLastTurn()
+              checkNoSPC()
               assert self.active : "$self is not your active Pokémon."
               assert opp.bench : "There is no Pokémon to switch"
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
               powerUsed()
               flip {
                 sw opp.active, opp.bench.select("Select the new active Pokémon.")
@@ -2672,7 +2673,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Once during your turn (before you attack), if Crobat ex is your active pokemon, you may put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Crobat ex is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert self.active : "$self is not your Active Pokémon"
               powerUsed()
               directDamage 10, opp.all.select()

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -486,7 +486,7 @@ public enum Emerald implements LogicCardInfo {
           pokePower "Water Cyclone", {
             text "As often as you like during your turn (before your attack), you may move a [W] Energy attached to 1 of your Active Pokémon to 1 of your Benched Pokémon. This power can’t be used if Swampert is affected by a Special Condition."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert my.active.cards.energyCount(W)>0 : "No [W] Energy is attached to ${my.active}"
               assert my.bench : "There is no Benched Pokémon"
               powerUsed()

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -874,7 +874,6 @@ public enum LegendMaker implements LogicCardInfo {
           energyCost C
           attackRequirement { assert my.deck : "Deck is empty" }
           onAttack {
-            def nam=self.name
             def tar = my.deck.search("Trainer Card (excluding Supporter cards)", {it.cardTypes.is(TRAINER) && !it.cardTypes.is(SUPPORTER)})
             tar.moveTo(my.hand)
             shuffleDeck()

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -288,7 +288,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Darkness Navigation", {
             text "Once during your turn (before your attack), if Dark Electrode has no Energy attached to it, you may search your deck for a [D] or Dark Metal Energy and attach it to Dark Electrode. Shuffle your deck afterward. This power can’t be used if Dark Electrode is affected by a Special Condition."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert !(self.cards.energyCount(C)) : "$self has Energies attached to it"
               checkLastTurn()
               powerUsed()
@@ -431,7 +431,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Cunning", {
             text "Once during your turn (before your attack), you may look at the top card of your opponent’s deck. Then, you may shuffle his or her deck. This power can’t be used if Dark Slowking is affected by a Special Condition."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert opp.deck
               checkLastTurn()
               powerUsed()
@@ -632,7 +632,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Dark Trance", {
             text "As often as you like during your turn (before your attack), you may move a [D] Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Dark Dragonite is affected by a Special Condition."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert my.all.findAll {it.cards.energyCount(D)>0}
               assert my.all.size()>=2
 
@@ -817,7 +817,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Gift Exchange", {
             text "Once during your turn (before your attack), if Delibird is your Active Pokémon, you may shuffle 1 card from your hand into your deck. Then, draw a card. This power can’t be used if Delibird is affected by a Special Condition."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert my.hand
               assert self.active : "$self is not your active Pokémon."
               checkLastTurn()
@@ -934,7 +934,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Dark Spell", {
             text "Once during your turn (before your attack), if Misdreavus is your Active Pokémon, you may flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Misdreavus is affected by a Special Condition or if your other Active Pokémon is not Misdreavus."
             actionA {
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert self.active : "$self is not your active Pokémon."
               checkLastTurn()
               powerUsed()
@@ -1102,7 +1102,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "Once during your turn (before your attack), if Dark Dragonair is your Active Pokémon, you may search your deck for an Evolution card. Show it to your opponent and put it into your hand. Shuffle your deck afterward. This power can’t be used if Dark Dragonair is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert self.active : "$self is not your active"
               powerUsed()
               my.deck.search(max : 1,"Search for an evolution",cardTypeFilter(EVOLUTION)).showToOpponent("Selected card.").moveTo(my.hand)
@@ -1247,7 +1247,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "Once during your turn (before your attack), if Dark Houndoom is your Active Pokémon, you may flip a coin. If heads, the Defending Pokémon (choose 1 if there are 2) is now Burned. This power can’t be used if Dark Houndoom is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               powerUsed()
               flip{apply BURNED}
             }
@@ -1451,7 +1451,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "Once during your turn (before your attack), you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can’t be used if Mantine is affected by a Special Condition."
             actionA {
               checkLastTurn()
-              assert !(self.specialConditions) : "$self is affected by a Special Condition"
+              checkNoSPC()
               assert my.all.findAll{it.numberOfDamageCounters && it != self} : "There is no Pokémon with damage counter outside from ${self}."
               powerUsed()
               heal 10, my.all.findAll{it.numberOfDamageCounters && it != self}.select("Select the pokemon to heal.")

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4661,11 +4661,18 @@ public enum CosmicEclipse implements LogicCardInfo {
           text "Switch your Active Pokémon with 1 of your Benched Pokémon." +
             "When you play this card, you may discard 2 other cards from your hand. If you do, heal 120 damage from the Pokémon you moved to your Bench."
           onPlay {
+            def healingEff = false
             if (my.hand.getExcludedList(thisCard).size() >= 2 && confirm("Discard 2 cards to be able to heal the Pokémon you moved to the bench?")) {
               my.hand.getExcludedList(thisCard).select(count:2, "Choose 2 cards to discard.")discard()
-              heal 120, my.active
+              switchedPCS = my.active
+              healingEff = true
             }
+
             sw my.active, my.bench.select("Select the new Active Pokémon."), Source.TRAINER_CARD
+
+            if (healingEff) {
+              heal 120, switchedPCS
+            }
           }
           playRequirement {
             assert my.bench

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1404,8 +1404,10 @@ public enum DragonMajesty implements LogicCardInfo {
         return itemCard (this) {
           text "Switch your Active [W] Pokémon with 1 of your Benched Pokémon. If you do, heal 30 damage from the Pokémon you moved to your Bench.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
           onPlay {
-            heal 30, my.active
+            switchedPCS = my.active
             sw my.active, my.bench.select("Select the new active")
+            if (!switchedPCS.active)
+              heal 30, switchedPCS
           }
           playRequirement{
             assert my.active.types.contains(W)

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -713,7 +713,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Search your deck for a [G] Pokémon and put it into your hand. Shuffle your deck"
             energyCost G
             attackRequirement{
-              assert my.deck : "There is no more cards in your deck."
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack{
               my.deck.search("Select a [G] Pokémon to put on your hand",pokemonTypeFilter(G)).moveTo(my.hand)
@@ -1208,7 +1208,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Once during your turn (before your attack), you may discard the top card of your deck. If it's a basic Energy card, attach it to 1 of your Pokémon."
             actionA{
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck."
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               if(my.deck.subList(0,1).filterByType(BASIC_ENERGY)) {
                 attachEnergyFrom(my.deck.subList(0,1),my.all)
@@ -1267,7 +1267,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Search your deck for a card and put it into your hand. Then, shuffle your deck.\n"
             energyCost C
             attackRequirement{
-              assert my.deck : "There is no more cards in your deck."
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack{
               my.deck.select(max: 1).moveTo(hidden: true, my.hand)
@@ -3094,7 +3094,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Discard the top 2 cards of your opponent's deck."
             energyCost C,C
             attackRequirement{
-              assert opp.deck : "There is no more cards in your opponent's deck"
+              assert opp.deck : "There are no more cards in your opponent's deck"
             }
             onAttack{
               opp.deck.subList(0,2).discard()
@@ -3277,7 +3277,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Look at the top 8 cards of your deck and attach any number of Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck.\n"
             energyCost Y
             attackRequirement{
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
             }
             onAttack{
               my.deck.subList(0,8).showToMe("Top 8 cards of your deck")
@@ -3384,7 +3384,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Search your deck for up to 3 cards and put them into your hand. Then, shuffle your deck.\n"
             energyCost Y
             attackRequirement {
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
             }
             onAttack {
               my.deck.select(max: 3).moveTo(hidden: true, my.hand)
@@ -4289,7 +4289,7 @@ public enum LostThunder implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case MIXED_HERBS_184:
@@ -4351,7 +4351,7 @@ public enum LostThunder implements LogicCardInfo {
             my.deck.search("Choose Basic [G] Pokémon or a [G] Energy card",{(it.cardTypes.is(BASIC) && it.asPokemonCard().types.contains(G)) || (it.cardTypes.is(BASIC_ENERGY) && it.asEnergyCard().containsTypePlain(G) )}).moveTo(my.hand)
           }
           playRequirement{
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case PROFESSOR_ELM_S_LECTURE_188:
@@ -4361,7 +4361,7 @@ public enum LostThunder implements LogicCardInfo {
             my.deck.search(max : 3, "Choose up to 3 Pokémon with 60 HP or less",{it.cardTypes.is(POKEMON) && it.asPokemonCard().hp.value <= 60}).showToOpponent("Chosen Pokémon cards.").moveTo(my.hand)
           }
           playRequirement{
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case SIGHTSEER_189:

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1090,7 +1090,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             text "Search your deck for an Item card, reveal it, and put it into your hand. Then, shuffle your deck.\n"
             energyCost C
             attackRequirement{
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
             }
             onAttack{
               my.deck.search(count:1,"Choose an Item card",cardTypeFilter(ITEM)).showToOpponent("The chosen Item card.").moveTo(my.hand)

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -552,7 +552,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may put 2 damage counters on this Pokémon. If you do, search your deck for up to 2 [R] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
             actionA {
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               powerUsed()
               directDamage 20, self
               attachEnergyFrom(type: FIRE, my.deck, self)
@@ -767,7 +767,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may look at the top 6 cards of your deck and attach any number of [W] Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               powerUsed()
               my.deck.subList(0,6).showToMe("Top 6 cards of your deck")
               def tar = my.deck.subList(0,6).filterByBasicEnergyType(W)
@@ -1214,7 +1214,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Search your deck for up to 2 Electropower cards, reveal them, and put them into your hand. Then, shuffle your deck."
             energyCost L
             attackRequirement{
-              assert my.deck : "there is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
             }
             onAttack{
               my.deck.search(max:2,"Choose up to 2 Electropower cards",{it.name.contains("Electropower")}).showToOpponent("Chosen cards").moveTo(my.hand)
@@ -1258,7 +1258,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may search your deck for a Pokémon that has the Nuzzle attack, reveal it, and put it into your hand. Then, shuffle your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               powerUsed()
               my.deck.search("Find Pokemon with Nuzzle attack",{it.cardTypes.pokemon && it.moves.findAll{it.name=="Nuzzle"}}).moveTo(my.hand)
               shuffleDeck()
@@ -2361,7 +2361,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may put 3 damage counters on this Pokémon. If you do, search your deck for up to 3 [D] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
             actionA {
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               powerUsed()
               directDamage(30,self)
               my.deck.search(max:3,"Choose up to 3 [D] Energy cards", basicEnergyFilter(D)).each {
@@ -2983,7 +2983,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may look at the top 2 cards of your deck and put 1 of them into your hand. Put the other card on the bottom of your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               powerUsed()
               def sel = my.deck.subList(0,2).select("Choose 1 card to put into your hand")
               my.deck.subList(0,2).getExcludedList(sel).moveTo(suppressLog: true, my.deck)
@@ -3267,7 +3267,7 @@ public enum TeamUp implements LogicCardInfo {
           }
           playRequirement{
             assert opp.active.topPokemonCard.cardTypes.contains(STAGE2) : "There is no more card in your deck"
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case DANGEROUS_DRILL_138:
@@ -3332,7 +3332,7 @@ public enum TeamUp implements LogicCardInfo {
           }
           playRequirement{
             assert opp.active.topPokemonCard.cardTypes.contains(STAGE1) : "There is no more card in your deck"
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case FAIRY_CHARM_UB_142:
@@ -3396,7 +3396,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case JASMINE_145:
@@ -3407,7 +3407,7 @@ public enum TeamUp implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case JUDGE_WHISTLE_146:
@@ -3504,7 +3504,7 @@ public enum TeamUp implements LogicCardInfo {
             assert my.hand.find{it.name == "Dana"} : "You don't have Dana in your hand"
             assert my.hand.find{it.name == "Evelyn"} : "You don't have Evelyn in your hand"
             assert my.hand.find{it.name == "Nita"} : "You don't have Nita in your hand"
-            assert my.deck : "There is no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck"
           }
         };
       case NANU_150:
@@ -3518,7 +3518,7 @@ public enum TeamUp implements LogicCardInfo {
             list.discard()
           }
           playRequirement{
-            assert my.discard.filterByType(BASIC).findAll{it.asPokemonCard().types.contains(D)} : "There is no more cards in your deck"
+            assert my.discard.filterByType(BASIC).findAll{it.asPokemonCard().types.contains(D)} : "There are no more cards in your deck"
           }
         };
       case NITA_151:
@@ -3580,7 +3580,7 @@ public enum TeamUp implements LogicCardInfo {
           def actions=[]
           onPlay {
             actions=action("Stadium: Viridian Forest") {
-              assert my.deck : "There is no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck"
               assert my.hand : "You don't have cards in your hand"
               assert lastTurn != bg().turnCount : "Already used"
               bc "Used Viridian Forest effect"

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -2025,7 +2025,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             text "Prevent all damage done to your Benched Pokémon by your opponent's attacks."
             delayedA {
               before APPLY_ATTACK_DAMAGES, {
-                bg.dm().each {if(it.to.owner==self.owner && it.to.benched && it.dmg.value){
+                bg.dm().each {if(it.to.owner==self.owner && it.from.owner!=self.owner && it.to.benched && it.dmg.value){
                   bc "Bench Barrier reduces damage"
                   it.dmg=hp(0)
                 }}

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -437,7 +437,6 @@ public enum UnifiedMinds implements LogicCardInfo {
               def list = opp.all.findAll { it.evolution }
               assert list
               def pcs = list.select("Devolve one of your opponent's evolved Pokémon.")
-              assert pcs
               def top=pcs.topPokemonCard
               bc "$top devolved."
               pcs.cards.remove(top)


### PR DESCRIPTION
Card fixes:
* Mew (UNB 76): Shouldn't block damage done from its own side.
* Mallow & Lana (CEC 198): Heal should happen after the switch, otherwise it won't be blocked by some cards (e.g. Lunala GX's "Moongeist Beam").
* Switch Raft (DM 62): should heal only if the pokemon switched.

Minor changes:
* DE/EM/TRR: replaced some hardcoded assets with `checkNoSPC()`.
* LM: removed unnecesary `def`.
* UNM: removed unnecesary `assert`.
* LOT/SMP/TEU: replaced "is" for "are" in some warnings.