### PR TITLE
Champions path

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1166,6 +1166,22 @@ class TcgStatics {
     }
   }
 
+  /**
+   * Attach an energy card from a CardList to a PokemonCardList
+   *
+   * @param params  Optional settings Map
+   * @param params.count  Number of energy to attach. All must be attached. Overrides max and may.
+   * @param params.max  Maximum number of energy that can be chosen to attach
+   * @param params.tostrOverride  Override for the
+   * @param params.type The type of energy to attach
+   * @param params.basic  Whether the energy should be a Basic energy card
+   * @param params.may  Whether the player can fail the attachment (e.g. from Hand or Deck)
+   *
+   * @param from  CardList to choose the energy from
+   * @param to  PokemonCardSet or PcsList to choose PCS to attach the energy to
+   *
+   * @return  Tuple of the CardList of selected energy and the PokemonCardSet attached to
+   */
   static Tuple attachEnergyFrom (params=[:], CardList from, def to){
     if(to instanceof PcsList && to.empty) return
     Integer count = params.count ?: null
@@ -1221,15 +1237,15 @@ class TcgStatics {
    *
    * Does a customized assert with an automated fail warning, looking for any Pokémon following the given filters.
    *
-   * @param params Optional settings that can be added:
-   *   + benched: If true, checks for only Benched Pokémon; otherwise also includes the Active.
-   *   + opp: If true, checks for the opponent's bench instead of "my" bench.
-   *   + hasType: If set, restricts to benched Pokémon of a single specific type.
-   *   + hasVariants: A list of specific CardType values (currently: POKEMON_V | VMAX | TAG_TEAM | POKEMON_GX | POKEMON_EX | DELTA | EX). If set, the area filter will only accept PCS that have at least one of these CardTypes on its top card; otherwise, it'll take any Pokémon.
-   *   + negateVariants: If set to true, hasVariants will be inverted: only PCS that are __not__ any of the variants provided will be accepted.
-   *   + isStage: A list of specific CardType values (currently: EVOLVED | UNEVOLVED | BASIC | STAGE1 | STAGE2 | EVOLUTION). If set, the area filter will only accept PCS that return true for every single one of the included values; otherwise, it'll take any Pokémon regardless of stage.
-   *   + info: If set, it'll replace the end of the failed assert warning with a custom text, instead of the default "follow the stated condition(s)".
-   *   + overrideText: If true, params.info will override the entirety of the failed assert warning.
+   * @param params Optional settings that can be added
+   * @param params.benched: If true, checks for only Benched Pokémon; otherwise also includes the Active.
+   * @param params.opp: If true, checks for the opponent's bench instead of "my" bench.
+   * @param params.hasType: If set, restricts to benched Pokémon of a single specific type.
+   * @param params.hasVariants: A list of specific CardType values (currently: POKEMON_V | VMAX | TAG_TEAM | POKEMON_GX | POKEMON_EX | DELTA | EX). If set, the area filter will only accept PCS that have at least one of these CardTypes on its top card; otherwise, it'll take any Pokémon.
+   * @param params.negateVariants: If set to true, hasVariants will be inverted: only PCS that are __not__ any of the variants provided will be accepted.
+   * @param params.isStage: A list of specific CardType values (currently: EVOLVED | UNEVOLVED | BASIC | STAGE1 | STAGE2 | EVOLUTION). If set, the area filter will only accept PCS that return true for every single one of the included values; otherwise, it'll take any Pokémon regardless of stage.
+   * @param params.info: If set, it'll replace the end of the failed assert warning with a custom text, instead of the default "follow the stated condition(s)".
+   * @param params.overrideText: If true, params.info will override the entirety of the failed assert warning.
    *
    * @param filter Additional condition the filtered benched Pokémon must follow. Defaults to true (so any Pokémon).
    *
@@ -1535,13 +1551,16 @@ class TcgStatics {
    * Scoop up PokemonCardSets if not blocked by Scoop-Up Block
    *
    * @param params Optional settings map
-   *  + pokemonOnly: boolean - if true, scoops up all pokemon cards and discards the rest.
-   *  + only: CardList - only scoops up them, discards the rest.
+   * @param params.pokemonOnly: boolean - if true, scoops up all pokemon cards and discards the rest.
+   * @param params.only: CardList - only scoops up them, discards the rest.
+   *
    * @param target PokemonCardSet to work on
    * @param delegate Effect delegate used to determine most sources automatically, and to get the card name for the Scoop-Up Block message
    * @param source Allows you to specify the source of the scoop up. Use intended manually setting SRC_ABILITY.
    *
-   * @return boolean suceeded
+   * @return boolean successful scoop up
+   *
+   * @throws IllegalArgumentException If params.only was an unsupported type
    */
   static boolean scoopUpPokemon(params=[:], PokemonCardSet target, Object delegate, Source source=null) {
     if (source == null) {

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -1,4 +1,8 @@
-package tcgwars.logic.impl.gen8;
+package tcgwars.logic.impl.gen8
+
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen5.BlackWhite
+import tcgwars.logic.impl.gen5.EmergingPowers;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -28,7 +32,7 @@ import tcgwars.logic.effect.blocking.*;
 import tcgwars.logic.effect.event.*;
 import tcgwars.logic.effect.getter.*;
 import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -174,17 +178,21 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Pollen Bomb", {
           text "The opponent’s Active Pokémon is now Poisoned and Asleep."
           energyCost G, G, C
-          attackRequirement {}
+          attackRequirement {
+            assert !defending.specialConditions.contains(POISONED) || !defending.specialConditions.contains(ASLEEP) :
+            "$defending is already Poisoned and Asleep"
+          }
           onAttack {
-
+            apply POISONED
+            apply ASLEEP
           }
         }
         move "Solar Typhoon", {
           text "220 damage. This Pokémon can’t use Solar Typhoon during your next turn."
           energyCost G, G, G, C
-          attackRequirement {}
           onAttack {
             damage 220
+            cantUseAttack thisMove, self
           }
         }
       };
@@ -194,10 +202,7 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Call for Family", {
           text "Search your deck for a Basic Pokemon and put it on your Bench. Then, shuffle your deck."
           energyCost C
-          attackRequirement {}
-          onAttack {
-
-          }
+          callForFamily basic:true, 1, delegate
         }
       };
       case KAKUNA_3:
@@ -206,7 +211,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Bug Bite", {
           text "30 damage."
           energyCost G
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -218,21 +222,20 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Poison Jab", {
           text "80 damage. Your opponent’s Active Pokemon is now Poisoned."
           energyCost G
-          attackRequirement {}
           onAttack {
             damage 80
+            apply POISONED
           }
         }
       };
       case ELDEGOSS_5:
