### PR TITLE
Add getLastFullHP() method for PokemonCardSet

### DIFF
--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2740,7 +2740,7 @@ public enum TeamUp implements LogicCardInfo {
           weakness FIRE
           resistance PSYCHIC, MINUS20
           bwAbility "Key of Secrets" , {
-            text "Each of your [M] Pokémon's Resistance is now –40."
+            text "Each of your [M] Pokémon's Resistance is now -40."
             getter(GET_RESISTANCES) {holder->
               if(holder.effect.target.types.contains(M) && holder.effect.target.owner == self.owner){
                 def newR=[]

--- a/src/tcgwars/logic/util/PokemonCardSet.java
+++ b/src/tcgwars/logic/util/PokemonCardSet.java
@@ -36,6 +36,7 @@ public class PokemonCardSet implements PokemonStack, Serializable {
   private CardList set;
 
   private HP damage;
+  private HP lastFullHP = null;
 
   private PlayerType owner;
 
@@ -180,11 +181,16 @@ public class PokemonCardSet implements PokemonStack, Serializable {
   }
 
   public HP getFullHP(Battleground bg) {
-    return bg.em().activateGetter(new GetFullHP(this));
+    lastFullHP = bg.em().activateGetter(new GetFullHP(this));
+    return lastFullHP;
   }
 
   public HP getFullHP() {
-    return TcgStatics.bg().em().activateGetter(new GetFullHP(this));
+    lastFullHP = TcgStatics.bg().em().activateGetter(new GetFullHP(this));
+    return lastFullHP;
+  }
+  public HP getLastFullHP() {
+    return lastFullHP;
   }
 
   public HP getRemainingHP(Battleground bg) {


### PR DESCRIPTION
Needed to fix a UI bug, after adding HP info when hovering over the damage counters meter.

When the value is requested in-game, the cached value is updated. Then the StatusPanel can access this value consistently.