### PR TITLE
Prize-taking priority fixes, and some other general fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1649,23 +1649,14 @@ public enum DeltaSpecies implements LogicCardInfo {
           energyCost L, C
           attackRequirement {}
           onAttack {
-            flip 2, {}, {}, [
-              2:{ damage 20;
-                afterDamage{
-                  discardDefendingEnergy()
-                  discardDefendingEnergy()
-                }
-              },
-              1:{
-                damage 20
-                afterDamage{
-                  discardDefendingEnergy()
-                }
-              },
-              0:{
-                bc "$thisMove failed due to 2 TAILS."
-              }
-            ]
+            def discardTimes = 0
+
+            flip 2, { discardTimes += 1}
+            if (discardTimes) damage 20 else bc "$thisMove failed due to 2 TAILS."
+
+            afterDamage {
+              discardTimes.times{ discardDefendingEnergy() }
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1773,7 +1773,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack{
-            my.deck.search(min: 0, max:1,"Choose an Evolution cards",cardTypeFilter(EVOLUTION)).moveTo(my.hand)
+            my.deck.search(min: 0, max:1,"Choose an Evolution card",cardTypeFilter(EVOLUTION)).moveTo(my.hand)
             shuffleDeck()
           }
         }

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2585,12 +2585,14 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             text "40 damage. Flip 2 coins. For each heads, choose 1 Energy attached to the Defending Pokémon, if any, and discard it. If both are tails, this attack does nothing."
             energyCost W, C
             onAttack {
-              def noEff = true
-              flip 2, {
-                noEff = false
-                discardDefendingEnergy()
+              def discardTimes = 0
+
+              flip 2, { discardTimes += 1}
+              if (discardTimes) damage 40 else bc "$thisMove failed due to 2 TAILS."
+
+              afterDamage {
+                discardTimes.times{ discardDefendingEnergy() }
               }
-              if(!noEff) damage 40
             }
           }
           move "Dragon Rage", {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2778,7 +2778,10 @@ public enum CelestialStorm implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 30
-              if(defending.cards.filterByType(ENERGY).filterByEnergyType(R)) defending.cards.filterByType(ENERGY).filterByEnergyType(R).select("Choose the energy to discard").discard()
+              targeted (defending) {
+                if(defending.cards.filterByEnergyType(R))
+                  defending.cards.filterByEnergyType(R).select("Choose the energy to discard").discard()
+                }
             }
           }
           move "Water Pulse" , {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3705,14 +3705,12 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               gxPerform()
 
-              afterDamage {
-                delayed { // a permanent delayed effect
-                  after PROCESS_ATTACK_EFFECTS, {
-                    bg.dm().each {
-                      if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
-                        bc "Altered Creation GX +30"
-                        it.dmg += hp(30)
-                      }
+              delayed { // a permanent delayed effect
+                after PROCESS_ATTACK_EFFECTS, {
+                  bg.dm().each {
+                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
+                      bc "Altered Creation GX +30"
+                      it.dmg += hp(30)
                     }
                   }
                 }
@@ -3720,18 +3718,13 @@ public enum CosmicEclipse implements LogicCardInfo {
 
               if (self.cards.energySufficient( thisMove.energyCost + W )) {
                 bc "For the rest of the game, this player gets 1 additional prize when their opponent's Active gets Knocked Out from damage."
-                delayed {
+                delayed (priority: LAST) {
                   def pt = self.owner
-                  def flag = false
                   before KNOCKOUT, {
                     def pcs = ef.pokemonToBeKnockedOut
-                    flag = pcs.owner != pt && ef.byDamageFromAttack && pcs.active
-                  }
-                  after KNOCKOUT, {
-                    if(flag) {
-                      flag = false
+                    if (pcs.owner == self.owner.opposite && pcs.active && ef.byDamageFromAttack) {
                       bc "Altered Creation GX gives the player an additional prize."
-                      bg.em().run(new TakePrize(pt, ef.pokemonToBeKnockedOut))
+                      bg.em().run(new TakePrize(self.owner, pcs))
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3266,10 +3266,14 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost D, D, C, C
             onAttack {
               damage 120
-              delayed {
-                def pcs = defending
-                after KNOCKOUT, pcs, {
-                  bg.em().run(new TakePrize(self.owner, pcs))
+              delayed (priority: LAST) {
+                def pt = self.owner
+                before KNOCKOUT, {
+                  def pcs = ef.pokemonToBeKnockedOut
+                  if (pcs.owner == self.owner.opposite && ef.byDamageFromAttack && ef.attacker == self) {
+                    bc "Red Banquet gives the player an additional prize."
+                    bg.em().run(new TakePrize(self.owner, pcs))
+                  }
                 }
                 unregisterAfter 1
               }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3705,10 +3705,11 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               gxPerform()
 
+              bc "For the rest of the game, this player Pokémon’s attacks do 30 more damage to their opponent’s Active Pokémon."
               delayed { // a permanent delayed effect
                 after PROCESS_ATTACK_EFFECTS, {
                   bg.dm().each {
-                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner != self.owner) {
+                    if (it.from.owner == self.owner && it.dmg.value && it.to.active && it.to.owner  == self.owner.opposite) {
                       bc "Altered Creation GX +30"
                       it.dmg += hp(30)
                     }
@@ -3717,7 +3718,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
 
               if (self.cards.energySufficient( thisMove.energyCost + W )) {
-                bc "For the rest of the game, this player gets 1 additional prize when their opponent's Active gets Knocked Out from damage."
+                bc "[Additional cost covered] Also for the rest of the game, when the opponent’s Active Pokémon is Knocked Out by damage from those attacks, this player takes 1 more Prize card."
                 delayed (priority: LAST) {
                   def pt = self.owner
                   before KNOCKOUT, {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3267,7 +3267,6 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               damage 120
               delayed (priority: LAST) {
-                def pt = self.owner
                 before KNOCKOUT, {
                   def pcs = ef.pokemonToBeKnockedOut
                   if (pcs.owner == self.owner.opposite && ef.byDamageFromAttack && ef.attacker == self) {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3267,12 +3267,10 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               damage 120
               delayed (priority: LAST) {
-                before KNOCKOUT, {
-                  def pcs = ef.pokemonToBeKnockedOut
-                  if (pcs.owner == self.owner.opposite && ef.byDamageFromAttack && ef.attacker == self) {
-                    bc "Red Banquet gives the player an additional prize."
-                    bg.em().run(new TakePrize(self.owner, pcs))
-                  }
+                def pcs = defending
+                after KNOCKOUT, pcs, {
+                  bc "Red Banquet gives the player an additional prize."
+                  bg.em().run(new TakePrize(self.owner, pcs))
                 }
                 unregisterAfter 1
               }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1613,7 +1613,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             onAttack {
               damage 100
               gxPerform()
-              delayed {
+              delayed (priority: LAST) {
                 def pcs = defending
                 after KNOCKOUT, pcs, {
                   bg.em().run(new TakePrize(self.owner, pcs))

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1348,13 +1348,14 @@ public enum ForbiddenLight implements LogicCardInfo {
             text "60 damage. Flip 2 coins. For each heads, discard an Energy from your opponent’s Active Pokémon. If both of them are tails, this attack does nothing."
             energyCost P, C
             onAttack {
-              def hasEff = false
+              def discardTimes = 0
 
-              flip 2, {
-                hasEff=true
-                afterDamage{discardDefendingEnergy()}
+              flip 2, { discardTimes += 1}
+              if (discardTimes) damage 60 else bc "$thisMove failed due to 2 TAILS."
+
+              afterDamage {
+                discardTimes.times{ discardDefendingEnergy() }
               }
-              if(hasEff) damage 60
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2874,9 +2874,7 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 20
-              afterDamage {
-                discardDefendingSpecialEnergy(delegate)
-              }
+              discardDefendingSpecialEnergy(delegate)
             }
           }
           move "Berserk", {

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2282,7 +2282,7 @@ public enum GuardiansRising implements LogicCardInfo {
             text "If the Defending Pokémon is Knocked Out during your next turn, take 2 more Prize cards."
             energyCost C
             onAttack {
-              delayed {
+              delayed (priority: LAST) {
                 def pcs = defending
                 after KNOCKOUT, pcs, {
                   if(turnCount + 2 == bg.turnCount) {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1928,7 +1928,9 @@ public enum SunMoonPromos implements LogicCardInfo {
             onAttack{
               gxPerform()
               damage 130
-              opp.active.cards.filterByType(ENERGY).discard()
+              targeted (defending) {
+                opp.active.cards.filterByType(ENERGY).discard()
+              }
             }
           }
         };
@@ -2993,7 +2995,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               gxPerform()
 
               if (self.cards.energySufficient( thisMove.energyCost + P )) {
-                opp.active.cards.filterByType(ENERGY).discard()
+                targeted (defending) {
+                  opp.active.cards.filterByType(ENERGY).discard()
+                }
               }
 
               def pcs = defending

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2004,8 +2004,14 @@ public enum TeamUp implements LogicCardInfo {
             text "40 damage. Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon. If tails, this attack does nothing."
             energyCost C,C
             onAttack{
-              flip 1,{damage 40;
-                afterDamage{discardDefendingEnergy()}},{bc "$thisMove failed "}
+              flip 1, {
+                damage 40
+                afterDamage{
+                  discardDefendingEnergy()
+                }
+              }, {
+                bc "$thisMove failed "
+              }
             }
           }
         };
@@ -2868,19 +2874,14 @@ public enum TeamUp implements LogicCardInfo {
             text "30 damage. Flip 2 coins. For each heads, discard an Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing."
             energyCost W,L
             onAttack{
-              flip 2,{},{},[2:{damage 30;
-                afterDamage{
-                  discardDefendingEnergy()
-                  discardDefendingEnergy()
-                }
-              },1:{
-                damage 30;
-                afterDamage{
-                  discardDefendingEnergy()
-                }
-              },0:{
-                bc "$thisMove failed"
-              }]
+              def discardTimes = 0
+
+              flip 2, { discardTimes += 1}
+              if (discardTimes) damage 30 else bc "$thisMove failed due to 2 TAILS."
+
+              afterDamage {
+                discardTimes.times{ discardDefendingEnergy() }
+              }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -868,6 +868,7 @@ public enum UltraPrism implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
+                after EVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3027,7 +3027,9 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 }
               }
               if(self.cards.energySufficient(thisMove.energyCost + C)){
-                opp.active.cards.filterByType(ENERGY).discard()
+                targeted (defending) {
+                  opp.active.cards.filterByType(ENERGY).discard()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -342,7 +342,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             onAttack{
               damage 50
               gxPerform()
-              delayed {
+              delayed (priority: LAST) {
                 def pcs = defending
                 after KNOCKOUT, pcs, {
                   bg.em().run(new TakePrize(self.owner, pcs))

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3416,23 +3416,15 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "30 damage. Flip 2 coins. For each heads, discard an Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing."
             energyCost L, W
             onAttack{
-              flip 2, {}, {}, [
-                2:{ damage 30;
-                  afterDamage{
-                    discardDefendingEnergy()
-                    discardDefendingEnergy()
-                  }
-                },
-                1:{
-                  damage 30
-                  afterDamage{
-                    discardDefendingEnergy()
-                  }
-                },
-                0:{
-                  bc "$thisMove failed due to 2 TAILS."
-                }
-              ]}
+              def discardTimes = 0
+
+              flip 2, { discardTimes += 1}
+              if (discardTimes) damage 30 else bc "$thisMove failed due to 2 TAILS."
+
+              afterDamage {
+                discardTimes.times{ discardDefendingEnergy() }
+              }
+            }
           }
         };
       case DRAGONAIR_150:

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2919,7 +2919,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             energyCost D, D, D, D, C
             onAttack {
               damage 210
-              delayed {
+              delayed (priority: LAST) {
                 if (defending.pokemonGX || defending.pokemonEX) {
                   def pcs = defending
                   after KNOCKOUT, pcs, {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1378,7 +1378,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Inteleon V", hp:HP320, type:W, retreatCost:2) {
         weakness L
         move "Hydro Snipe", {
-          text "60 damage. You may return an Energy card from your opponent’s Active Pokemon to their hand."
+          text "60 damage. You may put an Energy attached to your opponent’s Active Pokémon into their hand."
           energyCost W
           attackRequirement {}
           onAttack {
@@ -1386,7 +1386,9 @@ public enum RebelClash implements LogicCardInfo {
 
             afterDamage {
               if (defending.cards.energyCount(C) && confirm("Return an Energy from your opponent's Active Pokémon to their hand?")) {
-                defending.cards.filterByType(ENERGY).select(count:1).moveTo(opp.hand)
+                targeted (defending) {
+                  defending.cards.filterByType(ENERGY).select(count:1).moveTo(opp.hand)
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1382,7 +1382,9 @@ public enum SwordShield implements LogicCardInfo {
           onAttack {
             damage 100
             if (opp.active.cards.filterByType(ENERGY) && confirm("Put an Energy attached to their active back to their hand?")) {
-              opp.active.cards.filterByType(ENERGY).select("Choose the Energy to put back in the opponent's hand.").moveTo(opp.hand)
+              targeted (defending) {
+                opp.active.cards.filterByType(ENERGY).select("Choose the Energy to put back in the opponent's hand.").moveTo(opp.hand)
+              }
             }
           }
         }


### PR DESCRIPTION
### Extra Prize Priority
Now should give the extra prize(s) before the opponent has to pick a new active. Affected cards:
* Arceus & Dialga & Palkia-GX (CEC 156)
  - Removed an unnecessary afterDamage (there's no damage)
  - Updated the bc to mention the extra damage enabled, and the eventual secondary effect.
* Guzzlord (CEC 136)
  - Now also does a bc on effect activation.
* Guzzlord-GX (CIN 63)
* Whimsicott (GRI 91)
* Beast Bringer (UNB 164)
* M-Sableye & Tyranitar-GX (UNM 126)

### General Fixes

* Implemented twister in a cleaner way, or updated old ones in:
  - Dragonair Delta (DS 42)
  - Gyarados-ex (FRLG 109)
  - Dragalge (FLI 53)
  - Dragonair (TEU 118)
  - Dragonair (UNM 149)
* Made some attacks targeted:
  - Pelipper (CES 112)
  - Tornadus-GX (SMP SM134)
  - Trevenant & Dusknoit-GX (SMP SM217)
  - Lucario & Melmetal-GX (UNB 120)
  - Inteleon (SSH 59)
  - Inteleon VMAX (RCL 50) _[Plus a minor text correction]_
* Removed an unnecessary afterDamage from Drampa-GX (GRI 115) _[discardDefendingSpecialEnergy already handles it]_
* Alolan Sandslash (UPR 29) should lose Spike Armor if devolved.