-      return copy (RebelClash.ELDEGOSS_19, this);
+      return copy (RebelClash.ELDEGOSS_V_19, this);
       case VULPIX_6:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
         move "Gnaw", {
           text "10 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -240,9 +243,11 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Singe", {
           text "Your opponent's Active Pokémon is now Burned."
           energyCost R, C
-          attackRequirement {}
+          attackRequirement {
+            assert !defending.specialConditions.contains(BURNED) : "$defending is already burned"
+          }
           onAttack {
-
+            apply BURNED
           }
         }
       };
@@ -262,7 +267,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Combustion", {
           text "30 damage."
           energyCost R, C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -274,9 +278,11 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Grand Flame", {
           text "90 damage. Attach up to 2 [R] Energy cards from your discard pile to 1 of your Benched Pokémon."
           energyCost R, R, C
-          attackRequirement {}
           onAttack {
             damage 90
+            if (my.bench) {
+              attachEnergyFrom max:2, type:R, my.discard, my.bench
+            }
           }
         }
         move "Flare Blitzer", {
@@ -285,6 +291,7 @@ public enum ChampionsPath implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 90
+            damage 30, self
           }
         }
       };
@@ -294,7 +301,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Bite", {
           text "10 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -302,7 +308,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Combustion", {
           text "50 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 50
           }
