### PR TITLE
Point all Super Scoop Up prints to the FRLG version, update removePCS(pcs) static

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -478,8 +478,8 @@ class TcgStatics {
     }
     else if (my.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      r.run(bg)
       my.bench.remove(pcs)
+      r.run(bg)
     }
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
@@ -494,8 +494,8 @@ class TcgStatics {
     }
     else if (opp.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      r.run(bg)
       opp.bench.remove(pcs)
+      r.run(bg)
     }
   }
   static PokemonCardSet benchPCS (Card card, ActivationReason reason=OTHER){

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2382,10 +2382,13 @@ public enum FireRedLeafGreen implements LogicCardInfo {
         return basicTrainer (this) {
           text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
           onPlay {
-            flip{
+            flip {
               def pcs = my.all.select()
-              pcs.cards.moveTo(hand)
-              removePCS(pcs)
+              targeted (pcs, TRAINER_CARD) {
+                my.hand.addAll(pcs.cards)
+                bc "Scooped Up ${pcs.cards} to hand."
+                removePCS(pcs)
+              }
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -3038,7 +3038,7 @@ public enum DiamondPearl implements LogicCardInfo {
           }
         };
       case SUPER_SCOOP_UP_115:
-        return copy (BlackWhite.SUPER_SCOOP_UP_103, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case WARP_POINT_116:
         return copy(PlasmaStorm.ESCAPE_ROPE_120, this);
       case ENERGY_SEARCH_117:

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen3.FireRedLeafGreen;
 import tcgwars.logic.impl.gen4.MysteriousTreasures;
 import tcgwars.logic.impl.gen5.PlasmaStorm;
 
@@ -1986,13 +1987,7 @@ public enum MajesticDawn implements LogicCardInfo {
           }
         };
       case SUPER_SCOOP_UP_87:
-        return basicTrainer (this) {
-          text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
-          onPlay {
-          }
-          playRequirement{
-          }
-        };
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case WARP_POINT_88:
         return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case DOME_FOSSIL_89:

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen3.FireRedLeafGreen;
 import tcgwars.logic.impl.gen5.*;
 import tcgwars.logic.impl.gen7.*;
 import static tcgwars.logic.card.HP.*;
@@ -1746,7 +1747,7 @@ public enum Unleashed implements LogicCardInfo {
       case RARE_CANDY_82:
         return copy(DarkExplorers.RARE_CANDY_100, this)
       case SUPER_SCOOP_UP_83:
-        return copy (BlackWhite.SUPER_SCOOP_UP_103, this)
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case CROBAT_84:
         return evolution (this, from:"Golbat", hp:HP130, type:PSYCHIC, retreatCost:0) {
           weakness L

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -1,5 +1,6 @@
 package tcgwars.logic.impl.gen7
 
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen5.PlasmaStorm
 import tcgwars.logic.impl.gen6.PrimalClash;
@@ -2788,7 +2789,7 @@ public enum BurningShadows implements LogicCardInfo {
           }
         };
       case SUPER_SCOOP_UP_124:
-        return copy (BlackWhite.SUPER_SCOOP_UP_103, this)
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case TORMENTING_SPRAY_125:
         return itemCard (this) {
           text "Choose a random card from your opponent's hand. Your opponent reveals that card. If it's a Supporter card, discard it.\nYou may play as many Item cards as you like during your turn (before your attack)."

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3274,7 +3274,7 @@ public enum CelestialStorm implements LogicCardInfo {
           }
         };
       case SUPER_SCOOP_UP_146:
-        return copy(BlackWhite.SUPER_SCOOP_UP_103, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case SWITCH_147:
         return copy(BlackWhite.SWITCH_104, this);
       case TATE_LIZA_148:

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -1,6 +1,7 @@
 package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.impl.gen2.Aquapolis
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen5.DarkExplorers
 import tcgwars.logic.impl.gen5.EmergingPowers
@@ -1427,7 +1428,7 @@ public enum ShiningLegends implements LogicCardInfo {
       case SOPHOCLES_65:
         return copy (BurningShadows.SOPHOCLES_123, this)
       case SUPER_SCOOP_UP_66:
-        return copy (BlackWhite.SUPER_SCOOP_UP_103, this)
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
       case SWITCH_67:
         return copy (BlackWhite.SWITCH_104, this)
       case ULTRA_BALL_68:


### PR DESCRIPTION
Moved the Neo Genesis code into this publicly-available print. Should work properly with certain abilities (Like Infinity Zone) with the changes applied here, and to removePCS(pcs)