### PR TITLE
Fixed Umbreon ex's Black Cry

### DIFF
--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2782,7 +2782,7 @@ public enum UnseenForces implements LogicCardInfo {
             cantRetreat(defending)
             delayed {
               getter (IS_ABILITY_BLOCKED) { Holder h->
-                if (h.effect.ability instanceof PokePower) {
+                if (h.effect.target.owner != self.owner && h.effect.target.active && h.effect.ability instanceof PokePower) {
                   h.object = true
                 }
               }


### PR DESCRIPTION
Black Cry no longer blocks all of opponent's PokePowers, just their active's.