### PR TITLE
Some more Fixes (DRM, SSH, DS, GRI)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -2433,10 +2433,10 @@ public enum DeltaSpecies implements LogicCardInfo {
           text "Search your discard pile for an Energy card, show it to your opponent, and put it into your hand."
           energyCost C
           attackRequirement {
-            assert my.discard.hasType(BASIC_ENERGY) : "No Basic Energy cards in Discard pile"
+            assert my.discard.find(cardTypeFilter(ENERGY)) : "No Energy cards in Discard pile"
           }
           onAttack {
-            my.discard.filterByType(BASIC_ENERGY).select().moveTo(my.hand)
+            my.discard.findAll(cardTypeFilter(ENERGY)).select().moveTo(my.hand)
           }
         }
         move "Bite", {

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -735,7 +735,7 @@ public enum DragonMajesty implements LogicCardInfo {
               for(pcs in all){
                 if(pcs.isSPC(CONFUSED) && pcs.owner==self.owner && pcs.types.contains(W)){
                   bc "Murmurs of the Sea clears confusion"
-                  clearSpecialCondition(self, SRC_ABILITY, [CONFUSED])
+                  clearSpecialCondition(pcs, SRC_ABILITY, [CONFUSED])
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -537,8 +537,10 @@ public enum GuardiansRising implements LogicCardInfo {
             onAttack {
               damage 30
               afterDamage {
+                def oldEnCnt = self.cards.energyCount(C)
                 discardSelfEnergy(C)
-                discardDefendingEnergy()
+                if (oldEnCnt > self.cards.energyCount(C))
+                  discardDefendingEnergy()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2389,7 +2389,10 @@ public enum SwordShield implements LogicCardInfo {
           text "Until this Grapploct leaves the Active Spot, the Defending Pokémon's attacks cost [C][C] more, and the Defending Pokémon can't retreat. This effect can't be applied more than once."
           energyCost F, F
           onAttack {
-            if (defending.active) {
+            if (keyStore("Octolock", self))
+              wcu "Can't apply Octolock to a Pokémon more than once."
+            else if (defending.active) {
+              keyStore("Octolock", self, true)
               targeted(defending) {
                 def eff1, eff2
                 delayed {
@@ -2401,21 +2404,15 @@ public enum SwordShield implements LogicCardInfo {
                   }
 
                   eff2 = getter (GET_MOVE_LIST, NORMAL, defending) {h->
-                    if (keyStore("Octolock", self)) {
-                      def list=[]
-                      for (move in h.object) {
-                        def copy=move.shallowCopy()
-                        copy.energyCost.addAll([C, C] as List<Type>)
-                        list.add(copy)
-                      }
-                      h.object=list
-                      bc "Attacks of $defending will cost [C][C] more while Octolock is active."
+                    def list=[]
+                    for (move in h.object) {
+                      def copy=move.shallowCopy()
+                      copy.energyCost.addAll([C, C] as List<Type>)
+                      list.add(copy)
                     }
+                    h.object=list
                   }
-
-                  register {
-                    keyStore("Octolock", self, true)
-                  }
+                  bc "Until this Grapploct leaves the Active Spot, attacks of $defending will now cost [C][C] more."
 
                   unregister {
                     keyStore("Octolock", self, 0)


### PR DESCRIPTION
* Phione (DRM 30) should remove conditions from the affected Pokémon, not itself.
* Attempted to correct Octolock's checks (SSH)
* Meowth (DS 77) should take any energy from discard, not just basic ones.
* Attempt on Oricorio (GRI) at checking for discardselfEnergy happening. Needed for other cards allowing to attack for free (e.g. Copy). Also affects:
  + Cresselia (UPR 59)
  + Torkoal (CEC 29)
  + Morpeko V (SSH 79)
  + Not quite, but also Lapras V (SSH 49)