### PR TITLE
Fix Rare Candy and Evosoda allowing to evolve from D to non-D

### DIFF
--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3056,6 +3056,18 @@ public enum DarknessAblaze implements LogicCardInfo {
                 prevent()
               }
             }
+            before EVOLVE_STANDARD, {
+              if (bg.em().retrieveObject("Infinity_Zone_" + self.hashCode()) && !ef.evolutionCard.types.contains(D)) {
+                wcu "Cannot play non-Darkness Pokemon"
+                prevent()
+              }
+            }
+            before EVOLVE, {
+              if (bg.em().retrieveObject("Infinity_Zone_" + self.hashCode()) && !ef.evolutionCard.types.contains(D)) {
+                wcu "Cannot play non-Darkness Pokemon"
+                prevent()
+              }
+            }
             before PUT_ON_BENCH, {
               if (!isPokemonPlayable(ef)) {
                 wcu "Cannot play non-Darkness Pokemon"


### PR DESCRIPTION
PR for #908.

Stops Evosoda and Rare Candy from allowing evolving from a D Pokémon to evolve to a non-D Pokémon. Sandstorm Rare Candy still gets discarded, but modern Rare Candy does not. Evosoda gets discarded, but since you search your deck with it that's fine.

This Ability is a beast.