### PR TITLE
SUIC_39 DAB - Allow proper cost choice

### DIFF
--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -1082,12 +1082,19 @@ public enum DarknessAblaze implements LogicCardInfo {
           onAttack {
             damage 130
             afterDamage {
+              // TODO: Make a static method to do this
               def targetCount = Math.min self.cards.energyCount(W), 2
               def finalCount = 0
-              while (finalCount < targetCount) {
+              while (self.cards.energyCount(W) > 0 && finalCount < targetCount) {
                 def info = "Select [W] Energy to return to your hand."
                 def energy = self.cards.findAll {energyFilter W}.select(info)
-                finalCount += energy.energyCount W
+                def energyCount = 1
+                if (energy.energyCount(W) > 1) {
+                  def choices = 1..energy.energyCount(W)
+                  def choiceInfo = "How many Energy do you want this card to count as?"
+                  energyCount = choose(choices, choices, choiceInfo)
+                }
+                finalCount += energyCount
                 energy.moveTo my.hand
               }
             }


### PR DESCRIPTION
When using energy providing multiple values you should be able to
choose how many of the provided energy count towards the cost
mentioned in the attack text.

Ex: With two Counter Energy attached while behind on prizes you
should be able to choose to discard both Counter Energy instead
of being forced to choose only one of them.