### PR TITLE
Multiple SM card fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3856,7 +3856,6 @@ public enum CosmicEclipse implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.hand.findAll(cardTypeFilter(POKEMON)) : "There are no Pokémon in your hand."
-              assert self.numberOfDamageCounters : "$self has no damage counters."
               powerUsed()
               my.hand.findAll(cardTypeFilter(POKEMON)).select("Discard a Pokémon to heal 60.").discard()
               heal(60, self)

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -630,9 +630,11 @@ public enum CrimsonInvasion implements LogicCardInfo {
               damage 90
               if(confirm("Add damage counters to Mamoswine for 10 more damage with each damage counter put that way?"))
               {
-                def num = choose([1,2,3,4,5,6,7,8,9])
-                damage 10*num
-                directDamage 10*num, self
+                def num = choose([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "How many damage counters would you like to put on $self?")
+                damage 90 + 10 * num
+                afterDamage{
+                  directDamage 10 * num, self
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -554,10 +554,16 @@ public enum TeamUp implements LogicCardInfo {
               checkLastTurn()
               assert my.deck : "There are no more cards in your deck"
               powerUsed()
+              def eff = delayed {
+                before KNOCKOUT, {
+                  prevent()
+                }
+              }
               directDamage 20, self
-              attachEnergyFrom(type: FIRE, my.deck, self)
-              attachEnergyFrom(type: FIRE, my.deck, self)
+              my.deck.search(max:2, "Search your deck for up to 2 [R] Energy cards and attach them to $self", basicEnergyFilter(R)).each{attachEnergy(self,it)}
               shuffleDeck()
+              eff.unregister()
+              checkFaint()
             }
           }
           move "Continuous Blaze Ball" , {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -560,7 +560,7 @@ public enum TeamUp implements LogicCardInfo {
                 }
               }
               directDamage 20, self
-              my.deck.search(max:2, "Search your deck for up to 2 [R] Energy cards and attach them to $self", basicEnergyFilter(R)).each{attachEnergy(self,it)}
+              my.deck.search(max:2, "Search your deck for up to 2 [R] Energy cards", basicEnergyFilter(R)).each{attachEnergy(self,it)}
               shuffleDeck()
               eff.unregister()
               checkFaint()
@@ -2376,11 +2376,18 @@ public enum TeamUp implements LogicCardInfo {
               checkLastTurn()
               assert my.deck : "There are no more cards in your deck"
               powerUsed()
+              def eff = delayed {
+                before KNOCKOUT, {
+                  prevent()
+                }
+              }
               directDamage(30,self)
               my.deck.search(max:3,"Choose up to 3 [D] Energy cards", basicEnergyFilter(D)).each {
                 attachEnergy(self, it)
               }
               shuffleDeck()
+              eff.unregister()
+              checkFaint()
             }
           }
           move "Crushing Punch" , {

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2333,7 +2333,7 @@ public enum UltraPrism implements LogicCardInfo {
                 directDamage 10, tar
               }
               eff.unregister()
-              bg().em().run(new CheckFaint())
+              checkFaint()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3210,7 +3210,6 @@ public enum UnbrokenBonds implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.hand.findAll(pokemonTypeFilter(M)) : "No [M} pokemon in hand"
-              assert self.numberOfDamageCounters : "$self is not damaged"
               powerUsed()
               my.hand.findAll(pokemonTypeFilter(M)).select("Discard").discard()
               heal(100,self)

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1026,7 +1026,6 @@ public enum UnbrokenBonds implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.hand.filterByBasicEnergyType(R)
-              assert my.deck
               powerUsed()
               my.hand.filterByBasicEnergyType(R).select("Discard").discard()
               draw 3

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3673,7 +3673,6 @@ public enum UnifiedMinds implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.hand.findAll{it.cardTypes.is(ULTRA_BEAST)} : "Your hand has no Ultra Beast cards in it."
-              assert my.deck : "Your deck is empty."
               powerUsed()
               my.hand.findAll{it.cardTypes.is(ULTRA_BEAST)}.select("Discard an Ultra Beast card.").discard()
               draw 3


### PR DESCRIPTION
* Mamoswine (Crimson Invasion) now puts damage counters on itself only after damaging the opponent's Active Pokémon. Now works like Froslass (Unified Minds).

* Charizard and Incineroar-GX (Team Up) should search and attach all energy before checking for it being KO'd. Also optimized Charizard's search.

> Q. If I use Charizard's "Roaring Resolve" Ability with only 10hp left, does he get KO'd when I place the 2 damage counters before or after I search & attach 2 {R} Energy cards?
> A. You must finish all the text of the Ability before checking for knockouts, so yes you would search your deck and attach {R} Energy cards before KO'ing Charizard. (Team Up FAQ; Jan 31, 2019 TPCi Rules Team)

* Naganadel & Guzzlord-GX (Cosmic Eclipse) and Naganadel-GX (Unified Minds) can now discard an Ultra Beast, even if they can't heal or draw respectively.

> Q. Can you use Naganadel & Guzzlord GX's "Violent Appetite" Ability to discard a Pokemon if Naganadel & Guzzlord GX is not damaged?
> A. Yes, you can. The main effect of this Ability is to discard a Pokemon from your hand. (Feb 27, 2020 TPCi Rules Team)

> Q. Can I use Zoroark GX's "Trade" Ability to discard a card from my hand if there are no cards left in my deck?
> A. Yes you can. The first part of Trade is to discard a card from your hand, period. Then you do as much of the rest of the Ability as you are able to. (Mar 21, 2019 TPCi Rules Team)
_[Regarding Abilities in this era, unless explicitly stated the discard is one of two events in order. It can be done even if the second can't (opposite isn't true tho, you must do first effect and "if you do" then you do the second. Newer cards like Cinccino SSH use discard as a cost, but make so in a different, clearer way.]_

* Similar to above, Melmetal (UNB) now can discard a [M] Pokémon even if it won't heal any damage.

* Salazzle (UNB) can now discard a [R] Energy card with Roast Reveal, even if the player is out of cards in their deck.

> Q. Can I use Ninetales' "Roast Reveal" Poke-POWER when I have no cards in my deck?
> A. Yes, you do as much of the power as you are able; discard 1 Fire Energy card from your hand, then the Poke-POWER's effect ends, without drawing any cards. (GS:Heart Gold/Soul Silver FAQ; Feb 11, 2010 PUI Rules Team)