### PR TITLE
Make Energy Evolution (Eevee SUM) handle timing conflict with Welder

### DIFF
--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2426,7 +2426,7 @@ public enum SunMoon implements LogicCardInfo {
               def welderFlag = false
               before PLAY_TRAINER, {
                 welderFlag = false
-                if ((ef.cardToPlay.name == "Welder")) {
+                if (ef.cardToPlay.name == "Welder") {
                   welderFlag = true
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2422,6 +2422,14 @@ public enum SunMoon implements LogicCardInfo {
           weakness FIGHTING
           bwAbility "Energy Evolution", {
             text "When you attach a basic Energy card from your hand to this Pokémon during your turn, you may search your deck for a card that evolves from this Pokémon that is the same type as that Energy card and put it onto this Pokémon to evolve it. Then, shuffle your deck."
+            def energyEvoSearch = {
+              def sel=self.owner.pbg.deck.select(min:0, "Energy Evolution ${ef.card.basicType}",
+              {it.cardTypes.is(EVOLUTION) && it.types.contains(ef.card.basicType) && it.predecessor==self.name}, self.owner)
+              if (sel) {
+                evolve(self, sel.first(), OTHER)
+              }
+              shuffleDeck(null, self.owner.toTargetPlayer())
+            }
             delayedA {
               def welderFlag = false
               before PLAY_TRAINER, {
@@ -2432,14 +2440,6 @@ public enum SunMoon implements LogicCardInfo {
               }
               after ATTACH_ENERGY, self, {
                 if(ef.reason==PLAY_FROM_HAND && ef.card instanceof BasicEnergyCard && self.owner.pbg.deck){
-                  def energyEvoSearch = {
-                    def sel=self.owner.pbg.deck.select(min:0, "Energy Evolution ${ef.card.basicType}",
-                      {it.cardTypes.is(EVOLUTION) && it.types.contains(ef.card.basicType) && it.predecessor==self.name}, self.owner)
-                    if(sel){
-                      evolve(self, sel.first(), OTHER)
-                    }
-                    shuffleDeck(null, self.owner.toTargetPlayer())
-                  }
                   def welderChoice = 0
                   if (welderFlag) {
                     welderChoice = choose([1, 2, 3], ["Use before drawing 3 cards", "Use after drawing 3 cards", "Don't use Energy Evolution"], "A basic Energy was attached to $self via Welder. When would you like to use Energy Evolution?")

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2442,7 +2442,7 @@ public enum SunMoon implements LogicCardInfo {
                   }
                   def welderChoice = 0
                   if (welderFlag) {
-                    def welderChoice = choose([1, 2, 3], ["Use before drawing 3 cards", "Use after drawing 3 cards", "Don't use Energy Evolution"], "A basic Energy was attached to $self via Welder. When would you like to use Energy Evolution?")
+                    welderChoice = choose([1, 2, 3], ["Use before drawing 3 cards", "Use after drawing 3 cards", "Don't use Energy Evolution"], "A basic Energy was attached to $self via Welder. When would you like to use Energy Evolution?")
 
                     if (welderChoice == 2){
                       powerUsed()

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2422,14 +2422,6 @@ public enum SunMoon implements LogicCardInfo {
           weakness FIGHTING
           bwAbility "Energy Evolution", {
             text "When you attach a basic Energy card from your hand to this Pokémon during your turn, you may search your deck for a card that evolves from this Pokémon that is the same type as that Energy card and put it onto this Pokémon to evolve it. Then, shuffle your deck."
-            def energyEvoSearch = {
-              def sel=self.owner.pbg.deck.select(min:0, "Energy Evolution ${ef.card.basicType}",
-              {it.cardTypes.is(EVOLUTION) && it.types.contains(ef.card.basicType) && it.predecessor==self.name}, self.owner)
-              if (sel) {
-                evolve(self, sel.first(), OTHER)
-              }
-              shuffleDeck(null, self.owner.toTargetPlayer())
-            }
             delayedA {
               def welderFlag = false
               before PLAY_TRAINER, {
@@ -2440,6 +2432,14 @@ public enum SunMoon implements LogicCardInfo {
               }
               after ATTACH_ENERGY, self, {
                 if(ef.reason==PLAY_FROM_HAND && ef.card instanceof BasicEnergyCard && self.owner.pbg.deck){
+                  def energyEvoSearch = {
+                    def sel=self.owner.pbg.deck.select(min:0, "Energy Evolution ${ef.card.basicType}",
+                      {it.cardTypes.is(EVOLUTION) && it.types.contains(ef.card.basicType) && it.predecessor==self.name}, self.owner)
+                    if(sel){
+                      evolve(self, sel.first(), OTHER)
+                    }
+                    shuffleDeck(null, self.owner.toTargetPlayer())
+                  }
                   def welderChoice = 0
                   if (welderFlag) {
                     welderChoice = choose([1, 2, 3], ["Use before drawing 3 cards", "Use after drawing 3 cards", "Don't use Energy Evolution"], "A basic Energy was attached to $self via Welder. When would you like to use Energy Evolution?")

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2447,7 +2447,7 @@ public enum SunMoon implements LogicCardInfo {
                     if (welderChoice == 2){
                       powerUsed()
                       delayed {
-                        after PLAY_TRAINER {
+                        after PLAY_TRAINER, {
                           energyEvoSearch.call()
                         }
                       }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -4459,8 +4459,10 @@ public enum UnbrokenBonds implements LogicCardInfo {
         return supporter (this) {
           text "Attach up to 2 [R] Energy cards from your hand to 1 of your Pokémon. If you do, draw 3 cards."
           onPlay {
+            bg.em().storeObject("Welder_Played",true)
             attachEnergyFrom(max:2,type:R,my.hand,my.all)
             draw 3
+            bg.em().storeObject("Welder_Played",false)
           }
           playRequirement{
             assert my.hand.filterByEnergyType(R)


### PR DESCRIPTION
Related ruling:

> Q. If I use Welder and attach a Fire Energy to an Eevee that has the "Energy Evolution" Ability, do I draw the cards for Welder first or search for a Flareon due to "Energy Evolution" first (or is it a choice)?
> 
> A. Since they are simultaneous actions, it is the player's choice of which order they can do this. (May 9, 2019 TPCi Rules Team)

A similar logic would need to be added to the other Energy Evolution cards (Definitely the XY-Furious Fists Eevee, also the Neo Discovery and Unseen Forces prints whenever Unlimited includes SM sets)