### PR TITLE
Sylveon CEC155: Remove seemingly non-working check

### DIFF
--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3716,7 +3716,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           globalAbility {
             delayed {
               after PLAY_SUPPORTER, {
-                if(ef.reason == PLAY_FROM_HAND && ef.cardToPlay.cardTypes.is(TAG_TEAM) && bg.currentTurn == self.owner) {
+                if(ef.cardToPlay.cardTypes.is(TAG_TEAM) && bg.currentTurn == self.owner) {
                   bg.em().storeObject("last_tag_team_supporter_play_turn", bg.turnCount)
                 }
               }


### PR DESCRIPTION
Although it'd be more correct to ensure the supporter card is played from hand, I think that is the part of this check that is failing. If this fixes it not applying the damage then this solution should work well enough for now.