### PR TITLE
Implementation attempt at Elemental Blast (Lugia-ex, UF 106)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2596,71 +2596,73 @@ public enum UnseenForces implements LogicCardInfo {
           energyCost R, W, L
           onAttack {
             damage 200
-            def energyRequired = [[R, 1], [W, 1], [L, 1]]
+            afterDamage{
+              def energyRequired = [[R, 1], [W, 1], [L, 1]]
 
-            def potentialEnergy = []
-            for (enCard in self.cards.filterByType(ENERGY)){
-              def enTypes = enCard.getEnergyTypes()
-              if (enTypes.size() == 1){
-                potentialEnergy.add([enTypeSet, enCard, "${enCard}"])
-              } else {
-                def i = 1
-                def total = enTypes.size()
-                for (enTypeSet in enTypes) {
-                  potentialEnergy.add([enTypeSet, enCard, "${enCard} - Energy #${i}/${total}"])
+              def potentialEnergy = []
+              for (enCard in self.cards.filterByType(ENERGY)){
+                def enTypes = enCard.getEnergyTypes()
+                if (enTypes.size() == 1){
+                  potentialEnergy.add([enTypeSet, enCard, "${enCard}"])
+                } else {
+                  def i = 1
+                  def total = enTypes.size()
+                  for (enTypeSet in enTypes) {
+                    potentialEnergy.add([enTypeSet, enCard, "${enCard} - Energy #${i}/${total}"])
+                  }
                 }
               }
-            }
 
-            def howMuchFulfillable(enRequirement, potEnergy){
-              def typeRequired = enRequirement[0]
-              def cntRequired = enRequirement[1]
-              def fulfillableAmount = potEnergy.count{it[0].contains(typeRequired)}
-              bc "${enRequirement} can be fulfilled with ${fulfillableAmount}"
-              return fulfillableAmount
-            }
-            def nonFulfillableReq = []
-            bc "Originally $energyRequired"
-            for (req in energyRequired){
-              def fulfillableAmount = howMuchFulfillable(req, potentialEnergy)
-              if (fulfillableAmount == 0){
-                bc "${req} can't be fulfilled"
-                nonFulfillableReq.add(req)
-              } else {
-                bc"${req} can be fulfilled up to $fulfillableAmount (prev. $req[1])"
-                req.putAt(1, Math.min(req.get(1), fulfillableAmount))
+              def howMuchFulfillable(enRequirement, potEnergy){
+                def typeRequired = enRequirement[0]
+                def cntRequired = enRequirement[1]
+                def fulfillableAmount = potEnergy.count{it[0].contains(typeRequired)}
+                bc "${enRequirement} can be fulfilled with ${fulfillableAmount}"
+                return fulfillableAmount
               }
-            }
-            energyRequired.removeAll(nonFulfillableReq)
-
-            bc "Post removal of non-fulfillables $energyRequired"
-            energyRequired.sort{ typeA, typeB ->
-              def fulA = howMuchFulfillable(typeA, potentialEnergy)
-              def fulB = howMuchFulfillable(typeB, potentialEnergy)
-              typeA.get(1) == typeB.get(1) ? (fulA == fulB ? 0 : fulA < fulB ? -1 : 1) : typeA.get(1) < typeB.get(1) ? -1 : 1
-            }
-            bc "Post sorting $energyRequired"
-
-            def energyToBeDiscarded = []
-            def cardsToBeDiscarded = []
-
-            for (enReq in energyRequired){
-              def optionsNum = (0..potentialEnergy.size() -1).toList()
-              def options = potentialEnergy.findAll{it[0].contains(enReq[0])}
-              if (options){
-                def chosenEnergy = 0
-                if (options.size() > 1) {
-                  chosenEnergy = choose(optionsNum,options.collect{it[2]})
+              def nonFulfillableReq = []
+              bc "Originally $energyRequired"
+              for (req in energyRequired){
+                def fulfillableAmount = howMuchFulfillable(req, potentialEnergy)
+                if (fulfillableAmount == 0){
+                  bc "${req} can't be fulfilled"
+                  nonFulfillableReq.add(req)
+                } else {
+                  bc"${req} can be fulfilled up to $fulfillableAmount (prev. $req[1])"
+                  req.putAt(1, Math.min(req.get(1), fulfillableAmount))
                 }
-                bc "Paying [${enReq[0]}] with ${options[chosenEnergy][2]}"
-                energyToBeDiscarded.add(options[chosenEnergy])
-                potentialEnergy.remove(options[chosenEnergy])
-              } else {
-                bc "No way to pay [${enReq[0]}], applying 'do as much as you can'"
               }
+              energyRequired.removeAll(nonFulfillableReq)
+
+              bc "Post removal of non-fulfillables $energyRequired"
+              energyRequired.sort{ typeA, typeB ->
+                def fulA = howMuchFulfillable(typeA, potentialEnergy)
+                def fulB = howMuchFulfillable(typeB, potentialEnergy)
+                typeA.get(1) == typeB.get(1) ? (fulA == fulB ? 0 : fulA < fulB ? -1 : 1) : typeA.get(1) < typeB.get(1) ? -1 : 1
+              }
+              bc "Post sorting $energyRequired"
+
+              def energyToBeDiscarded = []
+              def cardsToBeDiscarded = []
+
+              for (enReq in energyRequired){
+                def optionsNum = (0..potentialEnergy.size() -1).toList()
+                def options = potentialEnergy.findAll{it[0].contains(enReq[0])}
+                if (options){
+                  def chosenEnergy = 0
+                  if (options.size() > 1) {
+                    chosenEnergy = choose(optionsNum,options.collect{it[2]})
+                  }
+                  bc "Paying [${enReq[0]}] with ${options[chosenEnergy][2]}"
+                  energyToBeDiscarded.add(options[chosenEnergy])
+                  potentialEnergy.remove(options[chosenEnergy])
+                } else {
+                  bc "No way to pay [${enReq[0]}], applying 'do as much as you can'"
+                }
+              }
+              cardsToBeDiscarded = energyToBeDiscarded.collect{it[1]} as CardList
+              cardsToBeDiscarded.discard()
             }
-            cardsToBeDiscarded = energyToBeDiscarded.collect{it[1]} as CardList
-            cardsToBeDiscarded.discard
 
             //discardSelfEnergy R, W, L
           }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2648,16 +2648,21 @@ public enum UnseenForces implements LogicCardInfo {
               for (enReq in energyRequired){
                 def optionsNum = (0..potentialEnergy.size() -1).toList()
                 def options = potentialEnergy.findAll{it[0].contains(enReq[0])}
-                if (options){
-                  def chosenEnergy = 0
-                  if (options.size() > 1) {
-                    chosenEnergy = choose(optionsNum,options.collect{it[2]})
+                def cnt = 0
+                while (cnt < enReq[1]){
+                  if (options){
+                    def chosenEnergy = 0
+                    if (options.size() > 1) {
+                      chosenEnergy = choose(optionsNum,options.collect{it[2]})
+                    }
+                    bc "Paying [${enReq[0]}] with ${options[chosenEnergy][2]}"
+                    energyToBeDiscarded.add(options[chosenEnergy])
+                    potentialEnergy.remove(options[chosenEnergy])
+                    cnt++
+                  } else {
+                    bc "No way to pay [${enReq[0]}], applying 'do as much as you can'"
+                    cnt = enReq[1]
                   }
-                  bc "Paying [${enReq[0]}] with ${options[chosenEnergy][2]}"
-                  energyToBeDiscarded.add(options[chosenEnergy])
-                  potentialEnergy.remove(options[chosenEnergy])
-                } else {
-                  bc "No way to pay [${enReq[0]}], applying 'do as much as you can'"
                 }
               }
               cardsToBeDiscarded = energyToBeDiscarded.collect{it[1]} as CardList


### PR DESCRIPTION
If this works properly, I would only use it as a static for attacks requiring multiple big numbers of energy discarding. Singular discard are 100% fine with discardSelfEnergy. And this'll skip unfullfillable requirements, so copy attacks that don't use the original attack-cost may be able to skip part of the discard effect. Shouldn't happen for those in EX era like Copy though (I think).

Steps of operation:
* Collect all "potential energy", aka all the individual Energy Sets (e.g. 2 potential rainbows for a Double Rainbow **Energy card**, or a Holon's Castform)
* Remove all requirements that can't be fulfilled (no potential energy can cover it).
* Sort requirements, prioritizing those that have less fulfillment options across the potential energies available.
* Begin selecting. For each type requirement:
  - Collect all potential energies that can cover for said type. If list is empty, this requirement is done (just as a safeguard)
  - cnt is the amount already collected, will ask for energy until this value is the same as the required one.
    + Ask player if there are more than two options, otherwise just pick the only one. Either way, process selection and increase cnt.
    + If there are no more options, player has done as much as it could and this type is over.
* After all this, check the energies to be discarded. Collect all cards related to these, remove duplicates and discard them.