### PR TITLE
Alolan Muk bug fix

### DIFF
--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2071,7 +2071,7 @@ public enum TeamUp implements LogicCardInfo {
                 if(tar){
                   tar.select(max:tar.size(),"Choose the item to discard").discard()
                 }
-                shuffleDeck()
+                shuffleDeck(null, TargetPlayer.OPPONENT)
               }
             }
           }


### PR DESCRIPTION
Fixed Adventurous Appetite to shuffle opponent's deck instead of player's deck after use.