### PR TITLE
Update Stantler's Push Away Ability

### DIFF
--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1207,7 +1207,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
             afterDamage {
               if (opp.hand) {
-                def list = opp.hand.shuffledCopy().showToMe("Opponent's hand").filterByType(TRAINER)
+                def list = opp.hand.shuffledCopy().filterByType(TRAINER)
                 if(list){
                   list.select("Select a Trainer card to discard").discard()
                 }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1206,7 +1206,7 @@ public enum UnseenForces implements LogicCardInfo {
           onAttack {
             damage 20
             afterDamage {
-              if (opp.hand && opp.hand.filterByType(TRAINER)) {
+              if (opp.hand) {
                 def selected = opp.hand.shuffledCopy().select(min: 0, max: 1, "Select a Trainer card to discard", {it.cardTypes.is(TRAINER)})
                 if (selected) { selected.discard() }
               }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1206,11 +1206,9 @@ public enum UnseenForces implements LogicCardInfo {
           onAttack {
             damage 20
             afterDamage {
-              if (opp.hand) {
-                def list = opp.hand.shuffledCopy().filterByType(TRAINER)
-                if(list){
-                  list.select("Select a Trainer card to discard").discard()
-                }
+              if (opp.hand && opp.hand.filterByType(TRAINER)) {
+                def selected = opp.hand.shuffledCopy().select(min: 0, max: 1, "Select a Trainer card to discard", {it.cardTypes.is(TRAINER)})
+                if (selected) { selected.discard() }
               }
             }
           }


### PR DESCRIPTION
This PR introduces a change to Stantler's Push Away move so that it will be more convenient to use by removing the need to show the same card list prompt twice