### PR TITLE
Update checks for effects unregistering after FALL_BACK instead of SWITCH

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1014,26 +1014,26 @@ class TcgStatics {
     }
   }
 
-	static void defendingAttacksCostsMore (PokemonCardSet pcs, List<Type> energies) {
-		targeted(pcs) {
-			delayed {
-				def eff
-				register {
-					eff = getter (GET_MOVE_LIST, NORMAL, pcs) {h->
-						def list=[]
-						for(move in h.object){
-							def copy=move.shallowCopy()
-							copy.energyCost.addAll(energies)
-							list.add(copy)
-						}
-						h.object=list
-					}
-					bc "Attacks of $pcs will cost $energies more during next turn"
-				}
-				unregister {
-					eff.unregister()
-				}
-				unregisterAfter 2
+  static void defendingAttacksCostsMore (PokemonCardSet pcs, List<Type> energies) {
+    targeted(pcs) {
+      delayed {
+        def eff
+        register {
+          eff = getter (GET_MOVE_LIST, NORMAL, pcs) {h->
+            def list=[]
+            for(move in h.object){
+              def copy=move.shallowCopy()
+              copy.energyCost.addAll(energies)
+              list.add(copy)
+            }
+            h.object=list
+          }
+          bc "Attacks of $pcs will cost $energies more during next turn"
+        }
+        unregister {
+          eff.unregister()
+        }
+        unregisterAfter 2
         after FALL_BACK, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
         after DEVOLVE, pcs, {unregister()}
@@ -1049,12 +1049,12 @@ class TcgStatics {
           eff = getter (GET_RETREAT_COST, NORMAL, pcs) {h->
             h.object += 1
           }
-					bc "Retreat cost of $pcs will cost 1 more energy during the next turn."
-				}
-				unregister {
-					eff.unregister()
-				}
-				unregisterAfter 2
+          bc "Retreat cost of $pcs will cost 1 more energy during the next turn."
+        }
+        unregister {
+          eff.unregister()
+        }
+        unregisterAfter 2
         after FALL_BACK, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
         after DEVOLVE, pcs, {unregister()}

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -427,7 +427,7 @@ class TcgStatics {
           }
         }
         unregisterAfter 2
-        after SWITCH, defending, {unregister()}
+        after FALL_BACK, defending, {unregister()}
         after EVOLVE, defending, {unregister()}
         after DEVOLVE, defending, {unregister()}
       }
@@ -553,7 +553,7 @@ class TcgStatics {
           }
         }
       }
-      after SWITCH, pcs, {unregister()}
+      after FALL_BACK, pcs, {unregister()}
       unregisterAfter 3
     }
   }
@@ -625,7 +625,7 @@ class TcgStatics {
         }
       }
       unregisterAfter 3
-      after SWITCH, self, {unregister()}
+      after FALL_BACK, self, {unregister()}
       after EVOLVE, self, {unregister()}
       after DEVOLVE, self, {unregister()}
       register{registeredOn=bg.turnCount}
@@ -698,7 +698,7 @@ class TcgStatics {
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
       after DEVOLVE, self, {unregister()}
-      after SWITCH, self, {unregister()}
+      after FALL_BACK, self, {unregister()}
     }
   }
 
@@ -721,7 +721,7 @@ class TcgStatics {
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
       after DEVOLVE, self, {unregister()}
-      after SWITCH, self, {unregister()}
+      after FALL_BACK, self, {unregister()}
     }
   }
 
