### PR TITLE
Replace "it.dmg.value" with "it.notZero" for multiple damage modifiers applied before W/R, plus some other fixes in those code sections

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -359,9 +359,9 @@ public enum CrystalGuardians implements LogicCardInfo {
           text "If your opponent has any Pokémon-ex in play, each of Ludicolo's attacks does 30 more damage to the Defending Pokémon."
           delayedA {
             after PROCESS_ATTACK_EFFECTS, {
-              if (opp.all.any{ it.EX }) {
+              if (ef.attacker == self && opp.all.any{ it.EX }) {
                 bg.dm().each {
-                  if (it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value && it.notNoEffect) {
+                  if (it.to.owner != self.owner && it.to.active && it.notZero) {
                     bc "Overzealous +30"
                     it.dmg += hp(30)
                   }
@@ -614,7 +614,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self && self.getRemainingHP().value <= 40) {
                 bg.dm().each {
-                  if (it.to.owner == self.owner.opposite && it.to.active && it.dmg.value && it.notNoEffect) {
+                  if (it.to.owner == self.owner.opposite && it.to.active && it.notZero) {
                     bc "Water Pressure +40"
                     it.dmg += hp(40)
                   }

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1684,7 +1684,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
                 bg.dm().each {
-                  if (it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.from == self && it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Reversal Aura +20"
                     it.dmg += hp(20)
                   }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2480,7 +2480,7 @@ public enum Deoxys implements LogicCardInfo {
               }
               after PROCESS_ATTACK_EFFECTS, {
                 if(attackUsed) bg.dm().each {
-                  if(it.from==self && it.to.active && it.to.owner!=self.owner && it.dmg.value){
+                  if(it.from==self && it.to.active && it.to.owner!=self.owner && it.notZero){
                     it.dmg += hp(10)
                     attackUsed=true
                     bc "Strength Charm +10"

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -627,10 +627,12 @@ public enum Deoxys implements LogicCardInfo {
             text "As long as Slaking is your Active Pokémon, any damage done by attacks from your opponent’s Pokémon-ex is reduced by 30 (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each{
-                  if(it.to == self && it.notNoEffect && it.dmg.value && it.from.EX) {
-                    bc "Lazy Aura -30"
-                    it.dmg -= hp(30)
+                if (self.active && ef.attacker.owner == self.owner.opposite && ef.attacker.EX) {
+                  bg.dm().each{
+                    if(it.notZero) {
+                      bc "Lazy Aura -30"
+                      it.dmg -= hp(30)
+                    }
                   }
                 }
               }
@@ -2781,10 +2783,12 @@ public enum Deoxys implements LogicCardInfo {
               damage 80
               delayed {
                 after PROCESS_ATTACK_EFFECTS, {
-                  bg.dm().each {
-                    if(it.from.owner==self.owner.opposite && it.to==self && it.dmg.value && it.notNoEffect){
-                      bc "Pivot Throw increases damage"
-                      it.dmg+=hp(10)
+                  if (ef.attacker.owner == self.owner.opposite) {
+                    bg.dm().each {
+                      if(it.to==self && it.notZero && it.notNoEffect){
+                        bc "Pivot Throw increases damage"
+                        it.dmg+=hp(10)
+                      }
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -903,7 +903,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner == self.owner && ef.attacker.EX && ef.attacker.stage2) {
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Extra Feather +10"
                     it.dmg += hp(10)
                   }
@@ -2075,7 +2075,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner != self.owner) {
                 bg.dm().each {
-                  if (it.to.owner == self.owner && it.to.EX && it.to.stage2 && it.dmg.value) {
+                  if (it.to.owner == self.owner && it.to.EX && it.to.stage2 && it.notZero) {
                     bc "Extra Smoke -10"
                     it.dmg -= hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -226,7 +226,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner == self.owner && ef.attacker.topPokemonCard.cardTypes.is(DELTA)) {
                 bg.dm().each {
-                  if (it.to.active && it.to != self.owner && it.notNoEffect && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notNoEffect && it.notZero) {
                     bc "Battle Aura +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -414,10 +414,12 @@ public enum Emerald implements LogicCardInfo {
             onAttack {
               delayed{
                 after PROCESS_ATTACK_EFFECTS, {
-                  bg.dm().each{
-                    if(it.from == self && it.to.active && it.notNoEffect && it.dmg.value) {
-                      bc "Dragon Dance +30"
-                      it.dmg += hp(30)
+                  if (ef.attacker == self) {
+                    bg.dm().each{
+                      if(it.to.active && it.notZero) {
+                        bc "Dragon Dance +30"
+                        it.dmg += hp(30)
+                      }
                     }
                   }
                 }
@@ -1824,9 +1826,9 @@ public enum Emerald implements LogicCardInfo {
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
-                if (self.types.contains(D) || self.topPokemonCard.name.contains("Dark ")){
+                if ( ef.attacker == self && ( self.types.contains(D) || self.topPokemonCard.name.contains("Dark ") ) ){
                   bg.dm().each(){
-                    if(it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                    if(it.to.active && it.to.owner != self.owner && it.notZero) {
                       it.dmg += hp(10)
                     }
                   }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1852,7 +1852,7 @@ public enum Emerald implements LogicCardInfo {
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
                 if(ef.attacker == self) bg.dm().each {
-                  if(it.to.owner != self.owner && it.dmg.value) {
+                  if(it.to.owner != self.owner && it.notZero) {
                     bc "Double Rainbow Energy -10"
                     it.dmg -= hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -355,10 +355,12 @@ public enum HolonPhantoms implements LogicCardInfo {
             afterDamage{
               delayed{
                 after PROCESS_ATTACK_EFFECTS, {
-                  bg.dm().each{
-                    if(it.from.owner == self.owner.opposite && it.to == self && it.notNoEffect && it.dmg.value) {
-                      bc "Delta Reduction -30 (before W/R)"
-                      it.dmg -= hp(30)
+                  if (ef.attacker.owner == self.owner.opposite) {
+                    bg.dm().each{
+                      if(it.to == self && it.notNoEffect && it.notZero) {
+                        bc "Delta Reduction -30 (before W/R)"
+                        it.dmg -= hp(30)
+                      }
                     }
                   }
                 }
@@ -480,7 +482,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner == self.owner && bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.name.contains("Holon") && ef.attacker.topPokemonCard.cardTypes.is(DELTA)) {
                 bg.dm().each {
-                  if (it.to != self.owner && it.to.active && it.notNoEffect && it.dmg.value) {
+                  if (it.to != self.owner && it.to.active && it.notZero) {
                     bc "Delta Reactor +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -193,13 +193,15 @@ public enum LegendMaker implements LogicCardInfo {
           text "Any damage done to Aerodactyl by attacks from your opponent's Pokémon is reduced by 10 for each React Energy card attached to Aerodactyl (after applying Weakness and Resistance)."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
-              bg.dm().each {
-                if (it.to == self && it.dmg.value && it.notNoEffect) {
-                  def energies = self.cards.findAll{it.name == "React Energy"}
-                  if (energies) {
-                    def reducedDamage = energies.size()*10
-                    bc "Reactive Protection -$reducedDamage"
-                    it.dmg -= hp(reducedDamage)
+              if (ef.attacker.owner == self.owner.opposite) {
+                bg.dm().each {
+                  if (it.to == self && it.dmg.value && it.notNoEffect) {
+                    def energies = self.cards.findAll{it.name == "React Energy"}
+                    if (energies) {
+                      def reducedDamage = energies.size()*10
+                      bc "Reactive Protection -$reducedDamage"
+                      it.dmg -= hp(reducedDamage)
+                    }
                   }
                 }
               }
@@ -938,7 +940,7 @@ public enum LegendMaker implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self) {
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.notNoEffect && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     if (self.owner.pbg.all.any{
                       it.name == "Kabuto" ||
                       it.name == "Kabutops" ||
@@ -1440,7 +1442,7 @@ public enum LegendMaker implements LogicCardInfo {
             before PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self && self.isSPC(CONFUSED)) {
                 bg.dm().each {
-                  if (it.to == self.owner.opposite.active && it.notNoEffect && it.dmg.value) {
+                  if (it.to == self.owner.opposite.active && it.notZero) {
                     bc "Paranoid +50"
                     it.dmg += hp(50)
                   }

--- a/src/tcgwars/logic/impl/gen3/NintendoBlackStarPromos.groovy
+++ b/src/tcgwars/logic/impl/gen3/NintendoBlackStarPromos.groovy
@@ -605,7 +605,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self && opp.all.any{["Groudon", "Groudon ex", "Rayquaza", "Rayquaza ex"].contains(it.name)}) {
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Frenzy +40"
                     it.dmg += hp(40)
                   }
@@ -644,7 +644,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self && opp.all.any{["Kyogre", "Kyogre ex", "Rayquaza", "Rayquaza ex"].contains(it.name)}) {
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Frenzy +40"
                     it.dmg += hp(40)
                   }
@@ -686,7 +686,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == self && opp.all.any{["Kyogre", "Kyogre ex", "Groudon", "Groudon ex"].contains(it.name)}) {
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Frenzy +40"
                     it.dmg += hp(40)
                   }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -495,7 +495,7 @@ public enum PowerKeepers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if(ef.attacker == self && opp.all.any{it.EX}){
                 bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     bc "Overzealous +30"
                     it.dmg += hp(30)
                   }
@@ -1134,7 +1134,7 @@ public enum PowerKeepers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (self.active) {
                 bg.dm().each {
-                  if (it.to.active && it.dmg.value) {
+                  if (it.to.active && it.notZero) {
                     bc "Vigorous Aura +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2483,10 +2483,12 @@ public enum TeamRocketReturns implements LogicCardInfo {
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each {
-                  if(it.from == self && it.to.active && it.notNoEffect && it.dmg.value){
-                    bc "R Energy +10"
-                    it.dmg += hp(10)
+                if (ef.attacker == self) {
+                  bg.dm().each {
+                    if(it.to.active && it.notZero){
+                      bc "R Energy +10"
+                      it.dmg += hp(10)
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -345,10 +345,13 @@ public enum UnseenForces implements LogicCardInfo {
           text "As long as Feraligatr is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
             after PROCESS_ATTACK_EFFECTS, {
-              bg.dm().each {
-                if(self.active && it.to.owner==self.owner && it.from.owner==self.owner.opposite && it.dmg.value && it.notNoEffect) {
-                  bc "Intimidating Fang: -10"
-                  it.dmg-=hp(10)
+              if (self.active && ef.attacker.owner == self.owner.opposite) {
+                bg.dm().each {
+                  //Not checking for it.notNoEffect since it's applied before W/R, should count as an effect on the attacking pokemon.
+                  if(it.to.owner==self.owner && it.notZero) {
+                    bc "Intimidating Fang: -10"
+                    it.dmg-=hp(10)
+                  }
                 }
               }
             }
@@ -1017,7 +1020,7 @@ public enum UnseenForces implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if(ef.attacker == self && self.evolution) {
                 bg.dm().each {
-                  if (it.to.owner != self.owner && it.dmg.value && it.notNoEffect) {
+                  if (it.to.owner != self.owner && it.notZero) {
                     bc "Stages of Evolution +20"
                     it.dmg += hp(20)
                   }
@@ -1361,10 +1364,13 @@ public enum UnseenForces implements LogicCardInfo {
           text "As long as Granbull is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
             after PROCESS_ATTACK_EFFECTS, {
-              bg.dm().each {
-                if (self.active && it.to.owner == self.owner && it.dmg.value && it.notNoEffect) {
-                  bc "Intimidating Fang -10"
-                  it.dmg -= hp(10)
+              if (self.active && ef.attacker.owner == self.owner.opposite) {
+                bg.dm().each {
+                  //Not checking for it.notNoEffect since it's applied before W/R, should count as an effect on the attacking pokemon.
+                  if (it.to.owner == self.owner && it.notZero) {
+                    bc "Intimidating Fang -10"
+                    it.dmg -= hp(10)
+                  }
                 }
               }
             }
@@ -2408,10 +2414,14 @@ public enum UnseenForces implements LogicCardInfo {
         onPlay {reason->
           eff = delayed {
             after PROCESS_ATTACK_EFFECTS, {
-              bg.dm().each {if(it.from == self && ( self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size() ) && it.to.active && it.to.owner != self.owner && it.dmg.value){
-                bc "Solid Rage +20"
-                it.dmg += hp(20)
-              }}
+              if (ef.attacker == self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size() ) {
+                bg.dm().each {
+                  if(it.to.active && it.to.owner == self.owner.opposite && it.notZero){
+                    bc "Solid Rage +20"
+                    it.dmg += hp(20)
+                  }
+                }
+              }
             }
             after EVOLVE, self, {check(self)}
             after DEVOLVE, self, {check(self)}

--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -207,11 +207,15 @@ public enum Arceus implements LogicCardInfo {
             text "Each of Charizard’s attacks does 10 more damage for each Fire Pokémon on your Bench to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each{if(it.from==self && it.to.active && it.to.owner!=self.owner && it.dmg.value){
-                  int dmg = 10*my.bench.findAll{it.types.contains(R)}.size()
-                  it.dmg+=hp(dmg)
-                  if(dmg) bc "Fire Formation +$dmg"
-                }}
+                if (ef.attacker == self) {
+                  bg.dm().each {
+                    if(it.to.active && it.to.owner!=self.owner && it.notZero){
+                      int dmg = 10*my.bench.findAll{it.types.contains(R)}.size()
+                      it.dmg+=hp(dmg)
+                      if(dmg) bc "Fire Formation +$dmg"
+                    }
+                  }
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2910,7 +2910,7 @@ public enum DiamondPearl implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker == pcs) {
                 bg.dm().each {
-                  if (it.to.active && it.dmg.value) {
+                  if (it.to.active && it.notZero) {
                     bc "PlusPower +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -326,10 +326,12 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               afterDamage {
                 delayed {
                   after PROCESS_ATTACK_EFFECTS, {
-                    bg.dm().each {
-                      if(it.dmg.value){
-                        bc "${thisMove.name} increases damage"
-                        it.dmg+=20
+                    if (ef.attacker.owner == self.owner.opposite) {
+                      bg.dm().each {
+                        if(it.to == self && it.notNoEffect && it.dmg.value){
+                          bc "${thisMove.name} increases damage"
+                          it.dmg+=20
+                        }
                       }
                     }
                   }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -269,9 +269,9 @@ public enum MajesticDawn implements LogicCardInfo {
           //Adamant Orb: If an Active Pokémon has Weakness to [M] type, Dialga’s attacks do 20 more damage to that Pokémon (before applying Weakness and Resistance).
           delayedA {
             after PROCESS_ATTACK_EFFECTS, {
-              bg.dm().each {
-                if (it.from.owner==self.owner && it.from == self && self.active && it.to.active && it.to.owner!=self.owner && it.dmg.value) {
-                  if (it.to.getWeaknesses().findAll{it.type == M}) {
+              if (ef.attacker == self) {
+                bg.dm().each {
+                  if (it.to.active && it.to.owner!=self.owner && it.to.getWeaknesses().any{it.type == M} && it.notZero) {
                     bc "Adamant Orb +20"
                     it.dmg += hp(20)
                   }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -289,10 +289,12 @@ public enum MysteriousTreasures implements LogicCardInfo {
               afterDamage {
                 delayed {
                   before APPLY_ATTACK_DAMAGES, {
-                    bg.dm().each {
-                      if (it.to==self && it.dmg.value && it.notNoEffect && it.from.stage2) {
-                        bc "-30 to $self ($thisMove)"
-                        it.dmg-=hp(30)
+                    if (ef.attacker.owner == self.owner.opposite && ef.attacker.stage2) {
+                      bg.dm().each {
+                        if (it.to==self && it.dmg.value && it.notNoEffect) {
+                          bc "-30 to $self ($thisMove)"
+                          it.dmg-=hp(30)
+                        }
                       }
                     }
                   }
@@ -534,9 +536,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
                 def typesOfBasicEn = Type.values().toList().findAll{self.cards.filterByEnergyType(it)}
-                if(ef.attacker == self && !self.cards.filterByType(SPECIAL_ENERGY)){
+                if(ef.attacker == self && !self.cards.hasType(SPECIAL_ENERGY)){
                   bg.dm().each {
-                    if (it.to.active && it.to.getWeaknesses().any{we -> typesOfBasicEn.contains(we.type)} && it.dmg.value) {
+                    if (it.to.active && it.to.getWeaknesses().any{we -> typesOfBasicEn.contains(we.type)} && it.notZero) {
                       bc "Rainbow Scale +40"
                       it.dmg += hp(40)
                     }
@@ -1053,7 +1055,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 if (ef.attacker == self && boostedMoves.contains((ef as Attack).move.name)) {
                   bg.dm().each {
-                    if (it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                    if (it.to.active && it.to.owner != self.owner && it.notZero) {
                       bc "Dragon DNA +30"
                       it.dmg += hp(30)
                     }
@@ -3285,7 +3287,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   before APPLY_ATTACK_DAMAGES, {
                     if(ef.attacker.owner != self.owner) {
                       bg.dm().each{
-                        if(it.to == self && it.notNoEffect && it.dmg.value) {
+                        if(it.to == self && it.dmg.value) {
                           bc "$self - Armor Stone activated"
                           def reducedDmg = 0
                           flipUntilTails({ reducedDmg += 10 }, self.owner)
@@ -3429,7 +3431,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 if (ef.attacker == self && self.types.contains(D)){
                   bg.dm().each(){
                     //Self damage appears to be increased as well, similar to PlusPower
-                    if(it.to.active && it.dmg.value) {
+                    if(it.to.active && it.notZero) {
                       it.dmg += hp(10)
                     }
                   }
@@ -3523,10 +3525,12 @@ public enum MysteriousTreasures implements LogicCardInfo {
               //TODO: Modularize?
               delayed {
                 before APPLY_ATTACK_DAMAGES, {
-                  bg.dm().each {
-                    if(it.from.owner==self.owner.opposite && it.to==self && it.dmg.value && it.notNoEffect){
-                      bc "Close Combat increases damage"
-                      it.dmg+=hp(30)
+                  if (ef.attacker.owner == self.owner.opposite) {
+                    bg.dm().each {
+                      if(it.to==self && it.dmg.value && it.notNoEffect){
+                        bc "Close Combat increases damage"
+                        it.dmg+=hp(30)
+                      }
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1727,6 +1727,7 @@ public enum Unleashed implements LogicCardInfo {
         };
       case PLUSPOWER_80:
         return basicTrainer (this) {
+          //TODO: Handle errata here (and in all prints of pluspower in general).
           text "During this turn, your Pokémon’s attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
           onPlay {
             delayed {
@@ -1911,9 +1912,9 @@ public enum Unleashed implements LogicCardInfo {
             text "If Ursaring has any damage counters on it, each of Ursaring’s attacks does 60 more damage."
             delayedA {
               after PROCESS_ATTACK_EFFECTS,{
-                if(self.numberOfDamageCounters){
+                if(ef.attacker == self && self.numberOfDamageCounters){
                   bg.dm().each{
-                    if(it.from == self && it.dmg.value) {
+                    if(it.notZero) {
                       bc "Berserk +60"
                       it.dmg += hp(60)
                     }


### PR DESCRIPTION
When finished, should fix some issues with cards such as "Darkness Energy vs Metal Energy" in wizards formats, or "Professor Kukui vs Pressure/Intimidating_Fang" in recent formats.

Counts as a mass replacement, so leaving a checklist for looked-around gens:

[ ] **Gen 1** _[Groovy reimplementations]_
[ ] **Gen 1** _[Legacy implementation]_
[ ] **Gen 2**
[ ] **Gen 3** _[Sets in Legacy implementation, RS-HL]_
[ ] **Gen 3** _[Sets in Groovy implementation]_
[ ] **Gen 4** _[What's implemented here, DP-CL]_
[ ] **Gen 5** _[Legacy implementation]_
[ ] **Gen 6** _[Legacy implementation]_
[ ] **Gen 7**
[ ] **Gen 8**