### PR TITLE
CELEBI_SM224 Fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -3067,7 +3067,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
               def cards = my.deck.search(info, filter)
               cards.each {card->
-                selected.add card
+                card.moveTo selected
                 names.add card.name
               }
             }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -3057,7 +3057,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             assert my.deck : "Your deck is empty"
           }
           onAttack {
-            def selected = []
+            def selected = new CardList()
             def names = []
             3.times {n ->
               if(selected.size() < n) return


### PR DESCRIPTION
`[]` is an ArrayList by default. Explicitly create an empty `CardList`.
Pokémon was still in the same position in deck after the selection. Try to explicitly move it to the new `CardList` instead of just adding to the list. May need to add `hidden` key to this.