### PR TITLE
Use TreeSet to automatically order the non-dev Collection set

### DIFF
--- a/src/tcgwars/logic/card/Collection.java
+++ b/src/tcgwars/logic/card/Collection.java
@@ -260,7 +260,7 @@ public enum Collection {
   }
 
   public static Set<Collection> getLiveExpansions() {
-    Set<Collection> expansions = new HashSet<>();
+    Set<Collection> expansions = new TreeSet<>();
     for (GameType gameType : GameType.values()) {
       for (GameFormat gameFormat : gameType.getAvailableFormats()) {
         expansions.addAll(gameFormat.getIncludedCollections());


### PR DESCRIPTION
This should fix the jumbled mess currently displayed on the play server card database and inventory dropdowns.