### PR TITLE
Some DP/MT fixes, Implemented MT 1-67

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1185,10 +1185,6 @@ class TcgStatics {
   }
 
   static boolean isValidFossilCard(Card potentialFossil){
-    if (potentialFossil.cardTypes.is(STAGE2)){
-      def debug_test = bg.gm().getBasicsFromStage2(potentialFossil.name)
-      bc "${debug_test}"
-    }
     if(
       (potentialFossil.cardTypes.is(ITEM) && potentialFossil.name.contains("Fossil")) ||
       (potentialFossil.cardTypes.is(STAGE1) && potentialFossil.predecessor.contains("Fossil")) ||

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1188,7 +1188,7 @@ class TcgStatics {
     if(
       (potentialFossil.cardTypes.is(ITEM) && potentialFossil.name.contains("Fossil")) ||
       (potentialFossil.cardTypes.is(STAGE1) && potentialFossil.predecessor.contains("Fossil")) ||
-      (potentialFossil.cardTypes.is(STAGE2) && bg.gm().getBasicsFromStage2(potentialFossil.name).any{it.contains("Fossil")})
+      (potentialFossil.cardTypes.is(STAGE2) && bg().gm().getBasicsFromStage2(potentialFossil.name).any{it.contains("Fossil")})
     )
       return true
     else

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1185,10 +1185,14 @@ class TcgStatics {
   }
 
   static boolean isValidFossilCard(Card potentialFossil){
+    if (potentialFossil.cardTypes.is(STAGE2)){
+      def debug_test = bg.gm().getBasicsFromStage2(potentialFossil.name)
+      bc "${debug_test}"
+    }
     if(
       (potentialFossil.cardTypes.is(ITEM) && potentialFossil.name.contains("Fossil")) ||
       (potentialFossil.cardTypes.is(STAGE1) && potentialFossil.predecessor.contains("Fossil")) ||
-      (potentialFossil.cardTypes.is(STAGE2) && bg.gm().getBasicsFromStage2(potentialFossil.name).findAll{it.contains("Fossil")})
+      (potentialFossil.cardTypes.is(STAGE2) && bg.gm().getBasicsFromStage2(potentialFossil.name).any{it.contains("Fossil")})
     )
       return true
     else

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2168,7 +2168,7 @@ public enum DiamondPearl implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 20
-              delayed { //Taken from BS1 BULBASAUR
+              delayed (priority: LAST){ //Taken from BS1 BULBASAUR
                 before APPLY_ATTACK_DAMAGES, {
                   if(bg.dm().find{it.to == defending && it.from == self && it.dmg.value}) {
                     heal 10, self

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1347,7 +1347,9 @@ public enum DiamondPearl implements LogicCardInfo {
           move "Errand-Running", {
             text "Search your deck for a Trainer card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost ()
-            attackRequirement {}
+            attackRequirement {
+              assert my.deck
+            }
             onAttack {
               my.deck.search("Search your deck for a Trainer card (excluding Supporter and Stadium cards)", {it.cardTypes.is(ITEM)}).moveTo(my.hand)
               shuffleDeck()

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -268,7 +268,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   before APPLY_ATTACK_DAMAGES, {
                     bg.dm().each {
                       if (it.to==self && it.dmg.value && it.notNoEffect && it.from.topPokemonCard.cardTypes.is(STAGE2)) {
-                        bc "-30 to Alakazam (Psychic Guard)"
+                        bc "-30 to $self ($thisMove)"
                         it.dmg-=hp(30)
                       }
                     }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -909,6 +909,17 @@ public enum MysteriousTreasures implements LogicCardInfo {
           pokeBody "Poison Sacs", {
             text "Your opponent can’t remove the Special Condition Poisoned by evolving or devolving his or her Poisoned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Poisoned Pokémon.)"
             delayedA {
+              before POISONED_SPC, null, null, EVOLVE, {
+                if(ef.target == self.owner.opposite){
+                  prevent()
+                }
+              }
+              // Potential addition once level-up is implemented
+              // before POISONED_SPC, null, null, LEVEL_UP, {
+              //   if(ef.target == self.owner.opposite){
+              //     prevent()
+              //   }
+              // }
             }
           }
           move "Knuckle Claws", {
@@ -916,7 +927,8 @@ public enum MysteriousTreasures implements LogicCardInfo {
             energyCost P, C
             attackRequirement {}
             onAttack {
-              damage 0
+              damage 30
+              applyAfterDamage POISONED
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1581,14 +1581,15 @@ public enum MysteriousTreasures implements LogicCardInfo {
       case VIGOROTH_68:
         return evolution (this, from:"Slakoth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
+          /*def asleepBeforeEvolve = false*/
           move "Wake-up Punch", {
             text "10 damage. If Vigoroth evolved from Slakoth during this turn and Slakoth was Asleep, this attack’s base damage is 60 instead of 10."
             energyCost C
             attackRequirement {}
             onAttack {
               damage 10
-              //TODO: Check for the extra damage.
-              if (false) {
+              //TODO: Add "Slakoth was asleep" check for the extra damage.
+              if(self.lastEvolved == bg.turnCount/* && asleepBeforeEvolve*/){
                 damage 50
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -288,9 +288,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           move "Tail Influence", {
             text "30 damage. Your opponent flips a coin until he or she gets heads. For each tails, remove an Energy card attached to the Defending Pokémon and put it on the bottom of your opponent’s deck."
             energyCost C, C
-            attackRequirement {
-              assert defending.cards.any{it.cards.filterByType(ENERGY)} : "The defending Pokémon has no Energy cards attached to them"
-            }
+            attackRequirement {}
             onAttack {
               damage 30
               afterDamage{

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -994,7 +994,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 def doEff = true
                 flip 2, {}, {doEff = false}
                 if (doEff){
-                  targeted (defending, Source.POKEMONPOWER) {
+                  targeted (defending, SRC_ABILITY/*, Source.POKEMONPOWER*/) {
                     defending.cards.reverse().discard()
                     removePCS(defending)
                   }
@@ -1690,7 +1690,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               assert self.active : "$self is not your Active Pokémon"
               assert opp.bench : "Your opponent has no Pokémon in their bench."
               powerUsed()
-              flip { sw (defending, opp.bench.select("Select the new active"), Source.POKEMONPOWER) }
+              flip { sw (defending, opp.bench.select("Select the new active"), SRC_ABILITY/*, Source.POKEMONPOWER*/) }
             }
           }
           move "Hidden Power", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -222,7 +222,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 40
-              def tar = my.discard.filterByType(POKEMON_TOOL, SPECIAL_ENERGY)
+              def tar = my.discard.filterByType(ENERGY)
               tar.showToOpponent("Energy cards in your opponent's discard pile.")
               def toReturn = tar.findAll{it.cardTypes.is(SPECIAL_ENERGY) && it.name == "Metal Energy"}
               if (toReturn) {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1733,9 +1733,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
           customAbility {
             delayedA {
               before ASLEEP_SPC, null, null, BEGIN_TURN, {
-                if(self.isSPC(ASLEEP)) {
+                if(ef.target == self){ //MARK parentEvent
                   bc "Chesto Berry activates"
-                  clearSpecialCondition(self, ATTACK, [ASLEEP])
+                  clearSpecialCondition(self, ATTACK, [ASLEEP]) //TODO Source.HELD_ITEM
+                  prevent()
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2144,7 +2144,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
 
         };
       case PIKACHU_94:
-        return basic (this, hp:HP060, type:LIGHTNING, retreatCost:0) {
+        return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
           resistance M, MINUS20
           pokePower "Electro Recycle", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2852,9 +2852,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 def eff
                 register {
                   eff = getter (GET_BURN_DAMAGE) {h->
-                      if (h.effect.target == torridWaveRecipient && h.effect.target.active) {
-                          bc "Torrid Wave increases burn damage on $torridWaveRecipient to 30."
-                          h.object += 1
+                      if (h.effect.target == torridWaveRecipient && h.effect.target.active && h.object < hp(30)) {
+                        bc "Torrid Wave increases burn damage on $torridWaveRecipient to 30."
+                        h.object = hp(30)
                       }
                     }
                   }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -601,11 +601,11 @@ public enum MysteriousTreasures implements LogicCardInfo {
             onAttack {
               if (!self.getPokemonCards().any{it.name.contains("Magby")}) {
                 def tar = my.hand.filterByType(ENERGY).select(count:2, "Discard 2 Energies.")
-                damage 80
                 afterDamage{
                   tar.discard()
                 }
               }
+              damage 80
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -959,7 +959,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               //  TODO: Implement this oddly unique energy modification.
-              //  Notes (taken from JP Rulings, none in english):
+              //  Notes (taken from JP FAQs, none in english rulings):
               //    * The flipped energy cannot use any abilities included in it (see: Call Energy MD 92)
               //    * Neither does it keep its name while flipped. (See: Gorebyss LM 17)
               //    * The flipped energy can be moved around (see: Arcanine SW 22). But once moved it's still flipped and only provides [C] with no extra effect.
@@ -2695,7 +2695,13 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
 
             if (choice == 1){
-              chosenCard = my.deck.search(count:1, "Search your deck for a Trainer-Item card that has \"Fossil\" in its name or a Stage 1 or Stage 2 Evolution card that evolves from a Fossil.", {isValidFossilCard(it)} )
+              chosenCard = my.deck.search(count:1, "Search your deck for a Trainer-Item card that has \"Fossil\" in its name or a Stage 1 or Stage 2 Evolution card that evolves from a Fossil.", {
+                if (it.cardTypes.is(STAGE2)){
+                  def debug_test = bg.gm().getBasicsFromStage2(it.name)
+                  bc "${debug_test}"
+                }
+                isValidFossilCard(it)
+                } )
             } else /*if (choice == 2)*/ {
               chosenCard = my.discard.findAll{isValidFossilCard(it)}.select()
             }

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -86,8 +86,8 @@ public enum RisingRivals implements LogicCardInfo {
   KOFFING_68 ("Koffing", 68, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
   MUNCHLAX_69 ("Munchlax", 69, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   MUNCHLAX_70 ("Munchlax", 70, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
-  NIDORAN_FEMALE_71 ("Nidoran Female", 71, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
-  NIDORAN_MALE_72 ("Nidoran Male", 72, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
+  NIDORAN_FEMALE_71 ("Nidoran♀", 71, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
+  NIDORAN_MALE_72 ("Nidoran♂", 72, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
   NIDORINA_73 ("Nidorina", 73, Rarity.COMMON, [STAGE1, EVOLUTION, POKEMON, _PSYCHIC_]),
   NIDORINO_74 ("Nidorino", 74, Rarity.COMMON, [STAGE1, EVOLUTION, POKEMON, _PSYCHIC_]),
   NUZLEAF_75 ("Nuzleaf", 75, Rarity.COMMON, [STAGE1, EVOLUTION, POKEMON, _DARKNESS_]),
@@ -1836,7 +1836,7 @@ public enum RisingRivals implements LogicCardInfo {
 
         };
       case NIDORINA_73:
-        return evolution (this, from:"Nidoran Female", hp:HP080, type:PSYCHIC, retreatCost:2) {
+        return evolution (this, from:"Nidoran♀", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
           move "Jump Tackle", {
             text "30 damage. Nidorina does 10 damage to itself, and don’t apply Weakness and Resistance to this damage."
@@ -1857,7 +1857,7 @@ public enum RisingRivals implements LogicCardInfo {
 
         };
       case NIDORINO_74:
-        return evolution (this, from:"Nidoran Male", hp:HP080, type:PSYCHIC, retreatCost:1) {
+        return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
           move "Toxic", {
             text "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns."

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -134,7 +134,7 @@ public enum SecretWonders implements LogicCardInfo {
   MAREEP_94 ("Mareep", 94, Rarity.COMMON, [BASIC, POKEMON, _LIGHTNING_]),
   MURKROW_95 ("Murkrow", 95, Rarity.COMMON, [BASIC, POKEMON, _DARKNESS_]),
   NATU_96 ("Natu", 96, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
-  NIDORAN_MALE_97 ("Nidoran Male", 97, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
+  NIDORAN_MALE_97 ("Nidoran♂", 97, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
   PHANPY_98 ("Phanpy", 98, Rarity.COMMON, [BASIC, POKEMON, _FIGHTING_]),
   PIDGEY_99 ("Pidgey", 99, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   PSYDUCK_100 ("Psyduck", 100, Rarity.COMMON, [BASIC, POKEMON, _WATER_]),
@@ -1373,7 +1373,7 @@ public enum SecretWonders implements LogicCardInfo {
 
         };
       case NIDORINO_57:
-        return evolution (this, from:"Nidoran Male", hp:HP080, type:PSYCHIC, retreatCost:1) {
+        return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
           move "Spirited Drill", {
             text "20 damage. ."

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -83,8 +83,8 @@ public enum Triumphant implements LogicCardInfo {
   LICKITUNG_66 ("Lickitung", 66, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   MACHOP_67 ("Machop", 67, Rarity.COMMON, [BASIC, POKEMON, _FIGHTING_]),
   MAGNEMITE_68 ("Magnemite", 68, Rarity.COMMON, [BASIC, POKEMON, _LIGHTNING_]),
-  NIDORAN_FEMALE_69 ("Nidoran Female", 69, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
-  NIDORAN_MALE_70 ("Nidoran Male", 70, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
+  NIDORAN_FEMALE_69 ("Nidoran♀", 69, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
+  NIDORAN_MALE_70 ("Nidoran♂", 70, Rarity.COMMON, [BASIC, POKEMON, _PSYCHIC_]),
   PIDGEY_71 ("Pidgey", 71, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   PONYTA_72 ("Ponyta", 72, Rarity.COMMON, [BASIC, POKEMON, _FIRE_]),
   PORYGON_73 ("Porygon", 73, Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
@@ -1074,7 +1074,7 @@ public enum Triumphant implements LogicCardInfo {
 
         };
       case NIDORINA_45:
-        return evolution (this, from:"Nidoran Female", hp:HP080, type:PSYCHIC, retreatCost:2) {
+        return evolution (this, from:"Nidoran♀", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P
           move "Quick Blow", {
             text "20 damage. Flip a coin. If heads, this attack does 20 damage plus 10 more damage."
@@ -1095,7 +1095,7 @@ public enum Triumphant implements LogicCardInfo {
 
         };
       case NIDORINO_46:
-        return evolution (this, from:"Nidoran Male", hp:HP080, type:PSYCHIC, retreatCost:1) {
+        return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
           move "Horn Attack", {
             text "30 damage. "


### PR DESCRIPTION
* Make Leech Seed on Cherubi (DP 75) last priority.
* Added a temp debug bc for Fossil Excavator (MT 111), to find why it crashes when selecting a stage 2 card on search.
* Fixed Retreat Cost for Pikachu (MT 94).
* Made Chesto Berry prevent the next sleep coinflip on Buizel (MT 75). Right now it checks even though the condition is already gone.
* Partially implemented Vigoroth (MT 68). It should also check for Slakoth having been asleep before evolving that turn.
* Magmortar LV.X (MT 123) should override the burn damage value to 30, not plainly increase it. Other burn cards should also do the added check for the value not being already increased as much or even higher than needed.
* Have Budew (DP 43) assert having deck before using Errand-Running
* Fixed Nidoran names in all DP-era sets, since they were written as "Nidoran Male/Female" instead of using the ♀/♂ symbols like every other set.