@@ -314,15 +319,14 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Searing Flame", {
           text "50 damage. Your opponent's Active Pokémon is now Burned."
           energyCost R, C, C
-          attackRequirement {}
           onAttack {
             damage 50
+            apply BURNED
           }
         }
         move "Heat Crawler", {
           text "140 damage."
           energyCost R, R, C, C
-          attackRequirement {}
           onAttack {
             damage 140
           }
@@ -334,7 +338,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Bite", {
           text "10 damage."
           energyCost W
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -346,9 +349,11 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Aqua Jet", {
           text "50 damage. This attack also does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W
-          attackRequirement {}
           onAttack {
             damage 50
+            if (opp.bench) {
+              damage 20, opp.bench.select("Do 20 damage to?")
+            }
           }
         }
       };
@@ -358,17 +363,18 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Draw Up", {
           text "Attach up to 3 [W] Energy cards from your discard pile to this Pokémon."
           energyCost W
-          attackRequirement {}
+          attackRequirement {
+            assert my.discard.filterByEnergyType(W) : "No $W Energy in discard"
+          }
           onAttack {
-
+            attachEnergyFrom max:3, type:W, my.discard, self
           }
         }
         move "Ocean Waves", {
           text "120x damage. Flip 3 coins. This attack does 120 damage for each heads."
           energyCost W
-          attackRequirement {}
           onAttack {
-            damage 120
+            flip 3, { damage 120 }
           }
         }
       };
@@ -377,15 +383,24 @@ public enum ChampionsPath implements LogicCardInfo {
         weakness L
         bwAbility "Solid Shell", {
           text "This Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
-          actionA {
+          delayedA {
+            before APPLY_ATTACK_DAMAGES, {
+              bg.dm().each {
+                if (it.to == self && it.dmg.value && it.notNoEffect) {
+                  bc "$thisAbility -30"
+                  it.dmg -= hp(30)
+                }
+              }
+            }
           }
         }
         move "Powerful Bite", {
-          text "During your opponent's next turn, the Defending Pokémon can't retreat."
+          text "130 Damage. During your opponent's next turn, the Defending Pokémon can't retreat."
           energyCost W, W, C
           attackRequirement {}
           onAttack {
-
+            damage 130
+            cantRetreat defending
           }
         }
       };
@@ -394,7 +409,15 @@ public enum ChampionsPath implements LogicCardInfo {
         weakness L
         bwAbility "Solid Shell", {
           text "This Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
-          actionA {
+          delayedA {
+            before APPLY_ATTACK_DAMAGES, {
+              bg.dm().each {
+                if (it.to == self && it.dmg.value && it.notNoEffect) {
+                  bc "$thisAbility -30"
+                  it.dmg -= hp(30)
+                }
+              }
+            }
           }
         }
         move "G-Max Headbutt", {
@@ -403,6 +426,7 @@ public enum ChampionsPath implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 160
+            flip { damage 80 }
           }
         }
       };
@@ -412,7 +436,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Magical Shot", {
           text "30 damage."
           energyCost P
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -420,7 +443,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Swelling Pulse", {
           text "120+ damage. If this Pokémon was healed during this turn, this attack does 80 more damage."
           energyCost P, P, C
-          attackRequirement {}
           onAttack {
             damage 120
             if(self.lastHealedTurn == bg.turnCount) damage 80
@@ -433,7 +455,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Max Cure", {
           text "180 damage. Heal 50 damage from this Pokémon."
           energyCost P, P, C
-          attackRequirement {}
           onAttack {
             damage 180
             heal 50, self
@@ -447,7 +468,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Stampede", {
           text "10 damage."
           energyCost P
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -455,7 +475,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Magical Shot", {
           text "30 damage."
           energyCost P, C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -468,7 +487,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Beat", {
           text "20 damage."
           energyCost P
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -476,7 +494,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Super Psy Bolt", {
           text "40 damage."
           energyCost P, C
-          attackRequirement {}
           onAttack {
             damage 40
           }
@@ -488,15 +505,21 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Hazard Sensor", {
           text "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-          actionA {
+          delayedA {
+            before APPLY_ATTACK_DAMAGES, {
+              if (self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})) {
+                bc "$thisAbility activates"
+                apply CONFUSED, ef.attacker, SRC_ABILITY
+              }
+            }
           }
         }
         move "Life Sucker", {
           text "100 damage. Heal 30 damage from this Pokémon."
           energyCost P, C
-          attackRequirement {}
           onAttack {
             damage 100
+            heal 30, self
           }
         }
       };
