### PR TITLE
Added temp workarounds for VMAX filtering in Stage 1 checks

### DIFF
--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2637,7 +2637,13 @@ public enum BurningShadows implements LogicCardInfo {
           def eff
           onPlay {reason->
             eff = getter (GET_FULL_HP, self) {h->
-              if(self.topPokemonCard.cardTypes.is(STAGE1)) {
+              if(
+                self.topPokemonCard.cardTypes.is(STAGE1)
+                // [Temp Workaround for VMAX]
+                && !self.topPokemonCard.cardTypes.is(VMAX)
+                // [End of workaround for VMAX]
+                // TODO: Remove this when VMAX are no longer marked as STAGE1.
+              ) {
                 h.object += hp(40)
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -3698,6 +3698,13 @@ public enum LostThunder implements LogicCardInfo {
               assert self.turnCount < bg.turnCount : "Cannot evolve the turn you put it into play"
               powerUsed()
               def tar = my.hand.filterByType(STAGE1).select("Evolve To")
+              // [Temp Workaround for VMAX]
+              while (tar.first().getCardTypes.is(VMAX)){
+                wcu "You cannot evolve into a Pokémon VMAX"
+                tar = my.hand.filterByType(STAGE1).select("Evolve To")
+              }
+              // [End of workaround for VMAX]
+              // TODO: Remove this when VMAX are no longer marked as STAGE1.
               evolve(self, card.first(), PLAY_FROM_HAND)
             }
           }

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -3337,6 +3337,10 @@ public enum TeamUp implements LogicCardInfo {
           }
           playRequirement{
             assert opp.active.topPokemonCard.cardTypes.contains(STAGE1) : "Your opponent's Active Pokémon is not a Stage 1 Pokémon"
+            // [Temp Workaround for VMAX]
+            assert !opp.active.topPokemonCard.cardTypes.contains(VMAX) : "Your opponent's Active Pokémon is not a Stage 1 Pokémon"
+            // [End of workaround for VMAX]
+            // TODO: Remove this when VMAX are no longer marked as STAGE1.
             assert my.deck : "There are no more cards in your deck"
           }
         };

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -351,7 +351,13 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (sel_1) {
                 def pcs = my.all.findAll { it.name==sel_1.predecessor }.select("Evolve which Pokémon?")
                 evolve(pcs, sel_1, OTHER)
-                if (sel_1.cardTypes.is(STAGE1)) {
+                if (
+                  sel_1.cardTypes.is(STAGE1)
+                  // [Temp Workaround for VMAX]
+                  && !sel_1.cardTypes.is(VMAX)
+                  // [End of workaround for VMAX]
+                  // TODO: Remove this when VMAX are no longer marked as STAGE1.
+                ) {
                   def sel_2 = deck.search ("Select a Pokémon that evolves from ${sel_1.name}.", {it.cardTypes.is(EVOLUTION) && it.predecessor == sel_1.name}).first()
                   if(sel_2){
                     evolve(pcs, sel_2, OTHER)


### PR DESCRIPTION
Just as the LV.X devolution workaround, this is only additional checks and can be easily tracked and removed once no longer needed.