### PR TITLE
[Ready for Review] Various Fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen1/JungleNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/JungleNG.groovy
@@ -237,23 +237,10 @@ public enum JungleNG implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 20
-              def defType = (defending.types as List<Type>)
-              if(!defending.types.contains(C) || defType.size() != 1){
-                if(defType.size() == 1){
-                  opp.bench.each{
-                    if(it.types.contains(defType.get(0))) damage 10, it
-                  }
-                  my.bench.each{
-                    if(it.types.contains(defType.get(0))) damage 10, it
-                  }
-                }
-                else{
-                  opp.bench.each{
-                    if(it.types.contains(defType.get(0)) || it.types.contains(defType.get(1))) damage 10, it
-                  }
-                  my.bench.each{
-                    if(it.types.contains(defType.get(0))) damage 10, it
-                  }
+              def defendingTypes = (defending.types as List<Type>)
+              if(!defending.types.contains(C)){
+                [opp.bench, my.bench].each{
+                  it.findAll{it.types.any{defendingTypes.contains(it)}}.each{damage 10, it}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -301,6 +301,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             if (r==PLAY_FROM_HAND && my.deck && confirm("Use Peal of Thunder?")) {
               powerUsed()
               my.deck.subList(0,5).showToMe("Top 5 cards of your deck.")
+              //TODO: This should allow to choose which energies to attach. You could choose not to attach any and just discard all 5 cards.
               if (my.deck.subList(0,5).filterByType(ENERGY)) {
                 def tar = my.all.select("Attach Energies to?")
                 my.deck.subList(0,5).filterByType(ENERGY).each {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1170,17 +1170,8 @@ public enum DeltaSpecies implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 20
-            if (self.cards.filterByType(ENERGY).findAll {
-              it.asEnergyCard().containsTypePlain(W)
-            }) {
-              damage 20
-            }
-
-            if (self.cards.filterByType(ENERGY).findAll {
-              it.asEnergyCard().containsTypePlain(P)
-            }) {
-              discardDefendingSpecialEnergy(delegate)
-            }
+            if (self.cards.filterByEnergyType(W)) { damage 20 }
+            if (self.cards.filterByEnergyType(P)) { discardDefendingSpecialEnergy(delegate) }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -634,7 +634,7 @@ public enum Deoxys implements LogicCardInfo {
           pokeBody "Lazy Aura", {
             text "As long as Slaking is your Active Pokémon, any damage done by attacks from your opponent’s Pokémon-ex is reduced by 30 (before applying Weakness and Resistance)."
             delayedA {
-              before APPLY_ATTACK_DAMAGES, {
+              before PROCESS_ATTACK_EFFECTS, {
                 bg.dm().each{
                   if(it.to == self && it.notNoEffect && it.dmg.value && it.from.pokemonEX) {
                     bc "Lazy Aura -30"
@@ -1360,7 +1360,7 @@ public enum Deoxys implements LogicCardInfo {
           pokeBody "Intimidating Pattern", {
             text "As long as Masquerain is your Active Pokémon, any damage done by an opponent’s attack is reduced by 20 (before applying Weakness and Resistance). You can’t use more than 1 Intimidating Pattern Poké-Body each turn."
             delayedA {
-              before APPLY_ATTACK_DAMAGES, {
+              before PROCESS_ATTACK_EFFECTS, {
                 bg.dm().each{
                   if(it.from.owner == self.owner.opposite && self.active) {
                     bc "Intimidating Pattern -20"

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -634,7 +634,7 @@ public enum Deoxys implements LogicCardInfo {
           pokeBody "Lazy Aura", {
             text "As long as Slaking is your Active Pokémon, any damage done by attacks from your opponent’s Pokémon-ex is reduced by 30 (before applying Weakness and Resistance)."
             delayedA {
-              before PROCESS_ATTACK_EFFECTS, {
+              after PROCESS_ATTACK_EFFECTS, {
                 bg.dm().each{
                   if(it.to == self && it.notNoEffect && it.dmg.value && it.from.pokemonEX) {
                     bc "Lazy Aura -30"
@@ -1360,7 +1360,7 @@ public enum Deoxys implements LogicCardInfo {
           pokeBody "Intimidating Pattern", {
             text "As long as Masquerain is your Active Pokémon, any damage done by an opponent’s attack is reduced by 20 (before applying Weakness and Resistance). You can’t use more than 1 Intimidating Pattern Poké-Body each turn."
             delayedA {
-              before PROCESS_ATTACK_EFFECTS, {
+              after PROCESS_ATTACK_EFFECTS, {
                 bg.dm().each{
                   if(it.from.owner == self.owner.opposite && self.active) {
                     bc "Intimidating Pattern -20"

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -2060,7 +2060,7 @@ public enum DragonFrontiers implements LogicCardInfo {
         pokeBody "Extra Smoke", {
           text "Any damage done to your Stage 2 Pokémon-ex by your opponent's attacks is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before PROCESS_ATTACK_EFFECTS, {
+            after PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
                 if (it.to.owner == self.owner && it.to.EX && it.to.topPokemonCard.cardTypes.is(STAGE2) && it.dmg.value && it.notNoEffect) {
                   bc "Extra Smoke -10"

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -346,7 +346,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 40
-            reduceDamageNextTurn(hp(30), thisMove)
+            reduceDamageFromDefendingNextTurn(hp(30),thisMove,defending)
           }
         }
         move "Mega Impact", {
@@ -1265,7 +1265,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           energyCost W
           attackRequirement {}
           onAttack {
-            reduceDamageNextTurn(hp(20), thisMove)
+            reduceDamageFromDefendingNextTurn(hp(20),thisMove,defending)
           }
         }
       };
@@ -2060,7 +2060,7 @@ public enum DragonFrontiers implements LogicCardInfo {
         pokeBody "Extra Smoke", {
           text "Any damage done to your Stage 2 Pokémon-ex by your opponent's attacks is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before APPLY_ATTACK_DAMAGES, {
+            before PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
                 if (it.to.owner == self.owner && it.to.EX && it.to.topPokemonCard.cardTypes.is(STAGE2) && it.dmg.value && it.notNoEffect) {
                   bc "Extra Smoke -10"

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -340,7 +340,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 30
             afterDamage{
               delayed{
-                before PROCESS_ATTACK_EFFECTS, {
+                after PROCESS_ATTACK_EFFECTS, {
                   bg.dm().each{
                     if(it.from.owner == self.owner.opposite && it.to == self) {
                       bc "Delta Reduction -30 (before W/R)"

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -338,7 +338,20 @@ public enum HolonPhantoms implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 30
-            reduceDamageNextTurn(hp(30), thisMove)
+            afterDamage{
+              delayed{
+                before PROCESS_ATTACK_EFFECTS, {
+                  bg.dm().each{
+                    if(it.from.owner == self.owner.opposite && it.to == self) {
+                      bc "Delta Reduction -30 (before W/R)"
+                      it.dmg -= hp(30)
+                    }
+                  }
+                }
+                after SWITCH, self, {unregister()}
+                unregisterAfter 2
+              }
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -973,7 +973,7 @@ public enum LegendMaker implements LogicCardInfo {
         pokeBody "Ancient Fang", {
           text "As long as you have Kabuto, Kabutops, or Kabutops ex in play, Omastar's attacks do 20 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
           delayedA {
-            before PROCESS_ATTACK_EFFECTS, {
+            after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self) {
                 bg.dm().each {
                   if (it.to.active && it.to.owner != self.owner && it.notNoEffect && it.dmg.value) {

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1469,7 +1469,7 @@ public enum PowerKeepers implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 10
-            reduceDamageNextTurn(hp(10), thisMove)
+            reduceDamageFromDefendingNextTurn(hp(10),thisMove,defending)
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -734,7 +734,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "If Dark Sandslash is your Active Pokémon and is damaged by an opponent’s attack (even if Dark Sandslash is Knocked Out), the Attacking Pokémon is now Poisoned."
             delayedA (priority: LAST) {
               before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
+                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Poison Payback"
                   apply POISONED, (ef.attacker as PokemonCardSet)
                 }
@@ -982,16 +982,18 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "If Qwilfish is your Active Pokémon and is damaged by an opponent’s attack (even if Qwilfish is Knocked Out), flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
             delayedA (priority: LAST) {
               before APPLY_ATTACK_DAMAGES, {
-                def pcs = self.owner.opposite.pbg.active
-                def counterDmg = 0
-                bg.dm().each{
-                  if(it.to == self && it.notNoEffect && it.dmg.value) {
-                    bc "Spiny"
-                    pcs = it.from
-                    flipUntilTails {counterDmg += 10}
+                if (self.active) {
+                  def pcs = self.owner.opposite.pbg.active
+                  def counterDmg = 0
+                  bg.dm().each{
+                    if(it.to == self && it.notNoEffect && it.dmg.value) {
+                      bc "Spiny"
+                      pcs = it.from
+                      flipUntilTails {counterDmg += 10}
+                    }
                   }
+                  directDamage counterDmg, pcs
                 }
-                directDamage counterDmg, pcs
               }
             }
           }
@@ -2626,7 +2628,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "If Rocket’s Hitmonchan ex is your Active Pokémon and is damaged by an opponent’s attack (even if Rocket’s Hitmonchan ex is Knocked Out), put 2 damage counters on the Attacking Pokémon."
             delayedA (priority: LAST) {
               before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
+                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "$self Strikes Back!"
                   directDamage 20, (ef.attacker as PokemonCardSet)
                 }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -347,7 +347,7 @@ public enum UnseenForces implements LogicCardInfo {
         pokeBody "Intimidating Fang", {
           text "As long as Feraligatr is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before PROCESS_ATTACK_EFFECTS, {
+            after PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
                 if(self.active && it.to.owner==self.owner && it.dmg.value && it.notNoEffect) {
                   bc "Intimidating Fang: -10"
@@ -1350,7 +1350,7 @@ public enum UnseenForces implements LogicCardInfo {
         pokeBody "Intimidating Fang", {
           text "As long as Granbull is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before PROCESS_ATTACK_EFFECTS, {
+            after PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
                 if (self.active && it.to.owner == self.owner && it.dmg.value && it.notNoEffect) {
                   bc "Intimidating Fang -10"

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -347,9 +347,9 @@ public enum UnseenForces implements LogicCardInfo {
         pokeBody "Intimidating Fang", {
           text "As long as Feraligatr is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before APPLY_ATTACK_DAMAGES, {
+            before PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
-                if(it.to.owner==self.owner && it.dmg.value && it.notNoEffect && self.active) {
+                if(self.active && it.to.owner==self.owner && it.dmg.value && it.notNoEffect) {
                   bc "Intimidating Fang: -10"
                   it.dmg-=hp(10)
                 }
@@ -1350,9 +1350,9 @@ public enum UnseenForces implements LogicCardInfo {
         pokeBody "Intimidating Fang", {
           text "As long as Granbull is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            before APPLY_ATTACK_DAMAGES, {
+            before PROCESS_ATTACK_EFFECTS, {
               bg.dm().each {
-                if (it.to.owner == self.owner && it.dmg.value && it.notNoEffect) {
+                if (self.active && it.to.owner == self.owner && it.dmg.value && it.notNoEffect) {
                   bc "Intimidating Fang -10"
                   it.dmg -= hp(10)
                 }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2010,15 +2010,16 @@ public enum BurningShadows implements LogicCardInfo {
             text "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can't use more than 1 GX attack in a game.)"
             attackRequirement {
               gxCheck()
-              assert opp.bench.notEmpty : "Empty bench"
             }
             onAttack {
               gxPerform()
-              def pcs = opp.bench.select("Switch")
-              sw opp.active, pcs
-              apply POISONED
-              apply BURNED
-              apply PARALYZED
+              if opp.bench{
+                def pcs = opp.bench.select("Switch")
+                sw opp.active, pcs
+                apply POISONED, pcs
+                apply BURNED, pcs
+                apply PARALYZED, pcs
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1822,7 +1822,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "The attacks of your Pokémon-GX in play that evolve from Eevee cost [C] less. You can't apply more than 1 Speed Cheer Ability at a time."
             delayedA {
               before CHECK_ATTACK_REQUIREMENTS, {
-                if(ef.attacker.owner == self.owner && ef.attacker.pokemonGX && ef.attacker.topPokemonCard.predecessor == "Eevee" && bg.currentTurn == self.owner && bg.em().retrieveObject("Speed_Cheer") != bg.turnCount) {
+                if(ef.attacker.owner == self.owner && ef.attacker.pokemonGX && ef.attacker.topPokemonCard.realEvolution && ef.attacker.topPokemonCard.predecessor == "Eevee" && bg.currentTurn == self.owner && bg.em().retrieveObject("Speed_Cheer") != bg.turnCount) {
                   bg.em().storeObject("Speed_Cheer", bg.turnCount)
                   def copy = ef.move.shallowCopy()
                   if (copy.energyCost.contains(C)) {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3268,7 +3268,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 120
               delayed (priority: LAST) {
                 def pcs = defending
-                after KNOCKOUT, pcs, {
+                before KNOCKOUT, pcs, {
                   bc "Red Banquet gives the player an additional prize."
                   bg.em().run(new TakePrize(self.owner, pcs))
                 }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1784,7 +1784,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             energyCost M, C, C
             onAttack {
               damage 70
-              if(bench.notEmpty && confirm("shuffle this Pokémon and all cards attached to it into your deck?")){
+              if(confirm("shuffle this Pokémon and all cards attached to it into your deck?")){
                 afterDamage {
                   shuffleDeck(self.cards)
                   removePCS(self)

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1615,7 +1615,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
               gxPerform()
               delayed (priority: LAST) {
                 def pcs = defending
-                after KNOCKOUT, pcs, {
+                before KNOCKOUT, pcs, {
                   bg.em().run(new TakePrize(self.owner, pcs))
                   bg.em().run(new TakePrize(self.owner, pcs))
                 }

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -354,7 +354,7 @@ public enum DragonMajesty implements LogicCardInfo {
             text "Search your deck for up to 2 [R] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
             energyCost C
             attackRequirement{
-              assert my.deck : "There is no cards in your deck"
+              assert my.deck : "There are no cards in your deck"
             }
             onAttack{
               my.deck.search(max : 2,"Search your deck for up to 2 [R] Energy cards",basicEnergyFilter(R)).each{

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1336,7 +1336,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
             delayedA (priority: LAST) {
               before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
+                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Poison Point"
                   apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
                 }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2284,7 +2284,7 @@ public enum GuardiansRising implements LogicCardInfo {
             onAttack {
               delayed (priority: LAST) {
                 def pcs = defending
-                after KNOCKOUT, pcs, {
+                before KNOCKOUT, pcs, {
                   if(turnCount + 2 == bg.turnCount) {
                     bc "The Wages of Fluff kicks in"
                     bg.em().run(new TakePrize(self.owner, pcs))

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1226,7 +1226,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Burning Magma GX" , {
-            text "Discard the top 5 cards of your opponent's deck. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Discard the top 5 cards of your opponent's deck. (You can't use more than 1 GX attack in a game.)"
             energyCost R
             attackRequirement{
               gxCheck()
@@ -1415,7 +1415,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Burst GX" , {
-            text "Discard 1 of your Prize cards. If it's an Energy card, attach it to 1 of your Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Discard 1 of your Prize cards. If it's an Energy card, attach it to 1 of your Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost R
             attackRequirement{
               gxCheck()
@@ -1595,7 +1595,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Brinicles GX" , {
-            text "150 damage. Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "150 damage. Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost W,W,C
             attackRequirement{
               gxCheck()
@@ -2111,7 +2111,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Full Voltage GX" , {
-            text "Attach 5 basic Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Attach 5 basic Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)"
             energyCost L
             attackRequirement{
               gxCheck()
@@ -2435,7 +2435,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Intercept GX" , {
-            text "60× damage. This attack does 60 damage times the amount of Energy attached to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "60× damage. This attack does 60 damage times the amount of Energy attached to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost P,C,C
             attackRequirement{
               gxCheck()
@@ -2943,7 +2943,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Lay the Smackdown GX" , {
-            text "220 damage. This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "220 damage. This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost D,D,C
             attackRequirement{
               gxCheck()
@@ -3205,7 +3205,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Sublimation GX" , {
-            text "If your opponent's Active Pokémon is an Ultra Beast, it is Knocked Out. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "If your opponent's Active Pokémon is an Ultra Beast, it is Knocked Out. (You can't use more than 1 GX attack in a game.)"
             energyCost Y,C
             attackRequirement{
               gxCheck()
@@ -3587,7 +3587,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Dream Fear GX" , {
-            text "Choose 1 of your opponent's Benched Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into their deck. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Choose 1 of your opponent's Benched Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into their deck. (You can't use more than 1 GX attack in a game.)"
             energyCost Y
             attackRequirement{
               gxCheck()
@@ -3798,7 +3798,7 @@ public enum LostThunder implements LogicCardInfo {
             }
           }
           move "Lost Purge GX" , {
-            text "Put your opponent's Active Pokémon and all cards attached to it in the Lost Zone. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Put your opponent's Active Pokémon and all cards attached to it in the Lost Zone. (You can't use more than 1 GX attack in a game.)"
             energyCost C,C,C
             attackRequirement{
               gxCheck()

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2938,10 +2938,10 @@ public enum SunMoonPromos implements LogicCardInfo {
             text "Once during your turn (before your attack), you may discard a special energy from this pokemon. If you do, heal 80 damage from this Pokémon."
             actionA {
               checkLastTurn()
-              assert self.findAll(cardTypeFilter(SPECIAL)) : "There are no special energies attached"
               assert self.numberOfDamageCounters : "$self is not damaged"
+              assert self.cards.filterByType(SPECIAL_ENERGY) : "There are no special energies attached to $self"
               powerUsed()
-              my.hand.findAll(cardTypeFilter(POKEMON)).select("Discard a Pokemon to heal 80").discard()
+              self.cards.filterByType(SPECIAL_ENERGY).select("Discard a Special Energy from your hand to heal 80").discard()
               heal(80, self)
             }
           }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1446,7 +1446,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Requiem GX" , {
-            text "250 damage. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "250 damage. (You can't use more than 1 GX attack in a game.)"
             energyCost P,P,P,C
             attackRequirement{
               gxCheck()
@@ -1760,7 +1760,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Thunderous Rain GX" , {
-            text "This attack does 100 damage to each of your opponent's Pokémon that has any Energy attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "This attack does 100 damage to each of your opponent's Pokémon that has any Energy attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)"
             energyCost L,L,L,L
             attackRequirement{
               gxCheck()
@@ -1794,7 +1794,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Liberation GX" , {
-            text "120× damage. Your opponent reveals their hand. This attack does 120 damage for each Energy card you find there. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "120× damage. Your opponent reveals their hand. This attack does 120 damage for each Energy card you find there. (You can't use more than 1 GX attack in a game.)"
             energyCost F,F,C,C
             attackRequirement{
               gxCheck()
@@ -1889,7 +1889,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Thundering Hurricane GX" , {
-            text "100× damage. Flip 4 coins. This attack does 100 damage for each heads. (You can't user more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "100× damage. Flip 4 coins. This attack does 100 damage for each heads. (You can't user more than 1 GX attack in a game.)"
             energyCost L,L,L
             attackRequirement{
               gxCheck()
@@ -1920,7 +1920,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Destructive Cyclone GX" , {
-            text "130 damage. Discard all Energy from your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "130 damage. Discard all Energy from your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost C,C,C
             attackRequirement{
               gxCheck()
@@ -2355,7 +2355,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Swift Run GX" , {
-            text "110 damage. Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "110 damage. Prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn. (You can't use more than 1 GX attack in a game.)"
             energyCost L,C
             attackRequirement{
               gxCheck()
@@ -2412,7 +2412,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Joy Maker GX" , {
-            text "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)"
             energyCost C
             attackRequirement{
               gxCheck()

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2037,7 +2037,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           move "Splintered Shards GX" , {
-            text "30× damage. This attack does 30 damage for each Energy card in your opponent's discard pile. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "30× damage. This attack does 30 damage for each Energy card in your opponent's discard pile. (You can't use more than 1 GX attack in a game.)"
             energyCost F
             attackRequirement{
               gxCheck()
@@ -2344,7 +2344,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           move "Devilish Hands GX" , {
-            text "Choose 1 of your opponent's Pokémon-GX or Pokémon-EX 6 times. (You can choose the same Pokémon more than once.) For each time you chose a Pokémon, do 30 damage to it. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "Choose 1 of your opponent's Pokémon-GX or Pokémon-EX 6 times. (You can choose the same Pokémon more than once.) For each time you chose a Pokémon, do 30 damage to it. This damage isn't affected by Weakness or Resistance. (You can't use more than 1 GX attack in a game.)"
             energyCost D,D,D
             attackRequirement{
               gxCheck()
@@ -2385,7 +2385,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           move "Darkest Tornado GX" , {
-            text "10+ damage. This attack does 50 more damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "10+ damage. This attack does 50 more damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)"
             energyCost C,C,C
             attackRequirement{
               gxCheck()
@@ -2611,7 +2611,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           move "Iron Rule GX" , {
-            text "During your opponent's next turn, none of your opponent's Pokémon can attack (including newly played Pokémon). (You can't use more than 1 GX attack in a game.)\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."
+            text "During your opponent's next turn, none of your opponent's Pokémon can attack (including newly played Pokémon). (You can't use more than 1 GX attack in a game.)"
             energyCost C
             attackRequirement{
               gxCheck()

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2023,8 +2023,10 @@ public enum TeamUp implements LogicCardInfo {
             onActivate {r->
               if(r==PLAY_FROM_HAND && confirm('Use Twilight Eyes?')){
                 powerUsed()
-                if(opp.active.cards.filterByType(ENERGY)){
-                  opp.active.cards.filterByType(ENERGY).select("Discard").discard()
+                targeted (opp.active, SRC_ABILITY){
+                  if(opp.active.cards.filterByType(ENERGY)){
+                    opp.active.cards.filterByType(ENERGY).select("Discard").discard()
+                  }
                 }
               }
             }
@@ -3526,7 +3528,9 @@ public enum TeamUp implements LogicCardInfo {
         return supporter(this) {
           text "You can play this card only if your opponent's Active Pokémon is a Basic Pokémon.\nPut an Energy from your opponent's Active Pokémon on top of their deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            opp.active.cards.filterByType(ENERGY).select("Choose the energy to put on top of their deck").moveTo(addToTop: true, opp.deck)
+            targeted (opp.active, TRAINER_CARD) {
+              opp.active.cards.filterByType(ENERGY).select("Choose the energy to put on top of their deck").moveTo(addToTop: true, opp.deck)
+            }
           }
           playRequirement{
             assert opp.active.basic

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -671,7 +671,7 @@ public enum UltraPrism implements LogicCardInfo {
             damage 20
             delayedA (priority: LAST) {
               before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
+                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
                   bc "Incandescent Body burns attacker"
                   bg.dm().each{apply BURNED, it.from}
                 }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -1905,7 +1905,7 @@ public enum UltraPrism implements LogicCardInfo {
           }
 
           move "Abyssal Sleep", {
-            text "120 damage. Your opponentâ€™s Active PokÃ©mon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that PokÃ©mon is still Asleep."
+            text "120 damage. Your opponent's Active Pokémon is now Asleep. Your opponent flips 2 coins instead of 1 between turns. If either of them is tails, that Pokémon is still Asleep."
             energyCost D, D, D, D
             onAttack {
               damage 120

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -344,7 +344,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               gxPerform()
               delayed (priority: LAST) {
                 def pcs = defending
-                after KNOCKOUT, pcs, {
+                before KNOCKOUT, pcs, {
                   bg.em().run(new TakePrize(self.owner, pcs))
                   if(self.cards.energySufficient(thisMove.energyCost + C + C+ C+ C+ C+ C+ C)){
                     bg.em().run(new TakePrize(self.owner, pcs))

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3580,7 +3580,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 70
-              flip {afterDamage{discardDefendingEnergy();discardDefendingEnergy()}}
+              flip { afterDamage{ 2.times{ discardDefendingEnergy() } } }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2925,7 +2925,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               delayed (priority: LAST) {
                 if (defending.pokemonGX || defending.pokemonEX) {
                   def pcs = defending
-                  after KNOCKOUT, pcs, {
+                  before KNOCKOUT, pcs, {
                     bc "Knocked Out Pokémon was GX or EX. Player gets to take an additional prize."
                     bg.em().run(new TakePrize(self.owner, pcs))
                   }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1129,8 +1129,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             onAttack {
               damage 50
               afterDamage {
-                assert opp.bench : "Your opponent has no Pokémon on their bench."
-                moveEnergy(opp.active, opp.bench)
+                if (opp.bench) { moveEnergy(may: true, opp.active, opp.bench) }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2031,10 +2031,10 @@ public enum RebelClash implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Counterattack", {
           text "If this Pokemon is your Active Pokemon and is damaged by an opponent’s attack, place 3 damage counters on the attacking Pokemon."
-          delayedA {
+          delayedA (priority: LAST) {
             before APPLY_ATTACK_DAMAGES, {
               if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
-                powerused()
+                bc "Counterattack activates"
                 directDamage(30, ef.attacker, Source.SRC_ABILITY)
               }
             }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1925,7 +1925,9 @@ public enum RebelClash implements LogicCardInfo {
           onActivate {r->
             if (r==PLAY_FROM_HAND && opp.active.cards.energyCount(C) && confirm("Use Prankish?")) {
               powerUsed()
-              opp.active.cards.filterByType(ENERGY).select(count:1).moveTo(addToTop: true, opp.deck)
+              targeted (opp.active, SRC_ABILITY){
+                opp.active.cards.filterByType(ENERGY).select(count:1).moveTo(addToTop: true, opp.deck)
+              }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2896,7 +2896,7 @@ public enum SwordShield implements LogicCardInfo {
                 delayed {
                   before APPLY_ATTACK_DAMAGES, {
                     bg.dm().each {
-                      if (it.to==self && it.dmg.value) {
+                      if (it.to==self && it.dmg.value && it.notNoEffect) {
                         bc "-100 to Corviknight (Iron Wings)"
                         it.dmg-=hp(100)
                       }


### PR DESCRIPTION
* Tri Attack-GX on Alolan Muk-GX (BUS 84) can be used regardless of the opponent having bench.
  - This is an important fix (and might need to check around other GX attacks where this may apply), due to it allowing attacks (in cards like this one, a free attack) that enable boosts on cards like Hala.
  - Relevant ruling:
    > Q. If my opponent has no Benched Pokemon, can I still use Alolan Muk-GX's "Tri Hazard-GX" attack?
    >
    > A. You can use it, but it won't have any effect, and it will count as having used your GX attack for the game. (Burning Shadows FAQ; Aug 3, 2017 TPCi Rules Team)

* Fixed "Extra Prize" check on multiple cards being done after KOs instead of before them. Should fix opponent choosing the new active before the extra prizes are taken. Cards affected:
  - Guzzlord (CEC 136)
  - Guzzlord-GX (CIN 63)
  - Whimsicott (GRI 91)
  - Pheromosa & Buzzwole-GX (UNB 1)
  - Mega Sableye & Tyranitar-GX (UNM 126)
* Simplified code for Slowking (DS 28)
* Removed the following unintended text from several GX attacks: _"\nPokémon-GX rule: When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards."_
* Fixed some characters with broken encoding in Darkrai Prism Star (UPR 77)
* Made Fearow (UNB 146) use `2.times{[...]}` instead of repeating code.
* Wrapped Prankish from Clefable (RCL 75) around a `targeted`, marking it as an Ability effect to other cards.
* Fixed an assert inside the attack of Lumineon (UNM 40), also made the energy move optional as the card reads.
* Added an ability/trainer `target` to Lycanroc-GX (TEU 82) and Nita (TEU 151)
* Simplified the "Chain Lightning" attack from Electrode (Jungle 2)
* Fixed some attacks and abilities reducing damage from the opponent's Pokémon after applying Weakness & Resistance, instead of before as the text indicates. Affected cards:
  - Slaking (DX 15), Poké-Body "Lazy Aura"
  - Masquerain (DX 39), Poké-Body "Intimidating Pattern"
  - Meganium Delta (DF 4), Attack "Delta Reduction"
  - Togepi Delta (DF 41), Attack "Charm"
  - Kingdra-_ex_ Delta (DF 94), Poké-Body "Extra Smoke"
  - Deoxys Delta (HP 4), Attack "Delta Reduction" _[Changed to a specific delayed effect here, since it's only damage to Deoxys Delta]_
  - Chinchou (PK 49), Attack "Negative Ion"
  - Feraligatr (UF 4), Poké-Body "Intimidating Fang"
  - Granbull (UF 39), Poké-Body "Intimidating Fang" 
* Added a TODO for Charizard Delta (CG 4).
* Made some Pokémon check if they're active before using their Poké-Body/Ability:
  - Dark Sandslash (TRR 18)
  - Qwilfish (TRR 27)
  - Rocket's Hitmonchan-_ex_ (TRR 98)
  - Dragalge (FLI 53)
  - Magmortar (UPR 19)
* Made Kartana-GX (CIN 70) not assert bench being empty. You can shuffle it and lose the game due to not having any Pokémon in play (TODO: Check for more cards doing this unneeded check).
* Minor text fix on Reshiram-GX (DRM 11).
* Fixed "Iron Wings" on Corviknight (SSH 135) not being ignored by shred attacks.
* ~~Galarian Stunfisk (SSH 132) should now ask its owner for which energy to discard, not the opponent.~~ **(Reverted, better implemented in #584)**
  - Side-note: Against cards like Blacephalon-GX or Eldegoss V, this card shouldn't be able to discard any card. But it's last priority already... Would using `after APPLY_ATTACK_DAMAGES` instead of `before [...]` work?