### PR TITLE
Made some EX-era cards look for that time's definition of "Basic Pokémon" [in play], also a similar thing but for SM-era cards and "Evolution Pokémon"

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -224,7 +224,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 30
-            if (defending.basic) {
+            if (!defending.evolution) {
               apply CONFUSED
             }
           }
@@ -2028,17 +2028,18 @@ public enum CrystalGuardians implements LogicCardInfo {
           onActivate {
             eff1 = delayed{
               before CHECK_ATTACK_REQUIREMENTS, {
-                if(self.active && ef.attacker.basic) {
+                if(self.active && !ef.attacker.evolution) {
                   wcu "Intimidating Armor prevents attack"
                   prevent()
                 }
               }
             }
             eff2 = getter IS_ABILITY_BLOCKED, { Holder h->
-              if (self.active && h.effect.target.basic && h.effect.target.owner == self.owner.opposite && (h.effect.ability instanceof PokePower || h.effect.ability instanceof PokeBody)) {
+              if (self.active && !h.effect.target.evolution && h.effect.target.owner == self.owner.opposite && (h.effect.ability instanceof PokePower || h.effect.ability instanceof PokeBody)) {
                 h.object=true
               }
             }
+            // TODO: Is eff3 needed here?
             eff3 = getter IS_GLOBAL_ABILITY_BLOCKED, {Holder h->
               if (self.active && (h.effect.target as Card).cardTypes.is(BASIC) && h.effect.target.owner == self.owner.opposite) {
                 h.object=true

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1972,7 +1972,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           text "As long as Skarmory is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack."
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (ef.attacker.owner == self.owner.opposite && ef.attacker.basic && self.owner.pbg.all.size() == 1) {
+              if (ef.attacker.owner == self.owner.opposite && !ef.attacker.evolution && self.owner.pbg.all.size() == 1) {
                 wcu "Shining Horn prevents this Pokémon from attacking"
                 prevent()
               }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -583,14 +583,14 @@ public enum Deoxys implements LogicCardInfo {
             text "Prevent all effects, including damage, done to Ninjask by your opponent’s attacks from his or her Basic Pokémon."
             delayedA {
               before null, self, Source.ATTACK, {
-                if (self.owner.opposite.pbg.active.basic && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
+                if (!self.owner.opposite.pbg.active.evolution && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
                   bc "Fast Protection prevents effect"
                   prevent()
                 }
               }
               before APPLY_ATTACK_DAMAGES, {
                 bg.dm().each {
-                  if(it.to == self && it.notNoEffect && it.from.owner != self.owner && it.from.basic ){
+                  if(it.to == self && it.notNoEffect && it.from.owner != self.owner && !it.from.evolution ){
                     it.dmg = hp(0)
                     bc "Fast Protection prevents damage"
                   }
@@ -598,7 +598,7 @@ public enum Deoxys implements LogicCardInfo {
               }
               after ENERGY_SWITCH, {
                 def efs = (ef as EnergySwitch)
-                if(efs.from.basic && efs.from.owner != self.owner && efs.to == self && bg.currentState == Battleground.BGState.ATTACK){
+                if(!efs.from.evolution && efs.from.owner != self.owner && efs.to == self && bg.currentState == Battleground.BGState.ATTACK){
                   discard efs.card
                 }
               }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -293,7 +293,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "As long as Heracross is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack."
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (self.owner.pbg.all.size() == 1 && ef.attacker.owner != self.owner && ef.attacker.basic) {
+              if (self.owner.pbg.all.size() == 1 && ef.attacker.owner != self.owner && !ef.attacker.evolution) {
                 wcu "Shining Horn prevents Basic Pokemon from attacking."
                 prevent()
               }
@@ -2009,7 +2009,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             before BEGIN_TURN, {
               if (self.active) {
                 self.owner.opposite.pbg.bench.each {
-                  if (it.basic) {
+                  if (!it.evolution) {
                     directDamage 10, it
                   }
                 }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -696,7 +696,7 @@ public enum LegendMaker implements LogicCardInfo {
           text "As long as Absol is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack."
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (self.owner.pbg.all.size() == 1 && ef.attacker.owner != self.owner && ef.attacker.basic) {
+              if (self.owner.pbg.all.size() == 1 && ef.attacker.owner != self.owner && !ef.attacker.evolution) {
                 wcu "Shining Horn prevents attack"
                 prevent()
               }
@@ -730,7 +730,7 @@ public enum LegendMaker implements LogicCardInfo {
         pokeBody "Rear Sensor", {
           text "Each player's Active Basic Pokémon (excluding Pokémon-ex) can't use any Poké-Powers."
           getterA (IS_ABILITY_BLOCKED) { Holder h ->
-            if (h.effect.target.basic && h.effect.target.active && !h.effect.target.EX) {
+            if (!h.effect.target.evolution && h.effect.target.active && !h.effect.target.EX) {
               if (h.effect.ability instanceof PokePower) {
                 h.object=true
               }
@@ -1020,7 +1020,7 @@ public enum LegendMaker implements LogicCardInfo {
           text "As long as Pinsir is the only Pokémon you have in play, your opponent's Basic Pokémon can't attack."
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (ef.attacker.owner == self.owner.opposite && ef.attacker.basic && self.owner.pbg.all.size() == 1) {
+              if (ef.attacker.owner == self.owner.opposite && !ef.attacker.evolution && self.owner.pbg.all.size() == 1) {
                 wcu "Shining Horn prevents this Pokémon from attacking"
                 prevent()
               }
@@ -1099,7 +1099,7 @@ public enum LegendMaker implements LogicCardInfo {
           def endTurn = false
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (ef.attacker.owner == self.owner.opposite && self.active && ef.attacker.basic) {
+              if (ef.attacker.owner == self.owner.opposite && self.active && !ef.attacker.evolution) {
                 flip 1, {}, {
                   bc "Pattern Distraction prevented this Pokémon from attacking"
                   endTurn = true
@@ -1668,7 +1668,7 @@ public enum LegendMaker implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 10
-            if (defending.basic) {
+            if (!defending.evolution) {
               cantAttackNextTurn(defending)
             }
           }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -554,7 +554,7 @@ public enum LegendMaker implements LogicCardInfo {
           text "As long as Muk is your Active Pokémon, each player's Pokémon can't use any Poké-Powers."
           delayedA {
             getterA (IS_ABILITY_BLOCKED) { Holder h->
-              if (self.active && h.effect.target.owner != self.owner && !h.effect.target.basic && h.effect.ability instanceof PokePower) {
+              if (self.active && h.effect.target.owner != self.owner && h.effect.ability instanceof PokePower) {
                 h.object=true
               }
             }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -793,8 +793,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
               before BETWEEN_TURNS, {
                 if(self.active){
                   self.owner.opposite.pbg.bench.each{
-                    bc "$it / ${it.basic}"
-                    if(it.basic) directDamage 10, it
+                    bc "$it / ${!it.evolution}"
+                    if(!it.evolution) directDamage 10, it
                   }
                 }
               }
@@ -1149,7 +1149,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 10
-              if(defending.basic) applyAfterDamage PARALYZED
+              if(!defending.evolution) applyAfterDamage PARALYZED
               cantUseAttack thisMove, self
             }
           }
@@ -1397,7 +1397,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             delayedA {
               before APPLY_ATTACK_DAMAGES, {
                 bg.dm().each{
-                  if(it.to == self && it.from.basic && it.notNoEffect && it.dmg.value) {
+                  if(it.to == self && !it.from.evolution && it.notNoEffect && it.dmg.value) {
                     bc "Crust -20"
                     it.dmg -= hp(20)
                   }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -792,14 +792,14 @@ public enum UnseenForces implements LogicCardInfo {
           text "As long as Ursaring is your Active Pokémon, your opponent's Basic Pokémon can't attack or use any Poké-Powers."
           delayedA {
             before CHECK_ATTACK_REQUIREMENTS, {
-              if (self.active && ef.attacker.owner != self.owner && ef.attacker.basic) {
+              if (self.active && ef.attacker.owner != self.owner && !ef.attacker.evolution) {
                 wcu "Intimidating Ring prevents attack"
                 prevent()
               }
             }
           }
           getterA (IS_ABILITY_BLOCKED) { Holder h->
-            if (self.active && h.effect.target.owner != self.owner && h.effect.target.basic && h.effect.ability instanceof PokePower) {
+            if (self.active && h.effect.target.owner != self.owner && !h.effect.target.evolution && h.effect.ability instanceof PokePower) {
               h.object=true
             }
           }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -1565,7 +1565,7 @@ public enum BurningShadows implements LogicCardInfo {
             energyCost F, F
             onAttack {
               damage 60
-              if(defending.evolution) damage 60
+              if(defending.realEvolution) damage 60
             }
           }
           move "Bedrock Breaker", {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2291,7 +2291,7 @@ public enum CelestialStorm implements LogicCardInfo {
             onAttack {
               gxPerform()
               damage 100
-              if(defending.evolution) damage 100
+              if(defending.realEvolution) damage 100
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1430,7 +1430,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             energyCost F, C, C
             onAttack {
               damage 60
-              if(defending.evolution) damage 60
+              if(defending.realEvolution) damage 60
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -797,7 +797,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               delayed{
                 before APPLY_ATTACK_DAMAGES, {
                   bg.dm().each {
-                    if(it.to == self && it.from.evolution && it.dmg.value && it.notNoEffect) {
+                    if(it.to == self && it.from.realEvolution && it.dmg.value && it.notNoEffect) {
                       bc "Frost Wall"
                       it.dmg = hp(0)
                     }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -3845,7 +3845,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost C
             onAttack{
               damage 10
-              if(defending.evolution) damage 50
+              if(defending.realEvolution) damage 50
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2381,7 +2381,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost C
             onAttack {
               damage 30
-              if(defending.evolution) damage 30
+              if(defending.realEvolution) damage 30
             }
           }
           move "Hurricane Punch", {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1497,7 +1497,7 @@ public enum TeamUp implements LogicCardInfo {
             onAttack{
               damage 10
               my.bench.each{
-                if(it.evolution){
+                if(it.realEvolution){
                   damage 50
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -1646,7 +1646,7 @@ public enum UltraPrism implements LogicCardInfo {
             energyCost F
             onAttack {
               damage 60
-              if(defending.evolution) damage 60
+              if(defending.realEvolution) damage 60
             }
           }
           move "Wild Crash", {


### PR DESCRIPTION
Should correct issues with "treat that card as a Basic Pokémon", namely:
* Holon Fossil (HP 86)
* Anorith (LM 29)
* Strange Cave (LM 77)
* Omanyte (PK 56)

Many cards across the EX-era files were coded using `pcs.basic`, while many others used `!pcs.evolution`. Checking around, the correct definition for these attacks would be "Basic Pokémon [in Play]: Not an evolved card". There's no need to add/remove "BASIC" or "STAGE 1" cardTypes, the bottom intent of that text in the above cards' effect is not considering them as evolved. On the opposite side of the spectrum, Baby cards using "Baby Evolution" make the Basic put on top of them count as an evolved Pokémon, even though being a Basic Pokémon _card_:

> Q. Say I use my Pichu's "Baby Evolution" power to evolve Pichu into Pikachu, which is now an "evolved Basic Pokémon". Can I then play [Rare Candy](https://pkmncards.com/card/rare-candy-emerald-em-83/) on my Pikachu to evolve it into Raichu or Raichu-EX during the same turn?
>
> A. Since Pikachu would be considered an "Evolved Pokémon" at that point, Rare Candy cannot be used on that Pikachu. Rare Candy can only be used on "non-Evolved" Pokémon. (Apr 14, 2005 PUI Rules Team)

DP-era onwards, the term "Basic Pokémon" is now used for actual "BASIC" cards on top, so those should indeed work with `pcs.basic` as they already do:

> Q. If I have Uxie, Azelf, and Mesprit with the "Downer Material" Poke-BODY in play, and my opponent has a Snorlax evolved from a Munchlax in play, do they have to pay more for the evolved Basic Pokemon's attacks?
> 
> A. Yes, they do. While Snorlax is evolved it is still a Basic Pokemon card, and that is what Downer Material is looking at. (May 27, 2010 PUI Rules Team)

Likewise, checks for what in EX-era were called "Basic Pokémon [in Play]" now use the phrase "that isn't an evolved Pokémon". See: Mewtwo LV.X's Psybarrier.

As a reminder to myself, last commit includes changes for the EX Deoxys set in particular. There's another PR (#583) with changes for that set, so assuming both are good to merge it might be needed to rebase whichever is accepted last :P 

---

Also, just pushed updates for SM-era sets regarding "Evolution Pokémon". This term was added around the BW/XY era, with cards like craddily placing Stage 1 and 2 Pokémon in play. More notorious example being Breakpoint's Frogadier with "Shadow Duplicates":

> Glaceon-EX's "Crystal Ray" attack makes it immune to damage done by attacks from "Evolution Pokemon". This is a new term that means any Pokemon that is an evolution card. So a Stage 1 Frogadier brought to the Bench by "Water Duplicates" would be affected by this. Basic Pokemon and Restored Pokemon are not affected. (Fates Collide FAQ; May 5, 2016 TPCi Rules Team)

The cards updated all refer to "Evolution Pokémon", and so they should use the method `pcs.realEvolution`, instead of the current `pcs.evolution`. Cards from this era looking for "Basic Pokémon" all look for `pcs.basic` already, so no need for changes there.