### PR TITLE
Mark as basic alternative

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2571,12 +2571,12 @@ public enum Deoxys implements LogicCardInfo {
           def eff2
           onPlay {
             eff1 = getter IS_ABILITY_BLOCKED, { Holder h->
-              if (h.effect.ability instanceof PokeBody && h.effect.target.basic && !h.effect.target.EX && !h.effect.target.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {
+              if (h.effect.ability instanceof PokeBody && h.effect.target.notEvolution && !h.effect.target.EX && !h.effect.target.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {
                 h.object=true
               }
             }
             eff2 = getter IS_GLOBAL_ABILITY_BLOCKED, {Holder h->
-              if (h.effect.ability instanceof PokeBody && h.effect.target.basic && !h.effect.target.EX && !h.effect.target.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {
+              if (h.effect.ability instanceof PokeBody && h.effect.target.notEvolution && !h.effect.target.EX && !h.effect.target.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {
                 h.object=true
               }
             }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2514,7 +2514,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
         return basicTrainer (this) {
           text "Search your deck for a Basic Pokémon (excluding Pokémon-ex) and switch it with 1 of your Basic Pokémon (excluding Pokémon-ex) in play. (Any cards attached to that Pokémon, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Place the first Basic Pokémon in the discard pile. Shuffle your deck afterward."
           onPlay {
-            def pcs = my.all.findAll{it.topPokemonCard.cardTypes.is(BASIC) && it.topPokemonCard.cardTypes.isNot(EX)}.select()
+            def pcs = my.all.findAll{it.notEvolution && it.topPokemonCard.cardTypes.isNot(EX)}.select()
             def tpc = pcs.topPokemonCard
             def selected = my.deck.search(max:1,"Select a Basic Pokémon (excluding Pokémon-ex)",{it.cardTypes.is(BASIC) && it.cardTypes.isNot(EX)})
             if (selected) {
@@ -2524,7 +2524,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.all.findAll {it.topPokemonCard.cardTypes.is(BASIC) && it.topPokemonCard.cardTypes.isNot(EX)} : "No basic in play"
+            assert my.all.findAll {it.notEvolution && it.topPokemonCard.cardTypes.isNot(EX)} : "No basic in play"
           }
         };
       case VENTURE_BOMB_93:


### PR DESCRIPTION
Based on various rulings it seems that in Generation 3 and earlier, if a Pokémon card is in play it is considered Basic if it is not evolved. The Basic type on the card only matters while not in play. Generation 4 and on strictly goes by the card saying Basic on it.

These changes bring a few more cards that were checking for the cardType in line with this belief. This should mean that the cards STRANGE_CAVE, and ANORITH from Legend Maker, HOLON_FOSSIL from Holon Phantoms, and OMANYTE from Power Keepers should work as intended with the cards used in their original format.

However, this will be the first time notEvolution has been used in the codebase, so it may not work and need to be replaced with `![...].evolution`