### PR TITLE
Make opponent's hand to appear randomized to the player when needed

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -956,7 +956,7 @@ class TcgStatics {
   }
 
   static void astonish(int count=1){
-    if(checkBodyguard()) return
+    if(checkBodyguard() || !opp.hand) return
     def sel = opp.hand.shuffledCopy().select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to be shuffled into his or her deck").showToMe("Selected card(s)").showToOpponent("Astonish: these cards will be shuffled from your hand to your deck")
     sel.moveTo(opp.deck)
     shuffleDeck(null, TargetPlayer.OPPONENT)
@@ -970,7 +970,7 @@ class TcgStatics {
   }
 
   static void discardRandomCardFromOpponentsHand(){
-    if(opp.hand) opp.hand.select(hidden: true, "Discard a random card from your opponent's hand.").discard()
+    if (opp.hand) opp.hand.shuffledCopy().select(hidden: true, "Discard a random card from your opponent's hand.").discard()
   }
 
   static void switchYourActive(Map params=[:]){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -957,7 +957,7 @@ class TcgStatics {
 
   static void astonish(int count=1){
     if(checkBodyguard()) return
-    def sel = randomizedOpponentsHand().select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to be shuffled into his or her deck").showToMe("Selected card(s)").showToOpponent("Astonish: these cards will be shuffled from your hand to your deck")
+    def sel = opp.hand.shuffledCopy().select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to be shuffled into his or her deck").showToMe("Selected card(s)").showToOpponent("Astonish: these cards will be shuffled from your hand to your deck")
     sel.moveTo(opp.deck)
     shuffleDeck(null, TargetPlayer.OPPONENT)
 //		opp.hand.removeAll(sel)
@@ -1365,12 +1365,6 @@ class TcgStatics {
       chosenDeck.setSubList(0, list)
       bc "${delegate.thisMove} rearranged ${delegate.self}'s $bcString deck"
     }
-  }
-
-  static randomizedOpponentsHand() {
-    def oppHand = opp.hand.copy()
-    oppHand.shuffle()
-    return oppHand
   }
 
   static whirlwind2(int dmg = 0, int selfDmg = 0){

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1817,16 +1817,17 @@ public enum BaseSetNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
           onPlay {
-            opp.hand.showToMe("Opponent's hand")
-            my.hand.showToOpponent("Opponent's hand")
+            opp.hand.shuffledCopy().showToMe("Opponent's hand")
+            my.hand.getExcludedList(thisCard).shuffledCopy().showToOpponent("Opponent's hand")
             def tarOpp = opp.hand.filterByType(TRAINER)
-            def tarMy = my.hand.filterByType(TRAINER)
+            def tarMy = my.hand.getExcludedList(thisCard).filterByType(TRAINER)
             opp.hand.removeAll(tarOpp)
             my.hand.removeAll(tarMy)
             shuffleDeck(tarOpp, TargetPlayer.OPPONENT)
             shuffleDeck(tarMy)
           }
           playRequirement{
+            assert (opp.hand || my.hand) : "Neither player has any cards in hand"
           }
         };
       case POKEMON_BREEDER: //TODO: Use the implementation of Rare Candy (admin: they are not the same!)

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -1106,7 +1106,7 @@ public enum FossilNG implements LogicCardInfo {
             text "Your opponent plays with his or her hand face up. This power stops working while Omanyte is Asleep, Confused, or Paralyzed."
             actionA {
               //TODO: Make cards visible, even to spectators.
-              opp.hand.showToMe("opponent's hand")
+              opp.hand.shuffledCopy().showToMe("opponent's hand")
             }
           }
           move "Water Gun", {

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -1105,6 +1105,7 @@ public enum FossilNG implements LogicCardInfo {
           pokemonPower "Clairvoyance", {
             text "Your opponent plays with his or her hand face up. This power stops working while Omanyte is Asleep, Confused, or Paralyzed."
             actionA {
+              //TODO: Make cards visible, even to spectators.
               opp.hand.showToMe("opponent's hand")
             }
           }

--- a/src/tcgwars/logic/impl/gen1/JungleNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/JungleNG.groovy
@@ -1211,7 +1211,7 @@ public enum JungleNG implements LogicCardInfo {
               switch (choice){
                 case 0: my.deck.subList(0,1).showToMe("Top of your deck"); break;
                 case 1: opp.deck.subList(0,1).showToMe("Top of your opponent's deck"); break;
-                case 2: opp.hand.select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break;
+                case 2: opp.hand.shuffledCopy().select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break;
                 case 3: my.prizeCardSet.select(hidden: true, "Select a random card from your prizes").showToMe("Selected card"); break;
                 case 4: opp.prizeCardSet.select(hidden: true, "Select a random card from your opponent's prizes").showToMe("Selected card"); break;
               }

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -619,7 +619,7 @@ public enum TeamRocketNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
           onPlay {
-            def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(TRAINER)
+            def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(TRAINER)
             if(list){
               list.select(count: 1, "Discard").moveTo(opp.deck)
               shuffleDeck(null, TargetPlayer.OPPONENT)

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -619,8 +619,7 @@ public enum TeamRocketNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
           onPlay {
-            opp.hand.showToMe("Opponent's hand")
-            def list = opp.hand.filterByType(TRAINER)
+            def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(TRAINER)
             if(list){
               list.select(count: 1, "Discard").moveTo(opp.deck)
               shuffleDeck(null, TargetPlayer.OPPONENT)

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -2046,7 +2046,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             my.hand.select(count: amountToDiscard, "Discard until 6 cards left in hand").discard()
 
             def oppAmountToDiscard = Math.max(opp.hand.size() - 6, 0)
-            opp.hand.select(count: oppAmountToDiscard, "Discard until 6 cards left in hand").discard()
+            opp.hand.oppSelect(count: oppAmountToDiscard, "Discard until 6 cards left in hand").discard()
           }
         }
         move "Upstream", {

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -900,7 +900,7 @@ public enum Deoxys implements LogicCardInfo {
               assert self.active : "$self is not your active Pokémon."
               assert opp.hand : "There are no cards in your opponent's hand"
               powerUsed()
-              opp.hand.showToMe("Opponent's hand")
+              randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Slash", {

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -900,7 +900,7 @@ public enum Deoxys implements LogicCardInfo {
               assert self.active : "$self is not your active Pokémon."
               assert opp.hand : "There are no cards in your opponent's hand"
               powerUsed()
-              randomizedOpponentsHand().showToMe("Opponent's hand")
+              opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Slash", {

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -367,7 +367,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             assert opp.hand : "Your opponent has no cards in their hand"
             bg.em().storeObject("Sharing",bg.turnCount)
             powerUsed()
-            def randomOppHand = randomizedOpponentsHand()
+            def randomOppHand = opp.hand.shuffledCopy()
             if (randomOppHand.hasType(SUPPORTER)) {
               def sel = randomOppHand.select(min: 0, "Opponent's hand. You may select a Supporter and use it as the effect of this power.", cardTypeFilter(SUPPORTER))
               if (sel){

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -364,12 +364,12 @@ public enum DragonFrontiers implements LogicCardInfo {
             checkLastTurn()
             assert bg.em().retrieveObject("Sharing") != bg.turnCount : "You can’t use more than 1 Sharing Poké-Power each turn"
             checkNoSPC()
-            assert opp.hand : "Opponent hand is empty"
+            assert opp.hand : "Your opponent has no cards in their hand"
             bg.em().storeObject("Sharing",bg.turnCount)
             powerUsed()
-
-            if (opp.hand.hasType(SUPPORTER)) {
-              def sel = opp.hand.select(min: 0, "Opponent's hand. You may select a Supporter and use it as the effect of this power.", cardTypeFilter(SUPPORTER))
+            def randomOppHand = randomizedOpponentsHand()
+            if (randomOppHand.hasType(SUPPORTER)) {
+              def sel = randomOppHand.select(min: 0, "Opponent's hand. You may select a Supporter and use it as the effect of this power.", cardTypeFilter(SUPPORTER))
               if (sel){
                 delayed {
                   def eff
@@ -389,7 +389,7 @@ public enum DragonFrontiers implements LogicCardInfo {
                 bg.clearDeterministicCurrentThreadPlayerType()
               }
             } else {
-              opp.hand.showToMe("Opponent's hand. No supporter in there.")
+              randomOppHand.showToMe("Opponent's hand. No supporter in there.")
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2603,7 +2603,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             energyCost P, C
             onAttack {
               damage 40
-              opp.hand.showToMe("Opponent’s hand")
+              opp.hand.shuffledCopy().showToMe("Opponent’s hand")
               damage 10*opp.hand.findAll{it.cardTypes.is(TRAINER)}.size()
             }
           }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -791,11 +791,11 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "30+ damage. Look at your opponent's hand. This attack does 30 damage plus 10 more damage for each Trainer card in your opponent's hand."
           energyCost P, M
           onAttack {
-            opp.hand.showToMe("Opponent’s hand")
+            opp.hand.shuffledCopy().showToMe("Opponent’s hand")
             def trainerSize = opp.hand.findAll { it.cardTypes.is(TRAINER) }.size()
 
-            damage 30+10*trainerSize
             bc "Found $trainerSize Trainer cards"
+            damage 30+10*trainerSize
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2441,7 +2441,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             assert self.benched : "This Pokemon is not benched"
             assert opp.hand : "Opponent's hand is empty"
             powerUsed()
-            opp.hand.showToMe("Opponent's hand")
+            randomizedOpponentsHand().showToMe("Your opponent's hand")
           }
         }
         move "Super Psy Bolt", {

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -1401,7 +1401,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           energyCost L, C
           onAttack {
             damage 30
-            def chosenCard = randomizedOpponentsHand().select(hidden: true, count: 1, "Choose 1 card from your opponent's hand without looking.")
+            def chosenCard = opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose 1 card from your opponent's hand without looking.")
             def result = ""
 
             if (chosenCard.first().cardTypes.is(TRAINER)){
@@ -2441,7 +2441,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             assert self.benched : "This Pokemon is not benched"
             assert opp.hand : "Opponent's hand is empty"
             powerUsed()
-            randomizedOpponentsHand().showToMe("Your opponent's hand")
+            opp.hand.shuffledCopy().showToMe("Your opponent's hand")
           }
         }
         move "Super Psy Bolt", {

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -2085,7 +2085,7 @@ public enum PowerKeepers implements LogicCardInfo {
             assert opp.hand : "Opponent's hand is empty"
           }
           onAttack {
-            def pokeCards = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(POKEMON)
+            def pokeCards = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(POKEMON)
             if (pokeCards) {
               def card = pokeCards.select(max:1, "Select a Pokémon and use one of that Pokémon’s attacks as this attack.").first()
               bc "$card was chosen"

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -2085,10 +2085,9 @@ public enum PowerKeepers implements LogicCardInfo {
             assert opp.hand : "Opponent's hand is empty"
           }
           onAttack {
-            opp.hand.showToMe("Opponent's hand")
-            def tmp = opp.hand.filterByType(POKEMON).select(max:1, "Select a Pokémon and use one of that Pokémon’s attacks as this attack.")
-            if (tmp) {
-              def card = tmp.first()
+            def pokeCards = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(POKEMON)
+            if (pokeCards) {
+              def card = pokeCards.select(max:1, "Select a Pokémon and use one of that Pokémon’s attacks as this attack.").first()
               bc "$card was chosen"
               def moves = card.asPokemonCard().moves
               if (moves) {
@@ -2097,7 +2096,11 @@ public enum PowerKeepers implements LogicCardInfo {
                 def bef=blockingEffect(ENERGY_COST_CALCULATOR, BETWEEN_TURNS)
                 attack (move as Move)
                 bef.unregisterItself(bg().em())
+              } else {
+                bc "$thisMove failed! The selected Pokémon card had no attacks on it."
               }
+            } else {
+              bc "$thisMove failed! There were no Pokémon to copy an attack from."
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -326,8 +326,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
             energyCost D, C
             onAttack {
               damage 20
-              if (opp.hand){
-                opp.hand.select(hidden: true, "Select random card from opponent's hand").showToOpponent("Card to be discarded").discard()
+              afterDamage {
+                discardRandomCardFromOpponentsHand()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -326,7 +326,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             energyCost D, C
             onAttack {
               damage 20
-              if(opp.hand){
+              if (opp.hand){
                 opp.hand.select(hidden: true, "Select random card from opponent's hand").showToOpponent("Card to be discarded").discard()
               }
             }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1220,7 +1220,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
             afterDamage {
               if (opp.hand) {
-                def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(TRAINER)
+                def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(TRAINER)
                 if(list){
                   list.select("Select a Trainer card to discard").discard()
                 }
@@ -3452,7 +3452,7 @@ public enum UnseenForces implements LogicCardInfo {
             assert opp.hand : "Your opponent has no cards in their hand"
           }
           onAttack {
-            def basics = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(BASIC)
+            def basics = opp.hand.shuffledCopy().showToMe("Opponent's hand.").filterByType(BASIC)
             if (basics) {
               basics.select("Choose a pokemon to bench").each {
                 opp.hand.remove(it)

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1220,9 +1220,9 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
             afterDamage {
               if (opp.hand) {
-                opp.hand.showToMe("Opponent's hand")
-                if (opp.hand.filterByType(TRAINER)) {
-                  opp.hand.select(count: 1, "Select a Trainer card to discard.", cardTypeFilter(TRAINER)).discard()
+                def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(TRAINER)
+                if(list){
+                  list.select("Select a Trainer card to discard").discard()
                 }
               }
             }
@@ -3449,13 +3449,12 @@ public enum UnseenForces implements LogicCardInfo {
           energyCost C
           attackRequirement {
             assert opp.bench.notFull : "Opponent's Bench is full"
+            assert opp.hand : "Your opponent has no cards in their hand"
           }
           onAttack {
-            opp.hand.showToMe("Opponent's hand.")
-            if (opp.hand.findAll { it.cardTypes.is(BASIC) }) {
-              def basicPokemon = opp.hand.findAll { it.cardTypes.is(BASIC) }
-              def tar
-              basicPokemon.select("Choose a pokemon to bench").each {
+            def basics = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(BASIC)
+            if (basics) {
+              basics.select("Choose a pokemon to bench").each {
                 opp.hand.remove(it)
                 tar = benchPCS(it, OTHER, TargetPlayer.OPPONENT)
               }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -411,7 +411,7 @@ public enum DiamondPearl implements LogicCardInfo {
             onActivate {reason ->
               if(reason==PLAY_FROM_HAND && opp.hand && opp.bench.notFull && confirm('Use Gleam Eyes?')){
                 powerUsed()
-                def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(BASIC)
+                def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(BASIC)
                 if(list){
                   def card = list.select("Put a Basic Pokémon you find there onto your opponent's Bench").first()
                   opp.hand.remove(card)

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -411,8 +411,7 @@ public enum DiamondPearl implements LogicCardInfo {
             onActivate {reason ->
               if(reason==PLAY_FROM_HAND && opp.hand && opp.bench.notFull && confirm('Use Gleam Eyes?')){
                 powerUsed()
-                opp.hand.showToMe("Opponent's hand")
-                def list = opp.hand.filterByType(BASIC)
+                def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(BASIC)
                 if(list){
                   def card = list.select("Put a Basic Pokémon you find there onto your opponent's Bench").first()
                   opp.hand.remove(card)

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -3061,7 +3061,7 @@ public enum DiamondPearl implements LogicCardInfo {
               assert opp.hand : "Your Opponent has no cards in their hand."
               powerUsed()
 
-              def chosenCards = opp.hand.select(hidden: true, max: 2).showToOpponent("Cards randomly put aside by Supreme Command. They'll return to your hand at the end of your next turn.")
+              def chosenCards = opp.hand.shuffledCopy().select(hidden: true, max: 2).showToOpponent("Cards randomly put aside by Supreme Command. They'll return to your hand at the end of your next turn.")
               def supremeCommandBundles = bg.em().retrieveObject("supremeCommandBundles")
               if (!supremeCommandBundles)
                 supremeCommandBundles = [ : ]

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -1937,7 +1937,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             attackRequirement {
               assert opp.hand : "Opponent has no cards in hand."}
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Scratch", {
@@ -2449,7 +2449,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
         return itemCard (this) {
           text "LOOK AT YOUR OPPONENTS HAND!"
           onPlay {
-            randomizedOpponentsHand().showToMe("Opponent's hand")
+            opp.hand.shuffledCopy().showToMe("Opponent's hand")
           }
           playRequirement{
             assert opp.hand : "Opponent has no cards in hand."

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -827,7 +827,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             energyCost C
             onAttack {
               flip 3, {
-                if(opp.hand) {
+                if (opp.hand) {
                   opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("This card will be discarded").discard()
                 }
               }
@@ -1937,7 +1937,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             attackRequirement {
               assert opp.hand : "Opponent has no cards in hand."}
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Scratch", {
@@ -2449,7 +2449,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
         return itemCard (this) {
           text "LOOK AT YOUR OPPONENTS HAND!"
           onPlay {
-            opp.hand.showToMe("Opponent's hand")
+            randomizedOpponentsHand().showToMe("Opponent's hand")
           }
           playRequirement{
             assert opp.hand : "Opponent has no cards in hand."

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -828,7 +828,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             onAttack {
               flip 3, {
                 if (opp.hand) {
-                  opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("This card will be discarded").discard()
+                  opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("This card will be discarded").discard()
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1794,7 +1794,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             onAttack {
               damage 30
               afterDamage{
-                opp.hand.showToMe("Opponent’s hand")
+                if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent’s hand")
               }
             }
           }
@@ -2243,7 +2243,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 shuffleDeck(null, TargetPlayer.OPPONENT)
               }
               if (my.hand) {
-                def myCard = my.hand.oppSelect(hidden: true, count: 1, "Choose 1 random card from your opponent's hand to be shuffled into his or her deck").showToOpponent("Selected card(s)").showToMe("Hidden Power: this card will be shuffled from your hand to your deck")
+                def myCard = my.hand.shuffledCopy().oppSelect(hidden: true, count: 1, "Choose 1 random card from your opponent's hand to be shuffled into his or her deck").showToOpponent("Selected card(s)").showToMe("Hidden Power: this card will be shuffled from your hand to your deck")
                 myCard.moveTo(my.deck)
                 shuffleDeck()
               }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2238,7 +2238,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand && !checkBodyguard()) {
-                def oppCard = opp.hand.select(hidden: true, count: count, "Choose a random card from your opponent's hand to be shuffled into his or her deck").showToMe("Selected card(s)").showToOpponent("Hidden Power: this card will be shuffled from your hand to your deck")
+                def oppCard = opp.hand.shuffledCopy().select(hidden: true, count: count, "Choose a random card from your opponent's hand to be shuffled into his or her deck").showToMe("Selected card(s)").showToOpponent("Hidden Power: this card will be shuffled from your hand to your deck")
                 oppCard.moveTo(opp.deck)
                 shuffleDeck(null, TargetPlayer.OPPONENT)
               }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2973,7 +2973,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {
               assert opp.hand : "Opponent has no cards in hand."}
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Snowball Fight", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2973,7 +2973,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {
               assert opp.hand : "Opponent has no cards in hand."}
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Snowball Fight", {

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -2383,7 +2383,7 @@ public enum Stormfront implements LogicCardInfo {
               if (opp.deck) {
                 opp.deck.subList(0, 1).discard()
               }
-              opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("This card will be discarded").discard()
+              if (opp.hand) opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("This card will be discarded").discard()
             }
           }
           move "", {

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -359,7 +359,7 @@ public enum Undaunted implements LogicCardInfo {
               assert self.isActive() : "$self is not active"
               assert opp.hand : "Your opponent has no cards in their hand"
               powerUsed()
-              def randomOppHand = randomizedOpponentsHand()
+              def randomOppHand = opp.hand.shuffledCopy()
               if(randomOppHand.hasType(SUPPORTER)){
                 def card = randomOppHand.select(min:1, "Opponent's hand. Select a Supporter.", cardTypeFilter(SUPPORTER)).first()
                 bg.deterministicCurrentThreadPlayerType=self.owner

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -357,14 +357,16 @@ public enum Undaunted implements LogicCardInfo {
               checkLastTurn()
               checkNoSPC()
               assert self.isActive() : "$self is not active"
+              assert opp.hand : "Your opponent has no cards in their hand"
               powerUsed()
-              if(opp.hand.hasType(SUPPORTER)){
-                def card=opp.hand.select(min:1, "Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
+              def randomOppHand = randomizedOpponentsHand()
+              if(randomOppHand.hasType(SUPPORTER)){
+                def card = randomOppHand.select(min:1, "Opponent's hand. Select a Supporter.", cardTypeFilter(SUPPORTER)).first()
                 bg.deterministicCurrentThreadPlayerType=self.owner
                 bg.em().run(new PlayTrainer(card))
                 bg.clearDeterministicCurrentThreadPlayerType()
               } else {
-                opp.hand.showToMe("Opponent's hand")
+                randomOppHand.showToMe("Opponent's hand. No supporter there.")
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -1307,7 +1307,7 @@ public enum BurningShadows implements LogicCardInfo {
               checkLastTurn()
               assert opp.hand && opp.bench.notFull
               powerUsed()
-              def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(BASIC)
+              def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(BASIC)
               if(list){
                 def card = list.select("Put a Basic Pokémon you find there onto your opponent's Bench").first()
                 opp.hand.remove(card)
@@ -2527,7 +2527,7 @@ public enum BurningShadows implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Peck", {
@@ -2559,7 +2559,7 @@ public enum BurningShadows implements LogicCardInfo {
               afterDamage {
                 onAttack {
                   if (opp.hand) {
-                    def pokeToDiscard = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(POKEMON)
+                    def pokeToDiscard = opp.hand.shuffledCopy().showToMe("Opponent's hand.").filterByType(POKEMON)
                     if(pokeToDiscard){
                       pokeToDiscard.select("Select a Pokémon card to discard.").discard()
                     }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2797,7 +2797,7 @@ public enum BurningShadows implements LogicCardInfo {
         return itemCard (this) {
           text "Choose a random card from your opponent's hand. Your opponent reveals that card. If it's a Supporter card, discard it.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
-            opp.hand.select(hidden: true, "Select random card from opponent's hand").showToMe("Selected card").showToOpponent("Opponent used Tormenting Spray").each {if(it.cardTypes.is(SUPPORTER)) discard(it)}
+            opp.hand.shuffledCopy().select(hidden: true, "Select random card from opponent's hand").showToMe("Selected card").showToOpponent("Opponent used Tormenting Spray").each {if(it.cardTypes.is(SUPPORTER)) discard(it)}
           }
           playRequirement{
             assert opp.hand

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -1307,8 +1307,7 @@ public enum BurningShadows implements LogicCardInfo {
               checkLastTurn()
               assert opp.hand && opp.bench.notFull
               powerUsed()
-              opp.hand.showToMe("Opponent's hand")
-              def list = opp.hand.filterByType(BASIC)
+              def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(BASIC)
               if(list){
                 def card = list.select("Put a Basic Pokémon you find there onto your opponent's Bench").first()
                 opp.hand.remove(card)
@@ -2524,8 +2523,11 @@ public enum BurningShadows implements LogicCardInfo {
           move "See Through", {
             text "Your opponent reveals their hand."
             energyCost C
+            attackRequirement{
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Peck", {
@@ -2555,11 +2557,12 @@ public enum BurningShadows implements LogicCardInfo {
             onAttack {
               damage 70
               afterDamage {
-                if(opp.hand) {
-                  opp.hand.showToMe("Opponent's hand")
-                  def list = opp.hand.filterByType(POKEMON)
-                  if(list) {
-                    list.select("Discard").discard()
+                onAttack {
+                  if (opp.hand) {
+                    def pokeToDiscard = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(POKEMON)
+                    if(pokeToDiscard){
+                      pokeToDiscard.select("Select a Pokémon card to discard.").discard()
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -521,7 +521,7 @@ public enum CelestialStorm implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-                def supportersToShuffle = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(SUPPORTER)
+                def supportersToShuffle = opp.hand.shuffledCopy().showToMe("Opponent's hand.").filterByType(SUPPORTER)
                 if(supportersToShuffle){
                   supportersToShuffle.select("Select a supporter to put back into your opponent's deck.").moveTo(opp.deck)
                   shuffleDeck(null, TargetPlayer.OPPONENT)

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -520,10 +520,12 @@ public enum CelestialStorm implements LogicCardInfo {
               assert opp.hand : "Your opponent have no cards in hand"
             }
             onAttack {
-              opp.hand.showToMe("opponent's hand")
-              if(opp.hand.filterByType(SUPPORTER)){
-                opp.hand.filterByType(SUPPORTER).select("select a supporter to put back in deck.").moveTo(opp.deck)
-                shuffleDeck(null, TargetPlayer.OPPONENT)
+              if (opp.hand) {
+                def supportersToShuffle = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(SUPPORTER)
+                if(supportersToShuffle){
+                  supportersToShuffle.select("Select a supporter to put back into your opponent's deck.").moveTo(opp.deck)
+                  shuffleDeck(null, TargetPlayer.OPPONENT)
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1894,7 +1894,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in their hand."
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand.")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand.")
             }
           }
           move "Razor Fin", {
@@ -3272,7 +3272,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-                def itemsToDiscard = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(ITEM)
+                def itemsToDiscard = opp.hand.shuffledCopy().showToMe("Opponent's hand.").filterByType(ITEM)
                 if(itemsToDiscard){
                   itemsToDiscard.select("Select an Item to discard.").discard()
                 }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1894,7 +1894,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in their hand."
             }
             onAttack {
-              opp.hand.showToMe("Opponent's hand.")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand.")
             }
           }
           move "Razor Fin", {
@@ -3267,10 +3267,15 @@ public enum CosmicEclipse implements LogicCardInfo {
           move "Bag Slash", {
             text "Your opponent reveals their hand. Discard an Item card you find there."
             energyCost C
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              opp.hand.showToMe("Opponent's hand.")
-              if(opp.hand.filterByType(ITEM)){
-                opp.hand.filterByType(ITEM).select("Select an Item to discard.").discard()
+              if (opp.hand) {
+                def itemsToDiscard = randomizedOpponentsHand().showToMe("Opponent's hand.").filterByType(ITEM)
+                if(itemsToDiscard){
+                  itemsToDiscard.select("Select an Item to discard.").discard()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3655,7 +3655,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             onActivate {r->
               if (r == PLAY_FROM_HAND && my.deck && confirm("Use Flower Picking?")) {
                 powerUsed()
-                opp.hand.select(hidden: true, count:1).showToMe("Opponent's card being shuffled into their deck.").moveTo(hidden: false, opp.deck)
+                opp.hand.shuffledCopy().select(hidden: true, count:1).showToMe("Opponent's card being shuffled into their deck.").moveTo(hidden: false, opp.deck)
                 shuffleDeck(null, TargetPlayer.OPPONENT)
               }
             }
@@ -3677,7 +3677,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             onActivate { r->
               if (r == PLAY_FROM_HAND && my.deck && confirm("Use Flower Picking?")) {
                 powerUsed()
-                opp.hand.select(hidden: true, count:2).showToMe("Opponent's cards being shuffled into their deck.").moveTo(hidden: false, opp.deck)
+                opp.hand.shuffledCopy().select(hidden: true, count:2).showToMe("Opponent's cards being shuffled into their deck.").moveTo(hidden: false, opp.deck)
                 shuffleDeck(null, TargetPlayer.OPPONENT)
               }
             }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2059,7 +2059,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Flap", {
@@ -2362,7 +2362,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
         return itemCard (this) {
           text "Your opponent reveals their hand. You may have your opponent count the cards in their hand, shuffle those cards into their deck, then draw that many cards.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
-            randomizedOpponentsHand().showToMe("Opponent's hand")
+            opp.hand.shuffledCopy().showToMe("Opponent's hand")
             if(confirm("Replace opponent hand?")){
               def nbc = opp.hand.size()
               opp.hand.moveTo(hidden:true,opp.deck)

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2055,9 +2055,11 @@ public enum CrimsonInvasion implements LogicCardInfo {
           move "Bug Search", {
             text "Your opponent reveals their hand."
             energyCost C
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
-              opp.hand.shuffle()
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Flap", {
@@ -2360,7 +2362,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
         return itemCard (this) {
           text "Your opponent reveals their hand. You may have your opponent count the cards in their hand, shuffle those cards into their deck, then draw that many cards.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
-            opp.hand.showToMe("Opponent's hand")
+            randomizedOpponentsHand().showToMe("Opponent's hand")
             if(confirm("Replace opponent hand?")){
               def nbc = opp.hand.size()
               opp.hand.moveTo(hidden:true,opp.deck)

--- a/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
+++ b/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
@@ -263,10 +263,10 @@ public enum DetectivePikachu implements LogicCardInfo {
             text "Your opponent reveals their hand."
             energyCost L
             attackRequirement {
-              assert opp.hand
+              assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Surprise Attack", {

--- a/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
+++ b/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
@@ -266,7 +266,7 @@ public enum DetectivePikachu implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Surprise Attack", {

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2159,17 +2159,18 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-              def randomOppHand = opp.hand.shuffledCopy()
-              if(randomOppHand.hasType(SUPPORTER)){
-                def support = randomOppHand.select(max: 0, "Your opponent's hand. You may discard a Supporter card you find there and use the effect of that card as the effect of this attack.", cardTypeFilter(SUPPORTER))
-                if (support){
-                  discard support.first()
-                  bg.deterministicCurrentThreadPlayerType=self.owner
-                  bg.em().run(new PlayTrainer(support.first()))
-                  bg.clearDeterministicCurrentThreadPlayerType()
+                def randomOppHand = opp.hand.shuffledCopy()
+                if(randomOppHand.hasType(SUPPORTER)){
+                  def support = randomOppHand.select(max: 0, "Your opponent's hand. You may discard a Supporter card you find there and use the effect of that card as the effect of this attack.", cardTypeFilter(SUPPORTER))
+                  if (support){
+                    discard support.first()
+                    bg.deterministicCurrentThreadPlayerType=self.owner
+                    bg.em().run(new PlayTrainer(support.first()))
+                    bg.clearDeterministicCurrentThreadPlayerType()
+                  }
+                } else {
+                  randomOppHand.showToMe("Your opponent's hand. No supporter in there.")
                 }
-              } else {
-                randomOppHand.showToMe("Your opponent's hand. No supporter in there.")
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2159,7 +2159,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-              def randomOppHand = randomizedOpponentsHand()
+              def randomOppHand = opp.hand.shuffledCopy()
               if(randomOppHand.hasType(SUPPORTER)){
                 def support = randomOppHand.select(max: 0, "Your opponent's hand. You may discard a Supporter card you find there and use the effect of that card as the effect of this attack.", cardTypeFilter(SUPPORTER))
                 if (support){
@@ -2487,7 +2487,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-                def itemsInOppHand = randomizedOpponentsHand().showToMe("Opponent's hand. All items in it will be discarded.").filterByType(ITEM)
+                def itemsInOppHand = opp.hand.shuffledCopy().showToMe("Opponent's hand. All items in it will be discarded.").filterByType(ITEM)
                 if (itemsInOppHand)
                   itemsInOppHand.showToOpponent("Your opponent used Destructive Sound. All of these items in your hand will now be discarded.").discard()
                 else

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2158,14 +2158,18 @@ public enum ForbiddenLight implements LogicCardInfo {
               assert opp.hand
             }
             onAttack {
-              if(opp.hand.hasType(SUPPORTER)){
-                def card=opp.hand.select("Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
-                discard card
-                bg.deterministicCurrentThreadPlayerType=self.owner
-                bg.em().run(new PlayTrainer(card))
-                bg.clearDeterministicCurrentThreadPlayerType()
+              if (opp.hand) {
+              def randomOppHand = randomizedOpponentsHand()
+              if(randomOppHand.hasType(SUPPORTER)){
+                def support = randomOppHand.select(max: 0, "Your opponent's hand. You may discard a Supporter card you find there and use the effect of that card as the effect of this attack.", cardTypeFilter(SUPPORTER))
+                if (support){
+                  discard support.first()
+                  bg.deterministicCurrentThreadPlayerType=self.owner
+                  bg.em().run(new PlayTrainer(support.first()))
+                  bg.clearDeterministicCurrentThreadPlayerType()
+                }
               } else {
-                opp.hand.showToMe("Opponent's hand. No supporter in there.")
+                randomOppHand.showToMe("Your opponent's hand. No supporter in there.")
               }
             }
           }
@@ -2478,8 +2482,17 @@ public enum ForbiddenLight implements LogicCardInfo {
           move "Destructive Sound", {
             text "Your opponent reveals their hand. Discard all Item cards you find there."
             energyCost C, C
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              opp.hand.showToMe("Opponent's hand").filterByType(ITEM).discard()
+              if (opp.hand) {
+                def itemsInOppHand = randomizedOpponentsHand().showToMe("Opponent's hand. All items in it will be discarded.").filterByType(ITEM)
+                if (itemsInOppHand)
+                  itemsInOppHand.showToOpponent("Your opponent used Destructive Sound. All of these items in your hand will now be discarded.").discard()
+                else
+                  bc "No items were discarded by Destructive Sound."
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -360,9 +360,12 @@ public enum GuardiansRising implements LogicCardInfo {
           move "Poltergeist", {
             text "30× damage. Your opponent reveals their hand. This attack does 30 damage for each Trainer card you find there."
             energyCost C, C
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
-              damage 30*opp.hand.findAll {it.cardTypes.is(TRAINER)}.size()
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              damage 30*opp.hand.findAll{it.cardTypes.is(TRAINER)}.size()
             }
           }
           move "Horn Leech", {

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -364,7 +364,7 @@ public enum GuardiansRising implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
               damage 30*opp.hand.findAll{it.cardTypes.is(TRAINER)}.size()
             }
           }

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -1012,7 +1012,7 @@ public enum HiddenFates implements LogicCardInfo {
             assert opp.hand : "Your opponent has no cards in hand"
           }
           onAttack {
-            if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+            if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
           }
         }
         move "Spin Tackle", {

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -601,7 +601,7 @@ public enum HiddenFates implements LogicCardInfo {
               if(!checkBodyguard()) {
                 bc "Last Pattern activates"
                 bg.deterministicCurrentThreadPlayerType = self.owner
-                def sel=opp.hand.select(hidden: true, count: 2, "Choose 2 random cards from your opponent's hand to be discarded.")
+                def sel=opp.hand.shuffledCopy().select(hidden: true, count: 2, "Choose 2 random cards from your opponent's hand to be discarded.")
                 sel.discard()
                 bg.clearDeterministicCurrentThreadPlayerType()
               }

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -1008,8 +1008,11 @@ public enum HiddenFates implements LogicCardInfo {
         move "Curiosity", {
           text "Your opponent reveals their hand."
           energyCost C
+          attackRequirement {
+            assert opp.hand : "Your opponent has no cards in hand"
+          }
           onAttack {
-            opp.hand.showToMe("Opponent's hand")
+            if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
           }
         }
         move "Spin Tackle", {

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1472,7 +1472,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Look at your opponent's hand and put a card you find there in the Lost Zone."
             energyCost W
             onAttack{
-              if(opp.hand){
+              if (opp.hand){
                 opp.hand.select("Select the card to put in the Lost Zone").moveTo(opp.lostZone)
               }
             }
@@ -3748,13 +3748,18 @@ public enum LostThunder implements LogicCardInfo {
               assert opp.hand
             }
             onAttack {
-              if(opp.hand.hasType(SUPPORTER)){
-                def card=opp.hand.showToMe("Your opponent's hand.").select("Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
-                bg.deterministicCurrentThreadPlayerType=self.owner
-                bg.em().run(new PlayTrainer(card))
-                bg.clearDeterministicCurrentThreadPlayerType()
-              } else {
-                opp.hand.showToMe("Opponent's hand. No supporter in there.")
+              if (opp.hand) {
+                def randomOppHand = randomizedOpponentsHand()
+                if(randomOppHand.hasType(SUPPORTER)){
+                  def support = randomOppHand.select(max: 0, "Your opponent's hand. You may use the effect of a Supporter card you find there as the effect of this attack.", cardTypeFilter(SUPPORTER))
+                  if (support){
+                    bg.deterministicCurrentThreadPlayerType=self.owner
+                    bg.em().run(new PlayTrainer(support.first()))
+                    bg.clearDeterministicCurrentThreadPlayerType()
+                  }
+                } else {
+                  randomOppHand.showToMe("Your opponent's hand. No supporter in there.")
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -2151,7 +2151,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost C,C
             onAttack{
               damage 30
-              opp.hand.showToMe("Your opponent's hand")
+              opp.hand.shuffledCopy().showToMe("Your opponent's hand.")
               if(opp.hand.filterByType(ENERGY)) damage 60
             }
           }
@@ -4344,13 +4344,14 @@ public enum LostThunder implements LogicCardInfo {
         return supporter(this) {
           text "You can play this card only if 1 of your [P] Pokémon was Knocked Out during your opponent's last turn.\nYour opponent reveals their hand. Choose 2 cards you find there. Your opponent shuffles those cards into their deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            opp.hand.showToMe("Your opponent's hand").select(count : Math.min(2,opp.hand.size())).moveTo(opp.deck)
+            opp.hand.shuffledCopy().select(count : Math.min(2,opp.hand.size()), "Your opponent's hand. Choose 2 cards you find there, and your opponent will shuffle those cards into their deck.").showToOpponent("Your opponent used Morty. These two cards will be shuffled into your deck.").moveTo(opp.deck)
             shuffleDeck(null, TargetPlayer.OPPONENT)
           }
           playRequirement{
             assert bg.turnCount
             assert my.lastKnockoutByOpponentDamageTurn == bg.turnCount - 1: "No Pokémon has been Knocked Out during your opponent’s last turn"
-            assert my.knockoutTypesPerTurn.get(bg.turnCount - 1)?.contains(P) : "The Pokémon Knocked Out was not Fairy"
+            assert my.knockoutTypesPerTurn.get(bg.turnCount - 1)?.contains(P) : "The Pokémon Knocked Out was not Psychic"
+            assert opp.hand : "Your opponent has no cards in their hand"
           }
         };
       case NET_BALL_187:

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -3749,7 +3749,7 @@ public enum LostThunder implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-                def randomOppHand = randomizedOpponentsHand()
+                def randomOppHand = opp.hand.shuffledCopy()
                 if(randomOppHand.hasType(SUPPORTER)){
                   def support = randomOppHand.select(max: 0, "Your opponent's hand. You may use the effect of a Supporter card you find there as the effect of this attack.", cardTypeFilter(SUPPORTER))
                   if (support){

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1473,7 +1473,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost W
             onAttack{
               if (opp.hand){
-                opp.hand.select("Select the card to put in the Lost Zone").moveTo(opp.lostZone)
+                opp.hand.shuffledCopy().select("Select the card to put in the Lost Zone").moveTo(opp.lostZone)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -652,11 +652,8 @@ public enum SunMoon implements LogicCardInfo {
           bwAbility "Queenly Majesty", {
             text "When you play this card from your hand to evolve 1 of your Pokémon during your turn, you may have your opponent reveal their hand. Then, discard a card from it."
             onActivate {r->
-              if(r==Ability.ActivationReason.PLAY_FROM_HAND && confirm("Use Queenly Majesty?")){
-                if(opp.hand){
-                  opp.hand.showToMe("Opponent's hand")
-                  opp.hand.select("Discard").discard()
-                }
+              if(r==Ability.ActivationReason.PLAY_FROM_HAND && opp.hand && confirm("Use Queenly Majesty?")){
+                randomizedOpponentsHand().select("Your opponent's hand. Select a card to discard from it.").discard()
               }
             }
           }
@@ -2598,9 +2595,9 @@ public enum SunMoon implements LogicCardInfo {
             text "Once during your turn (before your attack), you may have your opponent reveal their hand."
             actionA {
               checkLastTurn()
-              assert opp.hand : "Empty hand"
+              assert opp.hand : "Your opponent has no cards in hand"
               powerUsed()
-              opp.hand.showToMe("Opponent's hand")
+              randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Headbutt Bounce", {
@@ -2833,14 +2830,15 @@ public enum SunMoon implements LogicCardInfo {
         return supporter (this) {
           text "Your opponent reveals their hand. Discard 2 Energy cards from it.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            opp.hand.showToMe("Opponent's hand")
-            def list = opp.hand.filterByType(ENERGY)
+            def randomOppHand = randomizedOpponentsHand()
+            randomOppHand.showToMe("Opponent's hand")
+            def list = randomOppHand.filterByType(ENERGY)
             if(list){
               list.select(count: 2, "Discard").discard()
             }
           }
           playRequirement{
-            assert opp.hand
+            assert opp.hand : "Your opponent has no cards in hand"
           }
         }
       case TIMER_BALL_134:

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -653,7 +653,7 @@ public enum SunMoon implements LogicCardInfo {
             text "When you play this card from your hand to evolve 1 of your Pokémon during your turn, you may have your opponent reveal their hand. Then, discard a card from it."
             onActivate {r->
               if(r==Ability.ActivationReason.PLAY_FROM_HAND && opp.hand && confirm("Use Queenly Majesty?")){
-                randomizedOpponentsHand().select("Your opponent's hand. Select a card to discard from it.").discard()
+                opp.hand.shuffledCopy().select("Your opponent's hand. Select a card to discard from it.").discard()
               }
             }
           }
@@ -2597,7 +2597,7 @@ public enum SunMoon implements LogicCardInfo {
               checkLastTurn()
               assert opp.hand : "Your opponent has no cards in hand"
               powerUsed()
-              randomizedOpponentsHand().showToMe("Opponent's hand")
+              opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Headbutt Bounce", {
@@ -2830,7 +2830,7 @@ public enum SunMoon implements LogicCardInfo {
         return supporter (this) {
           text "Your opponent reveals their hand. Discard 2 Energy cards from it.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(ENERGY)
+            def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(ENERGY)
             if(list){
               list.select(count: 2, "Discard").discard()
             }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2830,9 +2830,7 @@ public enum SunMoon implements LogicCardInfo {
         return supporter (this) {
           text "Your opponent reveals their hand. Discard 2 Energy cards from it.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            def randomOppHand = randomizedOpponentsHand()
-            randomOppHand.showToMe("Opponent's hand")
-            def list = randomOppHand.filterByType(ENERGY)
+            def list = randomizedOpponentsHand().showToMe("Opponent's hand").filterByType(ENERGY)
             if(list){
               list.select(count: 2, "Discard").discard()
             }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1806,7 +1806,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             onAttack{
               gxPerform()
               if (opp.hand){
-                opp.hand.showToMe("Your opponent's hand")
+                opp.hand.shuffledCopy().showToMe("Your opponent's hand")
                 opp.hand.filterByType(ENERGY).each{
                   damage 120
                 }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2965,7 +2965,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               afterDamage {
                 def number = Math.min(2, opp.hand.size())
                 if (number > 0) {
-                  opp.hand.select(hidden: true, count:number).showToMe("Chosen cards").moveTo(opp.deck)
+                  opp.hand.shuffledCopy().select(hidden: true, count:number).showToMe("Chosen cards").moveTo(opp.deck)
                   shuffleDeck(null, TargetPlayer.OPPONENT)
                 }
               }
@@ -3347,7 +3347,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               assert opp.hand.size() > 5 : "Opponent has 5 or less cards in hand."
             }
             onAttack {
-              opp.hand.select(hidden: true, count:opp.hand.size() - 5,"Choose the cards to discard.").discard()
+              opp.hand.shuffledCopy().select(hidden: true, count:opp.hand.size() - 5,"Choose the cards to discard.").discard()
             }
           }
           move "Tail Smash", {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1805,7 +1805,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
             onAttack{
               gxPerform()
-              if(opp.hand){
+              if (opp.hand){
                 opp.hand.showToMe("Your opponent's hand")
                 opp.hand.filterByType(ENERGY).each{
                   damage 120

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -3588,7 +3588,7 @@ public enum TeamUp implements LogicCardInfo {
         return supporter(this) {
           text "Your opponent reveals their hand. You may choose a Supporter card you find there and use the effect of that card as the effect of this card.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            def randomOppHand = randomizedOpponentsHand()
+            def randomOppHand = opp.hand.shuffledCopy()
             if(randomOppHand.hasType(SUPPORTER)){
               def card = randomOppHand.select("Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
               bg.deterministicCurrentThreadPlayerType=bg.currentTurn

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1424,7 +1424,7 @@ public enum TeamUp implements LogicCardInfo {
             text "50× damage. Your opponent reveals their hand. This attack does 50 damage for each Trainer card you find there."
             energyCost P,P
             onAttack{
-              if(opp.hand){
+              if (opp.hand){
                 opp.hand.showToMe("Your opponent's hand")
                 damage 50*opp.hand.filterByType(TRAINER).size()
               }
@@ -3588,13 +3588,14 @@ public enum TeamUp implements LogicCardInfo {
         return supporter(this) {
           text "Your opponent reveals their hand. You may choose a Supporter card you find there and use the effect of that card as the effect of this card.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
-            if(opp.hand.hasType(SUPPORTER)){
-              def card=opp.hand.select("Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
+            def randomOppHand = randomizedOpponentsHand()
+            if(randomOppHand.hasType(SUPPORTER)){
+              def card = randomOppHand.select("Opponent's hand. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
               bg.deterministicCurrentThreadPlayerType=bg.currentTurn
               bg.em().run(new PlayTrainer(card).setDontDiscard(true))
               bg.clearDeterministicCurrentThreadPlayerType()
             } else {
-              opp.hand.showToMe("Opponent's hand. No supporter in there.")
+              randomOppHand.showToMe("Opponent's hand. No supporter in there.")
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1428,7 +1428,7 @@ public enum TeamUp implements LogicCardInfo {
             }
             onAttack{
               if (opp.hand){
-                trainersInHand = opp.hand.shuffledCopy().showToMe("Your opponent's hand").filterByType(TRAINER)
+                def trainersInHand = opp.hand.shuffledCopy().showToMe("Your opponent's hand").filterByType(TRAINER)
                 damage 50 * trainersInHand.size()
               }
             }
@@ -3084,7 +3084,7 @@ public enum TeamUp implements LogicCardInfo {
                 if(opp.hand.size() >= 4){
                   def randomOppHand = opp.hand.shuffledCopy()
                   if (opp.hand.size() == 4){
-                    randomOppHand.shuffledCopy().showToMe("Your opponent's hand.")
+                    randomOppHand.showToMe("Your opponent's hand.")
                   } else {
                     randomOppHand.select(count:opp.hand.size() - 4,"Your opponent's hand. Choose cards to discard until they have exactly 4 left.").discard()
                   }

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1423,10 +1423,13 @@ public enum TeamUp implements LogicCardInfo {
           move "Poltergeist" , {
             text "50× damage. Your opponent reveals their hand. This attack does 50 damage for each Trainer card you find there."
             energyCost P,P
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in their hand"
+            }
             onAttack{
               if (opp.hand){
-                opp.hand.showToMe("Your opponent's hand")
-                damage 50*opp.hand.filterByType(TRAINER).size()
+                trainersInHand = opp.hand.shuffledCopy().showToMe("Your opponent's hand").filterByType(TRAINER)
+                damage 50 * trainersInHand.size()
               }
             }
           }
@@ -1839,8 +1842,11 @@ public enum TeamUp implements LogicCardInfo {
           move "Scout" , {
             text "You opponent reveals their hand."
             energyCost C
-            onAttack{
-              opp.hand.showToMe("Your opponent's hand")
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in their hand"
+            }
+            onAttack {
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Your opponent's hand")
             }
           }
           move "Low Kick" , {
@@ -3076,11 +3082,11 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
               afterDamage{
                 if(opp.hand.size() >= 4){
-                  if(opp.hand.size() == 4){
-                    opp.hand.showToMe("Your opponent's hand")
-                  }
-                  else{
-                    opp.hand.select(count:opp.hand.size() - 4,"Choose the cards to discard").discard()
+                  def randomOppHand = opp.hand.shuffledCopy()
+                  if (opp.hand.size() == 4){
+                    randomOppHand.shuffledCopy().showToMe("Your opponent's hand.")
+                  } else {
+                    randomOppHand.select(count:opp.hand.size() - 4,"Your opponent's hand. Choose cards to discard until they have exactly 4 left.").discard()
                   }
                 }
               }
@@ -3472,7 +3478,7 @@ public enum TeamUp implements LogicCardInfo {
               assert lastTurn != bg().turnCount : "Already used"
               bc "Used Lavender Town effect"
               lastTurn = bg().turnCount
-              opp.hand.showToMe("Your opponent's hand")
+              opp.hand.shuffledCopy().showToMe("Your opponent's hand")
             }
           }
           onRemoveFromPlay{

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2773,8 +2773,11 @@ public enum UltraPrism implements LogicCardInfo {
           move "Scout", {
             text "Your opponent reveals their hand."
             energyCost C
+            attackRequirement {
+              assert opp.hand : "Your opponent has no cards in hand"
+            }
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
             }
           }
           move "Take Down", {
@@ -2795,8 +2798,8 @@ public enum UltraPrism implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 20
-              opp.hand.showToMe("Opponent's hand")
-              if(opp.hand.filterByType(POKEMON)){
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand.filterByType(POKEMON)){
                 damage 80
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2777,7 +2777,7 @@ public enum UltraPrism implements LogicCardInfo {
               assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
             }
           }
           move "Take Down", {
@@ -2798,7 +2798,7 @@ public enum UltraPrism implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 20
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
               if (opp.hand.hasType(POKEMON)){
                 damage 80
               }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2704,7 +2704,7 @@ public enum UltraPrism implements LogicCardInfo {
             onAttack {
               damage 60
               if(opp.hand.size()>3)
-                opp.hand.select(hidden: true, count: opp.hand.size()-3).discard()
+                opp.hand.shuffledCopy().select(hidden: true, count: opp.hand.size()-3).discard()
             }
           }
 
@@ -3025,7 +3025,7 @@ public enum UltraPrism implements LogicCardInfo {
           text "Draw 2 cards. If you do, discard a random card from your opponent’s hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
             draw 2
-            if (opp.hand) opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("this card will be discarded").discard()
+            if (opp.hand) opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded").showToMe("Selected card").showToOpponent("this card will be discarded").discard()
           }
           playRequirement{
             assert my.deck
@@ -3279,7 +3279,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
             onAttack {
               gxPerform()
-              def card = opp.hand.select("Opponent's hand. Put one card as opponent prize").showToOpponent("This card from your hand is now in your prizes").first()
+              def card = opp.hand.shuffledCopy().select("Opponent's hand. Put one card as opponent prize").showToOpponent("This card from your hand is now in your prizes").first()
               opp.hand.remove(card)
               opp.prizeCardSet.add(card)
               bc "Put 1 card to prizes and shuffled them"

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2799,7 +2799,7 @@ public enum UltraPrism implements LogicCardInfo {
             onAttack {
               damage 20
               if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
-              if (opp.hand.filterByType(POKEMON)){
+              if (opp.hand.hasType(POKEMON)){
                 damage 80
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -2775,7 +2775,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
             onAttack {
               gxPerform()
-              opp.hand.select(count:2,"Opponent's hand. Discard 2").discard()
+              opp.hand.shuffledCopy().select(count:2,"Opponent's hand. Discard 2").discard()
             }
           }
 
@@ -3527,7 +3527,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             onAttack {
               flip 2,{
                 if (opp.hand) {
-                  opp.hand.select("Opponent's hand. Shuffle a card into their deck.").moveTo(opp.deck)
+                  opp.hand.shuffledCopy().select("Opponent's hand. Shuffle a card into their deck.").moveTo(opp.deck)
                   shuffleDeck(null, TargetPlayer.OPPONENT)
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -472,7 +472,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               checkLastTurn()
               powerUsed()
               flip {
-                def randomOppHand = randomizedOpponentsHand()
+                def randomOppHand = opp.hand.shuffledCopy()
                 randomOppHand.showToMe("Opponent's hand")
                 if(randomOppHand.any{it.cardTypes.is(BASIC)}){
                   def card = randomOppHand.findAll{it.cardTypes.is(BASIC)}.select("select the pokémon to put on the bench").first()
@@ -2982,7 +2982,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
             onAttack {
               if (opp.hand) {
-                def randomOppHand = randomizedOpponentsHand()
+                def randomOppHand = opp.hand.shuffledCopy()
                 randomOppHand.showToMe("Opponent's hand")
                 if (randomOppHand.hasType(POKEMON)){
                   def tmp = randomOppHand.filterByType(POKEMON).select(min:0, "You may discard a Pokémon you find there and use one of that Pokémon’s non-GX attacks as this attack.")

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -468,12 +468,14 @@ public enum UnbrokenBonds implements LogicCardInfo {
             text "Once during your turn (before your attack), if your opponent's Bench isn't full, you may flip a coin. If heads, your opponent reveals their hand. Put a Basic Pokémon you find there onto their Bench."
             actionA {
               assert opp.bench.notFull : "There is no more space on your opponent bench"
+              assert opp.hand : "Your opponent has no cards in hand"
               checkLastTurn()
               powerUsed()
               flip {
-                opp.hand.showToMe("Opponent's hand")
-                if(opp.hand.findAll{it.cardTypes.is(BASIC)}){
-                  def card = opp.hand.findAll{it.cardTypes.is(BASIC)}.select("select the pokémon to put on the bench").first()
+                def randomOppHand = randomizedOpponentsHand()
+                randomOppHand.showToMe("Opponent's hand")
+                if(randomOppHand.any{it.cardTypes.is(BASIC)}){
+                  def card = randomOppHand.findAll{it.cardTypes.is(BASIC)}.select("select the pokémon to put on the bench").first()
                   opp.hand.remove(card)
                   benchPCS(card, OTHER, TargetPlayer.OPPONENT)
                 }
@@ -2976,23 +2978,26 @@ public enum UnbrokenBonds implements LogicCardInfo {
             text "Your opponent reveals their hand. You may discard a Pokémon you find there and use one of that Pokémon’s non-GX attacks as this attack."
             energyCost D
             attackRequirement {
-              assert opp.hand
+              assert opp.hand : "Your opponent has no cards in hand"
             }
             onAttack {
-              opp.hand.showToMe("Opponent's hand")
-              if(opp.hand.filterByType(POKEMON)){
-                def tmp = opp.hand.filterByType(POKEMON).select(min:0, "You may discard a Pokémon you find there and use one of that Pokémon’s non-GX attacks as this attack.")
-                if(tmp){
-                  def card = tmp.first()
-                  bc "$card was chosen"
-                  discard card
-                  def moves = card.asPokemonCard().moves.findAll{!it.name.contains("GX")}
-                  if(moves){
-                    def move = choose(moves, "Choose attack")
-                    bc "$move was chosen"
-                    def bef=blockingEffect(ENERGY_COST_CALCULATOR, BETWEEN_TURNS)
-                    attack (move as Move)
-                    bef.unregisterItself(bg().em())
+              if (opp.hand) {
+                def randomOppHand = randomizedOpponentsHand()
+                randomOppHand.showToMe("Opponent's hand")
+                if (randomOppHand.hasType(POKEMON)){
+                  def tmp = randomOppHand.filterByType(POKEMON).select(min:0, "You may discard a Pokémon you find there and use one of that Pokémon’s non-GX attacks as this attack.")
+                  if(tmp){
+                    def card = tmp.first()
+                    bc "$card was chosen"
+                    discard card
+                    def moves = card.asPokemonCard().moves.findAll{!it.name.contains("GX")}
+                    if(moves){
+                      def move = choose(moves, "Choose attack")
+                      bc "$move was chosen"
+                      def bef=blockingEffect(ENERGY_COST_CALCULATOR, BETWEEN_TURNS)
+                      attack (move as Move)
+                      bef.unregisterItself(bg().em())
+                    }
                   }
                 }
               }
@@ -3521,7 +3526,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
             onAttack {
               flip 2,{
-                if(opp.hand) {
+                if (opp.hand) {
                   opp.hand.select("Opponent's hand. Shuffle a card into their deck.").moveTo(opp.deck)
                   shuffleDeck(null, TargetPlayer.OPPONENT)
                 }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3241,11 +3241,12 @@ public enum UnifiedMinds implements LogicCardInfo {
           bwAbility "Captivating Wink", {
             text "When you play this Pokémon from your hand onto your Bench during your turn, you may have your opponent reveal their hand and put any number of Basic Pokémon you find there onto their Bench."
             onActivate {
-              if (it == PLAY_FROM_HAND && confirm("Use Captivating Wink?")) {
-                opp.hand.showToMe("Opponent's hand.")
+              if (it == PLAY_FROM_HAND && opp.hand && confirm("Use Captivating Wink?")) {
+                def randomOppHand = randomizedOpponentsHand()
+                randomOppHand.showToMe("Opponent's hand.")
 
-                if (opp.hand.findAll{it.cardTypes.is(BASIC)}) {
-                  def basicPokemon = opp.hand.findAll{ it.cardTypes.is(BASIC) }
+                if (randomOppHand.hasType(BASIC)) {
+                  def basicPokemon = randomOppHand.findAll{ it.cardTypes.is(BASIC) }
                   def maximumAllowed = Math.min(basicPokemon.size(), opp.bench.freeBenchCount)
                   basicPokemon.select(min: 0, max: maximumAllowed).each {
                     opp.hand.remove(it)
@@ -3269,8 +3270,8 @@ public enum UnifiedMinds implements LogicCardInfo {
             attackRequirement { gxCheck() }
             onAttack {
               gxPerform()
-              opp.hand.showToMe("Opponent's hand.")
-              opp.hand.filterByType(SUPPORTER).discard()
+              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand. All supporters in it will be discarded.")
+              opp.hand.filterByType(SUPPORTER).showToOpponent("Your opponent used Big Eater GX: These Supporter cards will now be discarded.").discard()
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3242,7 +3242,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "When you play this Pokémon from your hand onto your Bench during your turn, you may have your opponent reveal their hand and put any number of Basic Pokémon you find there onto their Bench."
             onActivate {
               if (it == PLAY_FROM_HAND && opp.hand && confirm("Use Captivating Wink?")) {
-                def randomOppHand = randomizedOpponentsHand()
+                def randomOppHand = opp.hand.shuffledCopy()
                 randomOppHand.showToMe("Opponent's hand.")
 
                 if (randomOppHand.hasType(BASIC)) {
@@ -3270,7 +3270,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             attackRequirement { gxCheck() }
             onAttack {
               gxPerform()
-              if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand. All supporters in it will be discarded.")
+              if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand. All supporters in it will be discarded.")
               opp.hand.filterByType(SUPPORTER).showToOpponent("Your opponent used Big Eater GX: These Supporter cards will now be discarded.").discard()
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -2052,7 +2052,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "Discard a random card from your opponent's hand."
             energyCost C, C
             onAttack {
-              opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded.").showToMe("Selected card.").showToOpponent("This card will be discarded.").discard()
+              opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded.").showToMe("Selected card.").showToOpponent("This card will be discarded.").discard()
             }
           }
           move "Bug Bite", {

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -1864,7 +1864,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             assert opp.hand : "Your opponent's hand is empty"
           }
           onAttack {
-            opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand").showToMe("Selected card").showToOpponent("this card will be shuffled into your deck").moveTo(opp.deck)
+            opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand").showToMe("Selected card").showToOpponent("this card will be shuffled into your deck").moveTo(opp.deck)
             shuffleDeck(null, TargetPlayer.OPPONENT)
           }
         }
@@ -1901,8 +1901,10 @@ public enum DarknessAblaze implements LogicCardInfo {
           onAttack {
             damage 90
             afterDamage{
-              opp.hand.select(hidden: true, count: 2, "Choose 2 random cards from your opponent's hand").showToMe("Selected cards").showToOpponent("These cards will be shuffled into your deck").moveTo(opp.deck)
-              shuffleDeck(null, TargetPlayer.OPPONENT)
+              if (opp.hand){
+                opp.hand.shuffledCopy().select(hidden: true, count: 2, "Choose 2 random cards from your opponent's hand").showToMe("Selected cards").showToOpponent("These cards will be shuffled into your deck").moveTo(opp.deck)
+                shuffleDeck(null, TargetPlayer.OPPONENT)
+              }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2811,7 +2811,7 @@ public enum RebelClash implements LogicCardInfo {
 
             afterDamage {
               if (opp.hand) {
-                opp.hand.select("Choose 1 card to put on the bottom of your opponent's deck.").moveTo(opp.deck)
+                opp.hand.shuffledCopy().select("Choose 1 card to put on the bottom of your opponent's deck.").moveTo(opp.deck)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3623,7 +3623,7 @@ public enum RebelClash implements LogicCardInfo {
           my.hand.getExcludedList(thisCard).select(count:2, "Discard two cards.").discard()
           def randomOppHand = randomizedOpponentsHand()
           randomOppHand.showToMe("Opponent's hand.")
-          if (randomOppHand.filterByType(TRAINER)) {
+          if (randomOppHand.hasType(TRAINER)) {
             randomOppHand.filterByType(TRAINER).select(count:1).moveTo(opp.deck)
           }
         }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1305,7 +1305,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost W, W, C
           onAttack {
             damage 130
-            opp.hand.showToMe("Opponent's hand.")
+            if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand.")
           }
         }
       };
@@ -3621,9 +3621,10 @@ public enum RebelClash implements LogicCardInfo {
         text "Discard 2 cards from your hand in order to play this card. Your opponent reveals their hand. Choose a Trainer you find there and put it at the bottom of your opponent’s deck. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
           my.hand.getExcludedList(thisCard).select(count:2, "Discard two cards.").discard()
-          opp.hand.showToMe("Opponent's hand.")
-          if (opp.hand.filterByType(TRAINER)) {
-            opp.hand.filterByType(TRAINER).select(count:1).moveTo(opp.deck)
+          def randomOppHand = randomizedOpponentsHand()
+          randomOppHand.showToMe("Opponent's hand.")
+          if (randomOppHand.filterByType(TRAINER)) {
+            randomOppHand.filterByType(TRAINER).select(count:1).moveTo(opp.deck)
           }
         }
         playRequirement {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1305,7 +1305,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost W, W, C
           onAttack {
             damage 130
-            if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand.")
+            if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand.")
           }
         }
       };
@@ -3621,7 +3621,7 @@ public enum RebelClash implements LogicCardInfo {
         text "Discard 2 cards from your hand in order to play this card. Your opponent reveals their hand. Choose a Trainer you find there and put it at the bottom of your opponent’s deck. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
           my.hand.getExcludedList(thisCard).select(count:2, "Discard two cards.").discard()
-          def randomOppHand = randomizedOpponentsHand()
+          def randomOppHand = opp.hand.shuffledCopy()
           randomOppHand.showToMe("Opponent's hand.")
           if (randomOppHand.hasType(TRAINER)) {
             randomOppHand.filterByType(TRAINER).select(count:1).moveTo(opp.deck)

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1383,7 +1383,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost C
           onAttack {
             damage 40
-            opp.hand.select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded.").showToMe("Selected card.").showToOpponent("This card will be discarded.").discard()
+            opp.hand.shuffledCopy().select(hidden: true, count: 1, "Choose a random card from your opponent's hand to be discarded.").showToMe("Selected card.").showToOpponent("This card will be discarded.").discard()
           }
         }
         move "Hydro Snipe", {
@@ -2701,8 +2701,10 @@ public enum SwordShield implements LogicCardInfo {
           energyCost D
           onAttack {
             damage 20
-            if (opp.hand) {
-              opp.hand.select("Choose 1 card to put on the bottom of their deck").moveTo(opp.deck)
+            afterDamage{
+              if (opp.hand) {
+                opp.hand.shuffledCopy().select("Choose 1 card to put on the bottom of their deck").moveTo(opp.deck)
+              }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1572,8 +1572,10 @@ public enum SwordShield implements LogicCardInfo {
           energyCost L, C, C
           onAttack {
             damage 90
-            opp.hand.showToMe("Your opponent's hand.")
-            if (opp.hand.filterByType(ENERGY)) apply PARALYZED
+            if (opp.hand) {
+              opp.hand.shuffledCopy().showToMe("Your opponent's hand.")
+              if (opp.hand.filterByType(ENERGY)) apply PARALYZED
+            }
           }
         }
       };
@@ -2004,9 +2006,14 @@ public enum SwordShield implements LogicCardInfo {
         move "Poltergeist", {
           text "50x damage. Your opponent reveals their hand. This attack does 50 damage for each Trainer card you find there."
           energyCost P, C
+          attackRequirement {
+            assert opp.hand : "Your opponent has no cards in their hand"
+          }
           onAttack {
-            opp.hand.showToMe("Your opponent's hand.")
-            damage 50*opp.hand.filterByType(TRAINER).size()
+            if (opp.hand) {
+              def itemsInOppHand = opp.hand.shuffledCopy().showToMe("Your opponent's hand.").filterByType(TRAINER)
+              damage 50 * itemsInOppHand.size()
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -1660,16 +1660,17 @@ public enum PokemodBaseSet implements LogicCardInfo {
       return supporter (this) {
         text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
         onPlay {
-          opp.hand.showToMe("Opponent's hand")
-          my.hand.showToOpponent("Opponent's hand")
+          if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+          my.hand.getExcludedList(thisCard).showToOpponent("Opponent's hand")
           def tarOpp = opp.hand.filterByType(TRAINER)
-          def tarMy = my.hand.filterByType(TRAINER)
+          def tarMy = my.hand.getExcludedList(thisCard).filterByType(TRAINER)
           opp.hand.removeAll(tarOpp)
           my.hand.removeAll(tarMy)
           shuffleDeck(tarOpp, TargetPlayer.OPPONENT)
           shuffleDeck(tarMy)
         }
         playRequirement{
+          assert (opp.hand || my.hand) : "Neither player has any cards in hand"
         }
       };
       case POKEMON_BREEDER_76: //TODO: Use the implementation of Rare Candy (admin: they are not the same!)

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -1660,7 +1660,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
       return supporter (this) {
         text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
         onPlay {
-          if (opp.hand) randomizedOpponentsHand().showToMe("Opponent's hand")
+          if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand")
           my.hand.getExcludedList(thisCard).showToOpponent("Opponent's hand")
           def tarOpp = opp.hand.filterByType(TRAINER)
           def tarMy = my.hand.getExcludedList(thisCard).filterByType(TRAINER)

--- a/src/tcgwars/logic/util/CardList.groovy
+++ b/src/tcgwars/logic/util/CardList.groovy
@@ -61,6 +61,11 @@ public class CardList extends ArrayList<Card> {
   public CardList copy(){
     return new CardList(this);
   }
+  public CardList shuffledCopy(){
+    def shCopy = this.copy()
+    shCopy.shuffle()
+    return shCopy
+  }
 
   List<String> getFullNames(){
     this.collect {it.fullName}

--- a/src/tcgwars/logic/util/CardList.groovy
+++ b/src/tcgwars/logic/util/CardList.groovy
@@ -61,6 +61,7 @@ public class CardList extends ArrayList<Card> {
   public CardList copy(){
     return new CardList(this);
   }
+
   public CardList shuffledCopy(){
     def shCopy = this.copy()
     shCopy.shuffle()

--- a/src/tcgwars/logic/util/CardList.groovy
+++ b/src/tcgwars/logic/util/CardList.groovy
@@ -67,12 +67,6 @@ public class CardList extends ArrayList<Card> {
     return shCopy
   }
 
-  public CardList shuffledCopy(){
-    def shCopy = this.copy()
-    shCopy.shuffle()
-    return shCopy
-  }
-
   List<String> getFullNames(){
     this.collect {it.fullName}
   }


### PR DESCRIPTION
Fixes potential exploits where a player may use a hand-seeing power, then one that is meant to be random or hidden from their view. Without randomization they can predict which card to discard specifically, breaking many decks in the process.

Work on this must be done for legacy sets ASAP in my opinion. But this should solve a good amount of those interaction, as long as at least one groovy-coded card is involved.