### PR TITLE
Final batch of fixes for DP basic use, and modularization of EX-era babies

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -815,14 +815,10 @@ public enum CrystalGuardians implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Jigglypuff from your hand onto Igglybuff (this counts as evolving Igglybuff) and remove all damage counters from Igglybuff."
           actionA {
-            assert my.hand.findAll{it.name.contains("Jigglypuff")} : "There are no Pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Jigglypuff", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Jigglypuff") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Jigglypuff", self)
           }
         }
         pokeBody "Hover Lift", {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -840,14 +840,10 @@ public enum DeltaSpecies implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Marill from your hand onto Azurill (this counts as evolving Azurill) and remove all damage counters from Azurill."
           actionA {
-            assert my.hand.findAll{it.name.contains("Marill") && !it.cardTypes.is(EX) } : "There is no pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Marill", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Marill") && !it.cardTypes.is(EX) }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Marill", self)
           }
         }
         move "Type Match", {

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1373,14 +1373,10 @@ public enum DragonFrontiers implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Electabuzz from your hand onto Elekid (this counts as evolving Elekid) and remove all damage counters from Elekid."
           actionA {
-            assert my.hand.findAll{it.name.contains("Electabuzz")} : "There is no pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Electabuzz", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Electabuzz") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Electabuzz", self)
           }
         }
         move "Thunder Spear", {
@@ -1645,14 +1641,10 @@ public enum DragonFrontiers implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Jynx from your hand onto Smoochum (this counts as evolving Smoochum) and remove all damage counters from Smoochum."
           actionA {
-            assert my.hand.findAll{it.name.contains("Jynx")} : "There is no pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Jynx", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Jynx") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Jynx", self)
           }
         }
         move "Alluring Kiss", {

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1529,14 +1529,10 @@ public enum Emerald implements LogicCardInfo {
           pokePower "Baby Evolution", {
             text "Once during your turn (before your attack), you may put Pikachu from your hand onto Pichu (this counts as evolving Pichu) and remove all damage counters from Pichu."
             actionA {
-              assert my.hand.findAll{it.name == "Pikachu"} : "There is no pokémon in your hand to evolve ${self}."
+              checkCanBabyEvolve("Pikachu", self)
               checkLastTurn()
               powerUsed()
-              def tar = my.hand.findAll{it.name == "Pikachu"}.select()
-              if(tar) {
-                evolve(self, tar.first(), OTHER)
-                heal self.numberOfDamageCounters*10,self
-              }
+              babyEvolution("Pikachu", self)
             }
           }
           move "Collect", {

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2098,14 +2098,10 @@ public enum HolonPhantoms implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Pikachu from your hand onto Pichu (this counts as evolving Pichu) and remove all damage counters from Pichu."
           actionA {
-            assert my.hand.findAll{it.name.contains("Pikachu")} : "There is no pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Pikachu", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Pikachu") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Pikachu", self)
           }
         }
         move "Paste", {

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1972,14 +1972,10 @@ public enum LegendMaker implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Magmar from your hand onto Magby (this counts as evolving Magby) and remove all damage counters from Magby."
           actionA {
-            assert my.hand.findAll{it.name.contains("Magmar")} : "There is no pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Magmar", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Magmar") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Magmar", self)
           }
         }
         move "Ignite", {
@@ -2251,14 +2247,10 @@ public enum LegendMaker implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Wobbuffet from your hand onto Wynaut (this counts as evolving Wynaut) and remove all damage counters from Wynaut."
           actionA {
-            assert my.hand.findAll{it.name == "Wobbuffet"} : "There is no Pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Wobbuffet", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name == "Wobbuffet" }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Wobbuffet", self)
           }
         }
         move "Confusion Wave", {

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -798,14 +798,10 @@ public enum PowerKeepers implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Pikachu from your hand onto Pichu (this counts as evolving Pichu) and remove all damage counters from Pichu."
           actionA {
-            assert my.hand.findAll{it.name.contains("Pikachu")} : "There are no Pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Pikachu", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Pikachu") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Pikachu", self)
           }
         }
         move "Cry for Help", {
@@ -1865,14 +1861,10 @@ public enum PowerKeepers implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Wobbuffet from your hand onto Wynaut (this counts as evolving Wynaut) and remove all damage counters from Wynaut."
           actionA {
-            assert my.hand.findAll{it.name.contains("Wobbuffet")} : "There are no Pokémon in your hand to evolve ${self}."
+            checkCanBabyEvolve("Wobbuffet", self)
             checkLastTurn()
             powerUsed()
-            def tar = my.hand.findAll { it.name.contains("Wobbuffet") }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10, self
-            }
+            babyEvolution("Wobbuffet", self)
           }
         }
         move "Flail", {

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -907,14 +907,10 @@ public enum TeamRocketReturns implements LogicCardInfo {
           pokePower "Baby Evolution", {
             text "Once during your turn (before your attack), you may put Magmar from your hand onto Magby (this counts as evolving Magby), and remove all damage counters from Magby."
             actionA {
-              assert my.hand.findAll{it.name == "Magmar"} : "There is no pokémon in your hand to evolve ${self}."
+              checkCanBabyEvolve("Magmar", self)
               checkLastTurn()
               powerUsed()
-              def tar = my.hand.findAll{it.name == "Magmar"}.select()
-              if(tar) {
-                evolve(self, tar.first(), OTHER)
-                heal self.numberOfDamageCounters*10,self
-              }
+              babyEvolution("Magmar", self)
             }
           }
           move "Detour", {

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -885,14 +885,10 @@ public enum UnseenForces implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Clefairy from your hand onto Cleffa (this counts as evolving Cleffa) and remove all damage counters from Cleffa."
           actionA {
-            assert my.hand.findAll { it.name == "Clefairy" } : "There are no Pokémon in your hand to evolve ${self}."
-            checkLastTurn()
-            powerUsed()
-            def tar = my.hand.findAll { it.name == "Clefairy" }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10,self
-            }
+              checkCanBabyEvolve("Clefairy", self)
+              checkLastTurn()
+              powerUsed()
+              babyEvolution("Clefairy", self)
           }
         }
         move "Eeeeeeek", {
@@ -946,14 +942,10 @@ public enum UnseenForces implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Electabuzz from your hand onto Elekid (this counts as evolving Elekid) and remove all damage counters from Elekid."
           actionA {
-            assert my.hand.findAll { it.name == "Electabuzz" } : "There are no Pokémon in your hand to evolve ${self}."
-            checkLastTurn()
-            powerUsed()
-            def tar = my.hand.findAll { it.name == "Electabuzz" }.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10,self
-            }
+              checkCanBabyEvolve("Electabuzz", self)
+              checkLastTurn()
+              powerUsed()
+              babyEvolution("Electabuzz", self)
           }
         }
         move "Magnetic Trip", {
@@ -1162,14 +1154,10 @@ public enum UnseenForces implements LogicCardInfo {
         pokePower "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Jynx from your hand onto Smoochum (this counts as evolving Smoochum) and remove all damage counters from Smoochum."
           actionA {
-            assert my.hand.findAll{it.name == "Jynx"} : "There are no Pokémon in your hand to evolve ${self}."
-            checkLastTurn()
-            powerUsed()
-            def tar = my.hand.findAll{it.name == "Jynx"}.select()
-            if (tar) {
-              evolve(self, tar.first(), OTHER)
-              heal self.numberOfDamageCounters*10,self
-            }
+              checkCanBabyEvolve("Jynx", self)
+              checkLastTurn()
+              powerUsed()
+              babyEvolution("Jynx", self)
           }
         }
         move "Blown Kiss", {
@@ -1213,6 +1201,7 @@ public enum UnseenForces implements LogicCardInfo {
       case TYROGUE_33:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
+        //TODO Convert to Poké-Body, also edit babyEvolution() method for supporting this.
         pokeBody "Baby Evolution", {
           text "Once during your turn (before your attack), you may put Hitmonlee, Hitmonchan, or Hitmontop from your hand onto Tyrogue (this counts as evolving Tyrogue) and remove all damage counters from Tyrogue."
           actionA {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1129,7 +1129,7 @@ public enum DiamondPearl implements LogicCardInfo {
 
               def indexOfOldPrize = my.prizeCardSet.indexOf(tar)
               my.prizeCardSet.set(indexOfOldPrize, newPrize)
-              my.prizeCardSet.setVisible(newPrize, true) //TODO: If this doesn't work, maybe use tar?
+              my.prizeCardSet.setVisible(newPrize, true)
               my.hand.remove(newPrize)
             }
           }
@@ -2168,8 +2168,14 @@ public enum DiamondPearl implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 20
-              //bg.dm().find({it.to==defending && it.dmg.value})
-              //TODO: Think of a way to check for effective damage to the defending pokémon before healing.
+              delayed { //Taken from BS1 BULBASAUR
+                before APPLY_ATTACK_DAMAGES, {
+                  if(bg.dm().find{it.to == defending && it.from == self && it.dmg.value}) {
+                    heal 10, self
+                  }
+                }
+                unregisterAfter 1
+              }
             }
           }
 
@@ -2970,8 +2976,10 @@ public enum DiamondPearl implements LogicCardInfo {
                   before BETWEEN_TURNS, {
                     if(bg().currentTurn == self.owner.opposite) {
                       def bundles = bg().em().retrieveObject("supremeCommandBundles")
-                      if(bundles)
+                      if(bundles) {
                         self.owner.opposite.pbg.hand.addAll(bundles.get(self.id))
+                        bc "Supreme Command's effect has ended, taken cards have been put back to their owner's hand."
+                      }
                       unregister()
                     }
                   }


### PR DESCRIPTION
Main missing change for DP is implementing the Lv. X mechanic, but that needs help from the main devs no matter what 😅 

Changes done:
* Implemented "Leech Seed" on Cherubi (75)
* Removed a TODO on Noctowl (34)
* Added a `bc` after cards taken by Empoleon Lv. X (120) are given back.
* Implemented `checkCanBabyEvolve` and `babyEvolution` on all available EX era sets. Should work as before but simplified.