### PR TITLE
Correct return value of scoopUpPokemon static

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1553,7 +1553,7 @@ class TcgStatics {
       bc "Scoop-Up Block prevents $delegate.thisObject.name's effect."
       return false
     }
-    targeted(target, source) {
+    return !targeted(target, source) {
       CardList toHand
       if(params.only) {
         if (params.only instanceof Card) toHand = new CardList(params.only)
@@ -1579,9 +1579,7 @@ class TcgStatics {
       target.owner.pbg.discard.addAll(toDiscard2)
       toDiscard.getExcludedList(toDiscard2).discard()
       removePCS(target)
-      return true
     }
-    return false
   }
 
 }


### PR DESCRIPTION
Returning in a closure returns the value of that closure. Need to return the result of the closure instead. Since run returns `false` for success, need to invert it as well.