### PR TITLE
Multiple card fixes, revolving around adding DEVOLVE checks (but more stuff on a couple separate commits)

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -429,6 +429,7 @@ class TcgStatics {
         unregisterAfter 2
         after SWITCH, defending, {unregister()}
         after EVOLVE, defending, {unregister()}
+        after DEVOLVE, defending, {unregister()}
       }
     } }
   }
@@ -626,6 +627,7 @@ class TcgStatics {
       unregisterAfter 3
       after SWITCH, self, {unregister()}
       after EVOLVE, self, {unregister()}
+      after DEVOLVE, self, {unregister()}
       register{registeredOn=bg.turnCount}
     }
   }
@@ -695,6 +697,7 @@ class TcgStatics {
       }
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
+      after DEVOLVE, self, {unregister()}
       after SWITCH, self, {unregister()}
     }
   }
@@ -717,6 +720,7 @@ class TcgStatics {
       }
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
+      after DEVOLVE, self, {unregister()}
       after SWITCH, self, {unregister()}
     }
   }
@@ -733,6 +737,7 @@ class TcgStatics {
       }
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
+      after DEVOLVE, self, {unregister()}
       after SWITCH, self, {unregister()}
     }
   }
@@ -788,9 +793,11 @@ class TcgStatics {
         if(asLongAsSelfIsActive){
           after SWITCH, self, {unregister()}
           after EVOLVE, self, {unregister()}
+          after DEVOLVE, self, {unregister()}
         }
         after SWITCH, defending, {unregister()}
         after EVOLVE, defending, {unregister()}
+        after DEVOLVE, defending, {unregister()}
         unregisterAfter 2
       }
     } } }
@@ -1021,6 +1028,7 @@ class TcgStatics {
 				unregisterAfter 2
         after SWITCH, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
+        after DEVOLVE, pcs, {unregister()}
 			}
 		}
 	}
@@ -1041,6 +1049,7 @@ class TcgStatics {
 				unregisterAfter 2
         after SWITCH, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
+        after DEVOLVE, pcs, {unregister()}
 			}
 		}
 	}
@@ -1057,6 +1066,7 @@ class TcgStatics {
         unregisterAfter 3
         after SWITCH, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
+        after DEVOLVE, pcs, {unregister()}
       }
     }
   }
@@ -1286,6 +1296,7 @@ class TcgStatics {
   static void cantBeHealed(PokemonCardSet defending){
     delayed {
       after EVOLVE, defending, {unregister()}
+      after DEVOLVE, defending, {unregister()}
       after SWITCH, defending, {unregister()}
 
       before REMOVE_DAMAGE_COUNTER, defending, {

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1186,6 +1186,7 @@ public enum BaseSetNG implements LogicCardInfo {
                   }
                   after SWITCH, defending, {unregister()}
                   after EVOLVE, defending, {unregister()}
+                  after DEVOLVE, defending, {unregister()}
                 }
               }
             }
@@ -1399,6 +1400,7 @@ public enum BaseSetNG implements LogicCardInfo {
                   }
                 }
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
                 unregisterAfter 2
               }

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -766,6 +766,7 @@ public enum FossilNG implements LogicCardInfo {
                 unregisterAfter 2
                 after SWITCH, self,{unregister()}
                 after EVOLVE, self,{unregister()}
+                after DEVOLVE, self,{unregister()}
 
               }
             }

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1064,6 +1064,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                 }
                 after SWITCH, self, {unregister()}
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
 
                 unregisterAfter 2
               }
@@ -1126,6 +1127,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                     }
                     after SWITCH, defending, {unregister()}
                     after EVOLVE, defending, {unregister()}