@@ -738,7 +738,7 @@ class TcgStatics {
       unregisterAfter(2)
       after EVOLVE, self, {unregister()}
       after DEVOLVE, self, {unregister()}
-      after SWITCH, self, {unregister()}
+      after FALL_BACK, self, {unregister()}
     }
   }
   static callForFamily(Map params=[:],int count,Object delegate){
@@ -789,13 +789,13 @@ class TcgStatics {
     afterDamage { if (defending.active) { targeted(defending) {
       delayed {
         before RETREAT, defending, { wcu "${thisMove.name} prevents retreat."; prevent()}
-        before SWITCH, defending, { bc "${thisMove.name} prevents switch."; prevent()}
+        before FALL_BACK, defending, { bc "${thisMove.name} prevents switch."; prevent()}
         if(asLongAsSelfIsActive){
-          after SWITCH, self, {unregister()}
+          after FALL_BACK, self, {unregister()}
           after EVOLVE, self, {unregister()}
           after DEVOLVE, self, {unregister()}
         }
-        after SWITCH, defending, {unregister()}
+        after FALL_BACK, defending, {unregister()}
         after EVOLVE, defending, {unregister()}
         after DEVOLVE, defending, {unregister()}
         unregisterAfter 2
@@ -935,7 +935,7 @@ class TcgStatics {
         eff.unregister()
       }
       unregisterAfter 2
-      after SWITCH, self, {unregister()}
+      after FALL_BACK, self, {unregister()}
     }
   }
 
@@ -1032,7 +1032,7 @@ class TcgStatics {
 					eff.unregister()
 				}
 				unregisterAfter 2
-        after SWITCH, pcs, {unregister()}
+        after FALL_BACK, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
         after DEVOLVE, pcs, {unregister()}
 			}
@@ -1053,7 +1053,7 @@ class TcgStatics {
 					eff.unregister()
 				}
 				unregisterAfter 2
-        after SWITCH, pcs, {unregister()}
+        after FALL_BACK, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
         after DEVOLVE, pcs, {unregister()}
 			}
@@ -1070,7 +1070,7 @@ class TcgStatics {
           }}
         }
         unregisterAfter 3
-        after SWITCH, pcs, {unregister()}
+        after FALL_BACK, pcs, {unregister()}
         after EVOLVE, pcs, {unregister()}
         after DEVOLVE, pcs, {unregister()}
       }
@@ -1308,7 +1308,7 @@ class TcgStatics {
     delayed {
       after EVOLVE, defending, {unregister()}
       after DEVOLVE, defending, {unregister()}
-      after SWITCH, defending, {unregister()}
+      after FALL_BACK, defending, {unregister()}
 
       before REMOVE_DAMAGE_COUNTER, defending, {
         bc "Healing was prevented due to an effect"

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -936,6 +936,8 @@ class TcgStatics {
       }
       unregisterAfter 2
       after FALL_BACK, self, {unregister()}
+      after EVOLVE, self, {unregister()}
+      after DEVOLVE, self, {unregister()}
     }
   }
 

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1184,7 +1184,7 @@ public enum BaseSetNG implements LogicCardInfo {
                   unregister {
                     eff.unregister()
                   }
-                  after SWITCH, defending, {unregister()}
+                  after FALL_BACK, defending, {unregister()}
                   after EVOLVE, defending, {unregister()}
                   after DEVOLVE, defending, {unregister()}
                 }
@@ -1401,7 +1401,7 @@ public enum BaseSetNG implements LogicCardInfo {
                 }
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }
             }

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -764,7 +764,7 @@ public enum FossilNG implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH, self,{unregister()}
+                after FALL_BACK, self,{unregister()}
                 after EVOLVE, self,{unregister()}
                 after DEVOLVE, self,{unregister()}
 

--- a/src/tcgwars/logic/impl/gen1/JungleNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/JungleNG.groovy
@@ -885,6 +885,7 @@ public enum JungleNG implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
                 after FALL_BACK,defending, {unregister()}
               }
             }
@@ -1082,7 +1083,11 @@ public enum JungleNG implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after FALL_BACK,defending, {unregister()}
+                after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
                 after FALL_BACK,self, {unregister()}
+                after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
               }
             }
           }
@@ -1118,7 +1123,11 @@ public enum JungleNG implements LogicCardInfo {
 
                   unregisterAfter 2
                   after FALL_BACK,defending, {unregister()}
+                  after EVOLVE,defending, {unregister()}
+                  after DEVOLVE,defending, {unregister()}
                   after FALL_BACK,self, {unregister()}
+                  after EVOLVE,self, {unregister()}
+                  after DEVOLVE,self, {unregister()}
                 }
               }
             }
@@ -1356,7 +1365,11 @@ public enum JungleNG implements LogicCardInfo {
 
                   unregisterAfter 2
                   after FALL_BACK,defending, {unregister()}
+                  after EVOLVE,defending, {unregister()}
+                  after DEVOLVE,defending, {unregister()}
                   after FALL_BACK,self, {unregister()}
+                  after EVOLVE,self, {unregister()}
+                  after DEVOLVE,self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen1/JungleNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/JungleNG.groovy
@@ -885,7 +885,7 @@ public enum JungleNG implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,defending, {unregister()}
-                after SWITCH,defending, {unregister()}
+                after FALL_BACK,defending, {unregister()}
               }
             }
           }
