### PR TITLE
Make Obstruct wait for all other effects before checking.

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -681,7 +681,7 @@ class TcgStatics {
   }
 
   static void preventAllDamageFromCustomPokemonNextTurn(Move thisMove, PokemonCardSet self, Predicate<PokemonCardSet> predicate){
-    delayed {
+    delayed (priority: LAST) {
       before APPLY_ATTACK_DAMAGES, {
         bg.dm().each {
           if(it.to == self && it.notNoEffect && it.from != it.to && predicate.test(it.from) && bg.currentTurn==self.owner.opposite ){


### PR DESCRIPTION
Hopefully this gives Kartenvoy enough priority to mark itself as shred before this kicks in.