### PR TITLE
assertAnyPokemonInPlay() static method, isPokemonV() / isPokemonVMAX() PCS methods

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1163,7 +1163,8 @@ class TcgStatics {
    * @param message Additional text to be put at the end of the assert fail warning. If repText is set to true in params, message will override the entirety of said warning.
    *
    */
-  static void assertBench(params=[:], Closure c = null, String message = "") {
+  static void assertBench(params=[:], Closure c = null, String info = "") {
+    def failMessage
     def checkedBench = params.opp ? opp.bench : my.bench
 
     def hasPokeCnt = 0
@@ -1185,34 +1186,37 @@ class TcgStatics {
       }
     )
 
-    def typeString = param.isType ? " ${params.isType.getShortNotation()}" : ""
+    if (!params.repText) {
+      failMessage = info
+    } else {
+      def typeString = param.isType ? " ${params.isType.getShortNotation()}" : ""
 
-    def pokeString = "${typeString}Pokémon"
-    if (hasPokeCnt) (
-      pokeString = "${typeString}"
-      i = 1
-      [
-        (params.hasPokemonEX, "Pokémon-EX"),
-        (params.hasPokemonGX, "Pokémon-GX"),
-        (params.hasPokemonV, "Pokémon V")
-      ].each{
-        if (it[0]) {
-          pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")
-          i += 1
+      def pokeString = "${typeString}Pokémon"
+      if (hasPokeCnt) (
+        pokeString = "${typeString}"
+        i = 1
+        [
+          (params.hasPokemonEX, "Pokémon-EX"),
+          (params.hasPokemonGX, "Pokémon-GX"),
+          (params.hasPokemonV, "Pokémon V")
+        ].each{
+          if (it[0]) {
+            pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")
+            i += 1
+          }
         }
-      }
-    )
+      )
 
+      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!info.equals("") ? info : "follow the stated condition(s)"}"
+    }
 
-    if (!params.repText) message = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!message.equals("") ? message : "follow the stated condition(s)"}"
-
-    assert checkedBench.any{benchFilter} : message
+    assert checkedBench.any{benchFilter} : failMessage
   }