+                    after DEVOLVE, defending, {unregister()}
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2776,6 +2776,8 @@ public enum Deoxys implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
+                after SWITCH, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -2110,6 +2110,7 @@ public enum DragonFrontiers implements LogicCardInfo {
               unregisterAfter 2
               after SWITCH, self, { unregister() }
               after EVOLVE, self, { unregister() }
+              after DEVOLVE, self, { unregister() }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -421,6 +421,7 @@ public enum Emerald implements LogicCardInfo {
                 }
                 after SWITCH, self, {unregister()}
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 unregisterAfter 3
               }
             }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2714,6 +2714,7 @@ public enum DiamondPearl implements LogicCardInfo {
                   }
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()} //This attack could be copied by an evolution.
                   after SWITCH, self, {unregister()}
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1016,18 +1016,23 @@ public enum DiamondPearl implements LogicCardInfo {
               damage 60
               //TODO: Could be generalized into a method (adapted from LM DUSTOX_EX_86). Do some other cards use a similar effect under a different attack name/description?
               afterDamage{
-                delayed {
-                  before APPLY_ATTACK_DAMAGES, {
-                    bg.dm().each{
-                      if(it.to == opp.active && it.notNoEffect && it.dmg.value && bg.currentTurn == self.owner) {
-                        bc "Sand Eject +40"
-                        it.dmg += hp(40)
+                targeted (defending){
+                  bc "During ${my.owner.getPlayerUsername(bg)}'s next turn, if an attack does damage to the Defending ${defending} that attack will do 40 more damage (after W/R). (This effect can be removed by evolving or benching ${defending}.)"
+                  def pcs = defending
+                  delayed {
+                    before APPLY_ATTACK_DAMAGES, {
+                      bg.dm().each{
+                        if(it.to == pcs && it.notNoEffect && it.dmg.value && bg.currentTurn == self.owner) {
+                          bc "Sand Eject +40"
+                          it.dmg += hp(40)
+                        }
                       }
                     }
+                    after SWITCH, pcs, {unregister()}
+                    after EVOLVE, pcs, {unregister()}
+                    after DEVOLVE, pcs, {unregister()}
+                    unregisterAfter 3
                   }
-                  after SWITCH, defending, {unregister()}
-                  after EVOLVE, defending, {unregister()}
-                  unregisterAfter 3
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -293,6 +293,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, self, { unregister() }
                   after EVOLVE, self, { unregister() }
+                  after DEVOLVE, self, { unregister() }
                 }
               }
             }
@@ -1304,6 +1305,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   }
                   after SWITCH, self, {unregister()}
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                   unregisterAfter 1
                 }
                 bc "During this turn, Slaking's Lazy Blow attack's base damage is 130."
@@ -1321,6 +1323,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   }
                   after SWITCH, self, {unregister()}
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                   unregisterAfter 1
                 }
               }
@@ -2058,6 +2061,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
               }
             }
@@ -3496,6 +3500,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, self, {unregister()}
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                 }
               }
             }
@@ -3518,6 +3523,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
               }
             }
@@ -3551,6 +3557,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 }
                 //TODO: Remove if these are not needed.
                 // after EVOLVE, torridWaveRecipient, {unregister()}
