### PR TITLE
Fixes related to Switching, Heal Blocking and Pokémon evolving

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1104,11 +1104,14 @@ class TcgStatics {
   }
   static void cantBeHealed(PokemonCardSet defending){
     delayed {
+      after EVOLVE, defending, {unregister()}
+      after SWITCH, defending, {unregister()}
+
       before REMOVE_DAMAGE_COUNTER, defending, {
         bc "Healing was prevented due to an effect"
         prevent()
       }
-      unregisterAfter 3
+      unregisterAfter 2
     }
   }
   static void opponentCantPlaySupporterNextTurn(def _delegate){

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2462,8 +2462,6 @@ public enum CelestialStorm implements LogicCardInfo {
                     new Knockout(defending).run(bg)
                   }
                 }
-                after SWITCH, self, {unregister()}
-                after EVOLVE, self, {unregister()}
                 after SWITCH, defending, {unregister()}
                 after EVOLVE, defending, {unregister()}
                 unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4662,9 +4662,10 @@ public enum CosmicEclipse implements LogicCardInfo {
             "When you play this card, you may discard 2 other cards from your hand. If you do, heal 120 damage from the Pokémon you moved to your Bench."
           onPlay {
             def healingEff = false
+            def switchedPCS
             if (my.hand.getExcludedList(thisCard).size() >= 2 && confirm("Discard 2 cards to be able to heal the Pokémon you moved to the bench?")) {
-              my.hand.getExcludedList(thisCard).select(count:2, "Choose 2 cards to discard.")discard()
-              def switchedPCS = my.active
+              my.hand.getExcludedList(thisCard).select(count:2, "Choose 2 cards to discard.").discard()
+              switchedPCS = my.active
               healingEff = true
             }
 

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2060,8 +2060,6 @@ public enum GuardiansRising implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH, self, {unregister()}
-                after EVOLVE, self, {unregister()}
                 after SWITCH, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
               }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1648,15 +1648,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost P, P, P, P
             onAttack {
               damage 120
-              delayed {
-                before REMOVE_DAMAGE_COUNTER, defending, {
-                  bc "Moongeist Beam prevents healing"
-                  prevent()
-                }
-                after EVOLVE, defending, {unregister()}
-                after SWITCH, defending, {unregister()}
-                unregisterAfter 2
-              }
+              cantBeHealed(defending)
             }
           }
           move "Lunar Fall GX", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1644,7 +1644,7 @@ public enum SunMoon implements LogicCardInfo {
             }
           }
           move "Moongeist Beam", {
-            text "120 damage. The Defending Pokémon can't be healed during your next turn."
+            text "120 damage. The Defending Pokémon can’t be healed during your opponent’s next turn."
             energyCost P, P, P, P
             onAttack {
               damage 120
@@ -1653,7 +1653,9 @@ public enum SunMoon implements LogicCardInfo {
                   bc "Moongeist Beam prevents healing"
                   prevent()
                 }
-                unregisterAfter 3
+                after EVOLVE, defending, {unregister()}
+                after SWITCH, defending, {unregister()}
+                unregisterAfter 2
               }
             }
           }
@@ -2520,22 +2522,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost C, C, C
             onAttack {
               damage 50
-              targeted (defending) {
-                delayed {
-                  after PROCESS_ATTACK_EFFECTS, defending, {
-                    bg.dm().each {
-                      if(it.from==defending && it.notNoEffect && it.dmg.value){
-                        bc "Ferocious Bellow -50"
-                        it.dmg -= hp(50)
-                      }
-                    }
-                  }
-                  after EVOLVE, defending, {unregister()}
-                  after SWITCH, defending, {unregister()}
-                  after SWITCH, self, {unregister()}
-                  unregisterAfter 2
-                }
-              }
+              reduceDamageFromDefendingNextTurn(hp(50), thisMove, defending)
             }
           }
           move "Hammer In", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1468,6 +1468,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                     }
                   }
                 }
+                after EVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
                 unregisterAfter 2
               }


### PR DESCRIPTION
~~Drafted until figuring out a detail on Mallow & Lana.~~ **Ready to go!**

* Lunala-GX (SUM 66): Moongeist Beam's no heal effect should be removed on switch (Mallow & Lana, or Switch Raft should work here). **(Second Fix: Made Lunala use `cantBeHealed(defending)` and applied this fix there, should also fix Tentacool GRI 23)**
* Stoutland (SUM 50): Simplified "Ferocious Bellow" to  common method. Reason: The damage reduction is on the defending Pokémon, not on Stoutland. It shouldn't be unregistered after Stoutland switches out.
* Absol (GRI 81): Doom News shouldn't be unregistered if Absol switches out or evolves(?).
* Jirachi Prism Star (CES 97): Sams as Absol but with Perish Dream here.
* Frogadier (UNB 52): should lose the effect of AfterImage Strike if devolved.
