### PR TITLE
Multiple Fixes (EX, SSH, DAB, UPR+FLI)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1693,7 +1693,7 @@ public enum Emerald implements LogicCardInfo {
           def eff
           onPlay {
             eff = getter IS_ABILITY_BLOCKED, { Holder h->
-              if (h.effect.target.evolution && (h.effect.ability instanceof PokeBody || h.effect.ability instanceof PokePower) && (h.effect.target.types.contains(C) || h.effect.target.types.contains(D) || h.effect.target.types.contains(M))) {
+              if (h.effect.target.evolution && (h.effect.ability instanceof PokeBody || h.effect.ability instanceof PokePower || h.effect.ability instanceof PokemonPower) && (h.effect.target.types.contains(C) || h.effect.target.types.contains(D) || h.effect.target.types.contains(M))) {
                 h.object=true
               }
             }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1835,7 +1835,7 @@ public enum PowerKeepers implements LogicCardInfo {
         }
       };
       case PROFESSOR_BIRCH_80:
-      return copy(Deoxys.PROFESSOR_BIRCH_82, this);
+      return copy(Emerald.PROFESSOR_BIRCH_82, this);
       case SCOTT_81:
       return copy(Emerald.SCOTT_84, this);
       case SIDNEY_S_STADIUM_82:

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2978,8 +2978,8 @@ public enum DiamondPearl implements LogicCardInfo {
                   validPokemon = thisCard.player.pbg.all.findAll{it.topPokemonCard.name == thisCard.name && !it.topPokemonCard.cardTypes.is(LEVEL_UP)}
                 }
               }*/
-              before EVOLVE_STANDARD, {
-                if (ef.cardToPlay == thisCard) {
+              before EVOLVE, {
+                if ((ef.evolutionCard as Card) == thisCard) {
                    if (ef.pokemonToBeEvolved.topPokemonCard.cardTypes.is(LEVEL_UP)){
                      wcu "You can't level up a LV.X Pokémon."
                      prevent()
@@ -3054,8 +3054,8 @@ public enum DiamondPearl implements LogicCardInfo {
                   validPokemon = thisCard.player.pbg.all.findAll{it.topPokemonCard.name == thisCard.name && !it.topPokemonCard.cardTypes.is(LEVEL_UP)}
                 }
               }*/
-              before EVOLVE_STANDARD, {
-                if (ef.cardToPlay == thisCard) {
+              before EVOLVE, {
+                if ((ef.evolutionCard as Card) == thisCard) {
                    if (ef.pokemonToBeEvolved.topPokemonCard.cardTypes.is(LEVEL_UP)){
                      wcu "You can't level up a LV.X Pokémon."
                      prevent()
@@ -3118,8 +3118,8 @@ public enum DiamondPearl implements LogicCardInfo {
                   validPokemon = thisCard.player.pbg.all.findAll{it.topPokemonCard.name == thisCard.name && !it.topPokemonCard.cardTypes.is(LEVEL_UP)}
                 }
               }*/
-              before EVOLVE_STANDARD, {
-                if (ef.cardToPlay == thisCard) {
+              before EVOLVE, {
+                if ((ef.evolutionCard as Card) == thisCard) {
                    if (ef.pokemonToBeEvolved.topPokemonCard.cardTypes.is(LEVEL_UP)){
                      wcu "You can't level up a LV.X Pokémon."
                      prevent()

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -2212,7 +2212,7 @@ public enum RisingRivals implements LogicCardInfo {
           onPlay {
             def src = my.all.findAll{it.cards.filterByType(ENERGY)}.select("Select Pokemon to move energy from").first()
             def energyList = src.cards.filterByType(ENERGY).select(min:1, "Choose energy cards to move")
-            tar = my.all.getExcludedList(src).select("Choose Pokemon to move energy cards to").first()
+            tar = my.all.findAll{it != src}.select("Choose Pokemon to move energy cards to").first()
             energyList.each {
               energySwitch(src, tar, it)
             }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1083,7 +1083,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           resistance FIGHTING, MINUS20
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>8)
               def list=[]
               for(move in h.object){

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -540,13 +540,13 @@ public enum UltraPrism implements LogicCardInfo {
           weakness FIRE
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, NORMAL,self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){
                 def copy=move.shallowCopy()
                 if(toolReq){
-                  copy.energyCost.clear()
+                  copy.energyCost.retainAll()
                 }
                 list.add(copy)
               }
@@ -755,7 +755,7 @@ public enum UltraPrism implements LogicCardInfo {
           weakness WATER
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){
@@ -1088,7 +1088,7 @@ public enum UltraPrism implements LogicCardInfo {
           weakness GRASS
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){
@@ -1118,7 +1118,7 @@ public enum UltraPrism implements LogicCardInfo {
           weakness METAL
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){
@@ -1330,7 +1330,7 @@ public enum UltraPrism implements LogicCardInfo {
           resistance METAL, MINUS20
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){
@@ -2712,7 +2712,7 @@ public enum UltraPrism implements LogicCardInfo {
           resistance FIGHTING, MINUS20
           bwAbility "Roto Motor", {
             text "If you have 9 or more Pokémon Tool cards in your discard pile, ignore all Energy in the attack cost of each of this Pokémon’s attacks."
-            getterA GET_MOVE_LIST, self, {h->
+            getterA GET_MOVE_LIST, BEFORE_LAST, self, {h->
               def toolReq = (my.discard.filterByType(POKEMON_TOOL).size()>=9)
               def list=[]
               for(move in h.object){

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3533,7 +3533,7 @@ public enum DarknessAblaze implements LogicCardInfo {
                 if (!src) break;
                 def card=src.cards.filterByType(ENERGY).select("Energy to move").first()
 
-                def tar=my.all.getExcludedList(src).select("Target for energy (cancel to stop)", false)
+                def tar=my.all.findAll{it != src}.select("Target for energy (cancel to stop)", false)
                 if (!tar) break;
                 energySwitch(src, tar, card)
               }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1855,6 +1855,7 @@ public enum SwordShield implements LogicCardInfo {
           text "As often as you like during your turn, you may move 1 damage counter from 1 of your [P] Pokémon to another of your [P] Pokémon."
           actionA {
             assert my.all.find({ it.numberOfDamageCounters > 0 && it.types.contains(P) })
+            powerUsed()
             def source = my.all.findAll { it.numberOfDamageCounters > 0 && it.types.contains(P) }.select("Source for the damage counter?")
             def target = my.all.findAll { it.types.contains(P) }
             target.remove(source)


### PR DESCRIPTION
* Fixed Gengar (SSH) not using powerUsed()
* Fixed a wrong copy in PK
* Fixed an Engine Error in two cards (DAB, RR)
* Attempted a fix for the Roto Motor ability of UPR/FLI Rotoms
* Attempted a fix for LV.X cards in DP-Base.
* Test fix for Nintendo era cards not blocking Wizards era Pokémon Powers