@@ -1081,8 +1081,8 @@ public enum JungleNG implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH,defending, {unregister()}
-                after SWITCH,self, {unregister()}
+                after FALL_BACK,defending, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }
@@ -1117,8 +1117,8 @@ public enum JungleNG implements LogicCardInfo {
                   }
 
                   unregisterAfter 2
-                  after SWITCH,defending, {unregister()}
-                  after SWITCH,self, {unregister()}
+                  after FALL_BACK,defending, {unregister()}
+                  after FALL_BACK,self, {unregister()}
                 }
               }
             }
@@ -1355,8 +1355,8 @@ public enum JungleNG implements LogicCardInfo {
                   }
 
                   unregisterAfter 2
-                  after SWITCH,defending, {unregister()}
-                  after SWITCH,self, {unregister()}
+                  after FALL_BACK,defending, {unregister()}
+                  after FALL_BACK,self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1112,6 +1112,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                   if(opp.active.weaknesses)
                   {
                     def newWeakness = choose([R,F,G,W,P,L,M,D,Y,N],"Select the new weakness")
+                    bc "${defending}'s Weakness is now ${newWeakness}"
                     def eff
                     register {
                       eff = getter (GET_WEAKNESSES, defending) {h->

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1112,7 +1112,6 @@ public enum TeamRocketNG implements LogicCardInfo {
                   if(opp.active.weaknesses)
                   {
                     def newWeakness = choose([R,F,G,W,P,L,M,D,Y,N],"Select the new weakness")
-                    bc "${defending}'s Weakness is now ${newWeakness}"
                     def eff
                     register {
                       eff = getter (GET_WEAKNESSES, defending) {h->

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1061,7 +1061,7 @@ public enum TeamRocketNG implements LogicCardInfo {
 										bg.em().run(new DirectDamage(damage, pcs))*/
                   }
                 }
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
 
@@ -1124,7 +1124,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                     unregister {
                       eff.unregister()
                     }
-                    after SWITCH, defending, {unregister()}
+                    after FALL_BACK, defending, {unregister()}
                     after EVOLVE, defending, {unregister()}
                     after DEVOLVE, defending, {unregister()}
                   }

--- a/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
@@ -751,7 +751,11 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
 
                 unregisterAfter 2
                 after FALL_BACK,defending, {unregister()}
+                after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
                 after FALL_BACK,self, {unregister()}
+                after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
@@ -750,8 +750,8 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
                 }
 
                 unregisterAfter 2
-                after SWITCH, defending, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK,defending, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2730,6 +2730,8 @@ public enum Deoxys implements LogicCardInfo {
                   }
                 }
                 before FALL_BACK, self, {unregister()}
+                before EVOLVE, self, {unregister()}
+                before DEVOLVE, self, {unregister()}
                 unregisterAfter 2
               }
             }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2729,7 +2729,7 @@ public enum Deoxys implements LogicCardInfo {
                     discard efs.card
                   }
                 }
-                before SWITCH, self, {unregister()}
+                before FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }
             }
@@ -2777,7 +2777,7 @@ public enum Deoxys implements LogicCardInfo {
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -2139,7 +2139,7 @@ public enum DragonFrontiers implements LogicCardInfo {
                 eff.unregister()
               }
               unregisterAfter 2
-              after SWITCH, self, { unregister() }
+              after FALL_BACK, self, { unregister() }
               after EVOLVE, self, { unregister() }
               after DEVOLVE, self, { unregister() }
             }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -421,7 +421,7 @@ public enum Emerald implements LogicCardInfo {
                     }
                   }
                 }
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
                 unregisterAfter 3

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1717,7 +1717,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                       apply CONFUSED, pcs
                     }
                   }
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                   unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -251,7 +251,7 @@ public enum HolonPhantoms implements LogicCardInfo {
                     directDamage 50, pcs
                   }
                 }
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
                 unregisterAfter 2
@@ -362,7 +362,7 @@ public enum HolonPhantoms implements LogicCardInfo {
                     }
                   }
                 }
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
                 unregisterAfter 2
@@ -847,7 +847,7 @@ public enum HolonPhantoms implements LogicCardInfo {
                     list.clear()
                   }
                 }
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
                 unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1158,7 +1158,7 @@ public enum LegendMaker implements LogicCardInfo {
                     directDamage 70, pcs
                   }
                 }
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
                 unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -701,7 +701,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                       directDamage 50, pcs
                     }
                   }
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                   unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -429,7 +429,7 @@ public enum UnseenForces implements LogicCardInfo {
                     directDamage 30, pcs
                   }
                 }
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
                 unregisterAfter 2
