### PR TITLE
Fix energy icons not updating early enough

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2662,6 +2662,8 @@ public enum Deoxys implements LogicCardInfo {
           def check = {
             if(!it.evolution || it.EX){discard thisCard}
           }
+          def provides3Rainbow = {self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()}
+          typeImagesOverride = provides3Rainbow() ? [RAINBOW, RAINBOW, RAINBOW] : [C]
           onPlay {reason->
             eff = delayed {
               after EVOLVE, self, {check(self)}
@@ -2677,14 +2679,9 @@ public enum Deoxys implements LogicCardInfo {
             to.evolution && !to.EX
           }
           getEnergyTypesOverride{
-            if(self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              owner.typeImagesOverride = [RAINBOW, RAINBOW, RAINBOW]
+            if(provides3Rainbow())
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            }
-            else {
-              owner.typeImagesOverride = [C]
-              return [[C] as Set]
-            }
+            else return [[C] as Set]
           }
 
         };

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2422,6 +2422,8 @@ public enum FireRedLeafGreen implements LogicCardInfo {
       case MULTI_ENERGY_103:
         return specialEnergy (this, [[C]]) {
           text "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) Multi Energy provides [C] Energy when attached to a Pokémon that already has Special Energy cards attached to it."
+          def providesRainbow = {self && self.cards.filterByType(SPECIAL_ENERGY).size() == 0}
+          typeImagesOverride = providesRainbow() ? [RAINBOW] : [C]
           onPlay {reason->
           }
           onRemoveFromPlay {
@@ -2429,14 +2431,8 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self == null || self.cards.filterByType(SPECIAL_ENERGY).size() > 1) {
-              owner.typeImagesOverride = [C]
-              return [[C] as Set]
-            }
-            else {
-              owner.typeImagesOverride = [RAINBOW]
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
-            }
+            if(providesRainbow()) return [[R, D, F, G, W, Y, L, M, P] as Set]
+            else return [[C] as Set]
           }
         };
       case BLASTOISE_EX_104:

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2413,22 +2413,15 @@ public enum HolonPhantoms implements LogicCardInfo {
       case DELTA_RAINBOW_ENERGY_98:
       return specialEnergy (this, [[C]]) {
         text "δ Rainbow Energy provides [C] Energy. While attached to a Pokémon that has δ on its card, δ Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)"
+        def providesRainbow = {self && self.topPokemonCard.cardTypes.is(DELTA)}
+        typeImagesOverride = providesRainbow() ? [RAINBOW] : [C]
         onPlay {reason->
         }
         onRemoveFromPlay {
         }
         getEnergyTypesOverride {
-          if (!self || !self.topPokemonCard)
-            return [[C] as Set]
-          boolean cond1 = self.topPokemonCard.cardTypes.is(DELTA)
-          if (cond1) {
-            owner.typeImagesOverride = [RAINBOW]
-            return [[R, D, F, G, W, Y, L, M, P, N] as Set]
-          }
-          else {
-            owner.typeImagesOverride = [C]
-            return [[C] as Set]
-          }
+          if (providesRainbow()) return [[R, D, F, G, W, Y, L, M, P, N] as Set]
+          else return [[C] as Set]
         }
       };
       case CRAWDAUNT_EX_99:

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2416,6 +2416,8 @@ public enum CrimsonInvasion implements LogicCardInfo {
       case COUNTER_ENERGY_100:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\nIf you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn't a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time"
+          def provides2Rainbow = {self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()}
+          typeImagesOverride = provides2Rainbow() ? [RAINBOW, RAINBOW] : [C]
           onPlay {reason->
           }
           onRemoveFromPlay {
@@ -2423,14 +2425,8 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              owner.typeImagesOverride = [RAINBOW, RAINBOW]
-              return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            }
-            else {
-              owner.typeImagesOverride = [C]
-              return [[C] as Set]
-            }
+            if(provides2Rainbow()) return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+            else return [[C] as Set]
           }
         };
       case GYARADOS_GX_101:

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2747,6 +2747,8 @@ public enum ForbiddenLight implements LogicCardInfo {
         return specialEnergy (this, [[C]]) {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\nThis card provides [C] Energy.\nWhile this card is attached to an Ultra Beast, it provides every type of Energy but provides only 1 Energy at a time. The attacks of the Ultra Beast this card is attached to do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
           def eff
+          def providesRainbow = {self && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)}
+          typeImagesOverride = providesRainbow() ? [RAINBOW] : [C]
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
@@ -2765,14 +2767,8 @@ public enum ForbiddenLight implements LogicCardInfo {
           onMove {to->
           }
           getEnergyTypesOverride{
-            if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)) {
-              owner.typeImagesOverride = [RAINBOW]
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
-            }
-            else {
-              owner.typeImagesOverride = [C]
-              return [[C] as Set]
-            }
+            if(providesRainbow()) return [[R, D, F, G, W, Y, L, M, P] as Set]
+            else return [[C] as Set]
           }
         };
       case UNIT_ENERGY_FDY_118:

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3155,27 +3155,18 @@ public enum UltraPrism implements LogicCardInfo {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\n" +
             "This card provides [C] Energy.\n" +
             "While this card is attached to a Stage 2 Pokémon, it provides every type of Energy but provides only 1 Energy at a time. If you have 3 or more Stage 2 Pokémon in play, it provides every type of Energy but provides 4 Energy at a time."
+          def cond1 = {self && self.topPokemonCard.cardTypes.is(STAGE2)}
+          def cond2 = {self.owner.pbg.all.findAll{it.topPokemonCard.cardTypes.is(STAGE2)}.size() >= 3}
+          typeImagesOverride = (cond1() && cond2()) ? [RAINBOW, RAINBOW, RAINBOW] : cond1() ? [RAINBOW] : [C]
           onPlay {reason->
           }
           onRemoveFromPlay {
           }
           getEnergyTypesOverride {
-            if(!self || !self.topPokemonCard)
-              return [[C] as Set]
-            boolean cond1 = self.topPokemonCard.cardTypes.is(STAGE2)
-            boolean cond2 = self.owner.pbg.all.findAll{it.topPokemonCard.cardTypes.is(STAGE2)}.size() >= 3
-            if(cond1 && cond2) {
-              owner.typeImagesOverride = [RAINBOW, RAINBOW, RAINBOW]
+            if(cond1() && cond2()) 
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
-            }
-            else if(cond1) {
-              owner.typeImagesOverride = [RAINBOW]
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
-            }
-            else {
-              owner.typeImagesOverride = [C]
-              return [[C] as Set]
-            }
+            else if(cond1()) return [[R, D, F, G, W, Y, L, M, P] as Set]
+            else return [[C] as Set]
           }
 
         };


### PR DESCRIPTION
Using the owner property of the getEnergyTypesOverride closure was a neat idea, unfortunately it doesn't get called often enough to stay updated properly it seems. This _should_ show the right icons, and hopefully be updated at the right times.