### PR TITLE
General Fixes

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1397,16 +1397,18 @@ class TcgStatics {
   }
 
   static putDamageCountersOnOpponentsPokemon(int counters, def selectArea = opp.all){
-    def eff = delayed {
-      before KNOCKOUT, {
-        prevent()
+    if (selectArea.notEmpty) {
+      def eff = delayed {
+        before KNOCKOUT, {
+          prevent()
+        }
       }
+
+      counters.times{directDamage 10, selectArea.select("Put 1 damage counter on which pokémon? ${it}/${counters} counters placed") }
+
+      eff.unregister()
+      checkFaint()
     }
-
-    counters.times{directDamage 10, selectArea.select("Put 1 damage counter on which pokémon? ${it}/${counters} counters placed") }
-
-    eff.unregister()
-    checkFaint()
   }
 
   static boolean wasSwitchedOutThisTurn(PokemonCardSet self){

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1112,6 +1112,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                   if(opp.active.weaknesses)
                   {
                     def newWeakness = choose([R,F,G,W,P,L,M,D,Y,N],"Select the new weakness")
+                    bc "${defending}'s Weakness is now ${newWeakness}"
                     def eff
                     register {
                       eff = getter (GET_WEAKNESSES, defending) {h->

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -277,8 +277,9 @@ public enum DeltaSpecies implements LogicCardInfo {
           text "Once during your turn (before your attack), you may attach a [L] Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Dragonite is affected by a Special Condition."
           actionA {
             checkLastTurn()
-            assert my.bench.notEmpty : "Bench is empty"
             checkNoSPC()
+            assert my.bench.notEmpty : "Bench is empty"
+            assert my.discard.filterByEnergyType(L) : "You have no [L] Energy cards in your discard pile"
             powerUsed()
 
             attachEnergyFrom(type:L, my.discard, my.bench)

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1873,7 +1873,8 @@ public enum Emerald implements LogicCardInfo {
             to.evolution && !to.EX
           }
           getEnergyTypesOverride{
-            return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+            if (self) return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+            else return [[] as Set]
           }
 
         };

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2240,25 +2240,9 @@ public enum LegendMaker implements LogicCardInfo {
             h.object = hp(40)
           }
           eff2 = delayed {
-            boolean flag = false
-            def flaggedPokemon
-            before EVOLVE, {
-              flag = ef.pokemonToBeEvolved.active && ef.pokemonToBeEvolved.isSPC(BURNED)
-            }
-            after EVOLVE, {
-              if(flag) {
-                bc "Full Flame prevents removing burned when evolved"
-                apply(BURNED, ef.pokemonToBeEvolved, TRAINER_CARD)
-              }
-            }
-            before DEVOLVE, {
-              flaggedPokemon = my.active.isSPC(BURNED) ? my.active : (opp.active.isSPC(BURNED) ? opp.active : null)
-            }
-            after DEVOLVE, {
-              if(flaggedPokemon != null) {
-                bc "Full Flame prevents removing burned when evolved"
-                apply(BURNED, flaggedPokemon, TRAINER_CARD)
-              }
+            before BURNED_SPC, null, null, EVOLVE, {
+              bc "Full Flame prevents removing the Special Condition Burned by evolving or devolving"
+              prevent()
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2464,7 +2464,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
           onRemoveFromPlay {
           }
           getEnergyTypesOverride {
-            return [[D,M] as Set]
+            if (self) return [[D, M] as Set]
+            else return [[] as Set]
           }
         };
       case R_ENERGY_95:
@@ -2502,7 +2503,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
             to.name.contains("Dark ") || to.name.contains("Rocket's ")
           }
           getEnergyTypesOverride {
-            return [[D] as Set, [D] as Set]
+            if (self) return [[D] as Set, [D] as Set]
+            else return [[] as Set]
           }
         };
       case ROCKET_S_ARTICUNO_EX_96:

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -2187,7 +2187,9 @@ public enum SecretWonders implements LogicCardInfo {
             text "Murkrow can evolve during the turn you play it."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                prevent()
+                if(bg.currentTurn == self.owner){
+                  prevent()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -5,6 +5,11 @@ import static tcgwars.logic.card.Type.*;
 import static tcgwars.logic.card.CardType.*;
 import static tcgwars.logic.groovy.TcgBuilders.*;
 import static tcgwars.logic.groovy.TcgStatics.*
+import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
+import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectPriority.*
+import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
@@ -1101,7 +1106,7 @@ public enum SupremeVictors implements LogicCardInfo {
           pokeBody "Natural Cure", {
             text "When you attach an Energy card from your hand to Roserade , remove all Special Conditions from Roserade ."
             delayedA {
-              before ATTACH_ENERGY, self, {
+              after ATTACH_ENERGY, self, {
                 if (ef.reason == PLAY_FROM_HAND) {
                   clearSpecialCondition(self, SRC_ABILITY)
                 }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1101,7 +1101,7 @@ public enum SupremeVictors implements LogicCardInfo {
           pokeBody "Natural Cure", {
             text "When you attach an Energy card from your hand to Roserade , remove all Special Conditions from Roserade ."
             delayedA {
-              before ATTACH_ENERGY, self {
+              before ATTACH_ENERGY, self, {
                 if (ef.reason == PLAY_FROM_HAND) {
                   clearSpecialCondition(self, SRC_ABILITY)
                 }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3306,13 +3306,16 @@ public enum CelestialStorm implements LogicCardInfo {
       case UNDERGROUND_EXPEDITION_150:
         return copy(Skyridge.UNDERGROUND_EXPEDITION_140, this);
       case RAINBOW_ENERGY_151:
-        return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P]]) {
+        return specialEnergy (this, [[C]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon. (While not in play, Rainbow Energy counts as Colorless Energy.)"
           typeImagesOverride = [RAINBOW]
           onPlay {reason->
             if (reason == PLAY_FROM_HAND) {
               directDamage(10, self, Source.SRC_SPENERGY)
             }
+          }
+          getEnergyTypesOverride {
+            self != null ? [[R, D, F, G, W, Y, L, M, P] as Set] : [[C] as Set]
           }
         };
       case SHIFTRY_GX_152:

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -1088,7 +1088,10 @@ public enum CelestialStorm implements LogicCardInfo {
             text "If you go second, this Pokémon can evolve during your first turn."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                if(bg.turnCount == 2) prevent()
+                if(bg.turnCount == 2 && bg.currentTurn == self.owner){
+                  powerUsed()
+                  prevent()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3981,7 +3981,8 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "If your opponent’s Active Pokémon is a Pokémon-GX or Pokémon-EX, this Pokémon can evolve during the turn you play it."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                if (self.owner.opposite.pbg.active.pokemonGX || self.owner.opposite.pbg.active.pokemonEX) {
+                if (bg.currentTurn == self.owner && (self.owner.opposite.pbg.active.pokemonGX || self.owner.opposite.pbg.active.pokemonEX) ) {
+                  powerUsed()
                   prevent()
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2113,11 +2113,10 @@ public enum CrimsonInvasion implements LogicCardInfo {
                     if(my.bench && ef.pokemonToBeKnockedOut.owner==self.owner.opposite){
                       def tar = my.bench.select("Select the Pokémon to switch with Staraptor")
                       sw self, tar
+                      unregister()
                     }
                   }
-                  unregisterAfter 3
-                  after SWITCH,self, {unregister()}
-                  after EVOLVE,self, {unregister()}
+                  unregisterAfter 1
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2110,7 +2110,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
               afterDamage{
                 delayed{
                   before KNOCKOUT, {
-                    if(my.bench && ef.pokemonToBeKnockedOut.owner==self.owner.opposite){
+                    if(my.bench && (ef as Knockout).byDamageFromAttack && ef.pokemonToBeKnockedOut.owner==self.owner.opposite){
                       def tar = my.bench.select("Select the Pokémon to switch with Staraptor")
                       sw self, tar
                       unregister()

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -614,7 +614,7 @@ public enum DragonMajesty implements LogicCardInfo {
           bwAbility "Downpour" , {
             text "As often as you like during your turn (before your attack), you may discard a [W] Energy card from your hand."
             actionA{
-              assert my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W)
+              assert my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W) : "You have no [W] Energy cards in your hand"
               my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W).select("Select a [W] to discard").discard()
             }
           }

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -653,7 +653,8 @@ public enum DragonMajesty implements LogicCardInfo {
           bwAbility "Wash Out" , {
             text "As often as you like during your turn (before your attack), you may move a [W] Energy from 1 of your Benched Pokémon to your Active Pokémon."
             actionA{
-              assert my.bench : "You don't have Pokémon on your bench"
+              assertMyBench(info: "with any [W] Energy on them", {it.cards.energyCount(W)})
+              powerUsed()
               moveEnergy(type:W,my.bench,my.active)
             }
           }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1000,8 +1000,11 @@ public enum ForbiddenLight implements LogicCardInfo {
           bwAbility "Magnetic Circuit", {
             text "As often as you like during your turn (before your attack), you may attach a [L] Energy card from your hand to 1 of your Pokémon."
             actionA {
-              assert my.hand.findAll(basicEnergyFilter(L))
-              attachEnergyFrom(may: true, type: L, my.hand, my.all)
+              assert my.hand.filterByEnergyType(L) : "No [L] Energy in hand"
+              powerUsed()
+              def selEnergy = my.hand.filterByBasicEnergyType(L).first()
+              def pcs = my.all.select("Attach to?")
+              attachEnergy(pcs, selEnergy, PLAY_FROM_HAND)
             }
           }
           move "Zap Cannon", {

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2082,7 +2082,10 @@ public enum ForbiddenLight implements LogicCardInfo {
             text "If you go second, this Pokémon can evolve during your first turn."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                if(bg.turnCount == 2) prevent()
+                if(bg.turnCount == 2 && bg.currentTurn == self.owner){
+                  powerUsed()
+                  prevent()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -833,7 +833,9 @@ public enum SunMoonPromos implements LogicCardInfo {
                 if(!pl) break;
                 def src =pl.select("Source for damage counter (cancel to stop)", false)
                 if(!src) break;
-                def tar=opp.all.select("Target for damage counter (cancel to stop)", false)
+                def tar = opp.all
+                tar.remove(src)
+                tar = tar.select("Target for damage counter (cancel to stop)", false)
                 if(!tar) break;
 
                 src.damage-=hp(10)

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -820,6 +820,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             attackRequirement {
               assert opp.all.size() > 1 : "Your opponent only has one Pokémon in play"
             }
+            def eff
             onAttack {
               //Taken from UPR Tapu Lele
               eff = delayed {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2476,7 +2476,10 @@ public enum TeamUp implements LogicCardInfo {
             text "If you go second, this Pokémon can evolve during your first turn."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                if(bg.turnCount == 2) prevent()
+                if(bg.turnCount == 2 && bg.currentTurn == self.owner){
+                  powerUsed()
+                  prevent()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2332,7 +2332,9 @@ public enum UltraPrism implements LogicCardInfo {
                 if(!pl) break;
                 def src =pl.select("Source for damage counter (cancel to stop)", false)
                 if(!src) break;
-                def tar=opp.all.select("Target for damage counter (cancel to stop)", false)
+                def tar = opp.all
+                tar.remove(src)
+                tar = tar.select("Target for damage counter (cancel to stop)", false)
                 if(!tar) break;
 
                 src.damage-=hp(10)

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -1214,7 +1214,10 @@ public enum UltraPrism implements LogicCardInfo {
             text "If you go second, this Pokémon can evolve during your first turn."
             delayedA {
               before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-                if(bg.turnCount == 2) prevent()
+                if(bg.turnCount == 2 && bg.currentTurn == self.owner){
+                  powerUsed()
+                  prevent()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2039,8 +2039,11 @@ public enum UltraPrism implements LogicCardInfo {
           bwAbility "Magnetic Circuit", {
             text "As often as you like during your turn (before your attack), you may attach a [M] Energy card from your hand to 1 of your Pokémon."
             actionA {
-              assert my.hand.findAll(basicEnergyFilter(METAL))
-              attachEnergyFrom(may: true, type: METAL, my.hand, my.all)
+              assert my.hand.filterByEnergyType(M) : "No [M] Energy in hand"
+              powerUsed()
+              def list = my.hand.filterByEnergyType(M).select("Choose a [M] Energy Card to attach")
+              def pcs = my.all.select("Attach to?")
+              attachEnergy(pcs, list.first(), PLAY_FROM_HAND)
             }
           }
           move "Zap Cannon", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1465,10 +1465,12 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 before APPLY_ATTACK_DAMAGES, {
                   bg.dm().each {
                     if(it.to == self && it.notNoEffect && it.dmg.value && bg.currentTurn != self.owner) {
+                      def newDmg = it.dmg
                       flip {
                         bc "Afterimage Strike prevents damage!"
-                        it.dmg = hp(0)
+                        newDmg = hp(0)
                       }
+                      it.dmg = newDmg
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3033,6 +3033,8 @@ public enum UnifiedMinds implements LogicCardInfo {
           bwAbility "Shadow Connection", {
             text "As often as you like during your turn (before your attack), you may move a basic [D] Energy from 1 of your Pokémon to another of your Pokémon."
             actionA {
+              assertMyAll(info: "with any basic [D] Energy on them", {it.cards.filterByType(BASIC_ENERGY).energyCount(D)})
+              assert my.all.size() > 1 : "You only have one Pokémon in play"
               powerUsed()
               moveEnergy(basic: true, type: D, my.all, my.all)
             }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -308,8 +308,10 @@ public enum RebelClash implements LogicCardInfo {
           text "This Pokemon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-              powerUsed()
-              prevent()
+              if (bg.currentTurn == self.owner){
+                powerUsed()
+                prevent()
+              }
             }
           }
         }
@@ -328,8 +330,10 @@ public enum RebelClash implements LogicCardInfo {
           text "This Pokemon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
-              powerUsed()
-              prevent()
+              if (bg.currentTurn == self.owner){
+                powerUsed()
+                prevent()
+              }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1471,10 +1471,12 @@ public enum SwordShield implements LogicCardInfo {
         bwAbility "Ice Dance", {
           text "As often as you like during your turn, you may attach a [W] Energy card from your hand to 1 of your Benched [W] Pokémon."
           actionA {
-            if (confirm("Use Ice Dance?")) {
-              powerUsed()
-              attachEnergyFrom(type:W, my.hand, my.bench.findAll { it.types.contains(W) })
-            }
+            assert my.hand.filterByEnergyType(W) : "No [W] Energy in hand"
+            assertMyBench(hasType: W)
+            powerUsed()
+            def selEnergy = my.hand.filterByBasicEnergyType(W).first()
+            def pcs = my.bench.findAll{it.types.contains(W)}.select("Attach to?")
+            attachEnergy(pcs, selEnergy, PLAY_FROM_HAND)
           }
         }
         move "Aurora Beam", {

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -753,8 +753,9 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, R, R, C
           onAttack {
             damage 120
-            discardDefendingEnergy()
-            discardDefendingEnergy()
+            afterDamage{
+              2.times{ discardDefendingEnergy() }
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1869,6 +1869,7 @@ public enum SwordShield implements LogicCardInfo {
           text "As often as you like during your turn, you may move 1 damage counter from 1 of your [P] Pokémon to another of your [P] Pokémon."
           actionA {
             assertMyAll(hasType: P, info: "with damage counters on them", {it.numberOfDamageCounters})
+            assert my.all.count{it.types.contains(P)} > 1 : "You don't have another [P] Pokémon in play"
             powerUsed()
             def source = my.all.findAll { it.numberOfDamageCounters > 0 && it.types.contains(P) }.select("Source for the damage counter?")
             def target = my.all.findAll { it.types.contains(P) }


### PR DESCRIPTION
Moved some stuff from #888, and started working on some other more immediate fixes (the switch changes are a bit larger, I'd rather leave those on its own PR without these mixed in-between.)

Fixes to confirm working once merged: 

- [x] Frogadier (Unbroken Bonds) should no longer crash when "Afterimage Strike" flips heads.
- [x] Dragonite δ (Delta Species) should no longer be able to use "Delta Charge" when no [L] Energy is found in the discard pile.
- [x] Attacks that use the "put damage counters in the opponent's Pokémon" static should now check for Pokémon being in the area (mainly for when counters are placed in bench only). This should fix a timeout bug due to no valid target being selectable, specifically in Dragapult VMAX (Rebel Clash).
- [x] Tapu Lele (SM Promo SM45) should stop crashing after using Magical Swap, after adding a missing `def`.
    + Made it so both this one and the Ultra Prism print no longer allow moving a counter from a Pokémon to the same one (which didn't make a lot of sense)
- [x] Staraptor (Crimson Invasion) should now switch due to KO only once when using "Sky Hunting".
- [x] Added a bc for Porygon (Team Rocket). Not really a major change, and it's a groovy set not currently being used but might as well add it 😛 
- [x] Added a missing comma in Roserade[C] (Supreme Victors).
- [x] Fixed Rainbow Energy, Double Rainbow Energy, R Energy and Dark Metal Energy counting as their energy types while in hand when they shouldn't.
- [x] Updated Magnezone (Ultra Prism, Forbidden Light) and Frosmoth (Sword & Shield - Base Set) to work similarly to Porygon-Z (Unbroken Bonds) and Blastoise-ex (FireRed & LeafGreen).
- [x] Added a missing assert fail message on Feraligatr (Dragon Majesty).
- [x] Added some missing asserts for Quagsire (Dragon Majesty), Weavile (Unified Minds) and Gengar (Sword & Shield - Base Set).
- [x] Fixed Torkoal V (Sword & Shield - Base Set) so it discards Energies after damage is applied.
- [x] Fixed multiple "You can evolve first turn" Abilities. All now make a message in log, but also are restricted to its owner's turn (currently can be played on opponent's turn)
- [x] Fixed Full Flame not preserving the Burned condition on evolve/devolve.