### PR TITLE
General Card Fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -924,7 +924,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             assert opp.bench : "There is no Pokémon on your opponent's bench"
           }
           onAttack {
-            whirlwind()
+            sw defending, opp.bench.select()
             applyAfterDamage(ASLEEP)
           }
         }
@@ -1072,6 +1072,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           actionA {
             checkNoSPC()
             assert !my.prizeCardSet.allVisible : "All prizes are face up"
+            assert my.hand : "You don't have cards in your hand"
             checkLastTurn()
             powerUsed()
 

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2235,9 +2235,11 @@ public enum LegendMaker implements LogicCardInfo {
         move "String Pull", {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost C
-          attackRequirement {}
+          attackRequirement {
+            assert opp.bench : "There is no Pokémon on your opponent's bench"
+          }
           onAttack {
-            whirlwind()
+            sw defending, opp.bench.select()
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2399,8 +2399,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
             opp.hand.getExcludedList(thisCard).moveTo(opp.deck)
             shuffleDeck()
             shuffleDeck(null,TargetPlayer.OPPONENT)
-            draw choose(0..my.prizeCardSet.size(),"How many cards would you like to draw?")
-            draw(oppChoose(0..opp.prizeCardSet.size(),"How many cards would you like to draw?"),TargetPlayer.OPPONENT)
+            draw choose(1..my.prizeCardSet.size(),"How many cards would you like to draw?")
+            draw(oppChoose(1..opp.prizeCardSet.size(),"How many cards would you like to draw?"),TargetPlayer.OPPONENT)
           }
           playRequirement{
           }

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -519,7 +519,7 @@ public enum HiddenFates implements LogicCardInfo {
           delayedA {
             after ATTACH_ENERGY, {
               if(self.active && ef.reason == PLAY_FROM_HAND && ef.resolvedTarget.owner == self.owner.opposite)
-                directDamage 20, ef.resolvedTarget
+                directDamage 30, ef.resolvedTarget
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -3240,7 +3240,7 @@ public enum TeamUp implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.discard.findAll{it.cardTypes.is(BASIC_ENERGY) || it.cardTypes.is(POKEMON)} : "There is no more card in your deck"
+            assert my.discard.findAll{it.cardTypes.is(BASIC_ENERGY) || it.cardTypes.is(POKEMON)} : "There are no basic Pokémon or basic Energy cards in your discard"
           }
         };
       case BUFF_PADDING_136:

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1489,7 +1489,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost W, C, C
             onAttack {
               damage 60
-              flip {damage 60}
+              rockPaperScissors {damage 60}
             }
           }
 
@@ -3891,7 +3891,8 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 30
-              astonish(self.lastEvolved==bg.turnCount?2:1)
+              def count = (self.lastEvolved==bg.turnCount) ? 2 : 1
+              (1..count).each{ discardRandomCardFromOpponentsHand() }
             }
           }
           move "Lunge Out", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1489,7 +1489,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost W, C, C
             onAttack {
               damage 60
-              rockPaperScissors {damage 60}
+              flip {damage 60}
             }
           }
 

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -397,7 +397,7 @@ public enum RebelClash implements LogicCardInfo {
             assert my.discard.filterByType(BASIC_ENERGY) : "Your discard pile has no Basic Energy."
           }
           onAttack {
-            def energies = my.discard.filterByType(BASIC_ENERGY).select(min: 0, max: 5, "Select up to 5 Basic Energy cards to shuffle into your deck.")
+            def energies = my.discard.filterByType(BASIC_ENERGY).select(min: 1, max: 5, "Select up to 5 Basic Energy cards to shuffle into your deck.")
             energies.moveTo(my.deck)
             if (energies) {
               shuffleDeck()


### PR DESCRIPTION
* Rocket's Admin (TRR 86): Players should draw at least 1 card, if possible to.
* Jolteon (HIF 23) should put 3 damage counters per attach, not 2.
* Purugly (UNB 160): Now discards the cards, instead of shuffling them into the deck.
* ~~Pyukumuku (UNB 53): Now uses rockPaperScissors instead of flip.~~ **Reverted while rethinking this implementation,**
* Hypno (DS 23) now switches instead of doing whirlwind.
* Slowking (DS 28)'s Prize Shift now asserts the player having hand.
* Wurmple (LM 70) now switches instead of doing whirlwind.
* Brock's Grit (TEU 135) now gives the correct warning for no elegible cards.
* Shuckle (RCL 5) should return at least a single basic energy card.