-  static void assertMyBench(params=[:], Closure c = null, String message = "") {
+  static void assertMyBench(params=[:], Closure c = null, String info = "") {
     params.opp = false
     assertBench(params, c, cText)
   }
-  static void assertOppBench(params=[:], Closure c = null, String message = "") {
+  static void assertOppBench(params=[:], Closure c = null, String info = "") {
     params.opp = true
     assertBench(params, c, cText)
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1146,6 +1146,42 @@ class TcgStatics {
   static boolean isGxPerformed(){
     bg.em().retrieveObject("gx_"+my.owner)
   }
+
+  /* General checks for attacks and abilities */
+
+  //  * checkAnyBench
+  //    - Can be used with no arguments, or with a condition and additional text included.
+  //    - If a closure is given, it'll check for any "it" element in bench returning true.
+  //    - Optional params:
+  //      + opp: If true, checks for the opponent's bench instead of "my" bench.
+  //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
+  static void checkAnyBench(params=[:], Closure c, String cText) {
+    def checkedBench = params.opp ? opp.bench : my.bench
+    assert (
+      if (c != null) { checkedBench.any{c(it)} } else { checkedBench }
+    ) : (
+      if (params.repText) { cText } else {
+        (
+          if (params.opp) { "You don't" } else { "Your opponent doesn't" }
+        ) + " have any Benched Pokémon that " + (
+          if (cText) {
+            cText
+          } else {
+            "follow the stated condition(s)."
+          }
+        )
+      }
+    )
+  }
+  static void checkMyBench(params=[:], Closure c, String cText) {
+    params.opp = false
+    checkAnyBench(params, c, cText)
+  }
+  static void checkOppBench(params=[:], Closure c, String cText) {
+    params.opp = true
+    checkAnyBench(params, c, cText)
+  }
+
   static void cantBeHealed(PokemonCardSet defending){
     delayed {
       after EVOLVE, defending, {unregister()}

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1172,7 +1172,7 @@ class TcgStatics {
     def hasPokeCnt = 0
     [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV].each{hasPokeCnt += 1}
 
-    def benchFilter = {
+    def areaFilter = {
       if (filter == null) { true } else {
         (
           if (params.hasType) {it.types.contains(params.hasType)} else {true}
@@ -1215,7 +1215,7 @@ class TcgStatics {
       failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any $pokeString that ${params.info ? params.info : "follow the stated condition(s)"}"
     }
 
-    assert checkedArea.any(benchFilter) : failMessage
+    assert checkedArea.any(areaFilter) : failMessage
   }
 
   static void assertMyPokemon(params=[:], Closure filter = null) {

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1157,13 +1157,13 @@ class TcgStatics {
    *   + hasType: If set, restricts to benched Pokémon of a single specific type.
    *   + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
    *   + opp: If true, checks for the opponent's bench instead of "my" bench.
+   *   + info: If set, it'll replace the end of the failed assert warning with a custom text, instead of the default "follow the stated condition(s)".
+   *   + repText: If true, params.info will override the entirety of the failed assert warning.
    *
    * @param c Additional condition the filtered benched Pokémon must follow. Defaults to true (so any benched Pokémon).
    *
-   * @param info Additional text to be put at the end of the assert fail warning. If repText is set to true in params, info will override the entirety of said warning.
-   *
    */
-  static void assertBench(params=[:], Closure c = null, String info = "") {
+  static void assertBench(params=[:], Closure c = null) {
     def failMessage
     def checkedBench = params.opp ? opp.bench : my.bench
 
@@ -1186,8 +1186,8 @@ class TcgStatics {
       }
     )
 
-    if (!params.repText) {
-      failMessage = info
+    if (params.info + !params.repText) {
+      failMessage = params.info
     } else {
       def typeString = param.hasType ? " ${params.hasType.getShortNotation()}" : ""
 
@@ -1207,16 +1207,16 @@ class TcgStatics {
         }
       )
 
-      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!info.equals("") ? info : "follow the stated condition(s)"}"
+      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${params.info ? params.info : "follow the stated condition(s)"}"
     }
 
     assert checkedBench.any{benchFilter} : failMessage
   }
-  static void assertMyBench(params=[:], Closure c = null, String info = "") {
+  static void assertMyBench(params=[:], Closure c = null) {
     params.opp = false
     assertBench(params, c, cText)
   }
-  static void assertOppBench(params=[:], Closure c = null, String info = "") {
+  static void assertOppBench(params=[:], Closure c = null) {
     params.opp = true
     assertBench(params, c, cText)
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1151,7 +1151,7 @@ class TcgStatics {
 
   /**
    *
-   * Does a customized assert with a automated fail message.
+   * Does a customized assert with an automated fail warning.
    *
    * @param params Optional settings that can be added:
    *   + isType: if set, restricts to benched Pokémon of a single specific type.
@@ -1160,7 +1160,7 @@ class TcgStatics {
    *
    * @param c Additional condition the filtered benched Pokémon must follow. Defaults to true (so any benched Pokémon).
    *
-   * @param message Additional text to be put at the end of the assert fail warning. If repText is set to true in params, message will override the entirety of said warning.
+   * @param info Additional text to be put at the end of the assert fail warning. If repText is set to true in params, info will override the entirety of said warning.
    *
    */
   static void assertBench(params=[:], Closure c = null, String info = "") {

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1157,7 +1157,7 @@ class TcgStatics {
    *   + benched: If true, checks for only Benched Pokémon; otherwise also includes the Active.
    *   + opp: If true, checks for the opponent's bench instead of "my" bench.
    *   + hasType: If set, restricts to benched Pokémon of a single specific type.
-   *   + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
+   *   + hasPokemonEX/hasPokemonGX/hasPokemonV/hasPokemonMAX: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
    *   + info: If set, it'll replace the end of the failed assert warning with a custom text, instead of the default "follow the stated condition(s)".
    *   + repText: If true, params.info will override the entirety of the failed assert warning.
    *
@@ -1180,7 +1180,8 @@ class TcgStatics {
           if (!hasPokeCnt) {true} else {
             (params.hasPokemonEX && it.pokemonEX) ||
             (params.hasPokemonGX && it.pokemonGX) ||
-            (params.hasPokemonV && it.pokemonV)
+            (params.hasPokemonV && it.pokemonV) ||
+            (params.hasPokemonVMAX && it.pokemonVMAX)
           }
         ) && (
           filter.call(it)
@@ -1201,7 +1202,8 @@ class TcgStatics {
         [
           (params.hasPokemonEX, "Pokémon-EX"),
           (params.hasPokemonGX, "Pokémon-GX"),
-          (params.hasPokemonV, "Pokémon V")
+          (params.hasPokemonV, "Pokémon V"),
+          (params.hasPokemonVMAX, "Pokémon VMAX")
         ].each{
           if (it[0]) {
             pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1163,7 +1163,7 @@ class TcgStatics {
    * @param c Additional condition the filtered benched Pokémon must follow. Defaults to true (so any benched Pokémon).
    *
    */
-  static void assertBench(params=[:], Closure c = null) {
+  static void assertBench(params=[:], Closure filter = null) {
     def failMessage
     def checkedBench = params.opp ? opp.bench : my.bench
 
@@ -1171,7 +1171,7 @@ class TcgStatics {
     [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV].each{hasPokeCnt += 1}
 
     def benchFilter = (
-      if (c == null) { true } else {
+      if (filter == null) { true } else {
         (
           if (params.hasType) {it.types.contains(params.hasType)} else {true}
         ) && (
@@ -1181,7 +1181,7 @@ class TcgStatics {
             (params.hasPokemonV && it.pokemonV)
           }
         ) && (
-          c(it)
+          filter.call(it)
         )
       }
     )
@@ -1212,13 +1212,13 @@ class TcgStatics {
 
     assert checkedBench.any{benchFilter} : failMessage
   }
-  static void assertMyBench(params=[:], Closure c = null) {
+  static void assertMyBench(params=[:], Closure filter = null) {
     params.opp = false
-    assertBench(params, c)
+    assertBench(params, filter)
   }
-  static void assertOppBench(params=[:], Closure c = null) {
+  static void assertOppBench(params=[:], Closure filter = null) {
     params.opp = true
-    assertBench(params, c)
+    assertBench(params, filter)
   }
 
   static void cantBeHealed(PokemonCardSet defending){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1156,7 +1156,7 @@ class TcgStatics {
   //      + isType: if set, restricts to benched Pokémon of a single specific type.
   //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
-  //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
+  //      + repText: If true, cText will override the entire fail message instead of being added at the end.
   static void assertBench(params=[:], Closure c = null, String cText = null) {
     def checkedBench = params.opp ? opp.bench : my.bench
 

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1220,12 +1220,12 @@ class TcgStatics {
     assert checkedArea.any(areaFilter) : failMessage
   }
 
-  static void assertMyPokemon(params=[:], Closure filter = null) {
+  static void assertMyAll(params=[:], Closure filter = null) {
     params.benched = false
     params.opp = false
     assertAnyPokemonInPlay(params, filter)
   }
-  static void assertOppPokemon(params=[:], Closure filter = null) {
+  static void assertOppAll(params=[:], Closure filter = null) {
     params.benched = false
     params.opp = true
     assertAnyPokemonInPlay(params, filter)

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1172,7 +1172,7 @@ class TcgStatics {
     def hasPokeCnt = 0
     [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV, params.hasPokemonVMAX].each{hasPokeCnt += 1}
 
-    def areaFilter = (
+    def areaFilter = {
       (
           !params.hasType || it.types.contains(params.hasType)
       ) && (
@@ -1185,7 +1185,7 @@ class TcgStatics {
       ) && (
           filter == null || filter.call(it)
       )
-    )
+    }
 
     if (params.info && params.repText) {
       failMessage = params.info

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1172,22 +1172,20 @@ class TcgStatics {
     def hasPokeCnt = 0
     [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV, params.hasPokemonVMAX].each{hasPokeCnt += 1}
 
-    def areaFilter = {
-      if (filter == null) { true } else {
-        (
-          if (params.hasType) {it.types.contains(params.hasType)} else {true}
-        ) && (
-          if (!hasPokeCnt) {true} else {
-            (params.hasPokemonEX && it.pokemonEX) ||
-            (params.hasPokemonGX && it.pokemonGX) ||
-            (params.hasPokemonV && it.pokemonV) ||
-            (params.hasPokemonVMAX && it.pokemonVMAX)
-          }
-        ) && (
-          filter.call(it)
-        )
-      }
-    }
+    def areaFilter = (
+      (
+          !params.hasType || it.types.contains(params.hasType)
+      ) && (
+          !hasPokeCnt || (
+              (params.hasPokemonEX && it.pokemonEX) ||
+              (params.hasPokemonGX && it.pokemonGX) ||
+              (params.hasPokemonV && it.pokemonV) ||
+              (params.hasPokemonVMAX && it.pokemonVMAX)
+          )
+      ) && (
+          filter == null || filter.call(it)
+      )
+    )
 
     if (params.info + !params.repText) {
       failMessage = params.info

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1160,12 +1160,15 @@ class TcgStatics {
   static void checkAnyBench(params=[:], Closure c, String cText) {
     def checkedBench = params.opp ? opp.bench : my.bench
 
+    def isPokeCnt = 0
+    [params.isEX, params.isGX, params.isV].each{isPokeCnt += 1}
+
     def benchFilter = (
       if (c == null) { true } else {
         (
           if (params.type) {it.types.contains(params.type)} else {true}
         ) && (
-          if (!(params.isEX || params.isEX || params.isV)) {true} else {
+          if (!isPokeCnt) {true} else {
             (params.isEX && it.pokemonEX) ||
             (params.isGX && it.pokemonGX) ||
             (params.isV && it.pokemonV)
@@ -1176,10 +1179,22 @@ class TcgStatics {
       }
     )
 
+    def pokeString = "Pokémon"
+    if (isPokeCnt) (
+      pokeString = ""
+      i = 1
+      [(params.isEX, "Pokémon-EX"), (params.isGX, "Pokémon-GX"), (params.isV, "Pokémon V")].each{
+        if (it[0]) {
+          pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")
+          i += 1
+        }
+      }
+    )
+
     def failMessage = if (params.repText) { cText } else {
       "You" + (params.opp ? "r opponent does" : " do") + "n't have any " + (
         param.type ? params.type.getShortNotation() + " " : ""
-      ) + "Benched Pokémon" + (
+      ) + "Benched $pokeString" + () + (
         if (c != null) {
           " that " + (cText ? cText : "follow the stated condition(s)")
         }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1187,7 +1187,7 @@ class TcgStatics {
       )
     )
 
-    if (params.info + !params.repText) {
+    if (params.info && params.repText) {
       failMessage = params.info
     } else {
       def benchedString = (param.benched ? "Benched " : "")

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1211,7 +1211,7 @@ class TcgStatics {
         pokeString += "Pokémon"
       }
 
-      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any ${benchString}${typeString}${pokeString} that ${params.info ? params.info : "follow the stated condition(s)"}"
+      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any ${benchString + typeString + pokeString} that ${params.info ? params.info : "follow the stated condition(s)"}"
     }
 
     assert checkedArea.any(areaFilter) : failMessage

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1153,7 +1153,7 @@ class TcgStatics {
   //    - Can be used with no arguments, or with a condition and additional text included.
   //    - If a closure is given, it'll check for any "it" element in bench returning true.
   //    - Optional params:
-  //      + type: if set, restricts to benched Pokémon of a single specific type.
+  //      + isType: if set, restricts to benched Pokémon of a single specific type.
   //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
@@ -1166,7 +1166,7 @@ class TcgStatics {
     def benchFilter = (
       if (c == null) { true } else {
         (
-          if (params.type) {it.types.contains(params.type)} else {true}
+          if (params.isType) {it.types.contains(params.isType)} else {true}
         ) && (
           if (!hasPokeCnt) {true} else {
             (params.hasPokemonEX && it.pokemonEX) ||
@@ -1193,7 +1193,7 @@ class TcgStatics {
 
     def failMessage = if (params.repText) { cText } else {
       "You" + (params.opp ? "r opponent does" : " do") + "n't have any " + (
-        param.type ? params.type.getShortNotation() + " " : ""
+        param.isType ? params.isType.getShortNotation() + " " : ""
       ) + "Benched $pokeString" + () + (
         if (c != null) {
           " that " + (cText ? cText : "follow the stated condition(s)")

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1193,8 +1193,7 @@ class TcgStatics {
       def benchedString = (param.benched ? "Benched " : "")
       def typeString = (param.hasType ? "${params.hasType} " : "")
 
-      def pokeString = benchedString + typeString
-
+      def pokeString = ""
       if (hasPokeCnt) {
         i = 1
         [
@@ -1212,7 +1211,7 @@ class TcgStatics {
         pokeString += "Pokémon"
       }
 
-      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any $pokeString that ${params.info ? params.info : "follow the stated condition(s)"}"
+      failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any ${benchString}${typeString}${pokeString} that ${params.info ? params.info : "follow the stated condition(s)"}"
     }
 
     assert checkedArea.any(areaFilter) : failMessage

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1201,7 +1201,7 @@ class TcgStatics {
       )
     }
 
-    assert benchFilter : failMessage
+    assert checkedBench.any{benchFilter} : failMessage
   }
   static void assertMyBench(params=[:], Closure c, String cText) {
     params.opp = false

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1170,7 +1170,7 @@ class TcgStatics {
     def checkedArea = params.benched ? checkedPlayer.benched : checkedPlayer.all
 
     def hasPokeCnt = 0
-    [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV].each{hasPokeCnt += 1}
+    [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV, params.hasPokemonVMAX].each{hasPokeCnt += 1}
 
     def areaFilter = {
       if (filter == null) { true } else {

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1149,17 +1149,21 @@ class TcgStatics {
 
   /* General checks for attacks and abilities */
 
-  //  * assertBench
-  //    - Can be used with no arguments, or with a condition and additional text included.
-  //    - If a closure is given, it'll check for any "it" element in bench returning true.
-  //    - Optional params:
-  //      + isType: if set, restricts to benched Pokémon of a single specific type.
-  //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
-  //      + opp: If true, checks for the opponent's bench instead of "my" bench.
-  //      + repText: If true, cText will override the entire fail message instead of being added at the end.
-
-  
-  static void assertBench(params=[:], Closure c = null, String failMessage = "") {
+  /**
+   *
+   * Does a customized assert with a automated fail message.
+   *
+   * @param params Optional settings that can be added:
+   *   + isType: if set, restricts to benched Pokémon of a single specific type.
+   *   + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
+   *   + opp: If true, checks for the opponent's bench instead of "my" bench.
+   *
+   * @param c Additional condition the filtered benched Pokémon must follow. Defaults to true (so any benched Pokémon).
+   *
+   * @param message Additional text to be put at the end of the assert fail warning. If repText is set to true in params, message will override the entirety of said warning.
+   *
+   */
+  static void assertBench(params=[:], Closure c = null, String message = "") {
     def checkedBench = params.opp ? opp.bench : my.bench
 
     def hasPokeCnt = 0
@@ -1200,15 +1204,15 @@ class TcgStatics {
     )
 
 
-    if (!params.repText) failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!failMessage.equals("") ? failMessage : "follow the stated condition(s)"}"
+    if (!params.repText) message = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!message.equals("") ? message : "follow the stated condition(s)"}"
 
-    assert checkedBench.any{benchFilter} : failMessage
+    assert checkedBench.any{benchFilter} : message
   }
-  static void assertMyBench(params=[:], Closure c = null, String failMessage = "") {
+  static void assertMyBench(params=[:], Closure c = null, String message = "") {
     params.opp = false
     assertBench(params, c, cText)
   }
-  static void assertOppBench(params=[:], Closure c = null, String failMessage = "") {
+  static void assertOppBench(params=[:], Closure c = null, String message = "") {
     params.opp = true
     assertBench(params, c, cText)
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1214,11 +1214,11 @@ class TcgStatics {
   }
   static void assertMyBench(params=[:], Closure c = null) {
     params.opp = false
-    assertBench(params, c, cText)
+    assertBench(params, c)
   }
   static void assertOppBench(params=[:], Closure c = null) {
     params.opp = true
-    assertBench(params, c, cText)
+    assertBench(params, c)
   }
 
   static void cantBeHealed(PokemonCardSet defending){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1154,24 +1154,24 @@ class TcgStatics {
   //    - If a closure is given, it'll check for any "it" element in bench returning true.
   //    - Optional params:
   //      + type: if set, restricts to benched Pokémon of a single specific type.
-  //      + isEX/isGX/isV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
+  //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
   static void assertBench(params=[:], Closure c, String cText) {
     def checkedBench = params.opp ? opp.bench : my.bench
 
-    def isPokeCnt = 0
-    [params.isEX, params.isGX, params.isV].each{isPokeCnt += 1}
+    def hasPokeCnt = 0
+    [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV].each{hasPokeCnt += 1}
 
     def benchFilter = (
       if (c == null) { true } else {
         (
           if (params.type) {it.types.contains(params.type)} else {true}
         ) && (
-          if (!isPokeCnt) {true} else {
-            (params.isEX && it.pokemonEX) ||
-            (params.isGX && it.pokemonGX) ||
-            (params.isV && it.pokemonV)
+          if (!hasPokeCnt) {true} else {
+            (params.hasPokemonEX && it.pokemonEX) ||
+            (params.hasPokemonGX && it.pokemonGX) ||
+            (params.hasPokemonV && it.pokemonV)
           }
         ) && (
           c(it)
@@ -1180,10 +1180,10 @@ class TcgStatics {
     )
 
     def pokeString = "Pokémon"
-    if (isPokeCnt) (
+    if (hasPokeCnt) (
       pokeString = ""
       i = 1
-      [(params.isEX, "Pokémon-EX"), (params.isGX, "Pokémon-GX"), (params.isV, "Pokémon V")].each{
+      [(params.hasPokemonEX, "Pokémon-EX"), (params.hasPokemonGX, "Pokémon-GX"), (params.hasPokemonV, "Pokémon V")].each{
         if (it[0]) {
           pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")
           i += 1

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1189,7 +1189,7 @@ class TcgStatics {
     if (params.info + !params.repText) {
       failMessage = params.info
     } else {
-      def typeString = param.hasType ? " ${params.hasType.getShortNotation()}" : ""
+      def typeString = param.hasType ? " ${params.hasType}" : ""
 
       def pokeString = "${typeString}Pokémon"
       if (hasPokeCnt) (

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1149,7 +1149,7 @@ class TcgStatics {
 
   /* General checks for attacks and abilities */
 
-  //  * checkAnyBench
+  //  * assertBench
   //    - Can be used with no arguments, or with a condition and additional text included.
   //    - If a closure is given, it'll check for any "it" element in bench returning true.
   //    - Optional params:
@@ -1157,7 +1157,7 @@ class TcgStatics {
   //      + isEX/isGX/isV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
-  static void checkAnyBench(params=[:], Closure c, String cText) {
+  static void assertBench(params=[:], Closure c, String cText) {
     def checkedBench = params.opp ? opp.bench : my.bench
 
     def isPokeCnt = 0
@@ -1203,13 +1203,13 @@ class TcgStatics {
 
     assert benchFilter : failMessage
   }
-  static void checkMyBench(params=[:], Closure c, String cText) {
+  static void assertMyBench(params=[:], Closure c, String cText) {
     params.opp = false
-    checkAnyBench(params, c, cText)
+    assertBench(params, c, cText)
   }
-  static void checkOppBench(params=[:], Closure c, String cText) {
+  static void assertOppBench(params=[:], Closure c, String cText) {
     params.opp = true
-    checkAnyBench(params, c, cText)
+    assertBench(params, c, cText)
   }
 
   static void cantBeHealed(PokemonCardSet defending){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1162,7 +1162,7 @@ class TcgStatics {
     ) : (
       if (params.repText) { cText } else {
         (
-          if (params.opp) { "You don't" } else { "Your opponent doesn't" }
+          if (params.opp) { "Your opponent doesn't" } else { "You don't" } 
         ) + " have any Benched Pokémon that " + (
           if (cText) {
             cText

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1154,7 +1154,7 @@ class TcgStatics {
    * Does a customized assert with an automated fail warning.
    *
    * @param params Optional settings that can be added:
-   *   + isType: if set, restricts to benched Pokémon of a single specific type.
+   *   + hasType: If set, restricts to benched Pokémon of a single specific type.
    *   + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
    *   + opp: If true, checks for the opponent's bench instead of "my" bench.
    *
@@ -1173,7 +1173,7 @@ class TcgStatics {
     def benchFilter = (
       if (c == null) { true } else {
         (
-          if (params.isType) {it.types.contains(params.isType)} else {true}
+          if (params.hasType) {it.types.contains(params.hasType)} else {true}
         ) && (
           if (!hasPokeCnt) {true} else {
             (params.hasPokemonEX && it.pokemonEX) ||
@@ -1189,7 +1189,7 @@ class TcgStatics {
     if (!params.repText) {
       failMessage = info
     } else {
-      def typeString = param.isType ? " ${params.isType.getShortNotation()}" : ""
+      def typeString = param.hasType ? " ${params.hasType.getShortNotation()}" : ""
 
       def pokeString = "${typeString}Pokémon"
       if (hasPokeCnt) (

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1210,7 +1210,7 @@ class TcgStatics {
       failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${params.info ? params.info : "follow the stated condition(s)"}"
     }
 
-    assert checkedBench.any{benchFilter} : failMessage
+    assert checkedBench.any(benchFilter) : failMessage
   }
   static void assertMyBench(params=[:], Closure filter = null) {
     params.opp = false

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1157,7 +1157,7 @@ class TcgStatics {
   //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
-  static void assertBench(params=[:], Closure c, String cText) {
+  static void assertBench(params=[:], Closure c = null, String cText = null) {
     def checkedBench = params.opp ? opp.bench : my.bench
 
     def hasPokeCnt = 0
@@ -1191,7 +1191,7 @@ class TcgStatics {
       }
     )
 
-    def failMessage = if (params.repText) { cText } else {
+    def failMessage = if (cText && params.repText) { cText } else {
       "You" + (params.opp ? "r opponent does" : " do") + "n't have any " + (
         param.isType ? params.isType.getShortNotation() + " " : ""
       ) + "Benched $pokeString" + () + (
@@ -1203,11 +1203,11 @@ class TcgStatics {
 
     assert checkedBench.any{benchFilter} : failMessage
   }
-  static void assertMyBench(params=[:], Closure c, String cText) {
+  static void assertMyBench(params=[:], Closure c = null, String cText = null) {
     params.opp = false
     assertBench(params, c, cText)
   }
-  static void assertOppBench(params=[:], Closure c, String cText) {
+  static void assertOppBench(params=[:], Closure c = null, String cText = null) {
     params.opp = true
     assertBench(params, c, cText)
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1153,24 +1153,23 @@ class TcgStatics {
   //    - Can be used with no arguments, or with a condition and additional text included.
   //    - If a closure is given, it'll check for any "it" element in bench returning true.
   //    - Optional params:
+  //      + type: if set, restricts to benched Pokémon of a single specific type.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, instead of adding cText at the end of the assert it'll be the only thing printed.
   static void checkAnyBench(params=[:], Closure c, String cText) {
     def checkedBench = params.opp ? opp.bench : my.bench
     assert (
-      if (c != null) { checkedBench.any{c(it)} } else { checkedBench }
+      if (c != null) {
+        checkedBench.any{ (if (params.type) {it.types.contains(params.type)} else {true}) && c(it)}
+      } else { checkedBench }
     ) : (
-      if (params.repText) { cText } else {
-        (
-          if (params.opp) { "Your opponent doesn't" } else { "You don't" } 
-        ) + " have any Benched Pokémon that " + (
-          if (cText) {
-            cText
-          } else {
-            "follow the stated condition(s)."
-          }
-        )
-      }
+      if (params.repText) {
+          cText
+        } else {
+          "You${params.opp ? "r opponent does" : " do"}n't have any ${param.type ? params.type.getShortNotation() + " " : ""}Benched Pokémon" + (if (c != null) {
+            " that ${cText ? cText : "follow the stated condition(s)"}"
+          })
+        }
     )
   }
   static void checkMyBench(params=[:], Closure c, String cText) {

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1157,7 +1157,9 @@ class TcgStatics {
   //      + hasPokemonEX/hasPokemonGX/hasPokemonV: Can be expanded if needed. All of these unset will have the method search for any Pokémon no matter what, but if even a single one is set true it'll only filter those that are set true as well.
   //      + opp: If true, checks for the opponent's bench instead of "my" bench.
   //      + repText: If true, cText will override the entire fail message instead of being added at the end.
-  static void assertBench(params=[:], Closure c = null, String cText = null) {
+
+  
+  static void assertBench(params=[:], Closure c = null, String failMessage = "") {
     def checkedBench = params.opp ? opp.bench : my.bench
 
     def hasPokeCnt = 0
@@ -1179,11 +1181,17 @@ class TcgStatics {
       }
     )
 
-    def pokeString = "Pokémon"
+    def typeString = param.isType ? " ${params.isType.getShortNotation()}" : ""
+
+    def pokeString = "${typeString}Pokémon"
     if (hasPokeCnt) (
-      pokeString = ""
+      pokeString = "${typeString}"
       i = 1
-      [(params.hasPokemonEX, "Pokémon-EX"), (params.hasPokemonGX, "Pokémon-GX"), (params.hasPokemonV, "Pokémon V")].each{
+      [
+        (params.hasPokemonEX, "Pokémon-EX"),
+        (params.hasPokemonGX, "Pokémon-GX"),
+        (params.hasPokemonV, "Pokémon V")
+      ].each{
         if (it[0]) {
           pokeString += it[1] + (if (i == isPokeCnt) "" else if (i == isPokeCnt-1) " or " else ", ")
           i += 1
@@ -1191,23 +1199,16 @@ class TcgStatics {
       }
     )
 
-    def failMessage = if (cText && params.repText) { cText } else {
-      "You" + (params.opp ? "r opponent does" : " do") + "n't have any " + (
-        param.isType ? params.isType.getShortNotation() + " " : ""
-      ) + "Benched $pokeString" + () + (
-        if (c != null) {
-          " that " + (cText ? cText : "follow the stated condition(s)")
-        }
-      )
-    }
+
+    if (!params.repText) failMessage = "${params.opp ? "Your opponent doesn't" : "You don't"} have any Benched $pokeString that ${!failMessage.equals("") ? failMessage : "follow the stated condition(s)"}"
 
     assert checkedBench.any{benchFilter} : failMessage
   }
-  static void assertMyBench(params=[:], Closure c = null, String cText = null) {
+  static void assertMyBench(params=[:], Closure c = null, String failMessage = "") {
     params.opp = false
     assertBench(params, c, cText)
   }
-  static void assertOppBench(params=[:], Closure c = null, String cText = null) {
+  static void assertOppBench(params=[:], Closure c = null, String failMessage = "") {
     params.opp = true
     assertBench(params, c, cText)
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1172,7 +1172,7 @@ class TcgStatics {
     def hasPokeCnt = 0
     [params.hasPokemonEX, params.hasPokemonGX, params.hasPokemonV].each{hasPokeCnt += 1}
 
-    def benchFilter = (
+    def benchFilter = {
       if (filter == null) { true } else {
         (
           if (params.hasType) {it.types.contains(params.hasType)} else {true}
@@ -1186,7 +1186,7 @@ class TcgStatics {
           filter.call(it)
         )
       }
-    )
+    }
 
     if (params.info + !params.repText) {
       failMessage = params.info

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4583,7 +4583,8 @@ public enum CosmicEclipse implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert opp.bench.findAll { it.pokemonGX || it.pokemonEX } : "Your opponent has no Pokémon-GX or Pokémon-EX in play."
+            //assert opp.bench.findAll { it.pokemonGX || it.pokemonEX } : "Your opponent has no Pokémon-GX or Pokémon-EX in play."
+            checkOppBench(isGX: true, isEX: true)
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "Not enough cards in your hand."
           }
         };

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1560,8 +1560,8 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Once during your turn (before your attack), if this Pokémon is on your Bench, you may have your opponent switch their Active Pokémon with 1 of their Benched Pokémon. If you do, discard all cards attached to this Pokémon and put it on the bottom of your deck."
             actionA {
               checkLastTurn()
-              assert self.benched : "$self is not on the bench."
-              assert opp.bench : "Your opponent has no Benched Pokémon."
+              assert self.benched
+              checkOppBench()//assert opp.bench
               powerUsed()
               sw(opp.active, opp.bench.oppSelect("Choose a new Active Pokémon."))
               self.cards.getExcludedList(self.topPokemonCard).discard()
@@ -2638,7 +2638,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
             energyCost C, C
             attackRequirement {
-              assert opp.bench : "Your opponent has no benched Pokémon."
+              checkOppBench()//assert opp.bench
             }
             onAttack {
               sw(opp.active, opp.bench.select())
@@ -2993,7 +2993,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Your opponent switches their Active Pokémon with 1 of their Benched Pokémon."
             energyCost C
             attackRequirement{
-              assert opp.bench : "Your opponent has no Benched Pokémon."
+              checkOppBench()//assert opp.bench : "Your opponent has no Benched Pokémon."
             }
             onAttack{
               whirlwind()
@@ -3838,7 +3838,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost R, R, L, L
             attackRequirement {
               gxCheck()
-              assert opp.bench : "Opponent does not have any Benched Pokémon."
+              checkOppBench()//assert opp.bench : "Opponent does not have any Benched Pokémon."
             }
             onAttack {
               gxPerform()
@@ -4748,7 +4748,8 @@ public enum CosmicEclipse implements LogicCardInfo {
             }
           }
           playRequirement {
-            assert my.bench
+            //assert my.bench
+            checkMyBench()
           }
         };
       case MISTY_LORELEI_199:
@@ -4800,7 +4801,8 @@ public enum CosmicEclipse implements LogicCardInfo {
           }
           playRequirement{
             assert my.deck : "Your deck is empty."
-            assert my.bench.findAll({ it.types.contains(N) }) : "No [N] Pokémon on your bench."
+            //assert my.bench.findAll({ it.types.contains(N) }) : "No [N] Pokémon on your bench."
+            checkMyBench(repText: true, {it.types.contains(N)}, "You don't have any [N] Benched Pokémon")
           }
         };
       case PROFESSOR_OAK_S_SETUP_201:

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4803,7 +4803,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
             //assert my.bench.findAll({ it.types.contains(N) }) : "No [N] Pokémon on your bench."
-            assertMyBench(repText: true, type: N)
+            assertMyBench(type: N)
           }
         };
       case PROFESSOR_OAK_S_SETUP_201:

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1561,7 +1561,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert self.benched
-              checkOppBench()//assert opp.bench
+              assertOppBench()//assert opp.bench
               powerUsed()
               sw(opp.active, opp.bench.oppSelect("Choose a new Active Pokémon."))
               self.cards.getExcludedList(self.topPokemonCard).discard()
@@ -2638,7 +2638,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon."
             energyCost C, C
             attackRequirement {
-              checkOppBench()//assert opp.bench
+              assertOppBench()//assert opp.bench
             }
             onAttack {
               sw(opp.active, opp.bench.select())
@@ -2993,7 +2993,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Your opponent switches their Active Pokémon with 1 of their Benched Pokémon."
             energyCost C
             attackRequirement{
-              checkOppBench()//assert opp.bench : "Your opponent has no Benched Pokémon."
+              assertOppBench()//assert opp.bench : "Your opponent has no Benched Pokémon."
             }
             onAttack{
               whirlwind()
@@ -3838,7 +3838,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost R, R, L, L
             attackRequirement {
               gxCheck()
-              checkOppBench()//assert opp.bench : "Opponent does not have any Benched Pokémon."
+              assertOppBench()//assert opp.bench : "Opponent does not have any Benched Pokémon."
             }
             onAttack {
               gxPerform()
@@ -4584,7 +4584,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           }
           playRequirement{
             //assert opp.bench.findAll { it.pokemonGX || it.pokemonEX } : "Your opponent has no Pokémon-GX or Pokémon-EX in play."
-            checkOppBench(isGX: true, isEX: true)
+            assertOppBench(isGX: true, isEX: true)
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "Not enough cards in your hand."
           }
         };
@@ -4750,7 +4750,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           }
           playRequirement {
             //assert my.bench
-            checkMyBench()
+            assertMyBench()
           }
         };
       case MISTY_LORELEI_199:
@@ -4803,7 +4803,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
             //assert my.bench.findAll({ it.types.contains(N) }) : "No [N] Pokémon on your bench."
-            checkMyBench(repText: true, type: N)
+            assertMyBench(repText: true, type: N)
           }
         };
       case PROFESSOR_OAK_S_SETUP_201:

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4802,7 +4802,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
             //assert my.bench.findAll({ it.types.contains(N) }) : "No [N] Pokémon on your bench."
-            checkMyBench(repText: true, {it.types.contains(N)}, "You don't have any [N] Benched Pokémon")
+            checkMyBench(repText: true, type: N)
           }
         };
       case PROFESSOR_OAK_S_SETUP_201:

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1662,7 +1662,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost L, C, C
           onAttack {
             damage 90
-            if (defending.topPokemonCard.cardTypes.is(POKEMON_V) || defending.pokemonGX) {
+            if (defending.pokemonV || defending.pokemonGX) {
               damage 90
             }
           }
@@ -2990,7 +2990,7 @@ public enum SwordShield implements LogicCardInfo {
           delayedA{
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
-                if(it.to == self && it.from.topPokemonCard.cardTypes.is(VMAX) && it.from.owner == self.owner.opposite && it.dmg.value && it.notNoEffect) {
+                if(it.to == self && it.from.pokemonVMAX && it.from.owner == self.owner.opposite && it.dmg.value && it.notNoEffect) {
                   bc "Dauntless Shield prevents damage from Pokémon VMAX."
                   it.dmg = hp(0)
                 }

--- a/src/tcgwars/logic/util/PokemonCardSet.java
+++ b/src/tcgwars/logic/util/PokemonCardSet.java
@@ -304,7 +304,7 @@ public class PokemonCardSet implements PokemonStack, Serializable {
 
   public boolean isPokemonV(){
     def topCardTypes = getTopPokemonCard().getCardTypes()
-    return topCardTypes.is(CardType.POKEMON_V) || topCardTypes.is(CardType.POKEMON_VMAX);
+    return topCardTypes.is(CardType.POKEMON_V) || topCardTypes.is(CardType.VMAX);
   }
 
   public boolean isPokemonVMAX(){

--- a/src/tcgwars/logic/util/PokemonCardSet.java
+++ b/src/tcgwars/logic/util/PokemonCardSet.java
@@ -285,7 +285,7 @@ public class PokemonCardSet implements PokemonStack, Serializable {
   public boolean isEX() {
     return getTopPokemonCard().getCardTypes().is(CardType.EX);
   }
-  
+
   public boolean isPokemonEX(){
     return getTopPokemonCard().getCardTypes().is(CardType.POKEMON_EX);
   }
@@ -303,7 +303,8 @@ public class PokemonCardSet implements PokemonStack, Serializable {
   }
 
   public boolean isPokemonV(){
-    return getTopPokemonCard().getCardTypes().is(CardType.POKEMON_V);
+    def topCardTypes = getTopPokemonCard().getCardTypes()
+    return topCardTypes.is(CardType.POKEMON_V) || topCardTypes.is(CardType.POKEMON_VMAX);
   }
 
   public boolean isPokemonVMAX(){

--- a/src/tcgwars/logic/util/PokemonCardSet.java
+++ b/src/tcgwars/logic/util/PokemonCardSet.java
@@ -302,6 +302,14 @@ public class PokemonCardSet implements PokemonStack, Serializable {
     return getTopPokemonCard().getCardTypes().is(CardType.TAG_TEAM);
   }
 
+  public boolean isPokemonV(){
+    return getTopPokemonCard().getCardTypes().is(CardType.POKEMON_V);
+  }
+
+  public boolean isPokemonVMAX(){
+    return getTopPokemonCard().getCardTypes().is(CardType.VMAX);
+  }
+
   public List<Weakness> getWeaknesses(Battleground bg){
     return bg.em().activateGetter(new GetWeaknesses(this));
   }


### PR DESCRIPTION
Placed it in some cards from Cosmic Eclipse as examples.

* ~~Could probably use a "type filter" param, since a couple of cards make use of it (Like N's Resolve in the examples).~~ Already implemented into the draft.
* ~~Another potential param filter could be for "Pokémon ex/LV.X/EX/GX/V/VMAX", since a couple cards search for those specifically (See: Great Catcher CEC 192)~~ Implemented as well, just for EXs/GXs/Vs tho. More can be added later on, if needed, without much trouble.
  - Implemented isPokemonV() and isPokemonVMAX() on PCS for this to work