### PR TITLE
Fixes for Darkness Energy [Special] (EM and MT prints)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1808,9 +1808,11 @@ public enum Emerald implements LogicCardInfo {
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each(){
-                  if(it.from == self && it.to.active && it.to.owner != self.owner && self.types.contains(D) && it.dmg.value) {
-                    it.dmg += hp(10)
+                if (self.types.contains(D) || self.topPokemonCard.name.contains("Dark ")){
+                  bg.dm().each(){
+                    if(it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                      it.dmg += hp(10)
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
+++ b/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
@@ -1,6 +1,7 @@
 package tcgwars.logic.impl.gen4;
 
 import tcgwars.logic.impl.gen4.Unleashed;
+import tcgwars.logic.impl.gen4.MysteriousTreasures;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -1717,17 +1718,7 @@ public enum CallOfLegends implements LogicCardInfo {
           }
         };
       case DARKNESS_ENERGY_86:
-        return specialEnergy (this, [[C]]) {
-          text "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this Effect if the Pokémon that Darkness Energy is attached to isn’t [D]. Darkness Energy provides [D] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_87:
         return specialEnergy (this, [[C]]) {
           text "Damage done by attacks to the Pokémon that Metal Energy attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1,5 +1,6 @@
 package tcgwars.logic.impl.gen4;
 
+import tcgwars.logic.impl.gen4.MysteriousTreasures;
 import tcgwars.logic.impl.gen5.PlasmaStorm;
 
 import static tcgwars.logic.card.HP.*;
@@ -2042,17 +2043,7 @@ public enum MajesticDawn implements LogicCardInfo {
           }
         };
       case DARKNESS_ENERGY_93:
-        return specialEnergy (this, [[C]]) {
-          text "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t [D]. Darkness Energy provides [D] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case HEALTH_ENERGY_94:
         return specialEnergy (this, [[C]]) {
           text "Health Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter from that Pokémon."

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3408,7 +3408,26 @@ public enum MysteriousTreasures implements LogicCardInfo {
         return copy (Sandstorm.MULTI_ENERGY_93, this);
       case DARKNESS_ENERGY_119:
         //TODO: This version of "Darkness Energy (Special Energy)" shouldn't work on "Dark ____" cards, only on [D] Type Pokémon.
-        return copy (RubySapphire.DARKNESS_ENERGY_93, this);
+        return specialEnergy (this, [[D]]) {
+          text: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t [D]. Darkness Energy provides [D] Energy. (Doesn’t count as a basic Energy card.)"
+          def eff
+          onPlay {reason->
+            eff = delayed {
+              after PROCESS_ATTACK_EFFECTS, {
+                if (self.types.contains(D)){
+                  bg.dm().each(){
+                    if(it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                      it.dmg += hp(10)
+                    }
+                  }
+                }
+              }
+            }
+          }
+          onRemoveFromPlay {
+            eff.unregister()
+          }
+        }
       case METAL_ENERGY_120:
         return copy (RubySapphire.METAL_ENERGY_94, this);
       case ELECTIVIRE_LV_X_121:

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -1,5 +1,7 @@
 package tcgwars.logic.impl.gen4;
 
+import tcgwars.logic.impl.gen4.MysteriousTreasures;
+
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
 import static tcgwars.logic.card.CardType.*;
@@ -2270,17 +2272,7 @@ public enum RisingRivals implements LogicCardInfo {
           }
         };
       case DARKNESS_ENERGY_99:
-        return specialEnergy (this, [[C]]) {
-          text "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t [D]. Darkness Energy provides [D] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_100:
         return specialEnergy (this, [[C]]) {
           text "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t [M]. Metal Energy provides [M] Energy. (Doesn’t count as a basic Energy card.)"

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1,5 +1,7 @@
 package tcgwars.logic.impl.gen4;
 
+import tcgwars.logic.impl.gen4.MysteriousTreasures;
+
 import tcgwars.logic.effect.gm.PlayTrainer
 
 import static tcgwars.logic.card.HP.*;
@@ -2770,7 +2772,7 @@ public enum SecretWonders implements LogicCardInfo {
       case SWITCH_128:
         return copy(FireRedLeafGreen.SWITCH_102, this);
       case DARKNESS_ENERGY_129:
-        return copy (RubySapphire.DARKNESS_ENERGY_93, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_130:
         return copy (RubySapphire.METAL_ENERGY_94, this);
       case GARDEVOIR_LV_X_131:

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -1,5 +1,7 @@
 package tcgwars.logic.impl.gen4;
 
+import tcgwars.logic.impl.gen4.MysteriousTreasures;
+
 import tcgwars.logic.effect.gm.PlayTrainer
 
 import static tcgwars.logic.card.HP.*;
@@ -1671,17 +1673,7 @@ public enum Undaunted implements LogicCardInfo {
           }
         };
       case DARKNESS_ENERGY_79:
-        return specialEnergy (this, [[C]]) {
-          text "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn’t [D]. Darkness Energy provides [D] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_80:
         return specialEnergy (this, [[C]]) {
           text "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t [M]. Metal Energy provides [M] Energy. (Doesn’t count as a basic Energy card.)"


### PR DESCRIPTION
Now DP-era prints should follow the Mysterious Treasure print, which only does its effect when attached to [D] Pokémon. The EX Emerald print now properly works on those as well as on Pokémon with "Dark" in their name.

Also fixed most references to these two prints, from their relative reprints. Only missing ones for EM is the "EX Ruby & Sapphire" set, which is not made in Groovy so can't be fixed by this PR.