### PR TITLE
DAA: Implement Mountainous Smoke, plus some fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2242,7 +2242,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAttach EXP.ALL to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nDuring your opponent’s turn, if 1 of your Active Pokémon would be Knocked Out by your opponent’s attack, you may take 1 basic Energy card attached to that Knocked Out Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
           def eff
           def check = {
-            if (it.EX || it.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {discard thisCard}
+            if (it.EX || it.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON)) {discard thisCard}
           }
           onPlay {reason->
             eff = delayed {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2242,7 +2242,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAttach EXP.ALL to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nDuring your opponent’s turn, if 1 of your Active Pokémon would be Knocked Out by your opponent’s attack, you may take 1 basic Energy card attached to that Knocked Out Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
           def eff
           def check = {
-            if (it.EX || it.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON)) {discard thisCard}
+            if (it.EX || it.topPokemonCard.cardTypes.is(OWNERS_POKEMON)) {discard thisCard}
           }
           onPlay {reason->
             eff = delayed {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2445,12 +2445,16 @@ public enum CelestialStorm implements LogicCardInfo {
           globalAbility{
             delayed{
               after TAKE_PRIZE, {
-                def hasSmoke = bg.em().retrieveObject("Mountainous_Smoke")
-                if(thisCard.player.pbg.prizeCardSet.notEmpty && !hasSmoke && ef.card != null && ef.card == thisCard
+                //def hasSmoke = bg.em().retrieveObject("Billowing_Smoke")
+                if (
+                  thisCard.player.pbg.prizeCardSet.notEmpty
+                  //&& !hasSmoke
+                  && ef.card != null && ef.card == thisCard
                   && thisCard.player.pbg.bench.notFull && bg.currentTurn == thisCard.player
                   && thisCard.player.pbg.hand.contains(thisCard)
                   && checkGlobalAbility(thisCard)
-                  && confirm("You've picked ${thisCard}. Would you like to use Wish Upon a Star?")){
+                  && confirm("You've picked ${thisCard}. Would you like to use Wish Upon a Star?")
+                ) {
                   bc "${thisCard} used Wish Upon a Star"
                   thisCard.player.pbg.hand.remove(thisCard)
                   benchPCS(thisCard, OTHER, thisCard.player.toTargetPlayer())

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2445,7 +2445,8 @@ public enum CelestialStorm implements LogicCardInfo {
           globalAbility{
             delayed{
               after TAKE_PRIZE, {
-                if(thisCard.player.pbg.prizeCardSet.notEmpty && ef.card != null && ef.card == thisCard
+                def hasSmoke = bg.em().retrieveObject("Mountainous_Smoke")
+                if(thisCard.player.pbg.prizeCardSet.notEmpty && !hasSmoke && ef.card != null && ef.card == thisCard
                   && thisCard.player.pbg.bench.notFull && bg.currentTurn == thisCard.player
                   && thisCard.player.pbg.hand.contains(thisCard)
                   && checkGlobalAbility(thisCard)

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2448,16 +2448,14 @@ public enum DarknessAblaze implements LogicCardInfo {
       return evolution (this, from:"Spinarak", hp:HP110, type:D, retreatCost:2) {
         weakness F
         bwAbility "Spider Net", {
-          text "When you play this card from your hand to evolve 1 of your Pokémon, you may switch 1 of your opponent’s Evolution Pokémon with their Active Pokémon."
-          actionA {
-            onActivate {r->
-              if(r==Ability.ActivationReason.PLAY_FROM_HAND && opp.bench.findAll{it.realEvolution} && confirm("Use Spider Net")){
-                powerUsed()
-                def pcs = opp.bench.findAll{it.realEvolution}.select("New active")
-                if(pcs){
-                  targeted (pcs, SRC_ABILITY) {
-                    sw(opp.active, pcs, SRC_ABILITY)
-                  }
+          text "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent’s Benched Evolution Pokémon with their Active Pokémon."
+          onActivate {r->
+            if(r==Ability.ActivationReason.PLAY_FROM_HAND && opp.bench.findAll{it.realEvolution} && confirm("Use Spider Net")){
+              powerUsed()
+              def pcs = opp.bench.findAll{it.realEvolution}.select("New active")
+              if(pcs){
+                targeted (pcs, SRC_ABILITY) {
+                  sw(opp.active, pcs, SRC_ABILITY)
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3490,7 +3490,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             assert my.deck : "There are no cards left in your deck"
           }
           onAttack {
-            deck.select(count: 2).moveTo(hidden: true, hand)
+            my.deck.select(min:1, max:2, "Put up to 2 cards into your hand").moveTo(hidden: true, my.hand)
             shuffleDeck()
           }
         }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -1959,7 +1959,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 60
-            if(bg.stadiumInfoStruct.stadiumCard.name == "Glimwood Tangle"){
+            if(bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.name == "Glimwood Tangle"){
               damage 60
             }
           }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2568,7 +2568,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         bwAbility "Limber", {
           text "This Pokémon can’t be Paralyzed."
           delayedA{
-            before APPLY_SPECIAL_CONDITION, self {
+            before APPLY_SPECIAL_CONDITION, self, {
               if(ef.type == Paralyzed){
                 bc "$self's Limber pervents it from being Paralyzed"
                 prevent()

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -4052,24 +4052,41 @@ public enum DarknessAblaze implements LogicCardInfo {
         def eff
         onPlay {reason->
           eff = delayed {
-            before (KNOCKOUT,self) {
+            before KNOCKOUT, self, {
               if ((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite) {
-                bc "Mountainous Smoke activates."
-                bg.em().storeObject("Mountainous_Smoke", true)
+                bc "Billowing Smoke activates."
+                //
+                // Code following current compendium rulings
+                //
+                delayed {
+                  before TAKE_PRIZE, {
+                    prevent()
+                    def tar = opp.prizeCardSet.oppSelect(hidden: true, count: 1, "The knocked out Pokémon had Billowing Smoke attached. Select a prize card, and it'll be discarded instead of taken and put into your hand.")
+                    moveCard(suppressLog: true, tar, tar.player.pbg.discard)
+                    bc "$tar was discarded instead of taken as a Prize." // custom log entry
+                  }
+                  after KNOCKOUT, self, {
+                    unregister()
+                  }
+                }
+                //
+                // TODO: Use this code (and update Jirachi Prism Star) if the rulings on this card are updated/fixed (JP says they counts as taken prizes, Compendium currently says they don't)
+                //
+                /* bg.em().storeObject("Billowing_Smoke", true)
                 delayed {
                   after TAKE_PRIZE, {
                     if(self.owner.opposite.prizeCardSet.notEmpty && ef.card != null && ef.card.player == self.owner.opposite){
-                      bc "${ef.card} gets discarded due to Mountainous Smoke's effect."
+                      bc "${ef.card} gets discarded due to Billowing Smoke's effect."
                       def prizeOwner = ef.card.player
                       prizeOwner.pbg.hand.remove(ef.card)
                       prizeOwner.pbg.discard.add(ef.card)
                     }
                   }
                   after KNOCKOUT, self, {
-                    bg.em().storeObject("Mountainous_Smoke", false)
+                    bg.em().storeObject("Billowing_Smoke", false)
                     unregister()
                   }
-                }
+                } */
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2626,10 +2626,11 @@ public enum DarknessAblaze implements LogicCardInfo {
         bwAbility "Dark Squall", {
           text "As often as you like during your turn, you may attach a [D] Energy from your hand to one of your Pokémon in play."
           actionA {
-            assert my.hand.filterByBasicEnergyType(D) : "No [D] in hand"
+            assert my.hand.filterByEnergyType(D) : "No [D] Energy in hand"
             powerUsed()
-            def card = my.hand.filterByEnergyType(D).select("Choose a [D] Energy Card to attach")
-            attachEnergy(my.all.select("To?"), card)
+            def list = my.hand.filterByEnergyType(D).select("Choose a [D] Energy Card to attach")
+            def pcs = my.all.select("Attach to?")
+            attachEnergy(pcs, list.first(), PLAY_FROM_HAND)
           }
         }
         move "Jet Black Fangs", {

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2307,7 +2307,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 80
-            discardDefendingEnergy()
+            afterDamage{
+              discardDefendingEnergy()
+            }
           }
         }
         move "Heavy Rock Cannon", {

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2920,10 +2920,13 @@ public enum DarknessAblaze implements LogicCardInfo {
           onAttack {
             damage 30
             afterDamage{
-              def card = my.hand.filterByEnergyType(D).select(min:0, "Select a [D] Energy to attach from your hand.")
-              if(card){
-                def tar = my.bench.select("To?")
-                attachEnergy(tar, card)
+              def potentialEnergy = my.hand.filterByEnergyType(D)
+              if (my.bench && potentialEnergy){
+                def sel = potentialEnergy.select(min:0, "Select a [D] Energy to attach from your hand.")
+                if (sel) {
+                  def tar = my.bench.select("To?")
+                  attachEnergy(tar, sel.first(), PLAY_FROM_HAND)
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -4057,7 +4057,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             before (KNOCKOUT,self) {
               if ((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite) {
                 bc "Mountainous Smoke activates."
-                bg.em().retrieveAndStore("Mountainous_Smoke", {true})
+                bg.em().storeObject("Mountainous_Smoke", true)
                 delayed {
                   after TAKE_PRIZE, {
                     if(self.owner.opposite.prizeCardSet.notEmpty && ef.card != null && ef.card.player == self.owner.opposite){
@@ -4068,7 +4068,7 @@ public enum DarknessAblaze implements LogicCardInfo {
                     }
                   }
                   after KNOCKOUT, self, {
-                    bg.em().retrieveAndStore("Mountainous_Smoke", {false})
+                    bg.em().storeObject("Mountainous_Smoke", false)
                     unregister()
                   }
                 }


### PR DESCRIPTION
Not 100% liking this implementation (since the card ends up in the hand for a brief moment), but it should work fine. Hopefully the global value stops Jirachi appropriately.