@@ -506,15 +529,21 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Gnawing Aura", {
           text "As long as this Pokémon is in the Active Spot, whenever your opponent attaches an Energy card from their hand to 1 of their Pokémon, put 3 damage counters on that Pokémon."
-          actionA {
+          delayedA {
+            after ATTACH_ENERGY, {
+              if (self.active && ef.resolvedTarget && ef.resolvedTarget.owner != self.owner && ef.reason == PLAY_FROM_HAND) {
+                bc "$thisAbility - $ef.resolvedTarget receives 2 damage counters."
+                directDamage 30, ef.resolvedTarget, SRC_ABILITY
+              }
+            }
           }
         }
         move "Hollow Missile", {
           text "60 damage. Put 3 damage counters on your opponent's Benched Pokémon in any way you like."
           energyCost P, C
-          attackRequirement {}
           onAttack {
             damage 60
+            putDamageCountersOnOpponentsPokemon(3, opp.bench)
           }
         }
       };
@@ -524,17 +553,19 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Sugary Sprinkles", {
           text "Heal 30 damage from each of your Benched Pokémon."
           energyCost P
-          attackRequirement {}
+          attackRequirement {
+            assert my.bench.any { it.numberOfDamageCounters } : "No damaged Pokémon on bench"
+          }
           onAttack {
-
+            my.bench.each { heal 30, it }
           }
         }
         move "Sweet Splash", {
           text "100 damage. If the Defending Pokémon is a Basic Pokémon, it can't attack during your opponent's next turn."
           energyCost P, C, C
-          attackRequirement {}
           onAttack {
             damage 100
+            if (defending.basic) cantAttackNextTurn(defending)
           }
         }
       };
@@ -544,17 +575,33 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Adornment", {
           text "For each of your Benched Pokémon, search your deck for a [P] Energy card and attach it to that Pokémon. Then, shuffle your deck."
           energyCost C
-          attackRequirement {}
+          attackRequirement {
+            assert my.bench : "No Pokémon on bench"
+          }
           onAttack {
-
+            my.bench.each {
+              attachEnergyFrom count:1, may:true, type:P, my.deck, it
+            }
           }
         }
         move "G-Max Whisk", {
           text "60x damage. Discard any amount of Energy from your Pokémon. This attack does 60 damage for each card you discarded in this way."
           energyCost P, P
-          attackRequirement {}
+          attackRequirement {
+            assert my.all.any { it.cards.energyCount() } : "No Pokémon with energy cards attached"
+          }
           onAttack {
-            damage 60
+            def damageAmount = 0
+            while(my.all.any{it.cards.energyCount(C)}){
+              if(confirm("Discard energy from one pokémon for 60 damage by energy discarded? Current Damage: $damageAmount")){
+                def tar = my.all.findAll{it.cards.energyCount(C)}.select("Choose the pokémon to discard energy")
+                damageAmount += 60*tar.cards.filterByType(ENERGY).select(min:1,max : tar.cards.filterByType(ENERGY).size()).discard().size()
+              }
+              else{
+                break
+              }
+            }
+            damage damageAmount
           }
         }
       };
