### PR TITLE
Requirements fix for multiple SM era cards, fix attempt at Shiftry ex (CG 97)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -2240,10 +2240,16 @@ public enum CrystalGuardians implements LogicCardInfo {
         pokeBody "Dark Eyes", {
           text "After your opponent's Pokémon uses a Poké-Power, put 2 damage counters on that Pokémon."
           delayedA {
+            def pcs
+            before USED_ABILITY, {
+              if (ability instanceof PokePower){
+                pcs = ef.getResolvedTarget(bg, e)
+              }
+            }
             after POKEPOWER, {
               bc "Dark eyes activate"
               if (bg.currentThreadPlayerType != self.owner) {
-                directDamage(20, ef.resolvedTarget, Source.SRC_ABILITY)
+                directDamage(20, pcs, Source.SRC_ABILITY)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2734,7 +2734,8 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.hand.getExcludedList(thisCard).size() >= 2
+            assert my.hand.getExcludedList(thisCard).size() >= 2 : "You can't play $thisCard if you can't discard 2 cards from your hand"
+            assert opp.all.any{it.cards.energyCount(C)} : "You can't play $thisCard if your Opponent has no Energy attached to any of their Pokémon"
           }
         };
       case PO_TOWN_121:
@@ -2779,7 +2780,8 @@ public enum BurningShadows implements LogicCardInfo {
             draw 4
           }
           playRequirement{
-            assert my.hand.getExcludedList(thisCard).size() >= 2
+            assert my.hand.getExcludedList(thisCard).size() >= 2 : "You cannot play $thisCard if you can't discard 2 cards from your hand"
+            assert my.deck : "You can't play $thisCard if you don't have cards in deck."
           }
         };
       case SUPER_SCOOP_UP_124:

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2709,6 +2709,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           }
           playRequirement{
             assert my.hand.getExcludedList(thisCard)
+            assert my.deck
           }
         };
       case ULTRA_RECON_SQUAD_114:

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -589,7 +589,6 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may discard 2 Fire Energy cards from your hand. If you do, switch 1 of your opponent's Benched Pokémon with their Active Pokémon."
             actionA{
               checkLastTurn()
-              assert opp.bench.notEmpty() : "Opponent bench empty"
               def src = my.hand.filterByBasicEnergyType(R)
               assert src.size() >= 2 : "You don't have enough Fire Energy cards to discard"
               powerUsed()

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3019,7 +3019,7 @@ public enum UltraPrism implements LogicCardInfo {
           text "Draw 2 cards. If you do, discard a random card from your opponent’s hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
             draw 2
-            opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("this card will be discarded").discard()
+            if (opp.hand) opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("this card will be discarded").discard()
           }
           playRequirement{
             assert my.deck


### PR DESCRIPTION
Fixes for Ninetales (TEU), Sophocles and Plumeria (BUS), Mysterious Treasure (FLI) and Mars (UPR) based on a batch of rulings added about a year ago to the compendium, clarifying whether their initial discard is an effect in itself or a cost. More details for it at https://pokegym.net/index.php/2019/04/01/trash-talk/.