### PR TITLE
Some card fixes on WBSP, FRLG, DS and UL

### DIFF
--- a/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
@@ -896,6 +896,9 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             bg().gm().unregisterAction(it)
           }
         }
+        playRequirement{
+          assert my.deck : "There are no more cards in your deck."
+        }
       };
       case POKEMON_TOWER_42:
       return stadium (this) {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -2852,7 +2852,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       case SUPER_SCOOP_UP_100:
         return copy(Deoxys.SUPER_SCOOP_UP_99, this);
       case POTION_101:
-        return copy(FireRedLeafGreen.POTION, this);
+        return copy(FireRedLeafGreen.POTION_101, this);
       case SWITCH_102:
         return copy(FireRedLeafGreen.SWITCH_102, this);
       case DARKNESS_ENERGY_103:

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1237,11 +1237,14 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             text "Choose up to 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Onix can’t attack during your next turn."
             energyCost F, C
             onAttack {
-              multiSelect(opp.bench, 2).each{
-                targeted(it){
-                  damage 10, it
+              if (opp.bench) {
+                multiSelect(opp.bench, 2).each{
+                  targeted(it){
+                    damage 10, it
+                  }
                 }
               }
+              cantAttackNextTurn self
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1520,8 +1520,10 @@ public enum Unleashed implements LogicCardInfo {
             text "Flip 2 coins. For each heads, search your deck for a [G] Pokémon, show it to your opponent, and put it into your hand. If you do, shuffle your deck afterward."
             energyCost G
             onAttack {
-              flip 2, {
-                my.deck.search(max:2,"Choose up to 2 [G] pokemon to put in your hand.",{it.cardTypes.is(POKEMON) && it.types.contains(G)}).showToOpponent("Selected cards").moveTo(my.hand)
+              def cardsNum = 0
+              flip 2 { cardsNum += 1 }
+              if (cardsNum) {
+                my.deck.search(max:cardsNum,"Choose up to 2 [G] pokemon to put in your hand.",{it.cardTypes.is(POKEMON) && it.types.contains(G)}).moveTo(my.hand)
                 shuffleDeck()
               }
             }


### PR DESCRIPTION

* WBSP: Lucky Stadium (41) should check for players having cards in their deck.
* FRLG: Onix (42) now checks for bench, and applies the restriction to attack next turn.
* DS: Potion (101) was pointing to the wrong card id.
* UL: Tropius' (66) "Green Call" didn't search for the proper amount of [G] Pokémon.