@@ -3030,7 +3030,7 @@ public enum UnseenForces implements LogicCardInfo {
                   new CheckAbilities().run(bg)
                 }
                 unregisterAfter 2
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
               }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1046,7 +1046,7 @@ public enum DiamondPearl implements LogicCardInfo {
                         }
                       }
                     }
-                    after SWITCH, pcs, {unregister()}
+                    after FALL_BACK, pcs, {unregister()}
                     after EVOLVE, pcs, {unregister()}
                     after DEVOLVE, pcs, {unregister()}
                     unregisterAfter 3
@@ -1430,7 +1430,7 @@ public enum DiamondPearl implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
-                after SWITCH,self, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }
@@ -1922,7 +1922,7 @@ public enum DiamondPearl implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
-                after SWITCH,self, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }
@@ -2738,7 +2738,7 @@ public enum DiamondPearl implements LogicCardInfo {
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()} //This attack could be copied by an evolution.
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1430,6 +1430,7 @@ public enum DiamondPearl implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
                 after FALL_BACK,self, {unregister()}
               }
             }
@@ -1922,6 +1923,7 @@ public enum DiamondPearl implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
                 after FALL_BACK,self, {unregister()}
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -294,7 +294,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, self, { unregister() }
+                  after FALL_BACK, self, { unregister() }
                   after EVOLVE, self, { unregister() }
                   after DEVOLVE, self, { unregister() }
                 }
@@ -1304,7 +1304,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                     keyStore("EI_Buff_Lazy_Blow", self, 0)
                     bc "Energetic Impulse's effect wore off."
                   }
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
                   unregisterAfter 1
@@ -1322,7 +1322,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                     wcu "$pokePower prevents $self from attacking."
                     prevent()
                   }
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
                   unregisterAfter 1
@@ -2063,7 +2063,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }
@@ -3498,7 +3498,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
                 }
@@ -3524,7 +3524,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -525,7 +525,7 @@ public enum BurningShadows implements LogicCardInfo {
                       }
                     }
                     unregisterAfter 2
-                    after SWITCH, pcs, {unregister()}
+                    after FALL_BACK, pcs, {unregister()}
                     after EVOLVE, pcs, {unregister()}
                     after DEVOLVE, pcs, {unregister()}
                   }
@@ -1455,7 +1455,7 @@ public enum BurningShadows implements LogicCardInfo {
                   unregister {
                     eff.unregister()
                   }
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                   unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -487,7 +487,7 @@ public enum CelestialStorm implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
-                after SWITCH,self, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }
@@ -1820,7 +1820,7 @@ public enum CelestialStorm implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 3
-                after SWITCH,defending, {unregister()}
+                after FALL_BACK,defending, {unregister()}
                 after EVOLVE,defending, {unregister()}
               }
             }
@@ -1859,7 +1859,7 @@ public enum CelestialStorm implements LogicCardInfo {
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                 }
               }
             }
@@ -1956,7 +1956,7 @@ public enum CelestialStorm implements LogicCardInfo {
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                 }
               }
             }
@@ -2478,7 +2478,7 @@ public enum CelestialStorm implements LogicCardInfo {
                         new Knockout(pcs).run(bg)
                       }
                     }
-                    after SWITCH, pcs, {unregister()}
+                    after FALL_BACK, pcs, {unregister()}
                     after EVOLVE, pcs, {unregister()}
                     after DEVOLVE, pcs, {unregister()}
                     unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -487,6 +487,7 @@ public enum CelestialStorm implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
                 after FALL_BACK,self, {unregister()}
               }
             }
@@ -1140,6 +1141,8 @@ public enum CelestialStorm implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,self, {unregister()}
+                after DEVOLVE,self, {unregister()}
+                after FALL_BACK,self, {unregister()}
               }
             }
           }
@@ -1822,6 +1825,7 @@ public enum CelestialStorm implements LogicCardInfo {
                 unregisterAfter 3
                 after FALL_BACK,defending, {unregister()}
                 after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1754,7 +1754,7 @@ public enum CosmicEclipse implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 3
-                after SWITCH,defending, {unregister()}
+                after FALL_BACK,defending, {unregister()}
                 after EVOLVE,defending, {unregister()}
               }
             }
