### PR TITLE
Update TYRANITAR_88 to not crash during Megaton Tail attack

### DIFF
--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1896,8 +1896,8 @@ public enum Unleashed implements LogicCardInfo {
             energyCost D, D, C, C
             onAttack {
               damage 120
-              afterDamage{
-                my.deck.sublist(0,min(3, my.deck.size())).discard()
+              afterDamage {
+                my.deck.subList(0,Math.min(3, my.deck.size())).discard()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1897,7 +1897,7 @@ public enum Unleashed implements LogicCardInfo {
             onAttack {
               damage 120
               afterDamage {
-                my.deck.subList(0,Math.min(3, my.deck.size())).discard()
+                if (my.deck) my.deck.subList(0,Math.min(3, my.deck.size())).discard()
               }
             }
           }


### PR DESCRIPTION
This fixes the crash when using Megaton Tail on `TYRANITAR_88` from Unleashed.