### PR TITLE
Fixed conditional switches from bench to active

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -438,12 +438,12 @@ class TcgStatics {
   static sw (PokemonCardSet old, PokemonCardSet newp, Source source=Source.ATTACK) {
     bg().em().run(new Switch(old,newp,source))
   }
-  //use for "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon." If an additional effect depends on this, the method returns whether or not the switch happened.
-  static boolean swFromBench (PokemonCardSet old, PokemonCardSet newp, Source source=Source.ATTACK) {
-    targeted (newp, source) {
-      sw (old, newp, null)
+  static sw2 (def pcs1, def pcs2 = null, Source src = Source.ATTACK) {
+    if(pcs2 == null) {
+      return !(new Switch(pcs1.owner.pbg.active, src, pcs1).run(bg))
+    } else {
+      return !(new Switch(pcs1, pcs2, src).run(bg))
     }
-    return newp.active
   }
   static discardStadium(){
     if (bg().stadiumInfoStruct?.stadiumCard){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -985,6 +985,12 @@ class TcgStatics {
     }
   }
 
+  static void switchYourOpponentsBenchedWithActive(Source src = ATTACK){
+    if (opp.bench){
+      sw2(opp.bench.select("Select your opponent's new Active Pokémon."), src)
+    }
+  }
+
   static void spiritLink(delegate1, name){
     def eff
     delegate1.onPlay {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1010,8 +1010,8 @@ public enum DeltaSpecies implements LogicCardInfo {
             assert opp.bench : "There is no Pokémon on your opponent's bench"
           }
           onAttack {
-            sw defending, opp.bench.select()
-            applyAfterDamage(ASLEEP)
+            def target = opp.bench.select("Select the new Active Pokémon.")
+            if ( swFromBench (defending, target) ) { apply ASLEEP, target }
           }
         }
         move "Psyshot", {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1011,7 +1011,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( swFromBench (defending, target) ) { apply ASLEEP, target }
+            if ( sw2(target) ) { apply ASLEEP, target }
           }
         }
         move "Psyshot", {

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2880,11 +2880,11 @@ public enum Deoxys implements LogicCardInfo {
             energyCost C, C
             onAttack {
               def pcs = defending
-              if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
+              if (opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
                 def target = opp.bench.select("Select the new Active Pokémon.")
                 if ( sw2(target) ) { pcs = target }
               }
-              damage 20, pcs
+              damage 20
             }
           }
           move "Darkness Blast", {

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1389,7 +1389,7 @@ public enum Deoxys implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon to switch"
               powerUsed()
               flip {
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                switchYourOpponentsBenchedWithActive(SRC_ABILITY)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1389,7 +1389,7 @@ public enum Deoxys implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon to switch"
               powerUsed()
               flip {
-                sw opp.active, opp.bench.select("Select the new active Pokémon.")
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -2880,13 +2880,10 @@ public enum Deoxys implements LogicCardInfo {
             energyCost C, C
             onAttack {
               def pcs = defending
-              if(opp.bench){
-                if(confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")){
-                  pcs = opp.bench.select()
-                  sw defending, pcs
-                }
+              if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
+                def target = opp.bench.select("Select the new Active Pokémon.")
+                if ( swFromBench (defending, target) ) { pcs = target }
               }
-
               damage 20, pcs
             }
           }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1389,7 +1389,7 @@ public enum Deoxys implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon to switch"
               powerUsed()
               flip {
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -2882,7 +2882,7 @@ public enum Deoxys implements LogicCardInfo {
               def pcs = defending
               if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
                 def target = opp.bench.select("Select the new Active Pokémon.")
-                if ( swFromBench (defending, target) ) { pcs = target }
+                if ( sw2(target) ) { pcs = target }
               }
               damage 20, pcs
             }

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1758,9 +1758,8 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon to switch"
             }
             onAttack {
-              def pcs = opp.bench.select("New active")
-              sw defending, pcs
-              apply ASLEEP, pcs
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { apply ASLEEP, target }
             }
           }
           move "Quick Blow", {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1759,7 +1759,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { apply ASLEEP, target }
+              if ( sw2(target) ) { apply ASLEEP, target }
             }
           }
           move "Quick Blow", {

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2166,7 +2166,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert opp.bench : "There is no Pokémon on your opponent's bench"
           }
           onAttack {
-            sw defending, opp.bench.select()
+            swFromBench (defending, opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2166,7 +2166,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert opp.bench : "There is no Pokémon on your opponent's bench"
           }
           onAttack {
-            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+            switchYourOpponentsBenchedWithActive()
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1589,8 +1589,8 @@ public enum LegendMaker implements LogicCardInfo {
             assert opp.bench : "Your opponent has no benched Pokémon"
           }
           onAttack {
-            def pcs = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
-            if ( swFromBench (defending, pcs) ) { apply POISONED, pcs }
+            def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
+            if ( sw2(target) ) { apply POISONED, target }
           }
         }
       };
@@ -2166,7 +2166,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert opp.bench : "There is no Pokémon on your opponent's bench"
           }
           onAttack {
-            swFromBench (defending, opp.bench.select("Select your opponent's new Active Pokémon."))
+            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2725,7 +2725,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 def target = opp.bench.select("Select the new Active Pokémon.")
                 if ( sw2(target) ) { pcs = target }
               }
-              damage 10, pcs
+              damage 10
             }
           }
           move "Dark Ring", {

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2290,7 +2290,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 choice = choose([0,1],["Move 1 Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon","Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon"])
               }
               if(choice){
-                sw opp.active, opp.bench.select(), TRAINER_CARD
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
               }else{
                 moveEnergy(basic: false, opp.active, opp.bench.select("Select the pokemon getting the Energy"), TRAINER_CARD)
               }
@@ -2721,11 +2721,9 @@ public enum TeamRocketReturns implements LogicCardInfo {
             energyCost D
             onAttack {
               def pcs = defending
-              if(opp.bench){
-                if(confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")){
-                  pcs = opp.bench.select()
-                  sw defending, pcs
-                }
+              if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
+                def target = opp.bench.select("Select the new Active Pokémon.")
+                if ( swFromBench (defending, target) ) { pcs = target }
               }
               damage 10, pcs
             }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2290,7 +2290,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 choice = choose([0,1],["Move 1 Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon","Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon"])
               }
               if(choice){
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+                switchYourOpponentsBenchedWithActive(TRAINER_CARD)
               }else{
                 moveEnergy(basic: false, opp.active, opp.bench.select("Select the pokemon getting the Energy"), TRAINER_CARD)
               }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2290,7 +2290,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 choice = choose([0,1],["Move 1 Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon","Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon"])
               }
               if(choice){
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
               }else{
                 moveEnergy(basic: false, opp.active, opp.bench.select("Select the pokemon getting the Energy"), TRAINER_CARD)
               }
@@ -2723,7 +2723,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               def pcs = defending
               if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
                 def target = opp.bench.select("Select the new Active Pokémon.")
-                if ( swFromBench (defending, target) ) { pcs = target }
+                if ( sw2(target) ) { pcs = target }
               }
               damage 10, pcs
             }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -293,13 +293,13 @@ public enum UnseenForces implements LogicCardInfo {
           energyCost G
           onAttack {
             def pcs = defending
-            if (opp.bench && confirm("Switch the defending Pokémon with 1 of your opponent's benched pokémon?")) {
-              pcs = opp.bench.select("Select opponent's new Active Pokemon. New Active will be Asleep and Poisoned")
-              sw opp.active, pcs
+            if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { pcs = target }
             }
             targeted(pcs) {
-              apply POISONED, pcs
               apply ASLEEP, pcs
+              apply POISONED, pcs
             }
           }
         }