@@ -3751,7 +3751,7 @@ public enum CosmicEclipse implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1756,6 +1756,7 @@ public enum CosmicEclipse implements LogicCardInfo {
                 unregisterAfter 3
                 after FALL_BACK,defending, {unregister()}
                 after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2114,10 +2114,11 @@ public enum CrimsonInvasion implements LogicCardInfo {
                     if(my.bench && ef.pokemonToBeKnockedOut.owner==self.owner.opposite){
                       def tar = my.bench.select("Select the Pokémon to switch with Staraptor")
                       sw self, tar
-                      unregister()
                     }
                   }
-                  unregisterAfter 1
+                  unregisterAfter 3
+                  after SWITCH,self, {unregister()}
+                  after EVOLVE,self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1320,7 +1320,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,defending, {unregister()}
-                after SWITCH,defending, {unregister()}
+                after FALL_BACK,defending, {unregister()}
               }
             }
           }
@@ -1974,7 +1974,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
                 }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -1320,6 +1320,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after EVOLVE,defending, {unregister()}
+                after DEVOLVE,defending, {unregister()}
                 after FALL_BACK,defending, {unregister()}
               }
             }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2114,11 +2114,10 @@ public enum CrimsonInvasion implements LogicCardInfo {
                     if(my.bench && ef.pokemonToBeKnockedOut.owner==self.owner.opposite){
                       def tar = my.bench.select("Select the Pokémon to switch with Staraptor")
                       sw self, tar
+                      unregister()
                     }
                   }
-                  unregisterAfter 3
-                  after SWITCH,self, {unregister()}
-                  after EVOLVE,self, {unregister()}
+                  unregisterAfter 1
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1279,7 +1279,7 @@ public enum ForbiddenLight implements LogicCardInfo {
                     }
                   }
                   before EVOLVE, defending, {unregister()}
-                  before SWITCH, defending, {unregister()}
+                  before FALL_BACK, defending, {unregister()}
                   unregisterAfter 3
                 }
               }
@@ -1415,7 +1415,7 @@ public enum ForbiddenLight implements LogicCardInfo {
                   }
                 }
                 before EVOLVE, self, {unregister()}
-                before SWITCH, self, {unregister()}
+                before FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }
             }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1279,6 +1279,7 @@ public enum ForbiddenLight implements LogicCardInfo {
                     }
                   }
                   before EVOLVE, defending, {unregister()}
+                  before DEVOLVE, defending, {unregister()}
                   before FALL_BACK, defending, {unregister()}
                   unregisterAfter 3
                 }
@@ -1415,6 +1416,7 @@ public enum ForbiddenLight implements LogicCardInfo {
                   }
                 }
                 before EVOLVE, self, {unregister()}
+                before DEVOLVE, self, {unregister()}
                 before FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -633,7 +633,7 @@ public enum GuardiansRising implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }
@@ -2086,7 +2086,7 @@ public enum GuardiansRising implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }
@@ -2312,7 +2312,7 @@ public enum GuardiansRising implements LogicCardInfo {
                     bg.em().run(new TakePrize(self.owner, pcs))
                   }
                 }
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
                 unregisterAfter 3

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -634,6 +634,8 @@ public enum GuardiansRising implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after FALL_BACK, self, {unregister()}
+                after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -505,7 +505,7 @@ public enum LostThunder implements LogicCardInfo {
                       prevent()
                     }
                   }
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                   unregisterAfter 2

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -820,7 +820,6 @@ public enum SunMoonPromos implements LogicCardInfo {
             attackRequirement {
               assert opp.all.size() > 1 : "Your opponent only has one Pokémon in play"
             }
-            def eff
             onAttack {
               //Taken from UPR Tapu Lele
               eff = delayed {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -820,6 +820,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             attackRequirement {
               assert opp.all.size() > 1 : "Your opponent only has one Pokémon in play"
             }
+            def eff
             onAttack {
               //Taken from UPR Tapu Lele
               eff = delayed {

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -3001,7 +3001,7 @@ public enum SunMoonPromos implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -867,7 +867,7 @@ public enum UltraPrism implements LogicCardInfo {
                 unregisterAfter 2
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3151,6 +3151,8 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after FALL_BACK, self, {unregister()}
+                after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -669,7 +669,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   bg.em().run(new CheckAbilities())
                 }
                 unregisterAfter 3
-                after SWITCH, pcs, {unregister()}
+                after FALL_BACK, pcs, {unregister()}
                 after EVOLVE, pcs, {unregister()}
                 after DEVOLVE, pcs, {unregister()}
               }
@@ -1474,7 +1474,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 }
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }
             }
@@ -2146,7 +2146,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                     }
                     after EVOLVE, pcs, {unregister()}
                     after DEVOLVE, pcs, {unregister()}
