### PR TITLE
Ensure Special Energy show proper types

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2674,10 +2674,14 @@ public enum Deoxys implements LogicCardInfo {
             to.evolution && !to.EX
           }
           getEnergyTypesOverride{
-            if(self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size())
+            if(self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
+              owner.typeImagesOverride = [RAINBOW, RAINBOW, RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            else
+            }
+            else {
+              owner.typeImagesOverride = [C]
               return [[C] as Set]
+            }
           }
 
         };

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1959,6 +1959,7 @@ public enum Emerald implements LogicCardInfo {
           def check = {
             if(!it.evolution || it.EX){discard thisCard}
           }
+          typeImagesOverride = [RAINBOW, RAINBOW]
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2426,10 +2426,14 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self == null || self.cards.filterByType(SPECIAL_ENERGY).size() > 1)
+            if(self == null || self.cards.filterByType(SPECIAL_ENERGY).size() > 1) {
+              owner.typeImagesOverride = [C]
               return [[C] as Set]
-            else
+            }
+            else {
+              owner.typeImagesOverride = [RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set]
+            }
           }
         };
       case BLASTOISE_EX_104:

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2412,10 +2412,14 @@ public enum HolonPhantoms implements LogicCardInfo {
           if (!self || !self.topPokemonCard)
             return [[C] as Set]
           boolean cond1 = self.topPokemonCard.cardTypes.is(DELTA)
-          if (cond1)
+          if (cond1) {
+            owner.typeImagesOverride = [RAINBOW]
             return [[R, D, F, G, W, Y, L, M, P, N] as Set]
-          else
+          }
+          else {
+            owner.typeImagesOverride = [C]
             return [[C] as Set]
+          }
         }
       };
       case CRAWDAUNT_EX_99:

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2533,6 +2533,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
       case DARK_METAL_ENERGY_94:
         return specialEnergy (this, [[]]) {
           text "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides [D] Energy and [M] Energy, but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play and has no effect other than providing Energy.)"
+          // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -2192,15 +2192,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           onPlay {}
         };
       case RAINBOW_ENERGY_104:
-        return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P]]) {
-          text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon. (While not in play, Rainbow Energy counts as Colorless Energy.)"
-          typeImagesOverride = [RAINBOW]
-          onPlay {reason->
-            if(reason == PLAY_FROM_HAND){
-              directDamage(10, self)
-            }
-          }
-        };
+        return copy (CelestialStorm.RAINBOW_ENERGY_151, this)
       case AMPHAROS_105:
         return evolution (this, from:"Flaaffy", hp:HP140, type:LIGHTNING, retreatCost:2) {
           weakness F

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3289,6 +3289,7 @@ public enum CelestialStorm implements LogicCardInfo {
       case RAINBOW_ENERGY_151:
         return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon. (While not in play, Rainbow Energy counts as Colorless Energy.)"
+          typeImagesOverride = [RAINBOW]
           onPlay {reason->
             if (reason == PLAY_FROM_HAND) {
               // TODO Change to Source.Energy (doesn't exist yet)

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2423,10 +2423,14 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size())
+            if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
+              owner.typeImagesOverride = [RAINBOW, RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            else
+            }
+            else {
+              owner.typeImagesOverride = [C]
               return [[C] as Set]
+            }
           }
         };
       case GYARADOS_GX_101:

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2756,15 +2756,20 @@ public enum ForbiddenLight implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST))
+            if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)) {
+              owner.typeImagesOverride = [RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set]
-            else
+            }
+            else {
+              owner.typeImagesOverride = [C]
               return [[C] as Set]
+            }
           }
         };
       case UNIT_ENERGY_FDY_118:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\nWhile this card is attached to a Pokémon, it provides [F], [D], and [Y] Energy but provides only 1 Energy at a time."
+          // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3164,18 +3164,25 @@ public enum UltraPrism implements LogicCardInfo {
               return [[C] as Set]
             boolean cond1 = self.topPokemonCard.cardTypes.is(STAGE2)
             boolean cond2 = self.owner.pbg.all.findAll{it.topPokemonCard.cardTypes.is(STAGE2)}.size() >= 3
-            if(cond1 && cond2)
+            if(cond1 && cond2) {
+              owner.typeImagesOverride = [RAINBOW, RAINBOW, RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            else if(cond1)
+            }
+            else if(cond1) {
+              owner.typeImagesOverride = [RAINBOW]
               return [[R, D, F, G, W, Y, L, M, P] as Set]
-            else
+            }
+            else {
+              owner.typeImagesOverride = [C]
               return [[C] as Set]
+            }
           }
 
         };
       case UNIT_ENERGY_GRW_137:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\n While this card is attached to a Pokémon, it provides [G], [W], and [R] Energy but provides only 1 Energy at a time."
+          // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
           }
           onRemoveFromPlay {
@@ -3187,6 +3194,7 @@ public enum UltraPrism implements LogicCardInfo {
       case UNIT_ENERGY_LPM_138:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\n While this card is attached to a Pokémon, it provides [L], [P], and [M] Energy but provides only 1 Energy at a time."
+          // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3968,7 +3968,7 @@ public enum RebelClash implements LogicCardInfo {
         }
       };
       case CAPTURE_ENERGY_171:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "This card provides [C] Energy only while attached to a Pokemon. When attaching this card from your hand to 1 of your Pokemon, search your deck for a Basic Pokemon and put it on your Bench. Then, shuffle your deck."
         onPlay {reason->
           if (my.deck && my.bench.notFull) {
@@ -3978,6 +3978,9 @@ public enum RebelClash implements LogicCardInfo {
             }
             shuffleDeck()
           }
+        }
+        getEnergyTypesOverride {
+          return [[C] as Set]
         }
       };
       case HORROR_PSYCHIC_ENERGY_172:

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -3581,6 +3581,7 @@ public enum SwordShield implements LogicCardInfo {
       return specialEnergy (this, [[C]]) {
         text "You can attach this card to 1 of your Pokémon only if you discard another card from your hand." +
           "As long as this card is attached to a Pokémon, it provides every type of Energy but provides only 1 Energy at a time."
+        typeImagesOverride = [RAINBOW]
         onPlay {reason->
           if (reason == PLAY_FROM_HAND) {
             my.hand.getExcludedList(thisCard).select("Select a card to discard.").discard()


### PR DESCRIPTION
Also left a couple TODOs to request appropriate images
for some of the cards that provide more than one type,
but do not provide RAINBOW.

In theory `owner` should be the closure above the current closure. If this doesn't work, I have several other ideas to attempt this.

Also changed HGSS Rainbow to a copy of CES Rainbow since I'm done testing with it and having only one implementation is probably a good idea. I changed Capture energy to not have a type while not attached to a Pokémon (according to card text) and added a getEnergyTypesOverride for it to provide its C energy.