### PR TITLE
Scoop up block

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -912,6 +912,10 @@ class TcgStatics {
     }
   }
 
+  static boolean hasThetaStop(PokemonCardSet pcs) {
+    return pcs.lastAbilities.find {it.key instanceof AncientTrait && it.key.name.contains("Stop")}
+  }
+
   static omega_double(Object delegate){
     delegate.ancientTrait "θ Double", {
       text "This Pokémon may have up to 2 Pokémon Tool cards attached to it."
@@ -1517,7 +1521,7 @@ class TcgStatics {
       if (delegate.thisObject.cardTypes.is(ENERGY)) source = SRC_SPENERGY
     }
     if (params.discard == null) params.discard = true
-    if (bg.em().retrieveObject("ScoopUpBlock_Count$target.owner.opposite") && target.numberOfDamageCounters) {
+    if (bg.em().retrieveObject("ScoopUpBlock_Count$target.owner.opposite") && target.numberOfDamageCounters && !hasThetaStop(target)) {
       bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
       return
     }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -467,47 +467,35 @@ class TcgStatics {
   static removePCS(PokemonCardSet pcs){
     if(my.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
-      def failed = r.run(bg)
-      if (!failed) {
-        if (my.bench.isEmpty()){
-          my.active=null
-          bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
-          return
-        }
-        sw(null, my.bench.select("New active pokemon"))
+      r.run(bg)
+      if (my.bench.isEmpty()){
+        my.active=null
+        bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
+        return
       }
+      sw ( null, my.bench.select("New active pokemon"))
       //my.bench.remove(pcs)
     }
     else if (my.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      def idx = my.bench.indexOf(pcs)
       my.bench.remove(pcs)
-      def failed = r.run(bg)
-      if (failed) {
-        my.bench.add(idx, pcs)
-      }
+      r.run(bg)
     }
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
-      def failed = r.run(bg)
-      if (!failed) {
-        if (opp.bench.isEmpty()){
-          opp.active=null
-          bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
-          return
-        }
-        sw(null, opp.bench.oppSelect("New active pokemon"))
+      r.run(bg)
+      if (opp.bench.isEmpty()){
+        opp.active=null
+        bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
+        return
       }
+      sw ( null, opp.bench.oppSelect("New active pokemon"))
       //opp.bench.remove(pcs)
     }
     else if (opp.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      def idx = my.bench.indexOf(pcs)
       opp.bench.remove(pcs)
-      def failed = r.run(bg)
-      if (!failed) {
-        opp.bench.add(idx, pcs)
-      }
+      r.run(bg)
     }
   }
   static PokemonCardSet benchPCS (Card card, ActivationReason reason=OTHER){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -468,12 +468,12 @@ class TcgStatics {
     if(my.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
       def failed = r.run(bg)
-      if (my.bench.isEmpty()){
-        my.active=null
-        bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
-        return
-      }
       if (!failed) {
+        if (my.bench.isEmpty()){
+          my.active=null
+          bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
+          return
+        }
         sw(null, my.bench.select("New active pokemon"))
       }
       //my.bench.remove(pcs)
@@ -490,12 +490,12 @@ class TcgStatics {
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
       def failed = r.run(bg)
-      if (opp.bench.isEmpty()){
-        opp.active=null
-        bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
-        return
-      }
       if (!failed) {
+        if (opp.bench.isEmpty()){
+          opp.active=null
+          bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
+          return
+        }
         sw(null, opp.bench.oppSelect("New active pokemon"))
       }
       //opp.bench.remove(pcs)

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1507,7 +1507,7 @@ class TcgStatics {
       if (delegate.thisObject.cardTypes.is(ENERGY)) params.source = SRC_SPENERGY
     }
     if (params.discard == null) params.discard = true
-    if (bg.em().retrieveObject("ScoopUpBlock_$target.owner.opposite") && target.numberOfDamageCounters) {
+    if (bg.em().retrieveObject("ScoopUpBlock_Count$target.owner.opposite") && target.numberOfDamageCounters) {
       bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
       return
     }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1508,8 +1508,8 @@ class TcgStatics {
    * Scoop up PokemonCardSets if not blocked by Scoop-Up Block
    *
    * @param params Optional settings map
-   *  + discard: Indicates if any cards should be discarded. Default: true
-   *  + only: A card or list of cards to move to hand instead of discard.
+   *  + all: boolean - if true, scoops up all cards, else all pokemon cards. discards the rest.
+   *  + only: CardList - only scoops up them, discards the rest.
    * @param target PokemonCardSet to work on
    * @param delegate Effect delegate used to determine most sources automatically, and to get the card name for the Scoop-Up Block message
    * @param source Allows you to specify the source of the scoop up. Use intended manually setting SRC_ABILITY.
@@ -1520,7 +1520,7 @@ class TcgStatics {
       if (delegate.thisObject.cardTypes.is(POKEMON)) source = ATTACK
       if (delegate.thisObject.cardTypes.is(ENERGY)) source = SRC_SPENERGY
     }
-    if (params.discard == null) params.discard = true
+    if (params.all == null) params.all = true
     if (bg.em().retrieveObject("ScoopUpBlock_Count$target.owner.opposite") && target.numberOfDamageCounters && !hasThetaStop(target)) {
       bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
       return
@@ -1530,7 +1530,7 @@ class TcgStatics {
       CardList otherList = []
       otherList.addAll(target.cards.filterByType(TRAINER, ENERGY))
       pokemonList.addAll(target.cards.filterByType(POKEMON))
-      if (params.discard) {
+      if (!params.all) {
         if (params.only) {
           if (params.only instanceof Card) params.only = new CardList(params.only)
           bc "Scooped up ${params.only.getExcludedList(otherList)}"

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -480,10 +480,8 @@ class TcgStatics {
     }
     else if (my.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      def failed = r.run(bg)
-      if (!failed) {
-        my.bench.remove(pcs)
-      }
+      my.bench.remove(pcs)
+      r.run(bg)
     }
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
@@ -500,10 +498,8 @@ class TcgStatics {
     }
     else if (opp.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      def failed = r.run(bg)
-      if (!failed) {
-        opp.bench.remove(pcs)
-      }
+      opp.bench.remove(pcs)
+      r.run(bg)
     }
   }
   static PokemonCardSet benchPCS (Card card, ActivationReason reason=OTHER){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -480,8 +480,12 @@ class TcgStatics {
     }
     else if (my.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
+      def idx = my.bench.indexOf(pcs)
       my.bench.remove(pcs)
-      r.run(bg)
+      def failed = r.run(bg)
+      if (failed) {
+        my.bench.add(idx, pcs)
+      }
     }
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
@@ -498,8 +502,12 @@ class TcgStatics {
     }
     else if (opp.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
+      def idx = my.bench.indexOf(pcs)
       opp.bench.remove(pcs)
-      r.run(bg)
+      def failed = r.run(bg)
+      if (!failed) {
+        opp.bench.add(idx, pcs)
+      }
     }
   }
   static PokemonCardSet benchPCS (Card card, ActivationReason reason=OTHER){

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1508,7 +1508,7 @@ class TcgStatics {
    * Scoop up PokemonCardSets if not blocked by Scoop-Up Block
    *
    * @param params Optional settings map
-   *  + all: boolean - if true, scoops up all cards, else all pokemon cards. discards the rest.
+   *  + pokemonOnly: boolean - if true, scoops up all cards, else all pokemon cards. discards the rest.
    *  + only: CardList - only scoops up them, discards the rest.
    * @param target PokemonCardSet to work on
    * @param delegate Effect delegate used to determine most sources automatically, and to get the card name for the Scoop-Up Block message
@@ -1520,7 +1520,6 @@ class TcgStatics {
       if (delegate.thisObject.cardTypes.is(POKEMON)) source = ATTACK
       if (delegate.thisObject.cardTypes.is(ENERGY)) source = SRC_SPENERGY
     }
-    if (params.all == null) params.all = true
     if (bg.em().retrieveObject("ScoopUpBlock_Count$target.owner.opposite") && target.numberOfDamageCounters && !hasThetaStop(target)) {
       bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
       return
@@ -1530,7 +1529,7 @@ class TcgStatics {
       CardList otherList = []
       otherList.addAll(target.cards.filterByType(TRAINER, ENERGY))
       pokemonList.addAll(target.cards.filterByType(POKEMON))
-      if (!params.all) {
+      if (params.pokemonOnly || params.only) {
         if (params.only) {
           if (params.only instanceof Card) params.only = new CardList(params.only)
           bc "Scooped up ${params.only.getExcludedList(otherList)}"

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1500,4 +1500,43 @@ class TcgStatics {
     }
   }
 
+  static void scoopUpPokemon(params=[:], PokemonCardSet target, Object delegate, Source source=null) {
+    if (source == null) {
+      if (delegate.thisObject.cardTypes.is(TRAINER)) params.source = TRAINER_CARD
+      if (delegate.thisObject.cardTypes.is(POKEMON)) params.source = ATTACK
+      if (delegate.thisObject.cardTypes.is(ENERGY)) params.source = SRC_SPENERGY
+    }
+    if (params.discard == null) params.discard = true
+    if (bg.em().retrieveObject("ScoopUpBlock_$target.owner.opposite") && target.numberOfDamageCounters) {
+      bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
+      return
+    }
+    targeted(target, params.source) {
+      CardList pokemonList = []
+      CardList otherList = []
+      otherList.addAll(target.cards.filterByType(TRAINER, ENERGY))
+      pokemonList.addAll(target.cards.filterByType(POKEMON))
+      if (params.only) {
+        target.owner.pbg.discard.addAll(pokemonList.getExcludedList(params.only as Card))
+        target.owner.pbg.hand.add(params.only)
+      }
+      else {
+        target.owner.pbg.hand.addAll(pokemonList)
+      }
+      if (params.discard) {
+        otherList.discard()
+      }
+      else {
+        otherList.moveTo(target.owner.pbg.hand)
+      }
+      removePCS(target)
+      if (params.only) {
+        bc "Scooped up $params.only"
+      }
+      else {
+        bc "Scooped up $target"
+      }
+    }
+  }
+
 }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1525,30 +1525,27 @@ class TcgStatics {
       return
     }
     targeted(target, source) {
-      CardList pokemonList = []
-      CardList otherList = []
-      otherList.addAll(target.cards.filterByType(TRAINER, ENERGY))
-      pokemonList.addAll(target.cards.filterByType(POKEMON))
-      if (params.pokemonOnly || params.only) {
-        if (params.only) {
-          if (params.only instanceof Card) params.only = new CardList(params.only)
-          bc "Scooped up ${params.only.getExcludedList(otherList)}"
-        }
-        else {
-          params.only = new CardList(pokemonList)
-          bc "Scooped up $target"
-        }
-        def toDiscard
-        toDiscard = pokemonList.getExcludedList(params.only as CardList)
-        target.owner.pbg.discard.addAll(toDiscard)
-        target.owner.pbg.hand.addAll(pokemonList.getExcludedList(toDiscard as CardList))
-        toDiscard = otherList.getExcludedList(params.only as CardList).discard()
-        otherList.getExcludedList(toDiscard).moveTo(target.owner.pbg.hand)
+      CardList toHand
+      if(params.only) {
+        if (params.only instanceof Card) toHand = new CardList(params.only)
+        else if (params.only instanceof CardList) toHand = params.only as CardList
+        else throw new IllegalArgumentException("scoopUpPokemon() params.only=${params.only} type not supported")
+      } else if(params.pokemonOnly) {
+        toHand = target.cards.filterByType(POKEMON)
+      } else {
+        toHand = new CardList(target.cards)
       }
-      else {
-        target.owner.pbg.hand.addAll(pokemonList)
-        otherList.moveTo(target.owner.pbg.hand)
-      }
+      CardList toDiscard = target.cards.getExcludedList(toHand)
+
+      bc "Scooped up ${toHand}"
+
+      CardList toHand2 = toHand.filterByType(POKEMON)
+      target.owner.pbg.hand.addAll(toHand2)
+      toHand.getExcludedList(toHand2).moveTo(target.owner.pbg.hand)
+
+      CardList toDiscard2 = toDiscard.filterByType(POKEMON)
+      target.owner.pbg.discard.addAll(toDiscard2)
+      toDiscard.getExcludedList(toDiscard2).discard()
       removePCS(target)
     }
   }

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -467,35 +467,43 @@ class TcgStatics {
   static removePCS(PokemonCardSet pcs){
     if(my.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
-      r.run(bg)
+      def failed = r.run(bg)
       if (my.bench.isEmpty()){
         my.active=null
         bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
         return
       }
-      sw ( null, my.bench.select("New active pokemon"))
+      if (!failed) {
+        sw(null, my.bench.select("New active pokemon"))
+      }
       //my.bench.remove(pcs)
     }
     else if (my.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      my.bench.remove(pcs)
-      r.run(bg)
+      def failed = r.run(bg)
+      if (!failed) {
+        my.bench.remove(pcs)
+      }
     }
     else if(opp.active==pcs){
       def r=new RemoveFromPlay(pcs,null)
-      r.run(bg)
+      def failed = r.run(bg)
       if (opp.bench.isEmpty()){
         opp.active=null
         bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
         return
       }
-      sw ( null, opp.bench.oppSelect("New active pokemon"))
+      if (!failed) {
+        sw(null, opp.bench.oppSelect("New active pokemon"))
+      }
       //opp.bench.remove(pcs)
     }
     else if (opp.bench.contains(pcs)){
       def r=new RemoveFromPlay(pcs,null)
-      opp.bench.remove(pcs)
-      r.run(bg)
+      def failed = r.run(bg)
+      if (!failed) {
+        opp.bench.remove(pcs)
+      }
     }
   }
   static PokemonCardSet benchPCS (Card card, ActivationReason reason=OTHER){

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1867,7 +1867,7 @@ public enum BaseSetNG implements LogicCardInfo {
           onPlay {
             PokemonCardSet pcs = my.all.select()
             def tar = pcs.pokemonCards[pcs.pokemonCards.size() - 1]
-            scoopUpPokemon(only:tar, pcs, delegate)
+            scoopUpPokemon(all:false, only:tar, pcs, delegate)
           }
           playRequirement {
             confirmScoopLastPokemon()

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1867,7 +1867,7 @@ public enum BaseSetNG implements LogicCardInfo {
           onPlay {
             PokemonCardSet pcs = my.all.select()
             def tar = pcs.pokemonCards[pcs.pokemonCards.size() - 1]
-            scoopUpPokemon(all:false, only:tar, pcs, delegate)
+            scoopUpPokemon(only:tar, pcs, delegate)
           }
           playRequirement {
             confirmScoopLastPokemon()

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1865,18 +1865,9 @@ public enum BaseSetNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "Choose 1 of your own Pokémon in play and return its Basic Pokémon card to your hand. (Discard all cards attached to that card.)"
           onPlay {
-            def pcs = my.all.select()
-            targeted(pcs, Source.TRAINER_CARD) {
-              def temp = pcs.cards
-              def tar = temp.get(0)
-              while(temp.getExcludedList(tar).findAll{it.cardTypes.is(POKEMON)}){
-                temp = temp.getExcludedList(tar)
-                tar = temp.get(0)
-              }
-              pcs.cards.findAll{it==tar}.moveTo(my.hand)
-              pcs.cards.discard()
-              removePCS pcs
-            }
+            PokemonCardSet pcs = my.all.select()
+            def tar = pcs.pokemonCards[pcs.pokemonCards.size() - 1]
+            scoopUpPokemon(only:tar, pcs, delegate)
           }
           playRequirement {
             confirmScoopLastPokemon()

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2384,7 +2384,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           onPlay {
             flip {
               def pcs = my.all.select()
-              scoopUpPokemon(discard:false, pcs, delegate)
+              scoopUpPokemon(pcs, delegate)
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2384,11 +2384,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           onPlay {
             flip {
               def pcs = my.all.select()
-              targeted (pcs, TRAINER_CARD) {
-                my.hand.addAll(pcs.cards)
-                bc "Scooped Up ${pcs.cards} to hand."
-                removePCS(pcs)
-              }
+              scoopUpPokemon(discard:false, pcs, delegate)
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2634,7 +2634,7 @@ public enum BurningShadows implements LogicCardInfo {
           text "Put 1 of your Pokémon that has any damage counters on it and all cards attached to it into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
             def pcs = my.all.findAll {it.numberOfDamageCounters}.select()
-            scoopUpPokemon(discard:false, pcs, delegate)
+            scoopUpPokemon(pcs, delegate)
           }
           playRequirement{
             assert my.all.findAll {it.numberOfDamageCounters} : "No damaged pokemon in play"

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -2634,10 +2634,7 @@ public enum BurningShadows implements LogicCardInfo {
           text "Put 1 of your Pokémon that has any damage counters on it and all cards attached to it into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
           onPlay {
             def pcs = my.all.findAll {it.numberOfDamageCounters}.select()
-            targeted (pcs, TRAINER_CARD) {
-              pcs.cards.moveTo(hand)
-              removePCS(pcs)
-            }
+            scoopUpPokemon(discard:false, pcs, delegate)
           }
           playRequirement{
             assert my.all.findAll {it.numberOfDamageCounters} : "No damaged pokemon in play"

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1018,7 +1018,7 @@ public enum LostThunder implements LogicCardInfo {
               while(my.all){
                 def tar = my.all.select("Select a Pokémon to put in your hand.", false)
                 if(tar){
-                  scoopUpPokemon(discard:false, tar, delegate)
+                  scoopUpPokemon(tar, delegate)
                 } else {
                   break
                 }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -1018,8 +1018,7 @@ public enum LostThunder implements LogicCardInfo {
               while(my.all){
                 def tar = my.all.select("Select a Pokémon to put in your hand.", false)
                 if(tar){
-                  tar.cards.moveTo(my.hand)
-                  removePCS(tar)
+                  scoopUpPokemon(discard:false, tar, delegate)
                 } else {
                   break
                 }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1174,10 +1174,7 @@ public enum SunMoon implements LogicCardInfo {
               assert bg.turnCount > 2
               powerUsed()
               // TODO: Get a ruling on this re:Scoop-Up Block (MR_MIME_66:TEAM_UP)
-              scoopUpPokemon([:], self, delegate, SRC_ABILITY)
-//              self.cards.getExcludedList(self.topPokemonCard).discard()
-//              moveCard(self.topPokemonCard, my.hand)
-//              removePCS(self)
+              scoopUpPokemon(all:false, self, delegate, SRC_ABILITY)
             }
           }
           move "Water Gun", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1174,6 +1174,7 @@ public enum SunMoon implements LogicCardInfo {
               assert self.turnCount != bg.turnCount
               assert bg.turnCount > 2
               powerUsed()
+              // TODO: Get a ruling on this re:Scoop-Up Block (MR_MIME_66:TEAM_UP)
               self.cards.getExcludedList(self.topPokemonCard).discard()
               moveCard(self.topPokemonCard, my.hand)
               removePCS(self)

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -6,7 +6,6 @@ import tcgwars.logic.impl.gen5.EmergingPowers
 import tcgwars.logic.impl.gen5.NextDestinies
 import tcgwars.logic.impl.gen6.KalosStarterSet
 import tcgwars.logic.impl.gen6.Xy
-import tcgwars.logic.impl.gen7.CelestialStorm
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -1175,9 +1174,10 @@ public enum SunMoon implements LogicCardInfo {
               assert bg.turnCount > 2
               powerUsed()
               // TODO: Get a ruling on this re:Scoop-Up Block (MR_MIME_66:TEAM_UP)
-              self.cards.getExcludedList(self.topPokemonCard).discard()
-              moveCard(self.topPokemonCard, my.hand)
-              removePCS(self)
+              scoopUpPokemon([:], self, delegate, SRC_ABILITY)
+//              self.cards.getExcludedList(self.topPokemonCard).discard()
+//              moveCard(self.topPokemonCard, my.hand)
+//              removePCS(self)
             }
           }
           move "Water Gun", {

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1174,7 +1174,7 @@ public enum SunMoon implements LogicCardInfo {
               assert bg.turnCount > 2
               powerUsed()
               // TODO: Get a ruling on this re:Scoop-Up Block (MR_MIME_66:TEAM_UP)
-              scoopUpPokemon(all:false, self, delegate, SRC_ABILITY)
+              scoopUpPokemon(pokemonOnly:true, self, delegate, SRC_ABILITY)
             }
           }
           move "Water Gun", {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1,7 +1,9 @@
 package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.card.energy.BasicEnergyCard
-import tcgwars.logic.card.pokemon.PokemonCard;
+import tcgwars.logic.card.pokemon.PokemonCard
+import tcgwars.logic.effect.ability.Ability
+import tcgwars.logic.effect.ability.CheckAbilities;
 import tcgwars.logic.effect.gm.Attack
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.impl.gen5.BlackWhite
@@ -1766,28 +1768,14 @@ public enum TeamUp implements LogicCardInfo {
                   prevent()
                 }
               }
-              // Handle Trainers that discard attached cards when scooping up
-              def scoopUpBlock = false
-              def playedCard = null
-              before PLAY_TRAINER, {
-                scoopUpBlock = false
-                if ((ef.cardToPlay.name.contains("Scoop Up") || ef.cardToPlay.name == "AZ") && ef.cardToPlay.player == self.owner.opposite) {
-                  scoopUpBlock = true
-                  playedCard = ef.cardToPlay.name
-                }
-              }
-              before null, null, TRAINER_CARD, {
-                if (scoopUpBlock && pcs.numberOfDamageCounters){
-                  if (!messageDisplayed) {
-                    messageDisplayed = true
-                    bc "Scoop-Up Block prevents $playedCard's effect."
-                  }
-                  prevent()
-                }
-              }
-              after PLAY_CARD, {
-                messageDisplayed = false
-              }
+            }
+            onActivate {
+              bg.em().storeObject("ScoopUpBlock_LastTurn"+self.owner, bg.turnCount)
+              bg.em().storeObject("ScoopUpBlock_Count"+self.owner, bg.em().retrieveObject("ScoopUpBlock_Count"+self.owner) ? bg.em().retrieveObject("ScoopUpBlock_Count"+self.owner)+1 : 1)
+            }
+            onDeactivate {
+              bg.em().storeObject("ScoopUpBlock_LastTurn"+self.owner, bg.turnCount)
+              bg.em().storeObject("ScoopUpBlock_Count"+self.owner, bg.em().retrieveObject("ScoopUpBlock_Count"+self.owner)-1)
             }
           }
           move "Psy Bolt" , {

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1747,7 +1747,7 @@ public enum TeamUp implements LogicCardInfo {
                 }
               }
               before MOVE_CARD, {
-                if (ef.newLocation == self.owner.opposite.pbg.hand && pcs && pcs.numberOfDamageCounters) {
+                if (ef.newLocation == self.owner.opposite.pbg.hand && pcs && pcs.numberOfDamageCounters && !hasThetaStop(pcs)) {
                   doBlock = true
                   if (!messageDisplayed) {
                     messageDisplayed = true

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -2,8 +2,6 @@ package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.card.energy.BasicEnergyCard
 import tcgwars.logic.card.pokemon.PokemonCard
-import tcgwars.logic.effect.ability.Ability
-import tcgwars.logic.effect.ability.CheckAbilities;
 import tcgwars.logic.effect.gm.Attack
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.impl.gen5.BlackWhite

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -1,9 +1,5 @@
 package tcgwars.logic.impl.gen7
 
-import tcgwars.logic.card.energy.BasicEnergyCard
-import tcgwars.logic.card.pokemon.PokemonCard
-import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.impl.gen5.BlackWhite
 
 import static tcgwars.logic.card.HP.*;
@@ -22,6 +18,7 @@ import tcgwars.logic.*;
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.gm.*
 import tcgwars.logic.util.*;
 
 public enum TeamUp implements LogicCardInfo {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3604,7 +3604,7 @@ public enum RebelClash implements LogicCardInfo {
           def validTargets = my.all.findAll{ !it.pokemonV && !it.pokemonGX }
 
           def tar = validTargets.select("Which Pokémon to put back into your hand?")
-          scoopUpPokemon(tar, delegate)
+          scoopUpPokemon(all:false, tar, delegate)
         }
         playRequirement {
           assertMyAll(negateVariants: true, hasVariants: [POKEMON_V, POKEMON_GX])

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3604,7 +3604,7 @@ public enum RebelClash implements LogicCardInfo {
           def validTargets = my.all.findAll{ !it.pokemonV && !it.pokemonGX }
 
           def tar = validTargets.select("Which Pokémon to put back into your hand?")
-          scoopUpPokemon(all:false, tar, delegate)
+          scoopUpPokemon(pokemonOnly:true, tar, delegate)
         }
         playRequirement {
           assertMyAll(negateVariants: true, hasVariants: [POKEMON_V, POKEMON_GX])

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1,8 +1,7 @@
 package tcgwars.logic.impl.gen8;
 
 import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen4.HeartgoldSoulsilver;
-import tcgwars.logic.impl.gen8.SwordShield;
+import tcgwars.logic.impl.gen4.HeartgoldSoulsilver
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -16,22 +15,10 @@ import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
+import tcgwars.logic.card.*
 import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.basic.*
 import tcgwars.logic.util.*;
 
 /**
@@ -3617,13 +3604,7 @@ public enum RebelClash implements LogicCardInfo {
           def validTargets = my.all.findAll{ !it.pokemonV && !it.pokemonGX }
 
           def tar = validTargets.select("Which Pokémon to put back into your hand?")
-          targeted(tar, Source.TRAINER_CARD) {
-            tar.cards.filterByType(TRAINER).discard()
-            tar.cards.filterByType(ENERGY).discard()
-
-            tar.cards.moveTo(my.hand)
-            removePCS(tar)
-          }
+          scoopUpPokemon(tar, delegate)
         }
         playRequirement {
           assertMyAll(negateVariants: true, hasVariants: [POKEMON_V, POKEMON_GX])

--- a/src/tcgwars/logic/util/BenchSet.java
+++ b/src/tcgwars/logic/util/BenchSet.java
@@ -3,6 +3,8 @@ package tcgwars.logic.util;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * @author axpendix@hotmail.com
@@ -19,8 +21,14 @@ public class BenchSet extends PcsList {
   }
 
   @Override
-  public void add(int index, PokemonCardSet element) {
-    throw new UnsupportedOperationException();
+  public void add(int index, PokemonCardSet e) {
+    if (isFull()) {
+      throw new IllegalStateException("Bench is full");
+    }
+    if (!IntStream.of(getFreeIndexes()).boxed().collect(Collectors.toList()).contains(index)) {
+      throw new IllegalStateException("Bench spot already occupied");
+    }
+    set(index, e);
   }
 
   @Override

--- a/src/tcgwars/logic/util/BenchSet.java
+++ b/src/tcgwars/logic/util/BenchSet.java
@@ -3,8 +3,6 @@ package tcgwars.logic.util;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * @author axpendix@hotmail.com
@@ -21,14 +19,8 @@ public class BenchSet extends PcsList {
   }
 
   @Override
-  public void add(int index, PokemonCardSet e) {
-    if (isFull()) {
-      throw new IllegalStateException("Bench is full");
-    }
-    if (!IntStream.of(getFreeIndexes()).boxed().collect(Collectors.toList()).contains(index)) {
-      throw new IllegalStateException("Bench spot already occupied");
-    }
-    set(index, e);
+  public void add(int index, PokemonCardSet element) {
+    throw new UnsupportedOperationException();
   }
 
   @Override


### PR DESCRIPTION
The TCGStatics change may need a second revision, this was just done quickly to reduce issues the ability blocking a RemoveFromPlay in a RemovePCS was running into.

Mr Mime's Scoop-Up Block should work in nearly every case that discarding doesn't happen _and_ need to be prevented by the ability. That remaining case is handled using special cases where the scoop up trainers are concerned, but depending on a future ruling, may or may not need changed to be more general somehow for say Wishiwashi SUM's ability.

Lastly, updates Recycle Energy (UNM copy only) and U-Turn Board to go prevent the MoveCard to discard effect if a MoveCard to hand effect succeeds instead of going to discard, then being moved to hand.