### PR TITLE
Potential fix for Empoleon Lv. X (DP 120)

### DIFF
--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2995,6 +2995,7 @@ public enum DiamondPearl implements LogicCardInfo {
               powerUsed()
               def supremeCommandBundles = [ : ]
               def supremeCommandCards = new CardList()
+              supremeCommandCards.setType(CardListType.PERSISTENT)
               def chosenCards = opp.hand.select(hidden: true, count:2).showToOpponent("Cards randomly put aside by Supreme Command. They'll return to your hand at the end of your next turn.").moveTo(hidden:true, supremeCommandCards)
 
               if(bg.em().retrieveObject("supremeCommandBundles") != null){


### PR DESCRIPTION
Feedback on how good/bad of an idea this might be would be appreciated.

Also not sure if a CardList can be set as persistent without a "name" attribute. Could I use the empoleon's UUID maybe? In case of a mirror match, so each "Out of Board" area has a separate identifier, even if not used.