### PR TITLE
NINE_D_8 DF - Must have Vulpix underneath

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -449,6 +449,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "Once during your turn (before your attack), you may remove 4 damage counters from Ninetales and discard Ninetales from Vulpix. If you do, search your deck for Ninetales or Ninetales ex and put it onto Vulpix (this counts as evolving Vulpix). Shuffle your deck afterward."
           actionA {
             checkLastTurn()
+            assert self.cards.any {it.name == "Vulpix"} : "You must be able to leave a Vulpix in play"
             powerUsed()
             heal 40, self
 


### PR DESCRIPTION
Relevant Ruling:
    Q. If Garchomp Lv.X uses its "Restore" to bring up Ninetales
    (Delta Species) from the discard pile, can Ninetales use its
    "Volunteer" Poke-POWER to find another Ninetales or Ninetales-EX?
    A. No. The Volunteer Poke-POWER must be able to leave a Vulpix in
    play. (May 29, 2008 PUI Rules Team)