### PR TITLE
Some more fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
@@ -1,6 +1,7 @@
 package tcgwars.logic.impl.gen3;
 
 import tcgwars.logic.impl.gen1.BaseSetNG;
+import tcgwars.logic.impl.gen2.Expedition;
 import tcgwars.logic.impl.gen3.FireRedLeafGreen;
 import tcgwars.logic.impl.gen7.CelestialStorm;
 
@@ -268,7 +269,9 @@ public enum PopSeries2 implements LogicCardInfo {
         }
       };
       case MULTI_TECHNICAL_MACHINE_01_9:
-      return basicTrainer (this) {
+      // Commented for now, TechnicalMachineGroovyImpl needs to be made first.
+        return copy(Expedition.MULTI_TECHNICAL_MACHINE_01_144, this);
+      /*return basicTrainer (this) {
         text "Attach this card to 1 of your Pokemon in play. This Pokemon may use this card's attack instead of its own. At the end of your turn, discard Multi Technical Machine 01"
         def eff1, eff2
         onPlay {reason->
@@ -304,7 +307,7 @@ public enum PopSeries2 implements LogicCardInfo {
             }
           }
         }
-      };
+      };*/
       case POKEMON_PARK_10:
       return stadium (this) {
         text "Once during each player's turn, when that player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter from that Pokémon."

--- a/src/tcgwars/logic/impl/gen3/PopSeries5.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries5.groovy
@@ -313,8 +313,8 @@ public enum PopSeries5 implements LogicCardInfo {
           onActivate {
             if (it==PLAY_FROM_HAND && opp.hand && confirm("Use Purple Ray?")) {
               powerUsed()
-              apply CONFUSED
-              apply CONFUSED, self
+              apply (CONFUSED, my.active, SRC_ABILITY)
+              apply (CONFUSED, opp.active, SRC_ABILITY)
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2461,11 +2461,12 @@ public enum TeamRocketReturns implements LogicCardInfo {
         return basicTrainer (this) {
           text "Flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. If tails, put 1 damage counter on 1 of your Pokémon."
           onPlay {
+            def info = "Select the target for Venture Bomb’s damage counter"
             flip 1,{
-              directDamage(10, opp.active,TRAINER_CARD)
+              directDamage(10, opp.all.select(info),TRAINER_CARD)
             },
               {
-                directDamage(10, my.active,TRAINER_CARD)
+                directDamage(10, my.all.select(info),TRAINER_CARD)
               }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -1798,7 +1798,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             //Errata'd, used to say "is Knocked Out by an opponent’s attack"
             delayedA {
               before KNOCKOUT, self, {
-                if((ef as Knockout).byDamageFromAttack){
+                if((ef as Knockout).byDamageFromAttack && self.active){
                   apply CONFUSED, self.owner.opposite.pbg.active
                   apply POISONED, self.owner.opposite.pbg.active
                 }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2887,7 +2887,10 @@ public enum SwordShield implements LogicCardInfo {
           text "30+ damage. This attack does 30 more damage for each of your Benched Pawniard."
           energyCost C
           onAttack {
-            damage 30+30*my.bench.findAll{it.name=='Pawniard'}.size()
+            damage 30
+            if (my.bench) {
+              damage 30 * my.bench.count{it.name=='Pawniard'}
+            }
           }
         }
         move "Slicing Blade", {


### PR DESCRIPTION
- [x] Espeon Star (POP Series 5) should now confuse both Active Pokémon, instead of only the opponent's.
- [x] Multi Technical Machine 01 (POP Series 2) now works as a copy of Expedition again.
  + Commented the old code, since Groovy Implementation of Technical Machines is still a TODO.
- [x] Bisharp (Sword & Shield - Base Set) should no longer cause a crash when you have no Benched Pokémon.
- [x] Venture Bomb (Team Rocket Returns) should now allow placing the counter on benched Pokémon, instead of always in the Active one.
- [x] Koffin (Team Rocket Returns) should now only activate "Knockout Gas" when it's the Active Pokémon.

These fixes have been tested locally.