-                    after SWITCH, pcs, {unregister()}
+                    after FALL_BACK, pcs, {unregister()}
                     unregister {
                       ef.unregister()
                     }
@@ -2222,7 +2222,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   unregisterAfter 2
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()} //Could be copied by an evolution.
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                 }
               }
             }
@@ -3150,7 +3150,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3079,6 +3079,8 @@ public enum UnifiedMinds implements LogicCardInfo {
                 }
                 unregisterAfter 2
                 after FALL_BACK, self, {unregister()}
+                after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1961,7 +1961,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                 }
                 after EVOLVE, self, {unregister()}
                 after DEVOLVE, self, {unregister()}
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
                 unregisterAfter 2
               }
             }
@@ -3078,7 +3078,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                   }
                 }
                 unregisterAfter 2
-                after SWITCH, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
               }
             }
           }
@@ -3825,7 +3825,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }
@@ -3908,7 +3908,7 @@ public enum UnifiedMinds implements LogicCardInfo {
                         }
                       }
                       unregisterAfter 2
-                      after SWITCH, self, { unregister() }
+                      after FALL_BACK, self, { unregister() }
                       after EVOLVE, self, { unregister() }
                       after DEVOLVE, self, { unregister() }
                     }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3161,7 +3161,7 @@ public enum DarknessAblaze implements LogicCardInfo {
                 }
               }
               unregisterAfter 2
-              after SWITCH, self, {unregister()}
+              after FALL_BACK, self, {unregister()}
               after EVOLVE, self, {unregister()}
               after DEVOLVE, self, {unregister()}
             }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -525,7 +525,7 @@ public enum RebelClash implements LogicCardInfo {
                     }
                   }
                   unregisterAfter 2
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }
@@ -2286,7 +2286,7 @@ public enum RebelClash implements LogicCardInfo {
                   }
                 }
 
-                after SWITCH, self, { unregister() }
+                after FALL_BACK, self, { unregister() }
                 after EVOLVE, self, { unregister() }
                 after DEVOLVE, self, { unregister() }
               }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2441,10 +2441,10 @@ public enum SwordShield implements LogicCardInfo {
                     eff2.unregister()
                   }
 
-                  after SWITCH, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                   after EVOLVE, self, {unregister()}
                   after DEVOLVE, self, {unregister()}
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
                 }
@@ -2925,7 +2925,7 @@ public enum SwordShield implements LogicCardInfo {
                   }
 
                   unregisterAfter 2
-                  after SWITCH, self, { unregister() }
+                  after FALL_BACK, self, { unregister() }
                   after EVOLVE, self, { unregister() }
                   after DEVOLVE, self, { unregister() }
                 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -1249,7 +1249,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
               }
               after EVOLVE, self, {unregister()}
               after DEVOLVE, self, {unregister()}
-              after SWITCH, self, {unregister()}
+              after FALL_BACK, self, {unregister()}
               unregisterAfter 2
             }
           }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
@@ -1135,10 +1135,10 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
                       prevent()
                     }
                   }
-                  after SWITCH, pcs, {unregister()}
+                  after FALL_BACK, pcs, {unregister()}
                   after EVOLVE, pcs, {unregister()}
                   after DEVOLVE, pcs, {unregister()}
-                  after SWITCH,self, {unregister()}
+                  after FALL_BACK,self, {unregister()}
                   after EVOLVE,self, {unregister()}
                   after DEVOLVE,self, {unregister()}
                   unregisterAfter 2


### PR DESCRIPTION
Should avoid issues related to the new targetting done by the Switch Event. Gusting a Pokémon currently doesn't trigger the `after SWITCH, [pcs/defending/self], { unregister() }` lines, since the SWITCH target in those is the gusted Pokémon from the bench and not the active. This PR changes it so the detection works properly again.

In addition:
* Added checks for EVOLVE/DEVOLVE in some cards that were missing them (for most cases, needed in the event of another Pokémon copying the attack, which may be able to evolve/devolve (Example: Zoroark BW and Zoroark BREAK)