+                // after DEVOLVE, torridWaveRecipient, {unregister()}
                 // after SWITCH, torridWaveRecipient, {unregister()}
                 after CLEAR_SPECIAL_CONDITION, torridWaveRecipient, {
                   if(ef.types.contains(BURNED)){

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -514,16 +514,21 @@ public enum BurningShadows implements LogicCardInfo {
             onAttack {
               damage 30
               afterDamage {
-                delayed {
-                  before ATTACH_ENERGY, defending, {
-                    if(ef.reason == PLAY_FROM_HAND) {
-                      wcu "Bubble Net: Can't attach energy"
-                      prevent()
+                targeted (defending) {
+                  bc "During ${opp.owner.getPlayerUsername(bg)}'s next turn, Energy can't be attached from their hand to the Defending ${defending}. (This effect can be removed by evolving or benching ${defending}.)"
+                  def pcs = defending
+                  delayed {
+                    before ATTACH_ENERGY, pcs, {
+                      if(ef.reason == PLAY_FROM_HAND) {
+                        wcu "Bubble Net: Can't attach energy to ${pcs}"
+                        prevent()
+                      }
                     }
+                    unregisterAfter 2
+                    after SWITCH, pcs, {unregister()}
+                    after EVOLVE, pcs, {unregister()}
+                    after DEVOLVE, pcs, {unregister()}
                   }
-                  unregisterAfter 2
-                  after SWITCH, defending, {unregister()}
-                  after EVOLVE, defending, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -1434,10 +1434,12 @@ public enum BurningShadows implements LogicCardInfo {
             energyCost C
             onAttack {
               targeted (defending) {
+                bc "Until the end of ${my.owner.getPlayerUsername(bg)}'s next turn, the weakness of the Defending ${defending} is [P]. (This effect can be removed by evolving or benching ${defending}.)"
+                def pcs = defending
                 delayed {
                   def eff
                   register {
-                    eff = getter (GET_WEAKNESSES, defending) {h->
+                    eff = getter (GET_WEAKNESSES, pcs) {h->
                       def list = h.object as List<Weakness>
                       if(list) {
                         list.get(0).type = PSYCHIC
@@ -1449,8 +1451,9 @@ public enum BurningShadows implements LogicCardInfo {
                   unregister {
                     eff.unregister()
                   }
-                  after SWITCH, defending, {unregister()}
-                  after EVOLVE, defending, {unregister()}
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                   unregisterAfter 2
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2468,15 +2468,17 @@ public enum CelestialStorm implements LogicCardInfo {
                 apply ASLEEP, self
 
                 targeted (defending) {
-                  bc "At the end of ${self.owner.opposite}'s next turn, $defending will be Knocked Out. (This effect can be removed by benching/evolving $defending)"
+                  bc "At the end of ${self.owner.opposite}'s next turn, the Defending ${defending} will be Knocked Out. (This effect can be removed by benching/evolving ${defending}.)"
+                  def pcs = defending
                   delayed {
                     before BETWEEN_TURNS, {
                       if(bg.currentTurn == self.owner.opposite){
-                        new Knockout(defending).run(bg)
+                        new Knockout(pcs).run(bg)
                       }
                     }
-                    after SWITCH, defending, {unregister()}
-                    after EVOLVE, defending, {unregister()}
+                    after SWITCH, pcs, {unregister()}
+                    after EVOLVE, pcs, {unregister()}
+                    after DEVOLVE, pcs, {unregister()}
                     unregisterAfter 2
                   }
                 }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -1856,6 +1856,7 @@ public enum CelestialStorm implements LogicCardInfo {
                   }
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                   after SWITCH, self, {unregister()}
                 }
               }
@@ -1952,6 +1953,7 @@ public enum CelestialStorm implements LogicCardInfo {
                   }
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                   after SWITCH, self, {unregister()}
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3709,18 +3709,23 @@ public enum CosmicEclipse implements LogicCardInfo {
             onAttack {
               damage 30
               afterDamage { targeted (defending) {
+                bc "During ${self.owner.opposite}'s next turn, the Defending ${defending}'s attacks do 30 less damage (before W/R). (This effect can be removed by benching/evolving ${defending}.)"
+                def pcs = defending
                 delayed {
-                  before APPLY_ATTACK_DAMAGES, {
-                    bg.dm().each {
-                      if(it.from==defending && ef.attacker==defending && it.dmg.value){
-                        bc "${thisMove.name} reduces damage"
-                        it.dmg-=hp(30)
+                  after PROCESS_ATTACK_EFFECTS, {
+                    if (ef.attacker == pcs){
+                      bg.dm().each {
+                        if(it.notNoEffect && it.dmg.value){
+                          bc "${thisMove.name} reduces damage"
+                          it.dmg-=hp(30)
+                        }
                       }
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, defending, {unregister()}
-                  after EVOLVE, defending, {unregister()}
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
               } }
             }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1977,6 +1977,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, self, {unregister()}
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2070,6 +2070,7 @@ public enum GuardiansRising implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
               }
             }
@@ -2298,6 +2299,7 @@ public enum GuardiansRising implements LogicCardInfo {
                 }
                 after SWITCH, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
+                after DEVOLVE, pcs, {unregister()}
                 unregisterAfter 3
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -495,16 +495,21 @@ public enum LostThunder implements LogicCardInfo {
             energyCost C,C
             onAttack{
               damage 30
-              delayed {
-                before null, defending, Source.TRAINER_CARD, {
-                  if (bg.currentThreadPlayerType != self.owner){
-                    bc "Trap Thread prevents effect"
-                    prevent()
+              targeted (defending) {
+                bc "During ${self.owner.opposite}'s next turn, whenever they play an Item or Supporter from their hand, all effects of that card done to the Defending ${defending} will be prevented. (This effect can be removed by benching/evolving ${defending}.)"
+                def pcs = defending
+                delayed {
+                  before null, pcs, Source.TRAINER_CARD, {
+                    if (bg.currentThreadPlayerType != self.owner){
+                      bc "Trap Thread prevents effect"
+                      prevent()
+                    }
                   }
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
+                  unregisterAfter 2
                 }
-                after SWITCH, defending, {unregister()}
-                after EVOLVE, defending, {unregister()}
-                unregisterAfter 2
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2996,6 +2996,7 @@ public enum SunMoonPromos implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -869,6 +869,7 @@ public enum UltraPrism implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -2131,21 +2131,27 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost P, C, C
             onAttack {
               damage 70
-              def pcs = defending
-              afterDamage { delayed {
-                def ef
-                register {
-                  ef = getter(GET_WEAKNESSES, pcs) { Holder<List<Weakness>> h ->
-                    h.object = h.object.collect { it = it.copy(); it.type = PSYCHIC; it }
+              afterDamage {
+                targeted (defending) {
+                  bc "Until the end of ${my.owner.getPlayerUsername(bg)}'s next turn, the weakness of the Defending ${defending} is [P]. (This effect can be removed by evolving or benching ${defending}.)"
+                  def pcs = defending
+                  delayed {
+                    def ef
+                    register {
+                      ef = getter(GET_WEAKNESSES, pcs) { Holder<List<Weakness>> h ->
+                        h.object = h.object.collect { it = it.copy(); it.type = PSYCHIC; it }
+                      }
+                    }
+                    after EVOLVE, pcs, {unregister()}
+                    after DEVOLVE, pcs, {unregister()}
+                    after SWITCH, pcs, {unregister()}
+                    unregister {
+                      ef.unregister()
+                    }
+                    unregisterAfter 3
                   }
                 }
-                after EVOLVE, pcs, {unregister()}
-                after FALL_BACK, pcs, {unregister()}
-                unregister {
-                  ef.unregister()
-                }
-                unregisterAfter 3
-              } }
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -667,6 +667,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 unregisterAfter 3
                 after SWITCH, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
+                after DEVOLVE, pcs, {unregister()}
               }
               bg.em().run(new CheckAbilities())
             }
@@ -1468,6 +1469,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   }
                 }
                 after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 after SWITCH, self, {unregister()}
                 unregisterAfter 2
               }
@@ -2211,6 +2213,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   }
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
+                  after DEVOLVE, self, {unregister()} //Could be copied by an evolution.
                   after SWITCH, self, {unregister()}
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3903,6 +3903,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                       unregisterAfter 2
                       after SWITCH, self, { unregister() }
                       after EVOLVE, self, { unregister() }
+                      after DEVOLVE, self, { unregister() }
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3812,16 +3812,22 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "During your opponent's next turn, if they attach an Energy card from their hand to the Defending Pokémon, their turn ends."
             energyCost C
             onAttack {
-              delayed {
-                after ATTACH_ENERGY, {
-                  if (ef.reason == PLAY_FROM_HAND && bg.currentTurn == self.owner.opposite && ef.resolvedTarget.owner == self.owner.opposite && ef.resolvedTarget.isActive()) {
-                    wcu "Lazy Howl ends your turn."
-                    bg.gm().betweenTurns()
+              targeted (defending) {
+                bc "During ${self.owner.opposite}'s next turn, if they attach an Energy card from their hand to the Defending ${defending}, their turn ends. (This effect can be removed by benching/evolving ${defending}.)"
+                def pcs = defending
+                delayed {
+                  //TODO: Don't end turn if action is not yet finished (e.g. Welder, Alcremie attack, Energy Evolution)
+                  after ATTACH_ENERGY, {
+                    if (ef.reason == PLAY_FROM_HAND && bg.currentTurn == self.owner.opposite && ef.resolvedTarget == pcs) {
+                      wcu "Lazy Howl ends your turn."
+                      bg.gm().betweenTurns()
+                    }
                   }
+                  unregisterAfter 2
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
-                unregisterAfter 2
-                after EVOLVE, defending, {unregister()}
-                after SWITCH, defending, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3163,6 +3163,7 @@ public enum DarknessAblaze implements LogicCardInfo {
               unregisterAfter 2
               after SWITCH, self, {unregister()}
               after EVOLVE, self, {unregister()}
+              after DEVOLVE, self, {unregister()}
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2290,6 +2290,7 @@ public enum RebelClash implements LogicCardInfo {
 
                 after SWITCH, self, { unregister() }
                 after EVOLVE, self, { unregister() }
+                after DEVOLVE, self, { unregister() }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -514,16 +514,23 @@ public enum RebelClash implements LogicCardInfo {
           energyCost C
           onAttack {
             damage 30
-            delayed{
-              before ATTACH_ENERGY, self.owner.opposite.pbg.active, {
-                if(ef.reason == PLAY_FROM_HAND && ef.resolvedTarget.owner == self.owner.opposite && ef.resolvedTarget.active) {
-                  wcu "Pattern Menace prevents you from attaching Energy."
-                  prevent()
+            afterDamage {
+              targeted (defending) {
+                bc "During ${opp.owner.getPlayerUsername(bg)}'s next turn, Energy can't be attached from their hand to the Defending ${defending}. (This effect can be removed by evolving or benching ${defending}.)"
+                def pcs = defending
+                delayed {
+                  before ATTACH_ENERGY, pcs, {
+                    if(ef.reason == PLAY_FROM_HAND) {
+                      wcu "Bubble Net: Can't attach energy to ${pcs}"
+                      prevent()
+                    }
+                  }
+                  unregisterAfter 2
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
               }
-              unregisterAfter 2
-              after SWITCH, defending, {unregister()}
-              after EVOLVE, defending, {unregister()}
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2913,6 +2913,7 @@ public enum SwordShield implements LogicCardInfo {
                   unregisterAfter 2
                   after SWITCH, self, { unregister() }
                   after EVOLVE, self, { unregister() }
+                  after DEVOLVE, self, { unregister() }
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2404,7 +2404,9 @@ public enum SwordShield implements LogicCardInfo {
               wcu "Can't apply Octolock to a Pokémon more than once."
             else if (defending.active) {
               keyStore("Octolock", self, true)
-              targeted(defending) {
+              targeted (defending) {
+                bc "Until this Grapploct leaves the Active Spot, the Defending ${defending}'s attacks cost [C][C] more, and said ${defending} can't retreat. (This effect can also be removed by benching/evolving ${defending}.)"
+                def pcs = defending
                 def eff1, eff2
                 delayed {
                   eff1 = delayed {
@@ -2423,7 +2425,6 @@ public enum SwordShield implements LogicCardInfo {
                     }
                     h.object=list
                   }
-                  bc "Until this Grapploct leaves the Active Spot, attacks of $defending will now cost [C][C] more."
 
                   unregister {
                     keyStore("Octolock", self, 0)
@@ -2433,8 +2434,10 @@ public enum SwordShield implements LogicCardInfo {
 
                   after SWITCH, self, {unregister()}
                   after EVOLVE, self, {unregister()}
-                  after SWITCH, defending, {unregister()}
-                  after EVOLVE, defending, {unregister()}
+                  after DEVOLVE, self, {unregister()}
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
                 }
 
               }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -1248,6 +1248,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
                 }
               }
               after EVOLVE, self, {unregister()}
+              after DEVOLVE, self, {unregister()}
               after SWITCH, self, {unregister()}
               unregisterAfter 2
             }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
@@ -1125,18 +1125,24 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             flip{
-              delayed {
-                before CHECK_ATTACK_REQUIREMENTS, {
-                  if(self.active && ef.attacker.owner != self.owner) {
-                    wcu "Leer prevents attack"
-                    prevent()
+              targeted (defending){
+                bc "During ${opp.owner.getPlayerUsername(bg)}'s next turn, the defending ${defending} can't attack ${self}. (This effect can be removed by benching/evolving either Pokémon.)"
+                def pcs = defending
+                delayed {
+                  before CHECK_ATTACK_REQUIREMENTS, {
+                    if(self.active && ef.attacker == pcs) {
+                      wcu "Leer prevents attack"
+                      prevent()
+                    }
                   }
+                  after SWITCH, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
+                  after SWITCH,self, {unregister()}
+                  after EVOLVE,self, {unregister()}
+                  after DEVOLVE,self, {unregister()}
+                  unregisterAfter 2
                 }
-                unregisterAfter 2
-                after SWITCH, defending, {unregister()}
-                after EVOLVE, defending, {unregister()}
-                after EVOLVE,self, {unregister()}
-                after SWITCH,self, {unregister()}
               }
             }
           }


### PR DESCRIPTION
First commit is pretty straightforward, just adds `after DEVOLVE` unregisters. I think they're needed in all modified cards but let me know if you think some shouldn't.

Regarding other commits: One situation I noticed on some cards is the effect remaining on the new active on certain situations. While maybe unnecessary, setting a pcs variable pointing to the specific... well, PCS, should make it work more reliably in theory, at least in my opinion. Also includes some changes in some implementations, beyond the DEVOLVE check above.