### PR TITLE
Opp's Active Energy Discard OoO fix, ADP extra prize order fix

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -172,11 +172,11 @@ class TcgStatics {
     new DiscardOpponentEnergyCard(Target.OPP_ACTIVE).run(bg())
   }
   static discardDefendingSpecialEnergy(Object delegate){
-    afterDamage { targeted (delegate.defending) {
+    targeted (delegate.defending) {
       if(delegate.defending.cards.filterByType(CardType.SPECIAL_ENERGY)){
         delegate.defending.cards.filterByType(CardType.SPECIAL_ENERGY).select("Discard").discard()
       }
-    } }
+    }
   }
   static discardAllSelfEnergy(Type type=null){
     def ef=new DiscardAllSelfEnergy(type)

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -618,7 +618,7 @@ public enum BaseSetNG implements LogicCardInfo {
             energyCost W, W, C, C
             onAttack {
               damage 40
-              afterDamage{discardDefendingEnergy()}
+              discardDefendingEnergy()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1571,23 +1571,12 @@ public enum DeltaSpecies implements LogicCardInfo {
           energyCost L, C
           attackRequirement {}
           onAttack {
-            flip 2, {}, {}, [
-              2:{ damage 20;
-                afterDamage{
-                  discardDefendingEnergy()
-                  discardDefendingEnergy()
-                }
-              },
-              1:{
-                damage 20
-                afterDamage{
-                  discardDefendingEnergy()
-                }
-              },
-              0:{
-                bc "$thisMove failed due to 2 TAILS."
-              }
-            ]
+            def noEff = true
+            flip 2, {
+              noEff = false
+              discardDefendingEnergy()
+            }
+            if (noEff) bc "$thisMove failed due to 2 TAILS." else damage 20
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -2250,9 +2250,7 @@ public enum Emerald implements LogicCardInfo {
             onAttack {
               damage 40
               if(my.all.findAll{it.name == "Regirock ex"}){
-                afterDamage{
-                  flip{discardDefendingEnergy()}
-                }
+                flip{ discardDefendingEnergy() }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2704,10 +2704,8 @@ public enum UnseenForces implements LogicCardInfo {
           energyCost R, R, C, C
           onAttack {
             damage 80
-            afterDamage {
-              discardSelfEnergy C
-              discardDefendingEnergy()
-            }
+            discardSelfEnergy C
+            discardDefendingEnergy()
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -302,7 +302,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             energyCost W, W, C, C
             onAttack {
               damage 80
-              afterDamage {discardDefendingEnergy()}
+              discardDefendingEnergy()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2877,7 +2877,7 @@ public enum BurningShadows implements LogicCardInfo {
             energyCost F, C
             onAttack {
               damage 30
-              afterDamage{discardDefendingEnergy()}
+              discardDefendingEnergy()
             }
           }
           move "Accelerock", {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2778,7 +2778,10 @@ public enum CelestialStorm implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 30
-              if(defending.cards.filterByType(ENERGY).filterByEnergyType(R)) defending.cards.filterByType(ENERGY).filterByEnergyType(R).select("Choose the energy to discard").discard()
+              targeted (defending) {
+                if(defending.cards.filterByEnergyType(R))
+                  defending.cards.filterByEnergyType(R).select("Choose the energy to discard").discard()
+                }
             }
           }
           move "Water Pulse" , {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3705,14 +3705,12 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               gxPerform()
 
-              afterDamage {
-                delayed { // a permanent delayed effect
-                  after PROCESS_ATTACK_EFFECTS, {
-                    bg.dm().each {
-                      if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
-                        bc "Altered Creation GX +30"
-                        it.dmg += hp(30)
-                      }
+              delayed { // a permanent delayed effect
+                after PROCESS_ATTACK_EFFECTS, {
+                  bg.dm().each {
+                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
+                      bc "Altered Creation GX +30"
+                      it.dmg += hp(30)
                     }
                   }
                 }
@@ -3720,18 +3718,13 @@ public enum CosmicEclipse implements LogicCardInfo {
 
               if (self.cards.energySufficient( thisMove.energyCost + W )) {
                 bc "For the rest of the game, this player gets 1 additional prize when their opponent's Active gets Knocked Out from damage."
-                delayed {
+                delayed (priority: LAST) {
                   def pt = self.owner
-                  def flag = false
                   before KNOCKOUT, {
                     def pcs = ef.pokemonToBeKnockedOut
-                    flag = pcs.owner != pt && ef.byDamageFromAttack && pcs.active
-                  }
-                  after KNOCKOUT, {
-                    if(flag) {
-                      flag = false
+                    if (pcs.owner == self.owner.opposite && pcs.active && ef.byDamageFromAttack) {
                       bc "Altered Creation GX gives the player an additional prize."
-                      bg.em().run(new TakePrize(pt, ef.pokemonToBeKnockedOut))
+                      bg.em().run(new TakePrize(self.owner, pcs))
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3705,10 +3705,11 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               gxPerform()
 
+              bc "For the rest of the game, this player Pokémon’s attacks do 30 more damage to their opponent’s Active Pokémon."
               delayed { // a permanent delayed effect
                 after PROCESS_ATTACK_EFFECTS, {
                   bg.dm().each {
-                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
+                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner  == self.owner.opposite) {
                       bc "Altered Creation GX +30"
                       it.dmg += hp(30)
                     }
@@ -3717,7 +3718,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
 
               if (self.cards.energySufficient( thisMove.energyCost + W )) {
-                bc "For the rest of the game, this player gets 1 additional prize when their opponent's Active gets Knocked Out from damage."
+                bc "[Additional cost covered] Also for the rest of the game, when the opponent’s Active Pokémon is Knocked Out by damage from those attacks, this player takes 1 more Prize card."
                 delayed (priority: LAST) {
                   def pt = self.owner
                   before KNOCKOUT, {

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1574,10 +1574,8 @@ public enum CrimsonInvasion implements LogicCardInfo {
             onAttack {
               damage 120
               if(confirm("You may discard an Energy from this Pokémon. If you do, discard an Energy from your opponent's Active Pokémon.") && self.cards.energyCount(C)){
-                afterDamage {
-                  discardSelfEnergy(C)
-                  discardDefendingEnergy()
-                }
+                discardSelfEnergy(C)
+                discardDefendingEnergy()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1352,7 +1352,7 @@ public enum ForbiddenLight implements LogicCardInfo {
 
               flip 2, {
                 hasEff=true
-                afterDamage{discardDefendingEnergy()}
+                discardDefendingEnergy()
               }
               if(hasEff) damage 60
             }
@@ -1571,7 +1571,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             energyCost F
             onAttack {
               damage 10
-              flip {afterDamage{discardDefendingEnergy()}}
+              flip {discardDefendingEnergy()}
             }
           }
 
@@ -1651,7 +1651,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             energyCost F
             onAttack {
               damage 20
-              flip {afterDamage{discardDefendingEnergy()}}
+              flip {discardDefendingEnergy()}
             }
           }
           move "Hammer In", {

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2874,9 +2874,7 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 20
-              afterDamage {
-                discardDefendingSpecialEnergy(delegate)
-              }
+              discardDefendingSpecialEnergy(delegate)
             }
           }
           move "Berserk", {

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -271,7 +271,7 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost G, C
             onAttack {
               damage 40
-              flip{afterDamage{discardDefendingEnergy()}}
+              flip{discardDefendingEnergy()}
             }
           }
 
@@ -942,7 +942,7 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost W, W
             onAttack {
               damage 40
-              flip{afterDamage{discardDefendingEnergy()}}
+              flip{discardDefendingEnergy()}
             }
           }
           move "Raging Floe", {
@@ -1405,7 +1405,7 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost P, C, C
             onAttack {
               damage 70
-              flip{afterDamage{discardDefendingEnergy()}}
+              flip{discardDefendingEnergy()}
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -287,7 +287,7 @@ public enum ShiningLegends implements LogicCardInfo {
             energyCost G, C
             onAttack {
               damage 30
-              afterDamage {discardDefendingEnergy()}
+              discardDefendingEnergy()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -395,7 +395,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 30
-              afterDamage {moveEnergy(defending, opp.bench)}
+              moveEnergy(defending, opp.bench)
             }
           }
 
@@ -1488,7 +1488,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost P, P, C, C
             onAttack {
               damage 90
-              flip{afterDamage {discardDefendingEnergy()}}
+              flip{ discardDefendingEnergy() }
             }
           }
 
@@ -2022,9 +2022,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost D, D, C
             onAttack {
               damage 30
-              flip { afterDamage {
-                discardDefendingEnergy()
-              } }
+              flip { discardDefendingEnergy() }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1324,9 +1324,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             energyCost C,C
             onAttack{
               damage 30
-              afterDamage{
-                flip {discardDefendingEnergy()}
-              }
+                flip { discardDefendingEnergy() }
             }
           }
           move "Doom Crush" , {
@@ -1928,7 +1926,9 @@ public enum SunMoonPromos implements LogicCardInfo {
             onAttack{
               gxPerform()
               damage 130
-              opp.active.cards.filterByType(ENERGY).discard()
+              targeted (defending) {
+                opp.active.cards.filterByType(ENERGY).discard()
+              }
             }
           }
         };
@@ -2993,7 +2993,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               gxPerform()
 
               if (self.cards.energySufficient( thisMove.energyCost + P )) {
-                opp.active.cards.filterByType(ENERGY).discard()
+                targeted (defending) {
+                  opp.active.cards.filterByType(ENERGY).discard()
+                }
               }
 
               def pcs = defending

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -895,9 +895,7 @@ public enum TeamUp implements LogicCardInfo {
             energyCost W,W,W
             onAttack{
               damage 100
-              afterDamage{
-                discardDefendingEnergy()
-              }
+              discardDefendingEnergy()
             }
           }
         };
@@ -2004,8 +2002,12 @@ public enum TeamUp implements LogicCardInfo {
             text "40 damage. Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon. If tails, this attack does nothing."
             energyCost C,C
             onAttack{
-              flip 1,{damage 40;
-                afterDamage{discardDefendingEnergy()}},{bc "$thisMove failed "}
+              flip 1, {
+                damage 40
+                discardDefendingEnergy()
+              }, {
+                bc "$thisMove failed "
+              }
             }
           }
         };
@@ -2868,19 +2870,13 @@ public enum TeamUp implements LogicCardInfo {
             text "30 damage. Flip 2 coins. For each heads, discard an Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing."
             energyCost W,L
             onAttack{
-              flip 2,{},{},[2:{damage 30;
-                afterDamage{
-                  discardDefendingEnergy()
-                  discardDefendingEnergy()
-                }
-              },1:{
-                damage 30;
-                afterDamage{
-                  discardDefendingEnergy()
-                }
-              },0:{
-                bc "$thisMove failed"
-              }]
+              def failedMove = true
+              flip 2, {
+                failedMove = false
+                discardDefendingEnergy()
+              }
+
+              if (failedMove) { bc "$thisMove failed" } else { damage 30 }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -1464,7 +1464,7 @@ public enum UltraPrism implements LogicCardInfo {
             energyCost P
             onAttack {
               damage 10
-              flip{afterDamage{discardDefendingEnergy()}}
+              flip{discardDefendingEnergy()}
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1007,11 +1007,9 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost R
             onAttack {
               damage 10
-              afterDamage {
-                targeted (defending) {
-                  if (defending.cards.energyCount(G)) {
-                    defending.cards.filterByEnergyType(G).select("Discard").discard()
-                  }
+              targeted (defending) {
+                if (defending.cards.energyCount(G)) {
+                  defending.cards.filterByEnergyType(G).select("Discard").discard()
                 }
               }
             }
@@ -3027,7 +3025,9 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 }
               }
               if(self.cards.energySufficient(thisMove.energyCost + C)){
-                opp.active.cards.filterByType(ENERGY).discard()
+                targeted (defending) {
+                  opp.active.cards.filterByType(ENERGY).discard()
+                }
               }
             }
           }
@@ -3578,7 +3578,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 70
-              flip {afterDamage{discardDefendingEnergy();discardDefendingEnergy()}}
+              flip { 2.times{discardDefendingEnergy()} }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2791,9 +2791,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 80
-              afterDamage {
-                discardDefendingEnergy()
-              }
+              discardDefendingEnergy()
             }
           }
         };
@@ -3416,23 +3414,14 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "30 damage. Flip 2 coins. For each heads, discard an Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing."
             energyCost L, W
             onAttack{
-              flip 2, {}, {}, [
-                2:{ damage 30;
-                  afterDamage{
-                    discardDefendingEnergy()
-                    discardDefendingEnergy()
-                  }
-                },
-                1:{
-                  damage 30
-                  afterDamage{
-                    discardDefendingEnergy()
-                  }
-                },
-                0:{
-                  bc "$thisMove failed due to 2 TAILS."
-                }
-              ]}
+              def failedMove = true
+              flip 2, {
+                failedMove = false
+                discardDefendingEnergy()
+              }
+
+              if (failedMove) { bc "$thisMove failed" } else { damage 30 }
+            }
           }
         };
       case DRAGONAIR_150:

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -771,10 +771,7 @@ public enum RebelClash implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 60
-
-            afterDamage {
-              flip { discardDefendingEnergy() }
-            }
+            flip { discardDefendingEnergy() }
           }
         }
       };
@@ -1378,14 +1375,13 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Inteleon V", hp:HP320, type:W, retreatCost:2) {
         weakness L
         move "Hydro Snipe", {
-          text "60 damage. You may return an Energy card from your opponent’s Active Pokemon to their hand."
+          text "60 damage. You may put an Energy attached to your opponent’s Active Pokémon into their hand."
           energyCost W
           attackRequirement {}
           onAttack {
             damage 60
-
-            afterDamage {
-              if (defending.cards.energyCount(C) && confirm("Return an Energy from your opponent's Active Pokémon to their hand?")) {
+            if (defending.cards.energyCount(C) && confirm("Return an Energy from your opponent's Active Pokémon to their hand?")) {
+              targeted (defending) {
                 defending.cards.filterByType(ENERGY).select(count:1).moveTo(opp.hand)
               }
             }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1382,7 +1382,9 @@ public enum SwordShield implements LogicCardInfo {
           onAttack {
             damage 100
             if (opp.active.cards.filterByType(ENERGY) && confirm("Put an Energy attached to their active back to their hand?")) {
-              opp.active.cards.filterByType(ENERGY).select("Choose the Energy to put back in the opponent's hand.").moveTo(opp.hand)
+              targeted (defending) {
+                opp.active.cards.filterByType(ENERGY).select("Choose the Energy to put back in the opponent's hand.").moveTo(opp.hand)
+              }
             }
           }
         }
@@ -2757,9 +2759,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost M, C
           onAttack {
             damage 40
-            afterDamage {
-              discardDefendingEnergy()
-            }
+            discardDefendingEnergy()
           }
         }
       };

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -515,7 +515,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           energyCost W, W, C, C
           onAttack {
             damage 40
-            afterDamage { discardDefendingEnergy() }
+            discardDefendingEnergy()
           }
         }
       };


### PR DESCRIPTION
### ADP Extra Prize
If it works, need to apply to other cards like Guzzlord (CEC).
* Now should give the extra prize before the opponent chooses a new active.
* Removed an unnecessary afterDamage (there's no damage)
* Updated the bc to mention the extra damage enabled, and the eventual secondary effect.

### `discardDefendingSpecialEnergy()` (and a couple similar effects) Order of Operation overhaul
This shouldn't be done after the damage, otherwise cards like Horror Psychic Energy (RCL 172) will trigger when they shouldn't. 

> Q. If I use an attack that says to "discard an Energy attached to your opponent's Active Pokemon" and I choose to discard their "Dangerous Energy" card, would I still receive the 2 damage counters from "Dangerous Energy" or not?
>
> A. You would not receive the 2 damage counters. (Ancient Origins FAQ; Aug 13, 2015 TPCi Rules Team)

Affects multiple cards:
* Poliwrath (BS) [Both regular and Pokémod versions]
* Dragonair Delta (DS 42) [Also reworked it's twister flip]
* Regice-ex (EM 98)
* Typhlosion-ex (UF 110) 
* Gyarados (HS 4)
* Lycanroc-GX (BUS 136)
* Pelipper (CES 112) [Also made it be targeted so it can be blocked]
* Hydreigon (CIN 62)
* Dragalge (FLI 53) [Reworked Twister]
* Croagunk (FLI 63)
* Tyrunt (FLI 68)
* Weepinbell (GRI 2)
* Glalie (GRI 32)
* Garbodor (GRI 51)
* Drampa GX (GRI 115)
* Feraligatr (SLG 20)
* Masquerain (SUM 8) [Moves energy, instead of discarding]
* Alolan Muk (SUM 58)
* Sandile (SUM 83)
* Zoroark (SMP SM89)
* Tornadus-GX (SMP SM134) [Just made the all-Energy-discard be a targeted effect]
* Trevenant & Dusknoir-GX (SMP SM217) [Same as Tornadus-GX]
* Gyarados (TEU 30)
* Pancham (TEU 81)
* Dragonair (TEU 118) [Reworked Twister]
* Croagunk (UPR 56)
* Salandit (UNB 30)
* Lucario & Melmetal-GX (UNB 120) [Same as Tornadus-GX]
* Fearow (UNB 146) [Also simplified the repetition of actions]
* Archeops (UNM 121)
* Dragonair (UNM 149) [Reworked Twister]
* Flapple (RCL 22)
* Inteleon VMAX (RCL 50) [Like Tornadus-GX, but with energý to hand; also updated text]
* Inteleon (SSH 59) [Like Tornadus-GX]
* Mawile (SSH 129)