### PR TITLE
Fix UNM SLAKING_170 Dynamic Swing Not Unregistering

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3931,11 +3931,11 @@ public enum UnifiedMinds implements LogicCardInfo {
                           it.dmg+=hp(100)
                         }
                       }
-                      unregisterAfter 2
-                      after FALL_BACK, self, { unregister() }
-                      after EVOLVE, self, { unregister() }
-                      after DEVOLVE, self, { unregister() }
                     }
+                    unregisterAfter 2
+                    after FALL_BACK, self, { unregister() }
+                    after EVOLVE, self, { unregister() }
+                    after DEVOLVE, self, { unregister() }
                   }
                 }
               }


### PR DESCRIPTION
This PR will correct when Dynamic Swing unregisters so that it will occur after the opponent's turn ends.

Currently doing two Dynamic Swings will cause the effect to incorrectly stack, taking +100 more damage for each time it's used it.