### PR TITLE
Added confirmation for scoop effects that may cause a game loss

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1446,6 +1446,12 @@ class TcgStatics {
       return false
   }
 
+  static confirmScoopLastPokemon() {
+    if (my.bench.empty){
+      assert confirm("You have no other Pokémon in play. Playing this card may cause you to lose the game. Are you sure you want to play it anyway?") : "Use of the card was canceled"
+    }
+  }
+
   static void loadMarkerCheckerAction(def delegate, actions) {
     def isCheckerLoaded = bg.em().retrieveObject("Checker_Loaded")
     if (isCheckerLoaded)

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1881,6 +1881,9 @@ public enum BaseSetNG implements LogicCardInfo {
               removePCS pcs
             }
           }
+          playRequirement {
+            confirmScoopLastPokemon()
+          }
         };
       case SUPER_ENERGY_REMOVAL:
         return basicTrainer (this) {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2392,7 +2392,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.bench : "you don't have pokemon to return to your hand"
+            confirmScoopLastPokemon()
           }
         };
       case VS_SEEKER_100:

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2643,6 +2643,7 @@ public enum BurningShadows implements LogicCardInfo {
           }
           playRequirement{
             assert my.all.findAll {it.numberOfDamageCounters} : "No damaged pokemon in play"
+            confirmScoopLastPokemon()
           }
         };
       case BODYBUILDING_DUMBBELLS_113:

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3631,6 +3631,7 @@ public enum RebelClash implements LogicCardInfo {
         }
         playRequirement {
           assertMyAll(negateVariants: true, hasVariants: [POKEMON_V, POKEMON_GX])
+          confirmScoopLastPokemon()
         }
       };
       case SKYLA_166:


### PR DESCRIPTION
These are playable, so restrictions were removed. Instead, now a warning is displayed about the game loss risk.

Main case for this is EX era, a player may wanna burn some super scoop ups as to be able to use Steven (even if risking a loss).

Tested already, working properly in dev.