### PR TITLE
General DAB: Alter self energy after damage, opponent before

### DIFF
--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -597,12 +597,10 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 100
-            afterDamage {
-              if (confirm("Return an Energy attached to the Active $opp.active.name to your opponent's hand?")) {
-                def info = "Select the Energy to return to the opponent's hand."
-                def selectedEnergy = defending.cards.filterByType(ENERGY).select info
-                if (selectedEnergy) selectedEnergy.moveTo opp.hand
-              }
+            if (confirm("Return an Energy attached to the Active $opp.active.name to your opponent's hand?")) {
+              def info = "Select the Energy to return to the opponent's hand."
+              def selectedEnergy = defending.cards.filterByType(ENERGY).select info
+              if (selectedEnergy) selectedEnergy.moveTo opp.hand
             }
           }
         }
@@ -705,11 +703,11 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 120
-            afterDamage {
-              if (self.cards.energyCount(C)) {
+            if (self.cards.energyCount(C)) {
+              afterDamage {
                 discardSelfEnergy C
-                discardDefendingEnergy()
               }
+              discardDefendingEnergy()
             }
           }
         }
@@ -790,7 +788,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 130
-            attachEnergyFrom basic:true, my.discard, my.bench
+            afterDamage {
+              attachEnergyFrom basic:true, my.discard, my.bench
+            }
           }
         }
       };
@@ -897,7 +897,9 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 110
             def info = "Discard all [W] Energy from this Pokémon to do 60 more damage?"
             if (self.cards.energyCount(W) && confirm(info)) {
-              discardAllSelfEnergy W
+              afterDamage {
+                discardAllSelfEnergy W
+              }
               damage 60
             }
           }
@@ -986,7 +988,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           onAttack {
             damage 20
             if (self.cards.energyCount(C) && confirm("Discard an Energy from $self.name to discard an energy from $defending.name?")) {
-              discardSelfEnergy C
+              afterDamage {
+                discardSelfEnergy C
+              }
               discardDefendingEnergy()
             }
           }
@@ -1438,7 +1442,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 50
-            discardAllSelfEnergy()
+            afterDamage {
+              discardAllSelfEnergy()
+            }
           }
         }
       };
@@ -2303,9 +2309,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 80
-            afterDamage{
-              discardDefendingEnergy()
-            }
+            discardDefendingEnergy()
           }
         }
         move "Heavy Rock Cannon", {
@@ -2355,7 +2359,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 130
-            discardSelfEnergy F
+            afterDamage {
+              discardSelfEnergy F
+            }
           }
         }
       };


### PR DESCRIPTION
Altering your own Energy while attacking happens after damage. Altering your opponent's Energy happens before damage. This is a quick PR to ensure this happens. Relevant mainly for Tsareena and returning Horror Energy to hand, and Zygarde with discarding Strong Energy while attacking.

Also attempting to use `afterDamage` inside of `if` statements to ensure this without breaking the flow of the code forcing you to reference back and forth. I don't forsee this breaking anything, but want to make sure this wasn't attempted before and ended up breaking something.

Relevant Rulings:
> Q. If I have Strong Energy attached to a Fighting type Pokemon and use an attack that says to discard an energy, do I get the bonus damage from Strong Energy before I discard it or not?
A. Yes, you do. (Furious Fists FAQ; Aug 28, 2014 TPCi Rules Team)

> Q. If I use an attack that says to "discard an Energy attached to your opponent's Active Pokemon" and I choose to discard their "Dangerous Energy" card, would I still receive the 2 damage counters from "Dangerous Energy" or not?
A. You would not receive the 2 damage counters. (Ancient Origins FAQ; Aug 13, 2015 TPCi Rules Team)