### PR TITLE
Applied some Erratas (TRR, FRLG), plus some notes for a couple already implemented

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2461,6 +2461,7 @@ public enum Deoxys implements LogicCardInfo {
       case STRENGTH_CHARM_92:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nWhenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon, the attack does 10 more damage (before applying Weakness and Resistance). Discard Strength Charm at the end of the turn in which this Pokémon attacks."
+          //TODO: Check for older non-groovy prints to apply the correct effect of this card. Got errata'd, used to increase damage after W/R (current behaviour: before W/R)
           def eff1
           def attackUsed = false
           onPlay {reason->

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1843,6 +1843,7 @@ public enum Emerald implements LogicCardInfo {
       case DOUBLE_RAINBOW_ENERGY_87:
         return specialEnergy (this, [[]]) {
           text "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (before applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy. (Major text change in Emerald. Using earlier versions requires reference.)"
+          //TODO: Check non-groovy prints, see if they properly reduce damage before W/R (pre-errata they did so after W/R)
           def eff
           def check = {
             if(!it.evolution || it.EX){discard thisCard}

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2570,7 +2570,6 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             //Errata'd, original text said "each Energy you discarded"
             energyCost L, C
             onAttack {
-              def count=0
               def toBeDiscarded = new CardList()
               while(true) {
                 def pl = my.all.findAll{
@@ -2578,15 +2577,14 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                 }
                 if(!pl) break;
 
-                def info = "Energy cards already marked for discard: ${count}\nCurrent base damage: 30 + ${20 * count}\nDiscard an Energy card from which Pokémon? (cancel to stop)"
+                def info = "Energy cards already marked for discard: ${toBeDiscarded.size()}\nCurrent base damage: 30 + ${20 * toBeDiscarded.size()}\nDiscard an Energy card from which Pokémon? (cancel to stop)"
                 def src = pl.select(info, false)
                 if(!src) break;
 
                 def selection = src.cards.filterByType(ENERGY).select("Card to discard")
                 toBeDiscarded.addAll(selection)
-                count++
               }
-              damage 30+20*count
+              damage 30+20*toBeDiscarded.size()
               afterDamage { toBeDiscarded.discard() }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2566,20 +2566,28 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
           move "Crush and Burn", {
-            text "30+ damage. You may discard as many Energy as you like attached to your Pokémon in play. If you do, this attack does 30 damage plus 20 more damage for each Energy you discarded."
+            text "30+ damage. You may discard as many Energy as you like attached to your Pokémon in play. If you do, this attack does 30 damage plus 20 more damage for each Energy card you discarded."
+            //Errata'd, original text said "each Energy you discarded"
             energyCost L, C
             onAttack {
               def count=0
-              while(1){
-                def pl=(my.all.findAll {it.cards.filterByType(ENERGY)})
+              def toBeDiscarded = new CardList()
+              while(true) {
+                def pl = my.all.findAll{
+                  it.cards.filterByType(ENERGY).any{enCard -> !toBeDiscarded.contains(enCard)}
+                }
                 if(!pl) break;
-                def src=pl.select("Source for energy (cancel to stop)", false)
+
+                def info = "Energy cards already marked for discard: ${count}\nCurrent base damage: 30 + ${20 * count}\nDiscard an Energy card from which Pokémon? (cancel to stop)"
+                def src = pl.select(info, false)
                 if(!src) break;
-                def card=src.cards.filterByType(ENERGY).select("Card to discard").first()
-                discard card
+
+                def selection = src.cards.filterByType(ENERGY).select("Card to discard")
+                toBeDiscarded.addAll(selection)
                 count++
               }
               damage 30+20*count
+              afterDamage { toBeDiscarded.discard() }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2304,17 +2304,18 @@ public enum FireRedLeafGreen implements LogicCardInfo {
         };
       case MT__MOON_94:
         return stadium (this) {
-          text "Any Pokémon (both yours and your opponent’s) with maximum HP less than 70 can’t use any Poké-Powers.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
+          text "Any Pokémon (both yours and your opponent’s) with maximum HP of 70 or less can’t use any Poké-Powers.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
+          //Errata: Originally said "HP of less than 70".
           def effect1
           def effect2
           onPlay {
             effect1 = getter IS_ABILITY_BLOCKED, { Holder h->
-              if (h.effect.target.fullHP.value < 70 && h.effect.ability instanceof PokePower) {
+              if (h.effect.target.fullHP.value <= 70 && h.effect.ability instanceof PokePower) {
                 h.object=true
               }
             }
             effect2 = getter IS_GLOBAL_ABILITY_BLOCKED, {Holder h->
-              if ((h.effect.target as Card).fullHP.value < 70) {
+              if ((h.effect.target as Card).fullHP.value <= 70) {
                 h.object=true
               }
             }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -492,6 +492,7 @@ public enum PowerKeepers implements LogicCardInfo {
         move "Brick Smash", {
           text "40 damage. This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
           energyCost F, C
+          //TODO: Check the Hidden Legends Machamp working as a reprint of this one. An errata was applied, so this attack applies Weakness.
           onAttack {
             noResistanceOrAnyEffectDamage(40, defending)
           }
@@ -1873,6 +1874,7 @@ public enum PowerKeepers implements LogicCardInfo {
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
           "Draw a number of cards up to the number of your opponent's Pokémon in play. If you have 7 or more cards (including this one) in your hand, you can't play this card."
+          //TODO: Check the Hidden Legends print, see if it works like this or with pre-errata text: originally said "If you have more than 7 cards (including this one)".
         onPlay {
           draw opp.all.size()
         }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -1393,10 +1393,12 @@ public enum TeamRocketReturns implements LogicCardInfo {
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
           pokePower "Ripples", {
-            text "Once during your turn (before your attack), you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can’t be used if Mantine is affected by a Special Condition."
+            text "Once during your turn (before your attack), if Mantine is your Active Pokémon, you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can’t be used if Mantine is affected by a Special Condition."
+            //Errata'd: Originally didn't mention Mantine needing to be Active in order to use Ripples.
             actionA {
               checkLastTurn()
               checkNoSPC()
+              assert self.active : "$self is not your Active Pokémon [Errata, may not show in the card itself]"
               assert my.all.findAll{it.numberOfDamageCounters && it != self} : "There is no Pokémon with damage counter outside from ${self}."
               powerUsed()
               heal 10, my.all.findAll{it.numberOfDamageCounters && it != self}.select("Select the pokemon to heal.")

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -475,7 +475,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness FIRE
           resistance WATER, MINUS30
           pokeBody "Buffer", {
-            text "If Jumpluff would be Knocked Out by an opponent’s attack, flip a coin. If heads, Jumpluff is not Knocked Out and its remaining HP becomes 10 instead."
+            text "If Jumpluff would be Knocked Out by damage from an opponent's attack, flip a coin. If heads, Jumpluff is not Knocked Out and its remaining HP becomes 10 instead."
+            //Errata'd, used to say "by an opponent’s attack".
             delayedA {
               before KNOCKOUT, self, {
                 if((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite){
@@ -1502,7 +1503,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness FIRE
           resistance WATER, MINUS30
           pokeBody "Buffer", {
-            text "If Skiploom would be Knocked Out by an opponent’s attack, flip a coin. If heads, Skiploom is not Knocked Out and its remaining HP becomes 10 instead."
+            text "If Skiploom would be Knocked Out by damage from an opponent's attack, flip a coin. If heads, Skiploom is not Knocked Out and its remaining HP becomes 10 instead."
+            //Errata'd, used to say "by an opponent’s attack".
             delayedA {
               before KNOCKOUT, self, {
                 if((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite){
@@ -1691,7 +1693,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness FIRE
           resistance WATER, MINUS30
           pokeBody "Buffer", {
-            text "If Hoppip would be Knocked Out by an opponent’s attack, flip a coin. If heads, Hoppip is not Knocked Out and its remaining HP becomes 10 instead."
+            text "If Hoppip would be Knocked Out by damage from an opponent's attack, flip a coin. If heads, Hoppip is not Knocked Out and its remaining HP becomes 10 instead."
+            //Errata'd, used to say "by an opponent’s attack".
             delayedA {
               before KNOCKOUT, self, {
                 if((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite){
@@ -1782,7 +1785,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
           pokeBody "Knockout Gas", {
-            text "If Koffing is your Active Pokémon and is Knocked Out by an opponent’s attack, the Attacking Pokémon is now Confused and Poisoned."
+            text "If Koffing is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, the Attacking Pokémon is now Confused and Poisoned."
+            //Errata'd, used to say "is Knocked Out by an opponent’s attack"
             delayedA {
               before KNOCKOUT, self, {
                 if((ef as Knockout).byDamageFromAttack){

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3561,7 +3561,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
           move "Flame Buster", {
-            text "Discard 2 [R] Energy attached to Magmortar. Choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) During your next turn, Magmortar can’t use Flame Bluster."
+            text "Discard 2 [R] Energy cards attached to Magmortar. Choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) During your next turn, Magmortar can’t use Flame Bluster."
+            //Errata'd, used to say "2 [R] Energy attached"
+            //TODO: Fix this attack so it discards energy cards, not just energy (also invert order, discard then damage).
             energyCost R, R, R, R
             attackRequirement {}
             onAttack {


### PR DESCRIPTION
Applied some erratas:
  - Added some comments and edited card text for more clarity (so they're not unerrata'd by mistake)
  - Now Mantine (TRR 45) can only use Ripples from the Active Position:
    > * Mantine's Poké-POWER only works when it is the player's Active Pokémon. Official Wording: Once during your turn (before your attack), if Mantine is your Active Pokémon, you may remove 1 damage counter from 1 of your Pokémon (excluding Mantine). This power can't be used if Mantine is affected by a Special Condition. (Dec 16, 2004 PUI Announcements)
  - Mt. Moon (FRLG 94) now affects Pokémon with <= 70 HP, instead of just < 70:
    > * Mt. Moon should read: "Any Pokémon (both yours and your opponent's) with maximum HP of 70 or less can't use any Poké-Powers." This errata replaces text of "less than 70" with "70 or less". If a Pokémon has a maximum HP of 70, that Pokémon cannot use a Poké-POWER while this Stadium card is in play. (Oct 1, 2004 PUI Announcements)
  - Electrode-ex (FRLG 107) now counts Energy cards discarded instead of total Energy:
    > * Electrode-EX's "Crush and Burn" attack does extra damage based on the number of Energy cards discarded, not the amount of Energy provided. Official Wording: You may discard as many Energy cards as you like attached to your Pokémon in play. If you do, this attack does 30 damage plus 20 more damage for each Energy [B]card[/B] you discarded. (Dec 16, 2004 PUI Announcements)