@@ -564,7 +611,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Low Kick", {
           text "10 damage."
           energyCost F
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -572,9 +618,9 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Steady Punch", {
           text "20+ damage. Flip a coin. If heads, this attack does 40 more damage."
           energyCost F, C
-          attackRequirement {}
           onAttack {
             damage 20
+            flip { damage 40 }
           }
         }
       };
@@ -584,7 +630,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Low Kick", {
           text "30 damage."
           energyCost F
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -592,9 +637,9 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Pummel", {
           text "50+ damage. Flip a coin. If heads, this attack does 70 more damage."
           energyCost F, F, C
-          attackRequirement {}
           onAttack {
             damage 50
+            flip { damage 70 }
           }
         }
       };
@@ -604,9 +649,12 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Macho Revenge", {
           text "20x damage. This attack does 20 damage for each Fighting Pokémon in your discard pile."
           energyCost F, C
-          attackRequirement {}
+          attackRequirement {
+            assert my.discard.filterByType(POKEMON).any {it.asPokemonCard().types.contains(F) } :
+            "No $F Pokémon in the discard pile"
+          }
           onAttack {
-            damage 20
+            damage 20 * my.discard.filterByType(POKEMON).findAll {it.asPokemonCard().types.contains(F) }.size()
           }
         }
         move "Dynamite Punch", {
@@ -615,6 +663,7 @@ public enum ChampionsPath implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 200
+            damage 50, self
           }
         }
       };
@@ -624,17 +673,17 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Aura Sphere", {
           text "40 damage. This attack also does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost F
-          attackRequirement {}
           onAttack {
             damage 40
+            if (opp.bench) { damage 20, opp.bench.select() }
           }
         }
         move "Beatdown Smash", {
           text "180 damage. During your next turn, this Pokémon can't use Beatdown Smash."
           energyCost F, F, C
-          attackRequirement {}
           onAttack {
             damage 180
+            cantUseAttack thisMove, self
           }
         }
       };
@@ -644,7 +693,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Bite", {
           text "30 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -652,7 +700,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Power Blast", {
           text "130 damage. Discard a [F] Energy from this Pokémon."
           energyCost F, F, C, C
-          attackRequirement {}
           onAttack {
             damage 130
             afterDamage {
@@ -667,15 +714,16 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Collect", {
           text "Draw a card."
           energyCost C
-          attackRequirement {}
+          attackRequirement {
+            assert my.deck : "Your deck is empty"
+          }
           onAttack {
-
+            draw 1
           }
         }
         move "Bite", {
           text "20 damage."
           energyCost F, C
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -687,7 +735,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Rock Throw", {
           text "30 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -698,6 +745,7 @@ public enum ChampionsPath implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 150
+            cantUseAttack thisMove, self
           }
         }
       };
@@ -707,7 +755,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Ram", {
           text "10 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -719,17 +766,17 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Tie Up", {
           text "20 damage. The Defending Pokémon can’t retreat during your opponent’s next turn."
           energyCost F
-          attackRequirement {}
           onAttack {
             damage 20
+            cantRetreat defending
           }
         }
         move "Moonsault Press", {
           text "120+ damage. Flip a coin. If heads, this attack does 100 more damage."
           energyCost F, F, C
-          attackRequirement {}
           onAttack {
             damage 120
+            flip { damage 100 }
           }
         }
       };
