### PR TITLE
DAB: Fix Powerful [C] Energy, Implemented some trainers

### DIFF
--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3313,7 +3313,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           my.deck.add(0, card)
         }
         playRequirement{
-          assert my.deck.notEmpty
+          assert my.deck.notEmpty : "Your deck is empty"
         }
       };
       case MOUNTAINOUS_SMOKE_179:


### PR DESCRIPTION
Powerful [C] should now provide [C] when attached.