### PR TITLE
Attempt at Imprison implementation, changes to Shockwave and potential way to check until markers are added

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1963,25 +1963,27 @@ public enum DragonFrontiers implements LogicCardInfo {
                       if (!currentPokemon) break;
                     }
                   }
-                }
-                actionMaker.unregister()
-              }
-            }
-            getter (IS_ABILITY_BLOCKED) { Holder h ->
-              def imprisonChecker = bg.em().retrieveObject("Imprison_Checker")
-              if(imprisonChecker == null || imprisonChecker != self.hashCode()) {
-                if (imprisonChecker == null){
-                  bg.em().storeObject("Imprison_Checker", self.hashCode())
-                }
-                if(bg.em().retrieveObject("Imprison") != null){
-                  Imprison = bg.em().retrieveObject("Imprison")
-                }
+                  delayed {
+                    getter (IS_ABILITY_BLOCKED) { Holder h ->
+                      def imprisonChecker = bg.em().retrieveObject("Imprison_Checker")
+                      if(imprisonChecker == null || imprisonChecker != self.hashCode()) {
+                        if (imprisonChecker == null){
+                          bg.em().storeObject("Imprison_Checker", self.hashCode())
+                        }
+                        if(bg.em().retrieveObject("Imprison") != null){
+                          Imprison = bg.em().retrieveObject("Imprison")
+                        }
 
-                if (Imprison.contains(h.effect.target)) {
-                  if (h.effect.ability instanceof PokePower || h.effect.ability instanceof PokeBody) {
-                    h.object=true
+                        if (Imprison.contains(h.effect.target)) {
+                          if (h.effect.ability instanceof PokePower || h.effect.ability instanceof PokeBody) {
+                            h.object=true
+                          }
+                        }
+                      }
+                    }
                   }
                 }
+                actionMaker.unregister()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -2249,7 +2249,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             if(bg.em().retrieveObject("Shock_Wave") != null){
               Shock_Wave = bg.em().retrieveObject("Shock_Wave")
             }
-            assert opp.all.findAll{Shock_Wave.contains(it)} : "None of your opponent's Pokémon have Shock-Wave markers on them"
+            assert opp.all.any{Shock_Wave.contains(it)} : "None of your opponent's Pokémon have Shock-Wave markers on them"
             }
           onAttack {
             if(bg.em().retrieveObject("Shock_Wave") != null){

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1935,10 +1935,24 @@ public enum DragonFrontiers implements LogicCardInfo {
       case GARDEVOIR_EX_DELTA_93:
       return evolution (this, from:"Kirlia", hp:HP150, type:R, retreatCost:2) {
         weakness P
+        def Imprison = []
         pokePower "Imprison", {
           text "Once during your turn (before your attack), if Gardevoir ex is your Active Pokémon, you may put an Imprison marker on 1 of your opponent's Pokémon. Any Pokémon that has any Imprison markers on it can't use any Poké-Powers or Poké-Bodies. This power can't be used if Gardevoir ex is affected by a Special Condition."
           actionA {
-            // TODO
+            // TODO: Apply body/power restriction
+            if(bg.em().retrieveObject("Imprison") != null){
+              Imprison = bg.em().retrieveObject("Imprison")
+            }
+            def tar = opp.all.select("Choose a pokemon to put an Imprison marker on")
+            targeted (tar, SRC_ABILITY){
+              if (Imprison.contains(tar)) {
+                bc "$tar already has an Imprison marker"
+              } else {
+                Imprison.add(tar)
+                bc"$tar received an Imprison marker"
+                bg.em().storeObject("Imprison",Imprison)
+              }
+            }
           }
         }
         move "Flame Ball", {
@@ -2156,10 +2170,16 @@ public enum DragonFrontiers implements LogicCardInfo {
             if(bg.em().retrieveObject("Shock_Wave") != null){
               Shock_Wave = bg.em().retrieveObject("Shock_Wave")
             }
-            def tar = opp.all.findAll{!Shock_Wave.contains(it)}.select("Choose a pokemon to put a Shock-Wave marker on")
-            Shock_Wave.add(tar)
-            bc"$tar received a Shock-Wave marker"
-            bg.em().storeObject("Shock_Wave",Shock_Wave)
+            def tar = opp.all.select("Choose a pokemon to put a Shock-Wave marker on")
+            targeted (tar) {
+              if (Shock_Wave.contains(tar)) {
+                bc "$tar already has a Shock-Wave marker"
+              } else {
+                Shock_Wave.add(tar)
+                bc"$tar received a Shock-Wave marker"
+                bg.em().storeObject("Shock_Wave",Shock_Wave)
+              }
+            }
           }
         }
         move "Hyper Claws", {
@@ -2185,8 +2205,12 @@ public enum DragonFrontiers implements LogicCardInfo {
             if(bg.em().retrieveObject("Shock_Wave") != null){
               Shock_Wave = bg.em().retrieveObject("Shock_Wave")
             }
-            def ko = opp.all.findAll{Shock_Wave.contains(it)}.select("Choose a Pokémon to knock out")
-            new Knockout(ko).run(bg)
+            def pcs = opp.all.findAll{Shock_Wave.contains(it)}.select("Choose a Pokémon to knock out")
+            targeted (pcs) {
+              Shock_Wave.remove(pcs)
+              bg.em().storeObject("Shock_Wave",Shock_Wave)
+              new Knockout(pcs).run(bg)
+            }
           }
         }
       };


### PR DESCRIPTION
* First, regarding Tyranitar: Added some extra checks just so it has more verbose regarding a Pokémon already having a marker (it should be a valid target tho, even if useless). No Shockwave checker as with Imprison, but if that works I'd just make a variant for it.
  - Note: Might be worth allowing to attack if any Opponent's Pokémon has a marker, but show all Pokémon and loop until one with Shockwave is selected for the KO (as to keep consistency with the checker, in case multiple identical Pokémon exist with and without markers)
* Imprison's global Body/Power block and check action should register only once per game. These should remain even if said Gardevoir is knocked out, and not duplicate if another comes into play (before one enters play, there should be no way to replicate the PokéPower so all is good
  - For whenever working on it: Tyranitar-ex attacks could be copied by another Pokémon like Versatile Mew in theory, so it's checker action may need to be immediately registered upon entering hand; at least for its owner from game start, and not once played. (One alternative could be registering it's action on the Electromark attack itself, that might actually work better)