@@ -739,7 +786,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Ram", {
           text "10 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -747,7 +793,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Tail Snap", {
           text "30 damage."
           energyCost D, C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -759,7 +804,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Sharp Fang", {
           text "30 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -767,7 +811,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Tail Snap", {
           text "70 damage."
           energyCost D, C
-          attackRequirement {}
           onAttack {
             damage 70
           }
@@ -779,7 +822,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Pin Missile", {
           text "Flip 4 coins. This attack does 10 damage for each heads."
           energyCost C
-          attackRequirement {}
           onAttack {
             flip 4, {
               damage 10
@@ -793,7 +835,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Double-Edge", {
           text "60 damage. This Pokémon also does 20 damage to itself."
           energyCost C, C
-          attackRequirement {}
           onAttack {
             damage 60
             damage 20, self
@@ -816,7 +857,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Knuckle Impact", {
           text "180 damage. During your next turn, this Pokémon can't attack."
           energyCost C, C, C
-          attackRequirement {}
           onAttack {
             damage 180
             cantAttackNextTurn self
@@ -829,32 +869,13 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Dark Cutter", {
           text "70 damage."
           energyCost D, D
-          attackRequirement {}
           onAttack {
             damage 70
           }
         }
       };
       case PURRLION_39:
-      return basic (this, hp:HP070, type:D, retreatCost:1) {
-        weakness G
-        move "Dig Claws", {
-          text "10 damage."
-          energyCost D
-          attackRequirement {}
-          onAttack {
-            damage 10
-          }
-        }
-        move "Fake Out", {
-          text "20 damage. Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed."
-          energyCost C, C
-          attackRequirement {}
-          onAttack {
-            damage 20
-          }
-        }
-      };
+      return copy (DarknessAblaze.PURRLOIN_106, this)
       case LIEPARD_40:
       return copy (DarknessAblaze.LIEPARD_107, this);
       case SCRAGGY_41:
@@ -863,7 +884,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Stampede", {
           text "10 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -871,7 +891,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Ram", {
           text "20 damage."
           energyCost D, C
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -883,7 +902,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Corner", {
           text "30 damage. During your opponent's next turn, the Defending Pokémon can't retreat."
           energyCost D
-          attackRequirement {}
           onAttack {
             damage 30
             cantRetreat defending
@@ -892,7 +910,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Bad Brawl", {
           text "110 damage. If you played Piers from your hand during this turn, this attack does 90 more damage."
           energyCost D, C, C
-          attackRequirement {}
           onAttack {
             damage 90
             if(bg.em().retrieveObject("Piers") == bg.turnCount){
@@ -902,14 +919,13 @@ public enum ChampionsPath implements LogicCardInfo {
         }
       };
       case TRUBBISH_43:
-      return copy (RebelClash.TRUBBISH_117, this);
+      return copy (TRUBBISH_117, this);
       case INKAY_44:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness G
         move "Tackle", {
           text "10 damage."
           energyCost D
-          attackRequirement {}
           onAttack {
             damage 10
           }
@@ -917,7 +933,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Attack from Behind", {
           text "20+ damage. If your opponent's Active Pokémon is Confused, this attack does 50 more damage."
           energyCost C, C
-          attackRequirement {}
           onAttack {
             damage 20
             if(defending.isSPC(CONFUSED)){
@@ -932,7 +947,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Eerie Wave", {
           text "50 damage. Your opponent's Active Pokémon is now Confused."
           energyCost D, C
-          attackRequirement {}
           onAttack {
             damage 50
             afterDamage{
@@ -943,7 +957,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Random Peck", {
           text "80+ damage. Flip 2 coins. This attack does 40 more damage for each heads."
           energyCost D, D, C
-          attackRequirement {}
           onAttack {
             damage 80
             flip 2, {
@@ -958,7 +971,9 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Filch", {
           text "Draw a card."
           energyCost C
-          attackRequirement {}
+          attackRequirement {
+            assert my.deck : "Your deck is empty"
+          }
           onAttack {
             draw 1
           }
@@ -966,7 +981,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Tail Smack", {
           text "30 damage."
           energyCost D, C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -978,15 +992,23 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance G, MINUS30
         bwAbility "Hard Coat", {
           text "This Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance)."
-          actionA {
+          delayedA {
+            before APPLY_ATTACK_DAMAGES, {
+              bg.dm().each {
+                if (it.to == self && it.dmg.value && it.notNoEffect) {
+                  bc "$thisAbility -30"
+                  it.dmg -= hp(30)
+                }
+              }
+            }
           }
         }
         move "Gatling Slug", {
           text "10+ damage. This attack does 40 more damage for each [M] Energy attached to this Pokémon."
           energyCost C, C, C
-          attackRequirement {}
           onAttack {
             damage 10
+            damage 40 * self.cards.energyCount(M)
           }
         }
       };
@@ -997,7 +1019,6 @@ public enum ChampionsPath implements LogicCardInfo {
         move "Peck", {
           text "20 damage."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -1009,13 +1030,25 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Miraculous Charm", {
           text "Prevent all damage done to this Pokémon by attacks from your opponent's Pokémon V and Pokémon-GX."
-          actionA {
+          // TODO: This could be made a static that takes a closure that gets evaluated in the if statement.
+          // Similar to part of Safeguards effect. Safeguard could possibly use it as well.
+          // Ex: abilityPreventsDamage(String info, Object delegate, Closure filter={true}, def target=self)
+          delayedA {
+            before APPLY_ATTACK_DAMAGES, {
+              bg.dm().each{
+                def info = "$thisAbility Camo prevents all damage from Pokémon V and Pokémon-GX"
+                def filter = { attacker -> attacker.pokemonGX || attacker.pokemonV }
+                if (it.to == self && it.from.owner != self.owner && filter(it.from) && it.notNoEffect && it.dmg.value) {
+                  bc info
+                  it.dmg=hp(0)
+                }
+              }
+            }
           }
         }
         move "Speed Dive", {
           text "60 damage."
           energyCost C, C
-          attackRequirement {}
           onAttack {
             damage 60
           }
@@ -1026,7 +1059,7 @@ public enum ChampionsPath implements LogicCardInfo {
       case FULL_HEAL_51:
       return copy (RebelClash.FULL_HEAL_159, this);
       case GREAT_BALL_52:
-      return copy (RebelClash.GREAT_BALL_52, this);
+      return copy (EmergingPowers.GREAT_BALL_93, this);
       case HOP_53:
       return copy (SwordShield.HOP_165, this);
       case HYPER_POTION_54:
@@ -1038,9 +1071,9 @@ public enum ChampionsPath implements LogicCardInfo {
       case MILO_57:
       return copy (RebelClash.MILO_161, this);
       case PIERS_58:
-      return copy (RebelClash.PIERS_165, this);
+      return copy (DarknessAblaze.PIERS_165, this);
       case POKE_BALL_59:
-      return copy (RebelClash.POKE_BALL_164, this);
+      return copy(FireRedLeafGreen.POKE_BALL_95, this);
       case POKEMON_CENTER_LADY_60:
       return copy(SwordShield.POKEMON_CENTER_LADY_176, this);
       case POTION_61:
@@ -1089,7 +1122,7 @@ public enum ChampionsPath implements LogicCardInfo {
       case GRAPPLOCT_V_72:
       return copy (GRAPPLOCT_V_32, this);
       case HOP_73:
-      return copy (HOP_53, this);
+      return copy (SwordShield.HOP_165, this);
       case CHARIZARD_VMAX_74:
       return copy (DarknessAblaze.CHARIZARD_VMAX_20, this);
       case DREDNAW_VMAX_75:
@@ -1097,9 +1130,9 @@ public enum ChampionsPath implements LogicCardInfo {
       case GARDEVOIR_VMAX_76:
       return copy (GARDEVOIR_VMAX_17, this);
       case KABU_77:
-      return copy (KABU_55, this);
+      return copy (DarknessAblaze.KABU_163, this);
       case PIERS_78:
-      return copy (PIERS_58, this);
+      return copy (DarknessAblaze.PIERS_165, this);
       case CHARIZARD_V_79:
       return copy (DarknessAblaze.CHARIZARD_V_19, this);
       case STRANGE_CANNED_FOOD_80:

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -43,7 +43,7 @@ public enum ChampionsPath implements LogicCardInfo {
   WEEDLE_2 ("Weedle", 2, Rarity.COMMON, [POKEMON, BASIC, _GRASS_]),
   KAKUNA_3 ("Kakuna", 3, Rarity.COMMON, [POKEMON, EVOLUTION, STAGE1, _GRASS_]),
   BEEDRILL_4 ("Beedrill", 4, Rarity.UNCOMMON, [POKEMON, EVOLUTION, STAGE2, _GRASS_]),
-  ELDEGOSS_5 ("Eldegoss V", 5, Rarity.ULTRARARE, [POKEMON, BASIC, POKEMON_V, _GRASS_]),
+  ELDEGOSS_V_5 ("Eldegoss V", 5, Rarity.ULTRARARE, [POKEMON, BASIC, POKEMON_V, _GRASS_]),
   VULPIX_6 ("Vulpix", 6, Rarity.COMMON, [POKEMON, BASIC, _FIRE_]),
   VICTINI_7 ("Victini", 7, Rarity.UNCOMMON, [POKEMON, BASIC, _FIRE_]),
   INCINEROAR_V ("Incineroar V", 8, Rarity.ULTRARARE, [POKEMON, BASIC, POKEMON_V, _FIRE_]),
@@ -228,7 +228,7 @@ public enum ChampionsPath implements LogicCardInfo {
           }
         }
       };
-      case ELDEGOSS_5:
+      case ELDEGOSS_V_5:
       return copy (RebelClash.ELDEGOSS_V_19, this);
       case VULPIX_6:
       return basic (this, hp:HP060, type:R, retreatCost:1) {

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -503,7 +503,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each{
-                def info = "Deep Forest Camo prevents all damage from Pokémon V and Pokémon-GX"
+                def info = "$thisAbility prevents all damage from Pokémon V and Pokémon-GX"
                 def filter = { attacker -> attacker.pokemonGX || attacker.pokemonV }
                 if (it.to == self && it.from.owner != self.owner && filter(it.from) && it.notNoEffect && it.dmg.value) {
                   bc info
@@ -912,7 +912,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               if (self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})) {
-                bc "Scorching Feather activates"
+                bc "$thisAbility activates"
                 apply BURNED, ef.attacker, SRC_ABILITY
               }
             }
@@ -1641,7 +1641,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           delayedA {
             after ATTACH_ENERGY, {
               if (ef.resolvedTarget && ef.resolvedTarget.owner != self.owner && ef.reason == PLAY_FROM_HAND) {
-                bc "$thisAbility.name - $ef.resolvedTarget.name receives 2 damage counters."
+                bc "$thisAbility - $ef.resolvedTarget receives 2 damage counters."
                 directDamage 20, ef.resolvedTarget, SRC_ABILITY
               }
             }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3445,7 +3445,7 @@ public enum RebelClash implements LogicCardInfo {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
                 if (it.to == self && it.dmg.value && it.notNoEffect) {
-                  bc "Soft Wool -30"
+                  bc "$thisAbility -30"
                   it.dmg -= hp(30)
                 }
               }


### PR DESCRIPTION
Added documentation to `attachEnergyFrom` and updated some documentation in TcgStatics because it was hard to read in IDEA's intellisense-like feature. Would like to find a way to actually display map keys in said UI, but knowing that it is a map should be enough to look up what is needed.

Implemented the rest of the cards in the set. Seems like another basic and boring set like Hidden Fates, so wasn't too difficult 🤣 

Tried to specify copies a bit better. Was confusing which ones were actually in the current file and which ones were actually in other files. At some point we need to make sure we don't have any duplicate code for reprints. e.g. Some Poké Ball cards copy from FireRedLeafGreen, some copy from EmergingPowers.