### PR TITLE
Fix Pluspower (Base Set), move Devolve Effect timing so cards that wait for it work properly

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -511,7 +511,6 @@ class TcgStatics {
     bg().em().run(new ActivateAbilities((PokemonCard) card, pcs, reason));
   }
   static devolve (PokemonCardSet pcs, Card card, CardList newLocation){
-    bg().em().run(new Devolve(pcs));
     def blocked = bg().em().run(new MoveCard(card, newLocation));
     if (blocked) {
       return;
@@ -527,6 +526,8 @@ class TcgStatics {
         bg().em().run(new MoveCard(pcs.topNonLevelUpPokemonCard, newLocation));
         bg().em().run(new RemoveFromPlay(pcs, new CardList(pcs.topNonLevelUpPokemonCard)));
       }
+
+      bg().em().run(new Devolve(pcs));
     }
   }
   static babyEvolution(String evolName, PokemonCardSet baby){

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1943,15 +1943,12 @@ public enum BaseSetNG implements LogicCardInfo {
           }
         }
       case PLUSPOWER:
-        // This print increases after W/R, do not use it as copy for DP-era prints that do it before W/R (and affects both actives, while this one only affects the defending Pokémon).
+        // This print increases after W/R, do not use it as copy for DP-era prints that do it before W/R (and affects both actives, while this one only affects the defending Pokémon; also can only be attached to active here).
         return basicTrainer (this) {
           text "Attach PlusPower to your Active Pokémon. At the end of your turn, discard PlusPower. If this Pokémon’s attack does damage to the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
           def eff
           onPlay {reason->
-            def pcs = my.active
-            if (my.bench) {
-              pcs = my.all.select("Which Pokémon will you attach $thisCard to?")
-            }
+            def pcs = my.active //No PCS Selection in this print
             pcs.cards.add(thisCard)
             my.hand.remove(thisCard)
 

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2741,9 +2741,9 @@ public enum Deoxys implements LogicCardInfo {
                     discard efs.card
                   }
                 }
-                before FALL_BACK, self, {unregister()}
-                before EVOLVE, self, {unregister()}
-                before DEVOLVE, self, {unregister()}
+                after FALL_BACK, self, {unregister()}
+                after EVOLVE, self, {unregister()}
+                after DEVOLVE, self, {unregister()}
                 unregisterAfter 2
               }
             }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1995,17 +1995,15 @@ public enum DragonFrontiers implements LogicCardInfo {
                 bg.em().storeObject("Imprison",Imprison)
               }
             }
-            before DEVOLVE, {temp = opp.all}
             after DEVOLVE, {
-              opp.all.findAll{!temp.contains(it)}.each{
-                if(bg.em().retrieveObject("Imprison") != null){
-                  Imprison = bg.em().retrieveObject("Imprison")
-                }
-                if (Imprison.contains(it)) {
-                  bc "${it} loses its Imprison marker when devolved!"
-                  Imprison.remove(it)
-                  bg.em().storeObject("Imprison",Imprison)
-                }
+              if(bg.em().retrieveObject("Imprison") != null){
+                Imprison = bg.em().retrieveObject("Imprison")
+              }
+              def pcs = ef.resolvedTarget
+              if (Imprison.contains(pcs)) {
+                bc "${pcs} loses its Imprison marker when devolved!"
+                Imprison.remove(pcs)
+                bg.em().storeObject("Imprison",Imprison)
               }
             }
             //TODO: Find correct replacement for "pokemonToBeDevolved", to remove above code and use the one below.
@@ -2289,17 +2287,15 @@ public enum DragonFrontiers implements LogicCardInfo {
                 bg.em().storeObject("Shock_Wave",Shock_Wave)
               }
             }
-            before DEVOLVE, {temp = opp.all}
             after DEVOLVE, {
-              opp.all.findAll{!temp.contains(it)}.each{
-                if(bg.em().retrieveObject("Shock_Wave") != null){
-                  Shock_Wave = bg.em().retrieveObject("Shock_Wave")
-                }
-                if (Shock_Wave.contains(it)) {
-                  bc "${it} loses its Shock-wave marker when devolved!"
-                  Shock_Wave.remove(it)
-                  bg.em().storeObject("Shock_Wave",Shock_Wave)
-                }
+              if(bg.em().retrieveObject("Shock_Wave") != null){
+                Shock_Wave = bg.em().retrieveObject("Shock_Wave")
+              }
+              def pcs = ef.resolvedTarget
+              if (Shock_Wave.contains(pcs)) {
+                bc "${pcs} loses its Shock-wave marker when devolved!"
+                Shock_Wave.remove(pcs)
+                bg.em().storeObject("Shock_Wave",Shock_Wave)
               }
             }
             //TODO: Find correct term, to replace pokemonToBeDevolved

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1287,9 +1287,9 @@ public enum ForbiddenLight implements LogicCardInfo {
                       }
                     }
                   }
-                  before EVOLVE, defending, {unregister()}
-                  before DEVOLVE, defending, {unregister()}
-                  before FALL_BACK, defending, {unregister()}
+                  after EVOLVE, defending, {unregister()}
+                  after DEVOLVE, defending, {unregister()}
+                  after FALL_BACK, defending, {unregister()}
                   unregisterAfter 3
                 }
               }


### PR DESCRIPTION
* Pluspower (Base Set) should now only be attachable to the Active Pokémon, not any in play.
* Devolve now only is ran after the devolve static finishes (and isn't blocked). This should return old functionality in cards reacting to this event (without reverting/altering the changes recently made for Lv.X/scoop-up-block support).
* Some cards reacted before the DEVOLVE effect, which did nothing prior or after recent changes. They now should work correctly. This includes Imprison/Shock-Wave marker removal, Aegislash (Forbidden Light) and Deoxys ex (EX Deoxys)
  - Note here: Ditto (Vending), Ditto (Fossil) and Brock's Ninetales might have issues when a devolve is attempted on them. Those `before DEVOLVE` checks should be tested/looked at and either fixed. reworked or outright removed. This seems to apply to these cards regardless of this or other recent changes to devolve.