@@ -821,12 +821,12 @@ public enum UnseenForces implements LogicCardInfo {
           text "20 damage. Before doing damage, you may switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost C, C
           onAttack {
-            def target = defending
-            if (opp.bench && confirm("Before doing damage, do you want to switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")) {
-              target = opp.bench.select("Select the new active")
-              sw defending, target
+            def pcs = defending
+            if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { pcs = target }
             }
-            damage 20, target
+            damage 20, pcs
           }
         }
         move "Rock Smash", {
@@ -1153,9 +1153,8 @@ public enum UnseenForces implements LogicCardInfo {
             assert opp.bench : "Your opponent has no Benched Pokémon"
           }
           onAttack {
-            def pcs = opp.bench.oppSelect()
-            sw defending, pcs
-            apply ASLEEP, pcs
+            def target = opp.bench.select("Select the new Active Pokémon.")
+            if ( swFromBench (defending, target) ) { apply ASLEEP, target }
           }
         }
         move "Plunder", {
@@ -2937,7 +2936,7 @@ public enum UnseenForces implements LogicCardInfo {
           onActivate {r->
             if (r==PLAY_FROM_HAND && opp.bench && confirm("Use Darker Ring?")) {
               powerUsed()
-              sw opp.active, opp.bench.select("Choose your opponent's new active Pokémon."), SRC_ABILITY
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
             }
           }
         }
@@ -3555,13 +3554,14 @@ public enum UnseenForces implements LogicCardInfo {
         move "Hidden Power", {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
           energyCost P, C
+          attackRequirement{
+            assert opp.bench : "Your opponent has no Benched Pokémon"
+          }
           onAttack {
-            def target = defending
-            if (opp.bench) {
-              target = opp.bench.select("Select the new active")
-              sw defending, target
-              apply BURNED
-              apply CONFUSED
+            def target = opp.bench.select("Select the new Active Pokémon.")
+            if ( swFromBench (defending, target) ) {
+              apply BURNED, target
+              apply CONFUSED, target
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -826,7 +826,7 @@ public enum UnseenForces implements LogicCardInfo {
               def target = opp.bench.select("Select the new Active Pokémon.")
               if ( sw2(target) ) { pcs = target }
             }
-            damage 20, pcs
+            damage 20
           }
         }
         move "Rock Smash", {

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2937,7 +2937,7 @@ public enum UnseenForces implements LogicCardInfo {
             // Umbreon-EX's "Darker Ring" Poké-POWER is optional. You do not have to switch one of your opponent's benched Pokémon if you do not want to. (Sep 21, 2006 PUI Rules Team)
             if (r==PLAY_FROM_HAND && opp.bench && confirm("Use Darker Ring?")) {
               powerUsed()
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+              switchYourOpponentsBenchedWithActive(SRC_ABILITY)
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -295,7 +295,7 @@ public enum UnseenForces implements LogicCardInfo {
             def pcs = defending
             if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { pcs = target }
+              if ( sw2(target) ) { pcs = target }
             }
             targeted(pcs) {
               apply ASLEEP, pcs
@@ -824,7 +824,7 @@ public enum UnseenForces implements LogicCardInfo {
             def pcs = defending
             if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { pcs = target }
+              if ( sw2(target) ) { pcs = target }
             }
             damage 20, pcs
           }
@@ -1154,7 +1154,7 @@ public enum UnseenForces implements LogicCardInfo {
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( swFromBench (defending, target) ) { apply ASLEEP, target }
+            if ( sw2(target) ) { apply ASLEEP, target }
           }
         }
         move "Plunder", {
@@ -2934,9 +2934,10 @@ public enum UnseenForces implements LogicCardInfo {
         pokePower "Darker Ring", {
           text "Once during your turn (before your attack), when you play Umbreon ex from your hand to evolve 1 of your Pokémon, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           onActivate {r->
+            // Umbreon-EX's "Darker Ring" Poké-POWER is optional. You do not have to switch one of your opponent's benched Pokémon if you do not want to. (Sep 21, 2006 PUI Rules Team)
             if (r==PLAY_FROM_HAND && opp.bench && confirm("Use Darker Ring?")) {
               powerUsed()
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
             }
           }
         }
@@ -3559,7 +3560,7 @@ public enum UnseenForces implements LogicCardInfo {
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( swFromBench (defending, target) ) {
+            if ( sw2(target) ) {
               apply BURNED, target
               apply CONFUSED, target
             }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2299,7 +2299,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { apply ASLEEP, target }
+              if ( sw2(target) ) { apply ASLEEP, target }
             }
           }
           move "Gust", {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2295,11 +2295,11 @@ public enum DiamondPearl implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
             energyCost G
             attackRequirement {
-              assert opp.bench
+              assert opp.bench : "Your opponent has no Benched Pokémon"
             }
             onAttack {
-              sw opp.active, opp.bench.select()
-              apply ASLEEP, opp.active
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { apply ASLEEP, target }
             }
           }
           move "Gust", {

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2015,11 +2015,12 @@ public enum BurningShadows implements LogicCardInfo {
             onAttack {
               gxPerform()
               if (opp.bench){
-                def pcs = opp.bench.select("Switch")
-                sw opp.active, pcs
-                apply POISONED, pcs
-                apply BURNED, pcs
-                apply PARALYZED, pcs
+                def target = opp.bench.select("Select the new Active Pokémon.")
+                if ( swFromBench (defending, target) ) {
+                  apply POISONED, target
+                  apply BURNED, target
+                  apply PARALYZED, target
+                }
               }
             }
           }
@@ -2655,12 +2656,9 @@ public enum BurningShadows implements LogicCardInfo {
         return supporter (this) {
           text "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            def pcs = opp.bench.select("New active")
-            targeted (pcs, TRAINER_CARD) {
-              sw opp.active, pcs, TRAINER_CARD
-              if(my.bench) {
-                sw my.active, my.bench.select("New active"), TRAINER_CARD
-              }
+            def target = opp.bench.select("Select the new Active Pokémon.")
+            if ( swFromBench (opp.active, target, TRAINER_CARD) && my.bench) {
+              sw my.active, my.bench.select("Select your new Active Pokémon."), TRAINER_CARD
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2016,7 +2016,7 @@ public enum BurningShadows implements LogicCardInfo {
               gxPerform()
               if (opp.bench){
                 def target = opp.bench.select("Select the new Active Pokémon.")
-                if ( swFromBench (defending, target) ) {
+                if ( sw2(target) ) {
                   apply POISONED, target
                   apply BURNED, target
                   apply PARALYZED, target
@@ -2657,7 +2657,7 @@ public enum BurningShadows implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
             def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( swFromBench (opp.active, target, TRAINER_CARD) && my.bench) {
+            if ( sw2(target, TRAINER_CARD) && my.bench) {
               sw my.active, my.bench.select("Select your new Active Pokémon."), TRAINER_CARD
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -317,7 +317,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert opp.bench
               powerUsed()
               flip {
-                sw opp.active, opp.bench.select("New active."), SRC_ABILITY
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -386,8 +386,8 @@ public enum CelestialStorm implements LogicCardInfo {
             onAttack {
               def pcs = defending
               if(opp.bench && confirm("Switch the defending pokémon with 1 of your opponent's benched pokémon?")){
-                pcs = opp.bench.select("Switch")
-                sw opp.active, pcs
+                def target = opp.bench.select("Select the new Active Pokémon.")
+                if ( swFromBench (defending, target) ) { pcs = target }
               }
               targeted(pcs) {
                 apply POISONED, pcs
@@ -871,11 +871,10 @@ public enum CelestialStorm implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              def pcs = opp.bench.select("Switch")
-              targeted(pcs) {
-                sw opp.active, pcs
-                apply BURNED, pcs
-                apply CONFUSED, pcs
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) {
+                apply BURNED, target
+                apply CONFUSED, target
               }
             }
           }
@@ -2659,7 +2658,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert self.active : "$self is not your active pokémon"
               assert opp.bench : "There is no pokémon on your opponent's bench to switch"
               powerUsed()
-              sw self.owner.opposite.pbg.active, self.owner.opposite.pbg.bench.select("Choose the new active"), SRC_ABILITY
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
             }
           }
           move "Dragon Claw" , {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -317,7 +317,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert opp.bench
               powerUsed()
               flip {
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -387,7 +387,7 @@ public enum CelestialStorm implements LogicCardInfo {
               def pcs = defending
               if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with their Active Pokémon?")){
                 def target = opp.bench.select("Select the new Active Pokémon.")
-                if ( swFromBench (defending, target) ) { pcs = target }
+                if ( sw2(target) ) { pcs = target }
               }
               targeted(pcs) {
                 apply POISONED, pcs
@@ -872,7 +872,7 @@ public enum CelestialStorm implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) {
+              if ( sw2(target) ) {
                 apply BURNED, target
                 apply CONFUSED, target
               }
@@ -2658,7 +2658,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert self.active : "$self is not your active pokémon"
               assert opp.bench : "There is no pokémon on your opponent's bench to switch"
               powerUsed()
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
             }
           }
           move "Dragon Claw" , {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -385,7 +385,7 @@ public enum CelestialStorm implements LogicCardInfo {
             }
             onAttack {
               def pcs = defending
-              if(opp.bench && confirm("Switch the defending pokémon with 1 of your opponent's benched pokémon?")){
+              if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with their Active Pokémon?")){
                 def target = opp.bench.select("Select the new Active Pokémon.")
                 if ( swFromBench (defending, target) ) { pcs = target }
               }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -317,7 +317,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert opp.bench
               powerUsed()
               flip {
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                switchYourOpponentsBenchedWithActive(SRC_ABILITY)
               }
             }
           }
@@ -2658,7 +2658,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert self.active : "$self is not your active pokémon"
               assert opp.bench : "There is no pokémon on your opponent's bench to switch"
               powerUsed()
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+              switchYourOpponentsBenchedWithActive(SRC_ABILITY)
             }
           }
           move "Dragon Claw" , {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -363,8 +363,8 @@ public enum CosmicEclipse implements LogicCardInfo {
               after ATTACH_ENERGY, self, {
                 checkLastTurn()
                 if (self.active && ef.reason==PLAY_FROM_HAND && ef.card.asEnergyCard().containsType(G) && opp.bench && confirm("Use Shining Vine?")) {
-                  sw(opp.active, opp.bench.select(), SRC_ABILITY)
                   powerUsed()
+                  swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
                 }
               }
             }
@@ -2639,7 +2639,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              sw(opp.active, opp.bench.select())
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Zap Cannon", {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -364,7 +364,7 @@ public enum CosmicEclipse implements LogicCardInfo {
                 checkLastTurn()
                 if (self.active && ef.reason==PLAY_FROM_HAND && ef.card.asEnergyCard().containsType(G) && opp.bench && confirm("Use Shining Vine?")) {
                   powerUsed()
-                  swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                  sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
                 }
               }
             }
@@ -2639,7 +2639,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Zap Cannon", {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -364,7 +364,7 @@ public enum CosmicEclipse implements LogicCardInfo {
                 checkLastTurn()
                 if (self.active && ef.reason==PLAY_FROM_HAND && ef.card.asEnergyCard().containsType(G) && opp.bench && confirm("Use Shining Vine?")) {
                   powerUsed()
-                  sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                  switchYourOpponentsBenchedWithActive(SRC_ABILITY)
                 }
               }
             }
@@ -2639,7 +2639,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Zap Cannon", {

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2271,9 +2271,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
         return itemCard (this) {
           text "You can play this card only if you have more Prize cards remaining than your opponent.\nSwitch 1 of your opponent's Benched Pokémon with their Active Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
-            if(opp.bench){
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
-            }
+            switchYourOpponentsBenchedWithActive(TRAINER_CARD)
           }
           playRequirement{
             assert my.prizeCardSet.size() > opp.prizeCardSet.size()

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -313,7 +313,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { damage 40, target }
+              if ( sw2(target) ) { damage 40, target }
             }
           }
 
@@ -2272,7 +2272,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           text "You can play this card only if you have more Prize cards remaining than your opponent.\nSwitch 1 of your opponent's Benched Pokémon with their Active Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
             if(opp.bench){
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -312,9 +312,8 @@ public enum CrimsonInvasion implements LogicCardInfo {
               assert opp.bench.notEmpty : "Empty bench"
             }
             onAttack {
-              def pcs = opp.bench.select("Switch")
-              sw opp.active, pcs
-              damage 40
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { damage 40, target }
             }
           }
 
@@ -2273,8 +2272,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           text "You can play this card only if you have more Prize cards remaining than your opponent.\nSwitch 1 of your opponent's Benched Pokémon with their Active Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
             if(opp.bench){
-              def pcs = opp.bench.select("Switch")
-              sw opp.active, pcs, TRAINER_CARD
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2104,8 +2104,10 @@ public enum ForbiddenLight implements LogicCardInfo {
               assert opp.bench
             }
             onAttack {
-              sw defending, opp.bench.select("New opponent’s Active")
-              if(my.bench) sw self, my.bench.select("Your new Active")
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) && my.bench) {
+                sw self, my.bench.select("Your new Active")
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2105,7 +2105,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) && my.bench) {
+              if ( sw2(target) && my.bench) {
                 sw self, my.bench.select("Select your new Active Pokémon.")
               }
             }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2106,7 +2106,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
               if ( swFromBench (defending, target) && my.bench) {
-                sw self, my.bench.select("Your new Active")
+                sw self, my.bench.select("Select your new Active Pokémon.")
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -1906,7 +1906,7 @@ public enum GuardiansRising implements LogicCardInfo {
             onActivate {r->
               if(r==PLAY_FROM_HAND && opp.bench.notEmpty && confirm('Use Bloodthirsty Eyes?')) {
                 powerUsed()
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                switchYourOpponentsBenchedWithActive(SRC_ABILITY)
               }
             }
           }
@@ -2235,7 +2235,7 @@ public enum GuardiansRising implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -1452,8 +1452,8 @@ public enum GuardiansRising implements LogicCardInfo {
               assert opp.bench
             }
             onAttack {
-              sw opp.active, opp.bench.select("Switch")
-              damage 30, opp.active
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { damage 30, target }
             }
           }
           move "Link Blast", {
@@ -1906,8 +1906,7 @@ public enum GuardiansRising implements LogicCardInfo {
             onActivate {r->
               if(r==PLAY_FROM_HAND && opp.bench.notEmpty && confirm('Use Bloodthirsty Eyes?')) {
                 powerUsed()
-                def pcs = opp.bench.select('New defending')
-                sw opp.active, pcs, SRC_ABILITY
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -2236,10 +2235,7 @@ public enum GuardiansRising implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              def pcs = opp.bench.select()
-              targeted (pcs) {
-                sw opp.active, pcs
-              }
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -1453,7 +1453,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { damage 30, target }
+              if ( sw2(target) ) { damage 30, target }
             }
           }
           move "Link Blast", {
@@ -1906,7 +1906,7 @@ public enum GuardiansRising implements LogicCardInfo {
             onActivate {r->
               if(r==PLAY_FROM_HAND && opp.bench.notEmpty && confirm('Use Bloodthirsty Eyes?')) {
                 powerUsed()
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -2235,7 +2235,7 @@ public enum GuardiansRising implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1706,7 +1706,7 @@ public enum LostThunder implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon on your opponent's bench"
             }
             onAttack{
-              sw defending, opp.bench.select("Choose the new Active Pokémon.")
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Water Gun" , {
@@ -4033,7 +4033,7 @@ public enum LostThunder implements LogicCardInfo {
             if(opp.bench && my.hand.findAll({it.name=="Custom Catcher"}).size()>=2) {
               if(confirm("Use another Custom Catcher and switch your opponent active?") || toDraw == 0){
                 my.hand.findAll({it.name=="Custom Catcher" && it!= thisCard}).subList(0,1).discard()
-                sw opp.active, opp.bench.select("Choose the new active"), TRAINER_CARD
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
                 return
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1706,7 +1706,7 @@ public enum LostThunder implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon on your opponent's bench"
             }
             onAttack{
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Water Gun" , {
@@ -4033,7 +4033,7 @@ public enum LostThunder implements LogicCardInfo {
             if(opp.bench && my.hand.findAll({it.name=="Custom Catcher"}).size()>=2) {
               if(confirm("Use another Custom Catcher and switch your opponent active?") || toDraw == 0){
                 my.hand.findAll({it.name=="Custom Catcher" && it!= thisCard}).subList(0,1).discard()
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
                 return
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1706,7 +1706,7 @@ public enum LostThunder implements LogicCardInfo {
               assert opp.bench : "There is no Pokémon on your opponent's bench"
             }
             onAttack{
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Water Gun" , {
@@ -4033,7 +4033,7 @@ public enum LostThunder implements LogicCardInfo {
             if(opp.bench && my.hand.findAll({it.name=="Custom Catcher"}).size()>=2) {
               if(confirm("Use another Custom Catcher and switch your opponent active?") || toDraw == 0){
                 my.hand.findAll({it.name=="Custom Catcher" && it!= thisCard}).subList(0,1).discard()
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+                switchYourOpponentsBenchedWithActive(TRAINER_CARD)
                 return
               }
             }

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -279,7 +279,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { apply POISONED, target }
+              if ( sw2(target) ) { apply POISONED, target }
             }
           }
           move "Crunch", {

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -278,8 +278,8 @@ public enum ShiningLegends implements LogicCardInfo {
               assert opp.bench
             }
             onAttack {
-              sw opp.active, opp.bench.select()
-              apply POISONED, opp.active
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { apply POISONED, target }
             }
           }
           move "Crunch", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1914,7 +1914,7 @@ public enum SunMoon implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              sw opp.active, opp.bench.select()
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Claw Rend", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1914,7 +1914,7 @@ public enum SunMoon implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Claw Rend", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1914,7 +1914,7 @@ public enum SunMoon implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Claw Rend", {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1030,8 +1030,8 @@ public enum SunMoonPromos implements LogicCardInfo {
               assert opp.bench
             }
             onAttack {
-              sw opp.active, opp.bench.select()
-              apply CONFUSED, opp.active
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { apply CONFUSED, target }
             }
           }
           move "Jumping Side Kick", {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1031,7 +1031,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { apply CONFUSED, target }
+              if ( sw2(target) ) { apply CONFUSED, target }
             }
           }
           move "Jumping Side Kick", {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -334,7 +334,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Bug Bite" , {
@@ -607,9 +607,7 @@ public enum TeamUp implements LogicCardInfo {
               assert src.size() >= 2 : "You don't have enough Fire Energy cards to discard"
               powerUsed()
               src.select(count:2,"Discard").discard()
-              if (opp.bench){
-                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
-              }
+              switchYourOpponentsBenchedWithActive(SRC_ABILITY)
             }
           }
           move "Flame Tail" , {
@@ -2231,7 +2229,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Night Punishment" , {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -334,7 +334,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Bug Bite" , {
@@ -608,7 +608,7 @@ public enum TeamUp implements LogicCardInfo {
               powerUsed()
               src.select(count:2,"Discard").discard()
               if (opp.bench){
-                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
+                sw2(opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -1561,7 +1561,7 @@ public enum TeamUp implements LogicCardInfo {
             energyCost C,C
             onAttack{
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { damage 50, target }
+              if ( sw2(target) ) { damage 50, target }
             }
           }
           move "King's Drum" , {
@@ -2231,7 +2231,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Night Punishment" , {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -334,7 +334,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw opp.active, opp.bench.select("Choose the new active")
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Bug Bite" , {
@@ -608,10 +608,7 @@ public enum TeamUp implements LogicCardInfo {
               powerUsed()
               src.select(count:2,"Discard").discard()
               if (opp.bench){
-                def pcs = opp.bench.select("New active")
-                targeted (pcs, SRC_ABILITY) {
-                  sw(opp.active, pcs, SRC_ABILITY)
-                }
+                swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."), SRC_ABILITY)
               }
             }
           }
@@ -1563,12 +1560,8 @@ public enum TeamUp implements LogicCardInfo {
             text "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. This attack does 50 damage to the new Active Pokémon."
             energyCost C,C
             onAttack{
-              def tar = defending
-              if(opp.bench){
-                tar = opp.bench.select("Select the new active")
-                sw defending, tar
-              }
-              damage 50, tar
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { damage 50, target }
             }
           }
           move "King's Drum" , {
@@ -2238,7 +2231,7 @@ public enum TeamUp implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw defending, opp.bench.select("Choose the new active.")
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Night Punishment" , {

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -327,7 +327,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { apply POISONED, target }
+              if ( sw2(target) ) { apply POISONED, target }
             }
           }
           move "Flower Tornado", {

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -326,11 +326,8 @@ public enum UltraPrism implements LogicCardInfo {
               assert opp.bench.notEmpty
             }
             onAttack {
-              def pcs = opp.bench.select("Switch")
-              targeted(pcs) {
-                sw opp.active, pcs
-                apply POISONED, pcs
-              }
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { apply POISONED, target }
             }
           }
           move "Flower Tornado", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -683,7 +683,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              sw(opp.active, opp.bench.select())
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Gentle Slap", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -683,7 +683,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Gentle Slap", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -683,7 +683,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Gentle Slap", {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1342,7 +1342,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+              switchYourOpponentsBenchedWithActive()
             }
           }
           move "Sticky Web", {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1342,7 +1342,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              sw defending, opp.bench.select("Choose your opponent's new Active Pokémon.")
+              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Sticky Web", {
@@ -3610,12 +3610,8 @@ public enum UnifiedMinds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack {
-              def target = defending
-              if (opp.bench) {
-                target = opp.bench.select("Select the new Active Pokémon.")
-                sw defending, target
-                damage 30, target
-              }
+              def target = opp.bench.select("Select the new Active Pokémon.")
+              if ( swFromBench (defending, target) ) { damage 30, target }
             }
           }
           move "Dragon Tail", {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1342,7 +1342,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               assertOppBench()
             }
             onAttack{
-              swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+              sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
             }
           }
           move "Sticky Web", {
@@ -3611,7 +3611,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( swFromBench (defending, target) ) { damage 30, target }
+              if ( sw2(target) ) { damage 30, target }
             }
           }
           move "Dragon Tail", {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2767,10 +2767,8 @@ public enum RebelClash implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            def target = defending
-            target = opp.bench.select("Select the new Active Pokémon.")
-            sw defending, target
-            damage 30, target
+            def target = opp.bench.select("Select the new Active Pokémon.")
+            if ( swFromBench (defending, target) ) { damage 30, target }
           }
         }
         move "Brain Shake", {
@@ -3474,10 +3472,7 @@ public enum RebelClash implements LogicCardInfo {
       return supporter (this) {
         text "Choose 1 of your opponent’s Benched Pokemon and switch it with their Active Pokemon. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
-          def pcs = opp.bench.select("New active")
-          targeted (pcs, TRAINER_CARD) {
-            sw opp.active, pcs, TRAINER_CARD
-          }
+          swFromBench(opp.active, opp.bench.select("Select the new Active Pokémon."), TRAINER_CARD)
         }
         playRequirement {
           assertOppBench()

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2768,7 +2768,7 @@ public enum RebelClash implements LogicCardInfo {
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( swFromBench (defending, target) ) { damage 30, target }
+            if ( sw2(target) ) { damage 30, target }
           }
         }
         move "Brain Shake", {
@@ -3472,7 +3472,7 @@ public enum RebelClash implements LogicCardInfo {
       return supporter (this) {
         text "Choose 1 of your opponent’s Benched Pokemon and switch it with their Active Pokemon. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
-          swFromBench(opp.active, opp.bench.select("Select the new Active Pokémon."), TRAINER_CARD)
+          sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
         }
         playRequirement {
           assertOppBench()

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3472,7 +3472,7 @@ public enum RebelClash implements LogicCardInfo {
       return supporter (this) {
         text "Choose 1 of your opponent’s Benched Pokemon and switch it with their Active Pokemon. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
-          sw2(opp.bench.select("Select your opponent's new Active Pokémon."), TRAINER_CARD)
+          switchYourOpponentsBenchedWithActive(TRAINER_CARD)
         }
         playRequirement {
           assertOppBench()

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -524,7 +524,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
         move "Double Hit", {
@@ -1544,7 +1544,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
+            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
         move "Lightning Ball", {

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -524,7 +524,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+            switchYourOpponentsBenchedWithActive()
           }
         }
         move "Double Hit", {
@@ -1544,7 +1544,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            sw2(opp.bench.select("Select your opponent's new Active Pokémon."))
+            switchYourOpponentsBenchedWithActive()
           }
         }
         move "Lightning Ball", {

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -524,7 +524,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            sw(opp.active, opp.bench.select())
+            swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
         move "Double Hit", {
@@ -1544,7 +1544,7 @@ public enum SwordShield implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            sw(opp.active, opp.bench.select())
+            swFromBench (opp.active, opp.bench.select("Select your opponent's new Active Pokémon."))
           }
         }
         move "Lightning Ball", {


### PR DESCRIPTION
Many (but not all) attacks, abilities and poké-powers/bodies trigger a switch effect that's applied to the benched Pokémon. `sw` on itself is triggered for both switched pokemon as an ATTACK/TRAINER_CARD/SRC_ABILITY effect **(Update: This may not be accurate, tho a change is still needed.)**. ~~Using [swFromBench](https://github.com/axpendix/tcgone-engine-contrib/blob/0b6c994535cdb5fa4d44ea5d42ddfa0ba6ab21d1/src/tcgwars/logic/groovy/TcgStatics.groovy#L442) handles the targeting part on itself, and also provides a boolean return for when a following effect depends on the switch being successful or not (Drag Off and Guzma being prime examples).~~

**Update: Switched to a `sw2` method after talking with @axpendix, as sw already returns a boolean. `sw2` will return false if the switch is prevented, and also make the proper `Switch` call so the correct pcs is targeted (while making some switch lines shorter and clearer).**

This change makes trainers work properly against Omega Barrier or Unnerve Pokémon. Plus, attacks that depend on the switch in order to damage the new Pokémon properly do so (not affecting the active when not switched) in a cleaner way.