### PR TITLE
RCL, SSH - Fix special energies

### DIFF
--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3977,7 +3977,8 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          return [[C] as Set]
+          if (self) return [[C] as Set]
+          else return [[] as Set]
         }
       };
       case HORROR_PSYCHIC_ENERGY_172:
@@ -3998,7 +3999,8 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          return[[P] as Set]
+          if (self) return[[P] as Set]
+          else return [[] as Set]
         }
         onRemoveFromPlay {
           eff.unregister()
@@ -4013,11 +4015,12 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          return[[L] as Set]
+          if (self) return [[L] as Set]
+          else return [[] as Set]
         }
       };
       case TWIN_ENERGY_174:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[C, C]]) {
         text "This card provides 2 [C] Energy. If this card is attached to a Pokemon V or Pokemon GX, this card provides 1 [C] Energy instead."
         onPlay {reason->
         }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -3578,7 +3578,7 @@ public enum SwordShield implements LogicCardInfo {
         }
       };
       case AURORA_ENERGY_186:
-      return specialEnergy (this, [[C]]) {
+      return specialEnergy (this, [[]]) {
         text "You can attach this card to 1 of your Pokémon only if you discard another card from your hand." +
           "As long as this card is attached to a Pokémon, it provides every type of Energy but provides only 1 Energy at a time."
         typeImagesOverride = [RAINBOW]
@@ -3588,11 +3588,8 @@ public enum SwordShield implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          if (self != null) {
-            return [[R, D, F, G, W, Y, L, M, P] as Set]
-          } else {
-            return [[C] as Set]
-          }
+          if (self) return [[R, D, F, G, W, Y, L, M, P] as Set]
+          else return [[] as Set]
         }
         allowAttach {to->
           to.owner.pbg.hand.getExcludedList(thisCard).size() >= 1


### PR DESCRIPTION
Special energies that are supposed to only provide energy while
being attached to a Pokemon now do so properly.

Twin Energy now also "provides" 2 C energy while not attached instead of just 1 C.