### PR TITLE
New special energy fix

### DIFF
--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3356,7 +3356,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         }
       };
       case HEAT_FIRE_ENERGY_184:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "This card provides 1 [R] Energy while it’s attached to a Pokémon. If this card is attached to a [R] Pokémon, its maximum HP is increased by 20."
         onPlay {reason->
         }
@@ -3368,7 +3368,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         }
       };
       case HIDE_DARKNESS_ENERGY_185:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon, it provides [D] Energy. The Retreat Cost of the [D] Pokémon this card is attached to is 0."
         onPlay {reason->
         }
@@ -3380,7 +3380,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         }
       };
       case POWERFUL_COLORLESS_ENERGY_186:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon, it provides [C] Energy. The attacks of the [C] Pokémon this card is attached to do 20 more damage to your opponent’s Active Pokémon."
         onPlay {reason->
         }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3981,7 +3981,7 @@ public enum RebelClash implements LogicCardInfo {
         }
       };
       case HORROR_PSYCHIC_ENERGY_172:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "This card provides 1 [P] Energy while it’s attached to a Pokemon. When the [P] Pokemon this card is attached to is your Active Pokemon and is damaged by an opponents attack, put 2 damage counters on the Attacking Pokemon."
         def eff
         onPlay { reason->
@@ -4005,7 +4005,7 @@ public enum RebelClash implements LogicCardInfo {
         }
       };
       case SPEED_LIGHTNING_ENERGY_173:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "This card provides 1 [L] Energy while it’s attached to a Pokemon. When you attach this card from your hand to an [L] Pokemon, draw 2 cards"
         onPlay {reason->
           if (reason == PLAY_FROM_HAND && self.types.contains(L)) {


### PR DESCRIPTION
The new gen of special energys shouldn't provide energy unless they are attached to the correct type of pokemon. I wasn't sure before but powerful C energy shows why this is important. Leaving as a draft because merge conflicts and because im not sure if the engine will like energy with empty lists.