### PR TITLE
Dialogue: Text consistency, punctuation at the ends

### DIFF
--- a/src/tcgwars/logic/card/Collection.java
+++ b/src/tcgwars/logic/card/Collection.java
@@ -91,7 +91,7 @@ public enum Collection {
   POP_SERIES_8(288, "POP Series 8", "POP8", "gen4.PopSeries8"),
   POP_SERIES_9(289, "POP Series 9", "POP9", "gen4.PopSeries9"),
 
-  POKEMON_RUMBLE(290, "Pokemon Rumble", "RUMBLE", "gen4.PokemonRumble"),
+  POKEMON_RUMBLE(290, "Pokémon Rumble", "RUMBLE", "gen4.PokemonRumble"),
 
   //BLACK & WHITE
   BLACK_WHITE_PROMOS(310, "Black & White Promos", "BWP", "gen5.BlackWhitePromos"),

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -324,7 +324,7 @@ class TcgStatics {
   static oppChoose (List choices, String info="", defaultChoice=null){
     oppChoose(choices, null, info, defaultChoice)
   }
-  static multiSelect (List pcsList, int count, String info="Select Pokemon"){
+  static multiSelect (List pcsList, int count, String info="Select Pokémon"){
     LUtils.selectMultiPokemon(bg().ownClient(), pcsList, info, count)
   }
   static multiDamage (List pcsList, int count, int dmg, String info="Select to deal damage"){
@@ -479,7 +479,7 @@ class TcgStatics {
         bg.game.endGame(opp.owner, WinCondition.NOPOKEMON)
         return
       }
-      sw ( null, my.bench.select("New active pokemon"))
+      sw ( null, my.bench.select("New active Pokémon."))
       //my.bench.remove(pcs)
     }
     else if (my.bench.contains(pcs)){
@@ -495,7 +495,7 @@ class TcgStatics {
         bg.game.endGame(my.owner, WinCondition.NOPOKEMON)
         return
       }
-      sw ( null, opp.bench.oppSelect("New active pokemon"))
+      sw ( null, opp.bench.oppSelect("New active Pokémon."))
       //opp.bench.remove(pcs)
     }
     else if (opp.bench.contains(pcs)){
@@ -1040,7 +1040,7 @@ class TcgStatics {
     Source src = params.source ? params.source : ATTACK
     def doit = {
       if(bench.notEmpty && my.active){
-        def pcs = bench.select("Switch your active pokemon", !may)
+        def pcs = bench.select("Switch your active Pokémon.", !may)
         if(pcs){
           sw my.active, pcs, src
         }

--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -326,7 +326,7 @@ public enum BaseSetNG implements LogicCardInfo {
             actionA {
               checkNoSPC()
               assert my.hand.filterByBasicEnergyType(W) : "No [W] in hand"
-              assert my.all.find{it.types.contains(W)} : "No [W] pokemon"
+              assert my.all.find{it.types.contains(W)} : "No [W] Pokémon."
 
               powerUsed()
               def card = my.hand.filterByBasicEnergyType(W).first()
@@ -1770,7 +1770,7 @@ public enum BaseSetNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "Choose 1 of your own Pokémon in play and a Stage of Evolution. Discard all Evolution cards of that Stage or higher attached to that Pokémon. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
           onPlay {
-            def pcs = my.all.findAll{it.evolution}.select("Pokemon to devolve")
+            def pcs = my.all.findAll{it.evolution}.select("Pokémon to devolve")
             def pkmn = []
             pkmn.addAll(pcs.pokemonCards)
             pkmn.remove(pcs.topPokemonCard)
@@ -1852,7 +1852,7 @@ public enum BaseSetNG implements LogicCardInfo {
         return basicTrainer (this) {
           text "Trade 1 of the Basic Pokémon or Evolution cards in your hand for 1 of the Basic Pokémon or Evolution cards from your deck. Show both cards to your opponent. Shuffle your deck afterward."
           onPlay {
-            my.hand.select("Choose a Pokemon", cardTypeFilter(POKEMON)).select().moveTo(my.deck)
+            my.hand.select("Choose a Pokémon", cardTypeFilter(POKEMON)).select().moveTo(my.deck)
             my.deck.search (max: 1, cardTypeFilter(POKEMON)).moveTo(hand)
             shuffleDeck()
           }
@@ -2037,7 +2037,7 @@ public enum BaseSetNG implements LogicCardInfo {
           onPlay {
             def tar = my.all.findAll {it.cards.energyCount(C) && it.numberOfDamageCounters}
             if(tar) {
-              def pcs = tar.select("Heal which Pokemon?")
+              def pcs = tar.select("Heal which Pokémon?")
               targeted (pcs, TRAINER_CARD) {
                 pcs.cards.filterByType(ENERGY).select("Discard which Energy?").discard()
                 heal 40, pcs

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -258,7 +258,7 @@ public enum FossilNG implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.bench.find{it == self} : "Dragonite is not on the Bench"
-              if (confirm("switch Dragonite with your active pokemon")){
+              if (confirm("switch Dragonite with your active Pokémon.")){
                 powerUsed()
                 sw my.active, self
               }
@@ -901,7 +901,7 @@ public enum FossilNG implements LogicCardInfo {
               assert !self.specialConditions
               assert self.damage != self.fullHP - hp(10) : "Slowbro can't be Knocked Out by Strange Behavior!"
               def tar = my.all.findAll{it != self && it.numberOfDamageCounters}
-              assert tar : "There is no Pokemon with damage counter outside Slowbro"
+              assert tar : "There is no Pokémon with damage counter outside Slowbro"
               def pcs = tar.select()
 
               self.damage+=hp(10)

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -341,7 +341,7 @@ public enum TeamRocketNG implements LogicCardInfo {
                 if(my.bench.notFull){
                   def cnt = Math.min(my.bench.getFreeBenchCount(),2)
                   bc "$cnt"
-                  my.deck.search (max: cnt,"Search for 2 basic pokemon",{it.cardTypes.is(BASIC)}).each {
+                  my.deck.search (max: cnt,"Search for 2 basic Pokémon.",{it.cardTypes.is(BASIC)}).each {
                     benchPCS(it)
                   }
                   shuffleDeck()
@@ -1629,13 +1629,13 @@ public enum TeamRocketNG implements LogicCardInfo {
               if(oppConfirm("accepts the challenge (if decline your opponent draws 2 cards, otherwise you both put as many basic pokemon on your bench fro your deck)")){
                 if(my.bench.notFull) {
                   def myCnt = my.bench.getFreeBenchCount()
-                  my.deck.search(max:myCnt,"search for at most $myCnt Basic Pokemon",cardTypeFilter(BASIC)).each{
+                  my.deck.search(max:myCnt,"search for at most $myCnt Basic Pokémon",cardTypeFilter(BASIC)).each{
                     benchPCS(it)
                   }
                 }
                 if(opp.bench.notFull) {
                   def oppCnt = opp.bench.getFreeBenchCount()
-                  opp.deck.search(max:oppCnt,"search for at most $oppCnt Basic Pokemon",cardTypeFilter(BASIC)).each{
+                  opp.deck.search(max:oppCnt,"search for at most $oppCnt Basic Pokémon",cardTypeFilter(BASIC)).each{
                     benchPCS(it,OTHER)
                   }
                 }

--- a/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
@@ -483,7 +483,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
           text "40 damage. This attack can't be used unless Sabrina's Abra and the Defending Pokémon have the same number of Energy cards attached to them."
           energyCost P, C
           attackRequirement {
-            assert opp.cards.filterByType(ENERGY).size() == self.cards.filterByType(ENERGY).size() : "Abra and the defending Pokemon have different number of Energies"
+            assert opp.cards.filterByType(ENERGY).size() == self.cards.filterByType(ENERGY).size() : "Abra and the defending Pokémon have different number of Energies"
           }
           onAttack {
             damage 40
@@ -567,7 +567,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
 
             flip 1, {
               if (opp.bench) {
-                def target = opp.bench.select("Which Benched Pokemon to deal damage to?")
+                def target = opp.bench.select("Which Benched Pokémon to deal damage to?")
                 damage 30, target
               }
             }, {

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -272,7 +272,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
                 if(it.to == self && it.from.topPokemonCard.cardTypes.is(DELTA) && it.from.owner == self.owner.opposite && it.dmg.value && it.notNoEffect) {
-                  bc "Delta Protection reduces damage from δ Pokemon by 40"
+                  bc "Delta Protection reduces damage from δ Pokémon by 40"
                   it.dmg -= hp(40)
                 }
               }
@@ -633,10 +633,10 @@ public enum CrystalGuardians implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert self.active : "Cacturne is not an Active Pokemon"
-            assert opp.all.any{ it.numberOfDamageCounters } : "Opponent has no damaged Pokemon."
+            assert self.active : "Cacturne is not an Active Pokémon"
+            assert opp.all.any{ it.numberOfDamageCounters } : "Opponent has no damaged Pokémon."
             powerUsed()
-            directDamage 10, opp.all.findAll{ it.numberOfDamageCounters }.select("Which Pokemon to put 1 damage counter on?")
+            directDamage 10, opp.all.findAll{ it.numberOfDamageCounters }.select("Which Pokémon to put 1 damage counter on?")
           }
         }
         move "Triple Needle", {
@@ -720,7 +720,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             assert my.deck : "Deck is empty"
             bg.em().storeObject("Delta_Sign",bg.turnCount)
             powerUsed()
-            deck.search("Search your deck for a δ Pokemon", {it.cardTypes.pokemon && it.cardTypes.is(DELTA) }).showToOpponent("Opponent used Delta Sign").moveTo(my.hand)
+            deck.search("Search your deck for a δ Pokémon", {it.cardTypes.pokemon && it.cardTypes.is(DELTA) }).showToOpponent("Opponent used Delta Sign").moveTo(my.hand)
             shuffleDeck()
           }
         }
@@ -894,9 +894,9 @@ public enum CrystalGuardians implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert self.benched : "Pelipper is not on your Bench"
-            assert my.active.topPokemonCard.cardTypes.is(DELTA) : "Active is not a Delta Pokemon"
+            assert my.active.topPokemonCard.cardTypes.is(DELTA) : "Active is not a Delta Pokémon"
             powerUsed()
-            sw my.active, my.bench.select("Select a new active Pokemon."), SRC_ABILITY
+            sw my.active, my.bench.select("Select a new active Pokémon."), SRC_ABILITY
           }
         }
         move "Supersonic", {
@@ -2189,7 +2189,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           text "Discard 2 Energy attached to Kyogre ex. Choose 1 of your opponent's Pokémon. This attack does 70 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, W, C
           onAttack {
-            damage 70, opp.all.select("Deal 70 damage to which Pokemon?")
+            damage 70, opp.all.select("Deal 70 damage to which Pokémon?")
             afterDamage{
               discardSelfEnergy C,C
             }
@@ -2350,7 +2350,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           energyCost C, C, C
           def flag
           attackRequirement {
-            assert (flag || my.hand.filterByType(POKEMON)) : "No Pokemon in hand" //TODO: Ignore BREAKs and LEGENDs.
+            assert (flag || my.hand.filterByType(POKEMON)) : "No Pokémon in hand" //TODO: Ignore BREAKs and LEGENDs.
           }
           onAttack {
             flag = true

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -371,13 +371,13 @@ public enum DeltaSpecies implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert my.bench : "No benched Pokemon"
-            assert my.all.findAll { it.cards.filterByType(ENERGY) } : "No Energy Cards attached to your Pokemon"
+            assert my.bench : "No benched Pokémon"
+            assert my.all.findAll { it.cards.filterByType(ENERGY) } : "No Energy Cards attached to your Pokémon"
             powerUsed()
 
-            def source = my.all.findAll { it.cards.filterByType(ENERGY) }.select("Choose a Pokemon to move an Energy from")
+            def source = my.all.findAll { it.cards.filterByType(ENERGY) }.select("Choose a Pokémon to move an Energy from")
             def energyCard = source.cards.filterByType(ENERGY).select("Choose the energy to move").first()
-            def target = my.all.findAll{it != source}.select("Select a Pokemon to move the Energy to")
+            def target = my.all.findAll{it != source}.select("Select a Pokémon to move the Energy to")
             targeted (target, SRC_ABILITY) {
               energySwitch(source, target, energyCard)
             }
@@ -429,7 +429,7 @@ public enum DeltaSpecies implements LogicCardInfo {
               if (moved.stream().anyMatch(self.cards.&contains)) return
 
               if (opp.bench) {
-                damage 20, opp.bench.select("Deal 20 damage to which Benched Pokemon?")
+                damage 20, opp.bench.select("Deal 20 damage to which Benched Pokémon?")
               }
             }
           }
@@ -836,7 +836,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             assert my.hand.filterByType(BASIC_ENERGY) : "No Basic Energy in hand"
           }
           onAttack {
-            def chosenEnergy = my.hand.filterByType(BASIC_ENERGY).select(count: 1, "Select a Basic Energy card to search for a Pokemon of that Energy type.")
+            def chosenEnergy = my.hand.filterByType(BASIC_ENERGY).select(count: 1, "Select a Basic Energy card to search for a Pokémon of that Energy type.")
             chosenEnergy.showToOpponent("Your opponent has chosen this basic Energy card. They'll now search their deck for a Pokémon of that Energy type.")
             def cardType = chosenEnergy.basicType
             def sel = my.deck.search(max: 1, "search for a [${cardType}] Basic Pokémon or Evolution card", {
@@ -883,7 +883,7 @@ public enum DeltaSpecies implements LogicCardInfo {
                       prevent()
                     } else {
                       prevent()
-                      wcu "You have no energy attached to your Pokemon"
+                      wcu "You have no energy attached to your Pokémon"
                     }
                   } else {
                     prevent()
@@ -948,7 +948,7 @@ public enum DeltaSpecies implements LogicCardInfo {
                       prevent()
                     } else {
                       prevent()
-                      wcu "You have no energy attached to your Pokemon"
+                      wcu "You have no energy attached to your Pokémon"
                     }
                   } else {
                     prevent()
@@ -990,14 +990,14 @@ public enum DeltaSpecies implements LogicCardInfo {
             //TODO: Prevent Baby Evolution from happening.
             before EVOLVE_STANDARD, {
               if (bg.currentTurn == self.owner.opposite && ef.pokemonToBeEvolved.isSPC(ASLEEP)) {
-                wcu "Binding Aura prevents you from evolving an Asleep Pokemon"
+                wcu "Binding Aura prevents you from evolving an Asleep Pokémon"
                 prevent()
               }
             }
             before ATTACH_ENERGY, {
               def pcs = (ef as TargetedEffect).getResolvedTarget(bg, e)
               if (ef.reason == PLAY_FROM_HAND && bg.currentTurn == self.owner.opposite && pcs.isSPC(ASLEEP)) {
-                wcu "Binding Aura prevents you from attaching energies to an Asleep Pokemon"
+                wcu "Binding Aura prevents you from attaching energies to an Asleep Pokémon"
                 prevent()
               }
             }
@@ -2047,7 +2047,7 @@ public enum DeltaSpecies implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         pokeBody "Conductive Body", {
-          text "As long as Beldum is your active Pokemon, you pay [C] less to retreat Beldum for each Beldum on your Bench."
+          text "As long as Beldum is your active Pokémon, you pay [C] less to retreat Beldum for each Beldum on your Bench."
           getterA GET_RETREAT_COST, self, {h ->
             if (self.active) {
               my.bench.findAll { it.name == "Beldum" }.each {
@@ -2733,7 +2733,7 @@ public enum DeltaSpecies implements LogicCardInfo {
         }
         playRequirement{
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
-          assert my.discard.filterByType(BASIC_ENERGY) || my.discard.filterByType(POKEMON) : "No Basic Energy cards or Pokemon in discard pile."
+          assert my.discard.filterByType(BASIC_ENERGY) || my.discard.filterByType(POKEMON) : "No Basic Energy cards or Pokémon in discard pile."
         }
       };
       case HOLON_LASS_92:
@@ -2766,7 +2766,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           def toDiscard = my.hand.getExcludedList(thisCard).select(count:1, "Discard a card from your hand in order to play ${thisCard}.")
           toDiscard.discard()
 
-          deck.search(max: 3, "Search your deck for up to 3 Basic Pokemon with 100 HP or less", {
+          deck.search(max: 3, "Search your deck for up to 3 Basic Pokémon with 100 HP or less", {
             it.cardTypes.pokemon && it.cardTypes.is(BASIC) && it.asPokemonCard().hp.value <= 100
           }).showToOpponent("Opponent used Holon Mentor").moveTo(my.hand)
 
@@ -2805,7 +2805,7 @@ public enum DeltaSpecies implements LogicCardInfo {
 
           Battleground bg_test = Battleground.getInstance()
 
-          my.deck.search(max: 1, "Select a [M] or a Pokemon card with δ in its card.", {
+          my.deck.search(max: 1, "Select a [M] or a Pokémon card with δ in its card.", {
             (it.cardTypes.is(ENERGY) && it.asEnergyCard().containsTypePlain(M)) ||
               (it.cardTypes.is(POKEMON) && it.getCardTypes(bg_test).is(DELTA))
           }).showToOpponent("Opponent's used Holon Researcher, and will put this card into their hand.").moveTo(my.hand)
@@ -2827,7 +2827,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           actions=action("Stadium: Holon Ruins") {
             assert lastTurn != bg().turnCount : "Already used Holon Ruins"
             assert my.deck : "Deck is empty."
-            assert my.all.any{it.topPokemonCard.cardTypes.is(DELTA)} : "No Delta Pokemon in play."
+            assert my.all.any{it.topPokemonCard.cardTypes.is(DELTA)} : "No Delta Pokémon in play."
             bc "Used Holon Ruins effect"
             lastTurn = bg().turnCount
 

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -940,7 +940,7 @@ public enum Deoxys implements LogicCardInfo {
             actionA {
               checkLastTurn()
               checkNoSPC()
-              assert opp.bench : "There is no benched Pokemon"
+              assert opp.bench : "There is no benched Pokémon"
               powerUsed()
 
               sw opp.active, opp.bench.oppSelect(), SRC_ABILITY
@@ -1000,7 +1000,7 @@ public enum Deoxys implements LogicCardInfo {
             energyCost G
             onAttack {
               flip {
-                apply choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending pokemon")
+                apply choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending Pokémon.")
               }
             }
           }
@@ -2307,7 +2307,7 @@ public enum Deoxys implements LogicCardInfo {
             energyCost G
             onAttack {
               flip {
-                apply choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending pokemon")
+                apply choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending Pokémon.")
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -386,7 +386,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           onAttack {
             damage 60
 
-            if (my.hand.filterByType(POKEMON) && confirm("Discard Pokemon from Hand?")) {
+            if (my.hand.filterByType(POKEMON) && confirm("Discard Pokémon from Hand?")) {
               my.hand.filterByType(BASIC, EVOLUTION).select("Which card to discard?").discard()
               if (opp.bench) damage 20, opp.bench.select("Damage to?")
             }
@@ -403,7 +403,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             checkNoSPC()
             assert my.deck : "Deck is empty"
             powerUsed()
-            my.deck.search(max: 1, "Select a Pokemon card to put into your hand", {
+            my.deck.search(max: 1, "Select a Pokémon card to put into your hand", {
               it.cardTypes.is(POKEMON)
             }).showToOpponent("Your opponent used Invitation. They're moving this Pokémon card from their deck into their hand.").moveTo(my.hand)
             shuffleDeck()
@@ -472,7 +472,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             assert my.deck : "Deck is Empty"
           }
           onAttack {
-            deck.search("Search your deck for a δ Pokemon", {
+            deck.search("Search your deck for a δ Pokémon", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)
             }).showToOpponent("Your opponent used Delta Call. They're moving this Pokémon card from their deck into their hand.").moveTo(my.hand)
             shuffleDeck()
@@ -490,7 +490,7 @@ public enum DragonFrontiers implements LogicCardInfo {
       return basic (this, hp:HP080, type:G, retreatCost:3) {
         weakness F
         pokePower "Dozing", {
-          text "Once during your turn (before your attack), if Snorlax is your Active Pokemon, you may remove 2 damage counters from Snorlax and Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition"
+          text "Once during your turn (before your attack), if Snorlax is your Active Pokémon, you may remove 2 damage counters from Snorlax and Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition"
           actionA {
             checkLastTurn()
             checkNoSPC()
@@ -520,7 +520,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "Choose an attack on 1 of your opponent's Pokémon in play that has δ on its card. Delta Copy copies that attack except for its Energy cost. (You must still do anything else required for that attack.) Togetic performs that attack."
           energyCost C, C
           attackRequirement {
-            assert opp.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "Opponent has no Delta Pokemon"
+            assert opp.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "Opponent has no Delta Pokémon"
           }
           onAttack {
             def card = opp.all.findAll { it.topPokemonCard.cardTypes.is(DELTA) }.select("Source of move")
@@ -553,7 +553,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert self.active : "This Pokemon is not the Active Pokemon"
+            assert self.active : "This Pokémon is not the Active Pokémon"
             assert all.any{it.numberOfDamageCounters} : "No Damage Counters in any Pokémon"
             powerUsed()
             def source = all.findAll{it.numberOfDamageCounters}.select("Source for damage counter")
@@ -978,7 +978,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert self.evolution : "This Electabuzz is not an Evolved Pokemon"
+            assert self.evolution : "This Electabuzz is not an Evolved Pokémon"
             assert my.deck : "Deck is empty"
 
             powerUsed()
@@ -1864,7 +1864,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             checkLastTurn()
             checkNoSPC()
             assert my.hand.filterByType(BASIC_ENERGY) : "No Basic Energy in Hand"
-            assert my.all.any{ it.EX && it.stage2 } : "No Stage 2 Pokemon-ex in play"
+            assert my.all.any{ it.EX && it.stage2 } : "No Stage 2 Pokémon-ex in play"
             powerUsed()
             def tar = my.all.findAll{ it.EX && it.stage2 }.select()
             attachEnergyFrom(basic: true, my.hand, tar)
@@ -2255,9 +2255,9 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "80 damage. You may do 40 damage instead of 80 to the Defending Pokémon. If you do, this attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, W, C, C
           onAttack {
-            if (opp.bench && confirm("Deal 40 instead of 80 to Defending in order to do 40 damage to a Pokemon on the Opponent's bench?")) {
+            if (opp.bench && confirm("Deal 40 instead of 80 to Defending in order to do 40 damage to a Pokémon on the Opponent's bench?")) {
               damage 40
-              damage 40, opp.bench.select("Select a benched Pokemon to deal 40 damage to")
+              damage 40, opp.bench.select("Select a benched Pokémon to deal 40 damage to")
             } else {
               damage 80
             }
@@ -2411,7 +2411,7 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "Choose an attack on 1 of your opponent's Pokémon in play. Mimicry copies that attack. This attack does nothing if Mew Star doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew Star performs that attack."
           energyCost C
           onAttack {
-            def tar = opp.all.select("Choose Pokemon to copy moves from")
+            def tar = opp.all.select("Choose Pokémon to copy moves from")
             if (tar.topPokemonCard.moves) {
               def moveOptions = tar.topPokemonCard.moves
               def move = choose(moveOptions + ["End Turn (Skip)"], "Choose 1 of the Pokémon's attacks.")
@@ -2428,10 +2428,10 @@ public enum DragonFrontiers implements LogicCardInfo {
           text "Choose 1 basic Energy card attached to Mew Star. This attack does 20 damage to each of your opponent's Pokémon that is the same type as the basic Energy card that you chose. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W
           attackRequirement {
-            assert self.cards.filterByType(BASIC_ENERGY) : "This Pokemon has no Basic Energies."
+            assert self.cards.filterByType(BASIC_ENERGY) : "This Pokémon has no Basic Energies."
           }
           onAttack {
-            def energy = self.cards.filterByType(BASIC_ENERGY).select("Deal 20 damage to your opponent's Pokemon of the same type of the chosen Energy.")
+            def energy = self.cards.filterByType(BASIC_ENERGY).select("Deal 20 damage to your opponent's Pokémon of the same type of the chosen Energy.")
             def type = energy.basicType
             bc "Rainbow Wave - Chosen type is $type"
             def flag = false

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -576,7 +576,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               assert !self.specialConditions
               assert self.damage != self.fullHP - hp(10) : "Slowbro can't be Knocked Out by Strange Behavior!"
               def tar = my.all.findAll{it != self && it.numberOfDamageCounters}
-              assert tar : "There is no Pokemon with damage counter outside Slowbro"
+              assert tar : "There is no Pokémon with damage counter outside Slowbro"
               def pcs = tar.select()
 
               self.damage+=hp(10)
@@ -2248,7 +2248,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                 if (!self.active && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && self.owner.pbg.bench.notEmpty && self.owner.pbg.active.cards.filterByType(BASIC_ENERGY)) {
                   bc "EXP.ALL activates"
                   if (oppConfirm("EXP.ALL: Move an Energy from ${self.owner.pbg.active} to $self ?")) {
-                    def energy = self.owner.pbg.active.cards.filterByType(BASIC_ENERGY).oppSelect("Select an Energy from the Active Pokemon to move to the holder of EXP.ALL").first()
+                    def energy = self.owner.pbg.active.cards.filterByType(BASIC_ENERGY).oppSelect("Select an Energy from the Active Pokémon to move to the holder of EXP.ALL").first()
                     energySwitch(self.owner.pbg.active, self, energy)
                     discard thisCard
                   }
@@ -2363,7 +2363,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert opp.bench : "Opponent has no benched Pokemon"
+            assert opp.bench : "Opponent has no benched Pokémon"
           }
         };
       case PROF__OAK_S_RESEARCH_98:

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -226,7 +226,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             def fossilInHand = my.hand.any{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }
-            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokemon?")) {
+            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokémon?")) {
               my.hand.findAll{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }.select().discard()
               damage 30, opp.bench.select()
             }
@@ -455,11 +455,11 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert my.hand.filterByType(BASIC_ENERGY) || my.hand.any{it.name.contains("δ Rainbow Energy")}: "No Basic Energy or δ Rainbow Energy in Hand"
-            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokemon in play"
+            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokémon in play"
             //TODO: Handle Cursed Glare, shouldn't be allowed to attach in that case.
             powerUsed()
-            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokemon").first()
-            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokemon to attach the Energy to.")
+            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokémon").first()
+            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokémon to attach the Energy to.")
             attachEnergy(tar, energy)
           }
         }
@@ -1467,7 +1467,7 @@ public enum HolonPhantoms implements LogicCardInfo {
                       prevent()
                     } else {
                       prevent()
-                      wcu "You have no energy attached to your Pokemon"
+                      wcu "You have no energy attached to your Pokémon"
                     }
                   } else {
                     prevent()
@@ -1581,7 +1581,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Your opponent chooses 1 of his or her Pokémon. Put 4 damage counters on that Pokémon."
           energyCost M, C
           onAttack {
-            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokemon?")
+            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokémon?")
           }
         }
       };
@@ -2290,14 +2290,14 @@ public enum HolonPhantoms implements LogicCardInfo {
           },{
             def eligible = my.hand.findAll { ["Omanyte", "Kabuto", "Aerodactyl", "Aerodactyl ex", "Lileep", "Anorith"].contains(it.name) }
             if(eligible){
-              eligible.select("Select which Pokemon to bench").each {
+              eligible.select("Select which Pokémon to bench.").each {
                 benchPCS(it)
               }
             }
           }
         }
         playRequirement{
-          assert my.bench.notFull : "Your bench is full"
+          assert my.bench.notFull : "Your bench is full."
           assert my.deck || my.hand.getExcludedList(thisCard) : "You cannot play this card if its your only card in hand, and you have no more cards in deck"
         }
       };
@@ -2305,15 +2305,15 @@ public enum HolonPhantoms implements LogicCardInfo {
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
           "Each player's Pokémon that has δ on its card can use attacks on this card instead of its own." +
-          "[C] Delta Call - Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+          "[C] Delta Call - Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
         def eff
         onPlay {
           def moveBody = {
-            text "Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+            text "Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost C
-            attackRequirement { assert my.deck : "Deck is empty" }
+            attackRequirement { assert my.deck : "Deck is empty!" }
             onAttack {
-              deck.search("Search your deck for a δ Pokemon", {
+              deck.search("Search your deck for a δ Pokémon.", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)
             }).moveTo(my.hand)
               shuffleDeck()
@@ -2379,7 +2379,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             checkNoSPC()
             assert opp.bench.size() >= 4 : "Opponent needs to have 4 or more Benched Pokémon"
             powerUsed()
-            def tar = opp.bench.select("Choose a pokemon to return to your opponent's hand.")
+            def tar = opp.bench.select("Choose a Pokémon to return to your opponent's hand.")
             scoopUpPokemon([:], tar, delegate, SRC_ABILITY)
           }
         }
@@ -2398,8 +2398,8 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Once during your turn (before your attack), if Mew ex is on your Bench, you may look at your opponent's hand."
           actionA {
             checkLastTurn()
-            assert self.benched : "This Pokemon is not benched"
-            assert opp.hand : "Opponent's hand is empty"
+            assert self.benched : "This Pokémon is not benched"
+            assert opp.hand : "Opponent's hand is empty!"
             powerUsed()
             opp.hand.shuffledCopy().showToMe("Your opponent's hand")
           }
@@ -2418,7 +2418,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             afterDamage {
-              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve Defending?")) {
+              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve the Defending Pokémon?")) {
                 discardSelfEnergy(C, C)
                 def top=defending.topPokemonCard
                 devolve(defending, top, opp.deck)
@@ -2437,9 +2437,9 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert opp.bench : "Opponent has no Benched"
+            assert opp.bench : "Opponent has no Benched Pokémon."
             powerUsed()
-            sw(opp.active, opp.bench.oppSelect("New Active Pokemon"))
+            sw(opp.active, opp.bench.oppSelect("New Active Pokémon"))
           }
         }
         move "Sharp Fang", {

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -264,8 +264,8 @@ public enum LegendMaker implements LogicCardInfo {
           text "Count the number of React Energy cards attached to Cradily and choose up to that number of your opponent's Evolved Pokémon. Remove the highest Stage Evolution card from each of those Pokémon, then have your opponent shuffle those cards into his or her deck."
           energyCost C, C
           attackRequirement {
-            assert self.cards.any{it.name == "React Energy"} : "No React Energies attached to this Pokemon"
-            assert opp.all.any{ it.evolution } : "Your opponent has no evolved pokemon"
+            assert self.cards.any{it.name == "React Energy"} : "No React Energies attached to this Pokémon"
+            assert opp.all.any{ it.evolution } : "Your opponent has no evolved Pokémon."
           }
           onAttack {
             def evolvedPoke = opp.all.findAll{it.evolution}
@@ -570,9 +570,9 @@ public enum LegendMaker implements LogicCardInfo {
           text "Once during your turn, when you play Shiftry from your hand to evolve 1 of your Pokémon, you may choose 1 of your Evolved Pokémon in play (excluding any Shiftry). Return that Pokémon and all cards attached to it to your hand."
           onActivate { r->
             if (r==PLAY_FROM_HAND) {
-              if (my.all.any{ it.evolution && it.name != "Shiftry" } && confirm("Evolutionary Fan - Return 1 of your evolved Pokemon, and all cards attached to it, back to your hand?")){
+              if (my.all.any{ it.evolution && it.name != "Shiftry" } && confirm("Evolutionary Fan - Return 1 of your evolved Pokémon, and all cards attached to it, back to your hand?")){
                 powerUsed()
-                def pcs = my.all.findAll{ it.evolution && it.name != "Shiftry" }.select("Which Pokemon, and all cards attached to it, will you bring back to your hand?")
+                def pcs = my.all.findAll{ it.evolution && it.name != "Shiftry" }.select("Which Pokémon, and all cards attached to it, will you bring back to your hand?")
                 scoopUpPokemon([:], pcs, delegate, POKEPOWER)
               }
             }
@@ -607,11 +607,11 @@ public enum LegendMaker implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert opp.bench.any{ it.evolution && it.stage2 } : "Opponent's bench does not have any evolved Stage 2 Pokemon."
+            assert opp.bench.any{ it.evolution && it.stage2 } : "Opponent's bench does not have any evolved Stage 2 Pokémon."
 
             powerUsed()
 
-            def pcs = opp.bench.findAll { it.evolution && it.stage2 }.select("Select a Stage 2 Pokemon to become the new Active.")
+            def pcs = opp.bench.findAll { it.evolution && it.stage2 }.select("Select a Stage 2 Pokémon to become the new Active.")
             sw2 (pcs, null, SRC_ABILITY)
           }
         }
@@ -889,12 +889,12 @@ public enum LegendMaker implements LogicCardInfo {
           text "If Magneton would be Knocked Out by damage from an opponent's attack, you may move any number of React Energy cards from Magneton to your Pokémon in any way you like."
           delayedA {
             before KNOCKOUT, self, {
-              if ((ef as Knockout).byDamageFromAttack && bg.currentTurn == self.owner.opposite && self.owner.pbg.bench && self.cards.any{it.name == "React Energy"} && confirm("Move any number of React Energy cards from Magneton to your other Pokemon?", self.owner)) {
+              if ((ef as Knockout).byDamageFromAttack && bg.currentTurn == self.owner.opposite && self.owner.pbg.bench && self.cards.any{it.name == "React Energy"} && confirm("Move any number of React Energy cards from Magneton to your other Pokémon?", self.owner)) {
                 def list = self.cards.findAll{it.name == "React Energy"}
                 def sel = list.select("Card to move", self.owner)
                 while(list) {
                   def card = sel.first()
-                  def tar = self.owner.pbg.all.findAll{it != self}.select("Select Pokemon to move React Energy to", self.owner)
+                  def tar = self.owner.pbg.all.findAll{it != self}.select("Select Pokémon to move React Energy to", self.owner)
                   energySwitch(self, tar, card)
                   list.remove(card)
                   if (list){
@@ -989,7 +989,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack {
-            def selected = my.deck.search(max: 1, "Search for a [G] Pokemon (excluding Pokemon-ex) to put into your hand.", {
+            def selected = my.deck.search(max: 1, "Search for a [G] Pokémon (excluding Pokémon-ex) to put into your hand.", {
               (it.cardTypes.is(POKEMON) && it.asPokemonCard().types.contains(G) && !it.asPokemonCard().cardTypes.is(EX))
             }).showToOpponent("Pinsir used Cry For Help.").moveTo(my.hand)
             shuffleDeck()
@@ -1097,7 +1097,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack {
-            def selected = deck.search (max: 1, "Search for a [R] Pokemon (excluding Pokemon-ex) to put into your hand.", {
+            def selected = deck.search (max: 1, "Search for a [R] Pokémon (excluding Pokémon-ex) to put into your hand.", {
               (it.cardTypes.is(POKEMON) && it.asPokemonCard().types.contains(R) && !it.asPokemonCard().cardTypes.is(EX))
             }).showToOpponent("Torkoal used Cry For Help.").moveTo(my.hand)
             shuffleDeck()
@@ -1161,7 +1161,7 @@ public enum LegendMaker implements LogicCardInfo {
           energyCost C
           attackRequirement {
             assert my.deck : "You have no cards in your deck"
-            assert my.bench.notFull : "Your bench is full"
+            assert my.bench.notFull : "Your bench is full."
           }
           onAttack {
             def maxSpace = Math.min(my.bench.freeBenchCount, 2)
@@ -1192,7 +1192,7 @@ public enum LegendMaker implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert self.active : "$self is not your Active Pokemon"
+            assert self.active : "$self is not your Active Pokémon"
             assert my.deck : "Deck is empty"
             powerUsed()
 
@@ -1327,7 +1327,7 @@ public enum LegendMaker implements LogicCardInfo {
           text "If your opponent has any Evolved Pokémon in play, choose 1 of them and flip a coin. If heads, remove the highest Stage Evolution card on that Pokémon and have your opponent shuffled it into his or her deck."
           energyCost C, C
           attackRequirement {
-            assert opp.bench.any{ it.evolution } : "Opponent has no evolved Pokemon"
+            assert opp.bench.any{ it.evolution } : "Opponent has no evolved Pokémon"
           }
           onAttack {
             def list = opp.all.findAll { it.evolution }
@@ -2056,7 +2056,7 @@ public enum LegendMaker implements LogicCardInfo {
         move "Pebble Throw", {
           text "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost C
-          attackRequirement { assert opp.bench : "Opponent has no benched Pokemon"}
+          attackRequirement { assert opp.bench : "Opponent has no benched Pokémon"}
           onAttack {
             damage 10, opp.bench.select()
           }
@@ -2277,7 +2277,7 @@ public enum LegendMaker implements LogicCardInfo {
             assert elegible : "You have no Omanyte, Kabuto, Aerodactyl, Aerodactyl ex, Lileep or Anorith in your hand"
             bc "Used Strange Cave effect"
             lastTurn = bg().turnCount
-            elegible.select("Select which Pokemon to bench").each {
+            elegible.select("Select which Pokémon to bench").each {
               benchPCS(it)
             }
           }
@@ -2358,7 +2358,7 @@ public enum LegendMaker implements LogicCardInfo {
       };
       case MYSTERIOUS_FOSSIL_79:
       return itemCard (this) {
-        text "Play Mysterious Fossil as if it were a Basic Pokemon. While in play, Mysterious Fossil counts as a [C] Pokemon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked out, it doesn't count as a Knocked Out Pokemon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
+        text "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a [C] Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
         onPlay {
           Card pokemonCard, trainerCard = thisCard
           pokemonCard = basic (new CustomCardInfo(MYSTERIOUS_FOSSIL_79).setCardTypes(BASIC, POKEMON), hp:HP050, type:COLORLESS, retreatCost:0) {
@@ -2551,7 +2551,7 @@ public enum LegendMaker implements LogicCardInfo {
           }
         }
         move "Vortex Chop", {
-          text "70 damage. If the Defending Pokemon has any Resistance, this attack's base damage is 100 instead of 70."
+          text "70 damage. If the Defending Pokémon has any Resistance, this attack's base damage is 100 instead of 70."
           energyCost F, C, C
           onAttack {
             if (defending.resistances) {
@@ -2587,7 +2587,7 @@ public enum LegendMaker implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert self.active : "This Pokemon is not the Active Pokemon"
+            assert self.active : "This Pokémon is not the Active Pokémon"
             assert all.any{it.numberOfDamageCounters} : "No Damage Counters in any Pokémon"
             powerUsed()
             def source = all.findAll{it.numberOfDamageCounters}.select("Source for damage counter")
@@ -2742,7 +2742,7 @@ public enum LegendMaker implements LogicCardInfo {
           }
         }
         move "Ice Throw", {
-          text "80 damage. If the Defending Pokemon is a [F] Pokemon, this attack's base damage is 120 instead of 80"
+          text "80 damage. If the Defending Pokémon is a [F] Pokémon, this attack's base damage is 120 instead of 80"
           energyCost W, W, C, C
           onAttack {
             if (defending.types.contains(F)) {

--- a/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
@@ -272,7 +272,7 @@ public enum PopSeries2 implements LogicCardInfo {
       // Commented for now, TechnicalMachineGroovyImpl needs to be made first.
         return copy(Expedition.MULTI_TECHNICAL_MACHINE_01_144, this);
       /*return basicTrainer (this) {
-        text "Attach this card to 1 of your Pokemon in play. This Pokemon may use this card's attack instead of its own. At the end of your turn, discard Multi Technical Machine 01"
+        text "Attach this card to 1 of your Pokémon in play. This Pokémon may use this card's attack instead of its own. At the end of your turn, discard Multi Technical Machine 01"
         def eff1, eff2
         onPlay {reason->
           def pcs = my.active

--- a/src/tcgwars/logic/impl/gen3/PopSeries3.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries3.groovy
@@ -338,7 +338,7 @@ public enum PopSeries3 implements LogicCardInfo {
       };
       case HIGH_PRESSURE_SYSTEM_10:
       return stadium (this) {
-        text "Each player pays [C] less to retreat his or her [R] and [W] Pokemon)"
+        text "Each player pays [C] less to retreat his or her [R] and [W] Pokémon)"
         def eff
         onPlay {
           eff = getter (GET_RETREAT_COST) { Holder h->
@@ -353,7 +353,7 @@ public enum PopSeries3 implements LogicCardInfo {
       };
       case LOW_PRESSURE_SYSTEM_11:
       return stadium (this) {
-        text "Each [G] and [L] Pokemon in play (both yours and your opponent's) gets +10 HP."
+        text "Each [G] and [L] Pokémon in play (both yours and your opponent's) gets +10 HP."
         def eff
         onPlay {
           eff = getter (GET_FULL_HP) { Holder h->

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -215,7 +215,7 @@ public enum PowerKeepers implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
             powerUsed()
             def cardsNum = Math.min(5, my.deck.size())
             def list=rearrange(my.deck.subList(0, cardsNum), "Rearrange the top ${cardsNum} cards in your deck.")
@@ -282,11 +282,11 @@ public enum PowerKeepers implements LogicCardInfo {
           }
           onAttack {
             //TODO: This could be made into a static, other cards do similar attacks with other types.
-            def selected = self.cards.filterByEnergyType(F).select(min:1, max:5, "Select up to 5 [F] Energy cards to discard; for each card discarded, this attack will do 20 damage to 1 opponent's Pokemon of your choosing (you can pick the same Pokémon more than once.)")
+            def selected = self.cards.filterByEnergyType(F).select(min:1, max:5, "Select up to 5 [F] Energy cards to discard; for each card discarded, this attack will do 20 damage to 1 opponent's Pokémon of your choosing (you can pick the same Pokémon more than once.)")
             def count = 0
             def selNum = selected.size()
             while (count++ < selNum){
-              noWrDamage ( 20, opp.all.select("Deal 20 damage to which Pokemon? ${count-1}/${selNum} Pokémon selected.") )
+              noWrDamage ( 20, opp.all.select("Deal 20 damage to which Pokémon? ${count-1}/${selNum} Pokémon selected.") )
             }
             afterDamage {
               selected.discard()
@@ -333,7 +333,7 @@ public enum PowerKeepers implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert my.bench : "No benched Pokemon"
+            assert my.bench : "No benched Pokémon"
             assert my.discard.filterByEnergyType(R) : "You have no [R] Energy cards in your discard pile"
             powerUsed()
 
@@ -436,8 +436,8 @@ public enum PowerKeepers implements LogicCardInfo {
             assert my.deck : "Deck is empty"
             powerUsed()
 
-            my.deck.search(max: 1, "Search for a [P] Energy card to attach to one of your Pokemon.", {Card card -> card.asEnergyCard().containsTypePlain(P)}).each {
-              def tar = my.all.select("Attach $it to? That Pokemon will receive 2 damage counters.")
+            my.deck.search(max: 1, "Search for a [P] Energy card to attach to one of your Pokémon.", {Card card -> card.asEnergyCard().containsTypePlain(P)}).each {
+              def tar = my.all.select("Attach $it to? That Pokémon will receive 2 damage counters.")
               attachEnergy(tar, it)
               directDamage 20, tar, SRC_ABILITY
             }
@@ -766,7 +766,7 @@ public enum PowerKeepers implements LogicCardInfo {
           text "If your opponent has any Evolved Pokémon in play, remove the highest Stage Evolution card from each of them and put those cards back into his or her hand."
           energyCost C
           attackRequirement {
-            assert opp.all.any{ it.evolution } : "Opponent does not have any Evolved Pokemon in play."
+            assert opp.all.any{ it.evolution } : "Opponent does not have any Evolved Pokémon in play."
           }
           onAttack {
             opp.all.findAll { it.evolution }.each {
@@ -803,7 +803,7 @@ public enum PowerKeepers implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack {
-            def selected = deck.search (max: 1, "Search for a [L] Pokemon (excluding Pokemon-ex) to put into your hand.", {
+            def selected = deck.search (max: 1, "Search for a [L] Pokémon (excluding Pokémon-ex) to put into your hand.", {
               (it.cardTypes.is(POKEMON) && it.asPokemonCard().types.contains(L) && !it.asPokemonCard().cardTypes.is(EX))
             }).moveTo(my.hand)
             shuffleDeck()
@@ -1904,7 +1904,7 @@ public enum PowerKeepers implements LogicCardInfo {
             before APPLY_SPECIAL_CONDITION, {
               def pcs = ef.getResolvedTarget(bg, e)
               if ( pcs.types.contains(D) && [ASLEEP, CONFUSED, PARALYZED].contains(ef.type) ) {
-                bc "Sidney's Stadium - [D] Pokemon can't be Asleep, Confused or Paralyzed."
+                bc "Sidney's Stadium - [D] Pokémon can't be Asleep, Confused or Paralyzed."
                 prevent()
               }
             }
@@ -1922,7 +1922,7 @@ public enum PowerKeepers implements LogicCardInfo {
           draw choose(1..opp.all.size(),"How many cards would you like to draw?")
         }
         playRequirement {
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
           assert my.hand.size() < 7 : "You have 7 or more cards in your hand (including this card)"
         }
       };

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -1532,7 +1532,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             onAttack {
               damage 10
               flip {
-                applyAfterDamage choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending pokemon")
+                applyAfterDamage choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending Pokémon.")
               }
             }
           }
@@ -1721,7 +1721,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             energyCost C
             onAttack {
               flip {
-                applyAfterDamage choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending pokemon")
+                applyAfterDamage choose([POISONED,ASLEEP,CONFUSED,BURNED,PARALYZED],"Choose 1 Special Condition to apply to the defending Pokémon.")
               }
             }
           }
@@ -2283,11 +2283,11 @@ public enum TeamRocketReturns implements LogicCardInfo {
           onPlay {
             def choice = choose([0,1],["Select 1 card : put it in your hand","Select 3 cards : shuffle them in your deck"],"What do you want to do?")
             if(choice){
-              my.discard.filterByType(BASIC, EVOLUTION).select(count : 3,"Select a combination of 3 Basic Pokémon or Evolution cards.").showToOpponent("Opponent used Pokemon Retriever to shuffle these cards into their deck").moveTo(my.deck)
+              my.discard.filterByType(BASIC, EVOLUTION).select(count : 3,"Select a combination of 3 Basic Pokémon or Evolution cards.").showToOpponent("Opponent used Pokémon Retriever to shuffle these cards into their deck").moveTo(my.deck)
               shuffleDeck()
             }
             else{
-              my.discard.filterByType(BASIC, EVOLUTION).select(count : 1,"Select 1 Basic Pokémon or Evolution").showToOpponent("Opponent used Pokemon Retriever to put this card into their hand").moveTo(my.hand)
+              my.discard.filterByType(BASIC, EVOLUTION).select(count : 1,"Select 1 Basic Pokémon or Evolution").showToOpponent("Opponent used Pokémon Retriever to put this card into their hand").moveTo(my.hand)
             }
           }
           playRequirement{
@@ -2312,7 +2312,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           }
           playRequirement{
             assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You need more Prize cards left than your opponent to use this card"
-            assert opp.bench : "Your opponent has no Benched Pokémon"
+            assert opp.bench : "Your opponent has no Benched Pokémon."
           }
         };
       case ROCKET_S_ADMIN__86:

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -314,7 +314,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Search your deck for up to 2 [G] Pokémon, show them to your opponent, and put them into your hand. Shuffle your deck afterward. If you put any [G] Pokémon into your hand, you may switch Bellossom with 1 of your Benched Pokémon."
           energyCost G
           attackRequirement {
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
           onAttack {
             def cards = deck.search(min:0, max: 2, pokemonTypeFilter(G))
@@ -550,7 +550,7 @@ public enum UnseenForces implements LogicCardInfo {
           onAttack {
             damage 50
 
-            if (confirm("Would you like to add damage counters to increase the damage dealt to the defending Pokemon?"))
+            if (confirm("Would you like to add damage counters to increase the damage dealt to the defending Pokémon?"))
               {
                 def num = choose([1,2,3,4,5])
                 damage 10 * num
@@ -634,7 +634,7 @@ public enum UnseenForces implements LogicCardInfo {
           actionA {
             checkNoSPC()
             def tar = my.all.findAll { it.cards.filterByType(POKEMON_TOOL) }
-            assert tar: "None of your Pokemon have a Pokémon Tool card attached to them"
+            assert tar: "None of your Pokémon have a Pokémon Tool card attached to them"
             powerUsed()
             def pcs = tar.select()
             def tools = pcs.cards.filterByType(POKEMON_TOOL)
@@ -699,9 +699,9 @@ public enum UnseenForces implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
             powerUsed()
-            my.deck.search("Select one Pokemon Tool Card", {it.cardTypes.is(POKEMON_TOOL)} ).moveTo(my.hand)
+            my.deck.search("Select one Pokémon Tool Card", {it.cardTypes.is(POKEMON_TOOL)} ).moveTo(my.hand)
             shuffleDeck()
           }
         }
@@ -994,7 +994,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "10x damage. Does 10 damage times the number of your opponent's Benched Pokémon."
           energyCost F, C
           attackRequirement{
-            assert opp.bench : "Your opponent has no Benched Pokémon"
+            assert opp.bench : "Your opponent has no Benched Pokémon."
           }
           onAttack {
             damage 10 * opp.bench.size()
@@ -1030,7 +1030,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost F
           attackRequirement{
-            assert opp.bench : "Your opponent has no Benched Pokémon"
+            assert opp.bench : "Your opponent has no Benched Pokémon."
           }
           onAttack {
             damage 10, opp.bench.select("Deal 10 damage to which Pokémon?")
@@ -1150,7 +1150,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
           energyCost C
           attackRequirement{
-            assert opp.bench : "Your opponent has no Benched Pokémon"
+            assert opp.bench : "Your opponent has no Benched Pokémon."
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
@@ -1183,7 +1183,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Put 1 damage counter on 1 of your opponent's Pokémon."
           energyCost C
           onAttack {
-            directDamage 10, opp.all.select("Select a Pokemon to put a damage counter on")
+            directDamage 10, opp.all.select("Select a Pokémon to put a damage counter on")
           }
         }
       };
@@ -1245,7 +1245,7 @@ public enum UnseenForces implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert bg.em().retrieveObject("Snappy_Move") != bg.turnCount : "You can't use more than 1 Snappy Move Poké-Power each turn."
-            assert self.benched : "This Pokemon is not on your Bench"
+            assert self.benched : "This Pokémon is not on your Bench"
             assert my.deck : "You do not have any cards left in your deck"
             bg.em().storeObject("Snappy_Move", bg.turnCount)
             powerUsed()
@@ -1314,7 +1314,7 @@ public enum UnseenForces implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack {
-            my.deck.search (max: 1, "Search for a [W] or [F] Pokemon (excluding Pokemon-ex) to put into your hand.", {
+            my.deck.search (max: 1, "Search for a [W] or [F] Pokémon (excluding Pokémon-ex) to put into your hand.", {
               (it.cardTypes.is(POKEMON) && !it.asPokemonCard().cardTypes.is(EX) && (it.asPokemonCard().types.contains(W) || it.asPokemonCard().types.contains(F)))
             }).moveTo(my.hand)
             shuffleDeck()
@@ -1324,7 +1324,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W
           attackRequirement {
-            assert opp.bench: "Opponent does not have any Benched Pokemon"
+            assert opp.bench: "Opponent does not have any Benched Pokémon"
           }
           onAttack {
             multiSelect(opp.bench, 2).each {
@@ -1458,7 +1458,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Flip 2 coins. For each heads, remove 2 damage counters from 1 of your Pokémon."
           energyCost C
           attackRequirement {
-            assert my.all.findAll { it.numberOfDamageCounters }: "No damaged Pokemon"
+            assert my.all.findAll { it.numberOfDamageCounters }: "No damaged Pokémon"
           }
           onAttack {
             flip 2, {
@@ -1613,7 +1613,7 @@ public enum UnseenForces implements LogicCardInfo {
             def validTargets = my.all.findAll{
               it.cards.filterByType(BASIC_ENERGY) && !it.EX
             }
-            assert validTargets : "Your Non-ex Pokemon do not have Basic Energy cards."
+            assert validTargets : "Your Non-ex Pokémon do not have Basic Energy cards."
             assert my.discard.filterByType(BASIC_ENERGY) : "No Basic Energies in you discard pile."
 
             powerUsed()
@@ -2447,7 +2447,7 @@ public enum UnseenForces implements LogicCardInfo {
         onPlay { reason->
           if (reason == PLAY_FROM_HAND && self.active) {
             if (opp.bench) {
-              sw(opp.active, opp.bench.oppSelect("Cyclone Energy was played, which Pokemon to switch with the Active?"), SRC_SPENERGY)
+              sw(opp.active, opp.bench.oppSelect("Cyclone Energy was played, which Pokémon to switch with the Active?"), SRC_SPENERGY)
             }
           }
         }
@@ -3103,10 +3103,10 @@ public enum UnseenForces implements LogicCardInfo {
           text "Once during your turn, if Rocket's Persian ex is on your Bench, you may search your deck for a Pokémon with Dark or Rocket's in its name. Show it to your opponent and put it into your hand. Shuffle your deck afterward."
           actionA {
             checkLastTurn()
-            assert my.deck : "There are no more cards in your deck"
-            assert self.benched : "This Pokemon is not benched"
+            assert my.deck : "There are no more cards in your deck."
+            assert self.benched : "This Pokémon is not benched"
             powerUsed()
-            def card = my.deck.search("Select a Pokemon with Dark or Rocket's in its name to put into your hand", {
+            def card = my.deck.search("Select a Pokémon with Dark or Rocket's in its name to put into your hand", {
               it.cardTypes.is(POKEMON) &&
               (it.name.contains("Rocket's ") || it.name.contains("Dark "))
             })
@@ -3203,7 +3203,7 @@ public enum UnseenForces implements LogicCardInfo {
           onAttack {
             def myCard = my.hand.select("Select a card for your opponent to guess.")
 
-            def opponentChoice = oppChoose([1,2,3], ['Pokemon', 'Trainer', 'Energy'], "Guess the type of card your opponent has chosen")
+            def opponentChoice = oppChoose([1,2,3], ['Pokémon', 'Trainer', 'Energy'], "Guess the type of card your opponent has chosen")
 
             myCard.showToOpponent("Your Opponent's chosen card.")
             if (
@@ -3536,7 +3536,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Search your deck for up to 2 Pokémon Tool cards and attach them to any of your Pokémon (excluding Pokémon that already have a Pokémon Tool attached to them). Shuffle your deck afterward."
           energyCost C
           attackRequirement {
-            assert my.all.findAll({!(it.cards.filterByType(POKEMON_TOOL))}) : "Your Pokemon already have tools attached to them."
+            assert my.all.findAll({!(it.cards.filterByType(POKEMON_TOOL))}) : "Your Pokémon already have tools attached to them."
             assert my.deck : "Deck is empty."
           }
           onAttack {
@@ -3583,7 +3583,7 @@ public enum UnseenForces implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned and Confused."
           energyCost P, C
           attackRequirement{
-            assert opp.bench : "Your opponent has no Benched Pokémon"
+            assert opp.bench : "Your opponent has no Benched Pokémon."
           }
           onAttack {
             def target = opp.bench.select("Select the new Active Pokémon.")
@@ -4285,9 +4285,9 @@ public enum UnseenForces implements LogicCardInfo {
           energyCost C
           onAttack {
             flip 1, {
-              directDamage 20, opp.all.select("Put 2 damage counters on which Pokemon?")
+              directDamage 20, opp.all.select("Put 2 damage counters on which Pokémon?")
             }, {
-              directDamage 20, my.all.select("Put 2 damage counters on which Pokemon?")
+              directDamage 20, my.all.select("Put 2 damage counters on which Pokémon?")
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1033,7 +1033,7 @@ public enum DiamondPearl implements LogicCardInfo {
             text "Flip a coin until you get tails. Remove a number of damage counters equal to the number of heads from 1 of your Pokémon."
             energyCost C
             attackRequirement {
-              assert my.all.findAll { it.numberOfDamageCounters }: "No damaged Pokemon"
+              assert my.all.findAll { it.numberOfDamageCounters }: "No damaged Pokémon"
             }
             onAttack {
               def healAmount = 0
@@ -1993,7 +1993,7 @@ public enum DiamondPearl implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert self.benched : "$self is not on the Bench"
-              assert my.bench.notFull : "Your bench is full"
+              assert my.bench.notFull : "Your bench is full."
               powerUsed()
               flip {
                 deck.search (count: 1,{it.name.contains("Unown")}).each {
@@ -2289,7 +2289,7 @@ public enum DiamondPearl implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
             energyCost G
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assert opp.bench : "Your opponent has no Benched Pokémon."
             }
             onAttack {
               def target = opp.bench.select("Select the new Active Pokémon.")
@@ -2400,7 +2400,7 @@ public enum DiamondPearl implements LogicCardInfo {
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
           move "Horn Attack", {
-            text "10 damage. "
+            text "10 damage."
             energyCost C
             attackRequirement {}
             onAttack {
@@ -2444,7 +2444,7 @@ public enum DiamondPearl implements LogicCardInfo {
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS10
           move "Low Kick", {
-            text "20 damage. "
+            text "20 damage."
             energyCost F
             attackRequirement {}
             onAttack {
@@ -3103,7 +3103,7 @@ public enum DiamondPearl implements LogicCardInfo {
             actionA {
               checkNoSPC()
               checkLastTurn()
-              assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You need to have more Prize cards left than your opponent in order to use this Poké-Power"
+              assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You need to have more Prize cards left than your opponent in order to use this Poké-Power."
               assert opp.bench : "Your opponent has no benched Pokémon."
               powerUsed()
               //TODO: Check against immunity to pokéPower.

--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -599,7 +599,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F
           move "Drag Off", {
-            text "30 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokemon and switch it with the Defending Pokemon."
+            text "30 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
             energyCost C, C, C
             attackRequirement {}
             onAttack {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2173,7 +2173,7 @@ public enum GreatEncounters implements LogicCardInfo {
         return basicTrainer (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDiscard up to 2 cards from your hand. If you discard 1 card, draw 3 cards. If you discard 2 cards, draw 4 cards."
           playRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
             assert my.hand.size() > 1 : "You can't play this card"
           }
           onPlay {

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -657,7 +657,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               damage 20
               afterDamage{
                 if(my.bench) {
-                  def pcs = my.bench.select("Select the new active pokemon")
+                  def pcs = my.bench.select("Select the new active Pokémon.")
                   sw my.active, pcs
                 }
               }
@@ -719,7 +719,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               damage 20, self
               afterDamage{
                 if(my.bench) {
-                  def pcs = my.bench.select("Select the new active pokemon")
+                  def pcs = my.bench.select("Select the new active Pokémon.")
                   sw my.active, pcs
                 }
               }
@@ -863,13 +863,13 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             energyCost ()
             onAttack {
               if(my.bench.notFull) {
-                deck.search (max:my.bench.freeBenchCount,"Please search for Basic Pokemon to put on your bench.",cardTypeFilter(BASIC)).each {
+                deck.search (max:my.bench.freeBenchCount,"Please search for Basic Pokémon to put on your bench.",cardTypeFilter(BASIC)).each {
                   benchPCS(it)
                 }
                 shuffleDeck()
               }
               if(opp.bench.notFull) {
-                opp.deck.oppSelect(min:0,max:opp.bench.getFreeBenchCount(),"Pichu used Playground: Each player may search his or her deck for as many Basic Pokémon as he or she likes, put them onto his or her Bench. Please search for Basic Pokemon to put on your bench.",cardTypeFilter(BASIC)).each{
+                opp.deck.oppSelect(min:0,max:opp.bench.getFreeBenchCount(),"Pichu used Playground: Each player may search his or her deck for as many Basic Pokémon as he or she likes, put them onto his or her Bench. Please search for Basic Pokémon to put on your bench.",cardTypeFilter(BASIC)).each{
                   benchPCS(it, OTHER)
                 }
                 shuffleDeck(null, TargetPlayer.OPPONENT)
@@ -1684,7 +1684,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               damage 10
               afterDamage{
                 if(my.bench) {
-                  def pcs = my.bench.select("Select the new active pokemon")
+                  def pcs = my.bench.select("Select the new active Pokémon.")
                   sw my.active, pcs
                 }
               }
@@ -2142,7 +2142,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
         return supporter (this) {
           text "Search your deck for up to 3 Basic Pokémon, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
           onPlay {
-            my.deck.search(max : 3,"Select up to 3 basic pokemon", {it.cardTypes.is(BASIC)}).moveTo(my.hand)
+            my.deck.search(max : 3,"Select up to 3 basic Pokémon.", {it.cardTypes.is(BASIC)}).moveTo(my.hand)
             shuffleDeck()
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -3054,7 +3054,7 @@ public enum LegendsAwakened implements LogicCardInfo {
             energyCost P
             attackRequirement {}
             onAttack {
-              def tar = opp.all.select("Choose a Pokemon to put damage counters on")
+              def tar = opp.all.select("Choose a Pokémon to put damage counters on")
               int count = 0
               opp.all.each{count += it.cards.energyCount(C)}
               directDamage 10*count, tar
@@ -3168,7 +3168,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkNoSPC()
               checkLastTurn()
               assert bg.em().retrieveObject("Trade_Off") != bg.turnCount : "You cannot use more than one Trade Off per turn"
-              assert my.deck : "Your deck is empty"
+              assert my.deck : "Your deck is empty!"
               bg.em().storeObject("Trade_Off",bg.turnCount)
               powerUsed()
               def sel = my.deck.subList(0,2).select("Choose 1 card to put into your hand")

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2024,10 +2024,10 @@ public enum MajesticDawn implements LogicCardInfo {
             actions = action("Call Energy", [TargetPlayer.SELF]) {
               assert self.active : "Not active"
               assert my.bench.notFull : "Bench full"
-              assert my.deck : "Your deck is empty"
+              assert my.deck : "Your deck is empty!"
               bc "Used Call Energy effect"
               int count = bench.freeBenchCount>=2?2:1
-              my.deck.search (max: count,"Search your deck for up to 2 Basic Pokemon and put them onto your Bench", cardTypeFilter(BASIC)).each {
+              my.deck.search (max: count,"Search your deck for up to 2 Basic Pokémon and put them onto your Bench", cardTypeFilter(BASIC)).each {
                 benchPCS(it)
               }
               shuffleDeck()

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -726,7 +726,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             actionA {
               checkLastTurn()
               checkNoSPC()
-              assert my.bench : "No benched Pokemon"
+              assert my.bench : "No benched Pokémon"
               assert my.discard.filterByEnergyType(R) : "You have no [R] Energy cards in your discard pile"
               powerUsed()
 

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -1478,7 +1478,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
             onAttack {
               if (opp.active.cards.filterByType(ENERGY) && opp.bench) {
-                def energy = opp.active.findAll{it.cards.filterByType(ENERGY)}.select("Select energy to move to benched Pokemon").first()
+                def energy = opp.active.findAll{it.cards.filterByType(ENERGY)}.select("Select energy to move to benched Pokémon").first()
                 def tar = opp.bench.select("Select the Pokémon to move energy to")
                 energySwitch(opp.active, tar, energy)
               }
@@ -2213,9 +2213,9 @@ public enum RisingRivals implements LogicCardInfo {
         return basicTrainer (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nMove as many Energy cards attached to 1 of your Pokémon as you like to another of your Pokémon."
           onPlay {
-            def src = my.all.findAll{it.cards.filterByType(ENERGY)}.select("Select Pokemon to move energy from").first()
+            def src = my.all.findAll{it.cards.filterByType(ENERGY)}.select("Select Pokémon to move energy from").first()
             def energyList = src.cards.filterByType(ENERGY).select(min:1, "Choose energy cards to move")
-            tar = my.all.findAll{it != src}.select("Choose Pokemon to move energy cards to").first()
+            tar = my.all.findAll{it != src}.select("Choose Pokémon to move energy cards to").first()
             energyList.each {
               energySwitch(src, tar, it)
             }
@@ -2419,7 +2419,7 @@ public enum RisingRivals implements LogicCardInfo {
             onAttack {
               if(reason==PLAY_FROM_HAND && opp.bench && confirm("Use Bright Look?")) {
                 powerUsed()
-                sw opp.active, opp.bench.select("Choose your opponent's new active Pokemon"), SRC_ABILITY
+                sw opp.active, opp.bench.select("Choose your opponent's new active Pokémon"), SRC_ABILITY
             }
           }
         }
@@ -2429,7 +2429,7 @@ public enum RisingRivals implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 60
-              damage 30, my.all.choose("Choose Pokemon to do 30 damage to")
+              damage 30, my.all.choose("Choose Pokémon to do 30 damage to")
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -2757,7 +2757,7 @@ public enum SecretWonders implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
         };
       case TEAM_GALACTIC_S_MARS_126:

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -2336,7 +2336,7 @@ public enum Stormfront implements LogicCardInfo {
               checkLastTurn()
               checkNoSPC()
               powerUsed()
-              def pcs = my.all.select("Choose one of your Pokemon to knock out")
+              def pcs = my.all.select("Choose one of your Pokémon to knock out")
               new Knockout(pcs).run(bg)
               attachEnergyFrom(basic:true,my.discard, my.all)
               attachEnergyFrom(basic:true,my.discard, my.all)

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -174,7 +174,7 @@ public enum Undaunted implements LogicCardInfo {
             actionA {
               checkLastTurn()
               checkNoSPC()
-              assert my.all.findAll{it.numberOfDamageCounters} : "No damage on your Pokemon"
+              assert my.all.findAll{it.numberOfDamageCounters} : "No damage on your Pokémon"
               powerUsed()
               my.all.each{ heal 10, it, SRC_ABILITY }
             }

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -208,7 +208,7 @@ public enum Unleashed implements LogicCardInfo {
               while (max-- > 0) {
                 def tar = opp.all.findAll{ it.evolution }
                 if(!tar) break
-                def pcs = tar.select("Choose which Pokemon to devolve", false)
+                def pcs = tar.select("Choose which Pokémon to devolve", false)
                 if(!pcs) break
                 def top=pcs.topPokemonCard
                 devolve(pcs, top, opp.hand)
@@ -348,7 +348,7 @@ public enum Unleashed implements LogicCardInfo {
             actionA {
               checkLastTurn()
               checkNoSPC()
-              assert my.bench.findAll{it.types.contains(W)} : "No benched Water Pokemon"
+              assert my.bench.findAll{it.types.contains(W)} : "No benched Water Pokémon"
               powerUsed()
               sw my.active, my.bench.findAll{it.types.contains(W)}.select()
             }
@@ -1143,7 +1143,7 @@ public enum Unleashed implements LogicCardInfo {
             onAttack {
               damage 10
               if (opp.bench) {
-                damage 10, opp.bench.select("Which Benched Pokemon to deal damage to?")
+                damage 10, opp.bench.select("Which Benched Pokémon to deal damage to?")
               }
             }
           }
@@ -1683,7 +1683,7 @@ public enum Unleashed implements LogicCardInfo {
           onPlay {
             flip 1, {
               if (my.discard.filterByType(POKEMON)) {
-                my.discard.filterByType(POKEMON).select("Select a Pokemon").showToOpponent("Selected Pokemon").moveTo(addToTop:true, my.deck)
+                my.discard.filterByType(POKEMON).select("Select a Pokémon").showToOpponent("Selected Pokémon").moveTo(addToTop:true, my.deck)
               }
             }, {
               if (my.discard.filterByType(TRAINER)) {
@@ -1692,7 +1692,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.discard.filterByType(POKEMON,TRAINER) : "No Pokemon or Trainer in your discard"
+            assert my.discard.filterByType(POKEMON,TRAINER) : "No Pokémon or Trainer in your discard"
           }
         };
       case INTERVIEWER_S_QUESTIONS_77:
@@ -1713,7 +1713,7 @@ public enum Unleashed implements LogicCardInfo {
           text "Flip a coin. If heads, choose 1 of your Pokémon, and remove all Special Conditions and 6 damage counters from that Pokémon (all if there are less than 6)."
           onPlay {
             flip 1, {
-              my.all.findAll {it.numberOfDamageCounters || it.specialConditions}.select("Choose Pokemon to be healed").each{
+              my.all.findAll {it.numberOfDamageCounters || it.specialConditions}.select("Choose Pokémon to be healed").each{
                 heal 60, it
                 clearSpecialCondition(it, Source.TRAINER_CARD)
               }

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -288,7 +288,7 @@ public enum BurningShadows implements LogicCardInfo {
             text "Heal all damage from all of your Pokémon. Shuffle this Pokémon and all cards attached to it into your deck."
             energyCost G
             attackRequirement {
-              assert my.bench.notEmpty : "This is your only pokemon"
+              assert my.bench.notEmpty : "This is your only Pokémon."
             }
             onAttack {
               my.all.each {heal(it.damage.value, it)}
@@ -1555,7 +1555,7 @@ public enum BurningShadows implements LogicCardInfo {
             energyCost C, C, C
             attackRequirement {
               gxCheck()
-              assert opp.all.findAll {it.pokemonGX || it.pokemonEX} : "No opponent Pokemon-GX or Pokemon-EX in play"
+              assert opp.all.findAll {it.pokemonGX || it.pokemonEX} : "No opponent Pokémon-GX or Pokémon-EX in play"
             }
             onAttack {
               gxPerform()

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -4065,7 +4065,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost F, L
             onAttack {
               damage 90
-              if (self.cards.filterByType(POKEMON_TOOL) && confirm("Discard a Pokémon Tool card from this Pokemon to do 90 more damage?")) {
+              if (self.cards.filterByType(POKEMON_TOOL) && confirm("Discard a Pokémon Tool card from this Pokémon to do 90 more damage?")) {
                 self.cards.filterByType(POKEMON_TOOL).select().discard()
                 damage 90
               }

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1195,7 +1195,7 @@ public enum DragonMajesty implements LogicCardInfo {
               while (1) {
                 def tar = my.all.findAll {it.cards.filterByEnergyType(R).notEmpty()}
                 if (!tar) break
-                def pcs = tar.select("Pokemon that has [R] energy to discard. Cancel to stop", false)
+                def pcs = tar.select("Pokémon that has [R] energy to discard. Cancel to stop", false)
                 if (!pcs) break
                 pcs.cards.filterByEnergyType(R).select("[R] Energy to discard").discard()
                 count++

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -3070,16 +3070,16 @@ public enum GuardiansRising implements LogicCardInfo {
           onPlay {
             def i = 2
             while(i-- > 0){
-              if (bg.stadiumInfoStruct && confirm("Would you like to discard stadium in play (${bg.stadiumInfoStruct.stadiumCard})? If not, you can select a Pokemon Tool in play")) {
+              if (bg.stadiumInfoStruct && confirm("Would you like to discard stadium in play (${bg.stadiumInfoStruct.stadiumCard})? If not, you can select a Pokémon Tool in play")) {
                 if (stadiumCanBeAffectedByItemAndSupporter())
                   discard bg.stadiumInfoStruct.stadiumCard
                 continue
               }
               def tar = all.findAll {it.cards.hasType(POKEMON_TOOL)}
               if(tar) {
-                def sel = tar.select("Select Pokemon to discard a Pokemon Tool from (cancel to stop)", i == 1)
+                def sel = tar.select("Select Pokémon to discard a Pokémon Tool from (cancel to stop)", i == 1)
                 if(sel){
-                  def list = sel.cards.filterByType(POKEMON_TOOL).select("Discard a Pokemon Tool from $sel")
+                  def list = sel.cards.filterByType(POKEMON_TOOL).select("Discard a Pokémon Tool from $sel")
                   targeted (sel, TRAINER_CARD) {
                     list.discard()
                   }

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -545,7 +545,7 @@ public enum HiddenFates implements LogicCardInfo {
           text "Flip 4 coins. For each heads, search your deck for a [L] Energy card and attach it to 1 of your Pokémon-GX or Pokémon-EX. Then, shuffle your deck."
           energyCost C, C
           attackRequirement {
-            assert deck : "Your deck is empty"
+            assert deck : "Your deck is empty!"
           }
           onAttack {
             if(my.all.findAll {it.pokemonGX || it.pokemonEX}) {

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -447,7 +447,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Once during your turn (before your attack), you may use this Ability. Choose 1 of your Basic Pokémon in play. If you have a Stage 2 card in your hand that evolves from that Pokémon, put that card onto the Basic Pokémon to evolve it. You can use this Ability during your first turn or on a Pokémon that was put into play this turn."
             actionA{
               checkLastTurn()
-              assert my.all.findAll {it.basic} : "You have no basic pokemon"
+              assert my.all.findAll {it.basic} : "You have no basic Pokémon."
               assert my.hand.filterByType(STAGE2) : "You have no Stage 2 in hand"
               def tar = my.all.findAll {it.basic}.select("Choose the pokemon to be evolved")
               def possibleEvolutions = my.hand.filterByType(STAGE2).findAll{
@@ -1403,7 +1403,7 @@ public enum LostThunder implements LogicCardInfo {
               while (1) {
                 def tar = my.all.findAll {it.cards.filterByEnergyType(R).findAll {!toBeMoved.contains(it)}.notEmpty()}
                 if (!tar) break
-                def pcs = tar.select("Pokemon that has [R] energy to put in the Lost Zone. Cancel to stop", false)
+                def pcs = tar.select("Pokémon that has [R] energy to put in the Lost Zone. Cancel to stop", false)
                 if (!pcs) break
                 def dd = pcs.cards.filterByEnergyType(R).findAll {!toBeMoved.contains(it)}.select("[R] Energy to put in the Lost Zone")
                 toBeMoved.addAll(dd)
@@ -2192,7 +2192,7 @@ public enum LostThunder implements LogicCardInfo {
               my.bench.each {
                 count = count + it.numberOfDamageCounters
               }
-              assert count >= 66 : "You need ${66 - count} more damage counters on your Benched Pokemon."
+              assert count >= 66 : "You need ${66 - count} more damage counters on your Benched Pokémon."
               assert self.active : "Counters OK but $self must be active"
               powerUsed()
               bg.getGame().endGame(self.owner, WinCondition.OTHER);
@@ -2314,7 +2314,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Once during your turn (before your attack), you may discard all cards attached to this Pokémon and attach it to 1 of your Pokémon as a Pokémon Tool card. When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 fewer Prize card."
             actionA {
               checkLastTurn()
-              assert my.bench.notEmpty : "$self is your last pokemon"
+              assert my.bench.notEmpty : "$self is your last Pokémon."
               assert my.all.findAll {it!=self && it.cards.filterByType(POKEMON_TOOL).empty} : "No place to attach"
               powerUsed()
               def top = self.topPokemonCard
@@ -3277,7 +3277,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Look at the top 8 cards of your deck and attach any number of Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck.\n"
             energyCost Y
             attackRequirement{
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack{
               my.deck.subList(0,8).showToMe("Top 8 cards of your deck")
@@ -3307,7 +3307,7 @@ public enum LostThunder implements LogicCardInfo {
             text "20× damage. Discard up to 2 Trainer cards from your hand. This attack does 20 damage for each card you discarded in this way."
             energyCost Y
             attackRequirement{
-              assert my.hand.filterByType(TRAINER) : "No trainer in hand"
+              assert my.hand.filterByType(TRAINER) : "There are no Trainer cards in your hand."
             }
             onAttack{
               damage 20*my.hand.filterByType(TRAINER).select(max:2,"discard up to 2 Trainer cards for 20 damage").discard().size()
@@ -3384,7 +3384,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Search your deck for up to 3 cards and put them into your hand. Then, shuffle your deck.\n"
             energyCost Y
             attackRequirement {
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack {
               my.deck.select(max: 3).moveTo(hidden: true, my.hand)
@@ -3427,7 +3427,7 @@ public enum LostThunder implements LogicCardInfo {
               delayed{
                 before null, self, Source.ATTACK, {
                   if (self.owner.opposite.pbg.active.hasModernAbility() && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
-                    bc "Wonder Ray prevents effect"
+                    bc "Wonder Ray prevents effect."
                     prevent()
                   }
                 }
@@ -3435,7 +3435,7 @@ public enum LostThunder implements LogicCardInfo {
                   bg.dm().each {
                     if(it.to == self && it.notNoEffect && it.from.hasModernAbility()){
                       it.dmg = hp(0)
-                      bc "Wonder Ray prevents damage"
+                      bc "Wonder Ray prevents damage."
                     }
                   }
                 }
@@ -3490,7 +3490,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Heal 30 damage from 1 of your Pokémon."
             energyCost C
             attackRequirement {
-              assert my.all.findAll{it.numberOfDamageCounters} : "There are no damaged pokemon to heal"
+              assert my.all.findAll{it.numberOfDamageCounters} : "There are no damaged Pokémon to heal"
             }
             onAttack{
               heal 30, my.all.findAll{it.numberOfDamageCounters}.select("Heal")
@@ -3599,7 +3599,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost Y
             attackRequirement{
               gxCheck()
-              assert opp.bench : "Your opponent does not have benched Pokémon"
+              assert opp.bench : "Your opponent does not have any benched Pokémon."
             }
             onAttack{
               gxPerform()
@@ -4045,7 +4045,7 @@ public enum LostThunder implements LogicCardInfo {
         };
       case CUSTOM_CATCHER_171:
         return itemCard (this) {
-          text "You may play 2 Custom Catcher cards at once.If you played 1 card, draw cards from your deck until you have 3 cards in your hand.If you played 2 cards, switch 1 of your opponent's Benched Pokémon with their Active Pokémon. (This effect works one time for 2 cards.)\nYou may play as many Item cards as you like during your turn (before your attack)."
+          text "You may play 2 Custom Catcher cards at once. If you played 1 card, draw cards from your deck until you have 3 cards in your hand.If you played 2 cards, switch 1 of your opponent's Benched Pokémon with their Active Pokémon. (This effect works one time for 2 cards.)\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
             int toDraw = Math.max(0, 3 - my.hand.getExcludedList(thisCard).size())
             if(opp.bench && my.hand.findAll({it.name=="Custom Catcher"}).size()>=2) {
@@ -4307,7 +4307,7 @@ public enum LostThunder implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case MIXED_HERBS_184:
@@ -4341,7 +4341,7 @@ public enum LostThunder implements LogicCardInfo {
           onPlay {
             def tar = my.all.findAll{(it.numberOfDamageCounters !=0)}
             if(tar){
-              def pcs = tar.select("Select the pokémon to be healed")
+              def pcs = tar.select("Select the Pokémon to be healed")
 
               flip 2,{
                 heal 30, pcs
@@ -4370,7 +4370,7 @@ public enum LostThunder implements LogicCardInfo {
             my.deck.search("Choose Basic [G] Pokémon or a [G] Energy card",{(it.cardTypes.is(BASIC) && it.asPokemonCard().types.contains(G)) || (it.cardTypes.is(BASIC_ENERGY) && it.asEnergyCard().containsTypePlain(G) )}).moveTo(my.hand)
           }
           playRequirement{
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case PROFESSOR_ELM_S_LECTURE_188:
@@ -4380,7 +4380,7 @@ public enum LostThunder implements LogicCardInfo {
             my.deck.search(max : 3, "Choose up to 3 Pokémon with 60 HP or less",{it.cardTypes.is(POKEMON) && it.asPokemonCard().hp.value <= 60}).showToOpponent("Chosen Pokémon cards.").moveTo(my.hand)
           }
           playRequirement{
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case SIGHTSEER_189:
@@ -4449,7 +4449,7 @@ public enum LostThunder implements LogicCardInfo {
           }
           playRequirement{
             assert bg.turnCount == 2 : "This card is now useless"
-            assert opp.all.findAll {it.cards.energyCount(C)} : "There are no energy cards attached to your opponent's pokémon"
+            assert opp.all.findAll {it.cards.energyCount(C)} : "There are no energy cards attached to your opponent's Pokémon."
           }
         };
       case WHITNEY_193:

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -436,7 +436,7 @@ public enum ShiningLegends implements LogicCardInfo {
               checkLastTurn()
               assert opp.bench : "No opponent bench"
               powerUsed()
-              sw(opp.active, opp.bench.oppSelect("New Active Pokemon"))
+              sw(opp.active, opp.bench.oppSelect("New Active Pokémon"))
             }
           }
           move "Heat Blast", {
@@ -672,7 +672,7 @@ public enum ShiningLegends implements LogicCardInfo {
             actionA {
               checkLastTurn()
               def tar = my.all.findAll {it.numberOfDamageCounters && it.cards().energyCount(W)}
-              assert tar : "No suitable pokemon"
+              assert tar : "No suitable Pokémon."
               powerUsed()
               heal 20, tar.select("Heal 20 damage"), SRC_ABILITY
             }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1130,7 +1130,7 @@ public enum SunMoon implements LogicCardInfo {
             text "Heal all damage from all of your Pokémon. (You can't use more than 1 GX attack per game.)"
             energyCost C, C
             attackRequirement {
-              assert my.all.findAll {it.numberOfDamageCounters} : "Your Pokemon are allright"
+              assert my.all.findAll {it.numberOfDamageCounters} : "Your Pokémon are allright"
               gxCheck()
             }
             onAttack {
@@ -1644,7 +1644,7 @@ public enum SunMoon implements LogicCardInfo {
             energyCost P, P, P
             attackRequirement {
               gxCheck()
-              assert opp.all.findAll {it.basic && !it.pokemonGX} : "Opponent has no suitable pokemon"
+              assert opp.all.findAll {it.basic && !it.pokemonGX} : "Opponent has no suitable Pokémon."
             }
             onAttack {
               gxPerform()
@@ -1740,7 +1740,7 @@ public enum SunMoon implements LogicCardInfo {
               while (1) {
                 def tar = my.all.findAll {it.cards.filterByEnergyType(F).notEmpty()}
                 if (!tar) break
-                def pcs = tar.select("Pokemon that has [F] energy to discard. Cancel to stop", false)
+                def pcs = tar.select("Pokémon that has [F] energy to discard. Cancel to stop", false)
                 if (!pcs) break
                 pcs.cards.filterByEnergyType(F).select("[F] Energy to discard").discard()
                 count++
@@ -2241,7 +2241,7 @@ public enum SunMoon implements LogicCardInfo {
             text "Once during your turn (before your attack), you may heal 20 damage from 1 of your Pokémon."
             actionA {
               checkLastTurn()
-              assert my.all.findAll {it.numberOfDamageCounters} : "No suitable pokemon"
+              assert my.all.findAll {it.numberOfDamageCounters} : "No suitable Pokémon."
               powerUsed()
               def pcs=my.all.findAll {it.numberOfDamageCounters}.select("Heal which one")
               heal(20,pcs,SRC_ABILITY)
@@ -2822,7 +2822,7 @@ public enum SunMoon implements LogicCardInfo {
         return itemCard (this) {
           text "Your opponent switches their Active Pokémon with 1 of their Benched Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
           onPlay {
-            def pcs = opp.bench.oppSelect("Select new active pokemon")
+            def pcs = opp.bench.oppSelect("Select new active Pokémon.")
             sw(opp.active, pcs)
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1094,7 +1094,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             text "Search your deck for an Item card, reveal it, and put it into your hand. Then, shuffle your deck.\n"
             energyCost C
             attackRequirement{
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack{
               my.deck.search(count:1,"Choose an Item card",cardTypeFilter(ITEM)).showToOpponent("The chosen Item card.").moveTo(my.hand)
@@ -2651,7 +2651,7 @@ public enum SunMoonPromos implements LogicCardInfo {
           weakness FIGHTING
           resistance METAL, MINUS20
           move "Coffee Break", {
-            text "Heal 30 damage from this pokemon"
+            text "Heal 30 damage from this Pokémon."
             energyCost C
             onAttack {
               heal 30, self
@@ -2927,7 +2927,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
           move "Abnormal Overheating", {
-            text "160 damage. This Pokemon is now burned"
+            text "160 damage. This Pokémon is now burned"
             energyCost C, C, C
             onAttack {
               damage 160
@@ -3036,7 +3036,7 @@ public enum SunMoonPromos implements LogicCardInfo {
           text "Search your deck for up to 3 Pokémon-GX with different names, reveal them, and put them into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             def info = "Search your deck for up to 3 Pokémon-GX with different names."

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -556,7 +556,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may put 2 damage counters on this Pokémon. If you do, search your deck for up to 2 [R] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
             actionA {
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               def eff = delayed {
                 before KNOCKOUT, {
@@ -604,7 +604,7 @@ public enum TeamUp implements LogicCardInfo {
             actionA{
               checkLastTurn()
               def src = my.hand.filterByBasicEnergyType(R)
-              assert src.size() >= 2 : "You don't have enough Fire Energy cards to discard"
+              assert src.size() >= 2 : "You don't have enough Fire Energy cards to discard."
               powerUsed()
               src.select(count:2,"Discard").discard()
               switchYourOpponentsBenchedWithActive(SRC_ABILITY)
@@ -777,7 +777,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may look at the top 6 cards of your deck and attach any number of [W] Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               my.deck.subList(0,6).showToMe("Top 6 cards of your deck")
               def tar = my.deck.subList(0,6).filterByBasicEnergyType(W)
@@ -1240,7 +1240,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Search your deck for up to 2 Electropower cards, reveal them, and put them into your hand. Then, shuffle your deck."
             energyCost L
             attackRequirement{
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
             }
             onAttack{
               my.deck.search(max:2,"Choose up to 2 Electropower cards",{it.name.contains("Electropower")}).showToOpponent("Chosen cards").moveTo(my.hand)
@@ -1284,9 +1284,9 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may search your deck for a Pokémon that has the Nuzzle attack, reveal it, and put it into your hand. Then, shuffle your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
-              my.deck.search("Find Pokemon with Nuzzle attack",{it.cardTypes.pokemon && it.moves.findAll{it.name=="Nuzzle"}}).moveTo(my.hand)
+              my.deck.search("Find Pokémon with Nuzzle attack",{it.cardTypes.pokemon && it.moves.findAll{it.name=="Nuzzle"}}).moveTo(my.hand)
               shuffleDeck()
             }
           }
@@ -1541,7 +1541,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may search your deck for a Pokémon that isn't a Pokémon-GX or Pokémon-EX, reveal it, and put it into your hand. Then, shuffle your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               my.deck.search("Select one Pokémon that isn't a Pokémon-GX or Pokémon-EX",{it.cardTypes.is(POKEMON) && !it.cardTypes.is(POKEMON_GX) && !it.cardTypes.is(POKEMON_EX)}).moveTo(my.hand)
               shuffleDeck()
@@ -2446,7 +2446,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may put 3 damage counters on this Pokémon. If you do, search your deck for up to 3 [D] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
             actionA {
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               def eff = delayed {
                 before KNOCKOUT, {
@@ -3080,7 +3080,7 @@ public enum TeamUp implements LogicCardInfo {
             text "Once during your turn (before your attack), you may look at the top 2 cards of your deck and put 1 of them into your hand. Put the other card on the bottom of your deck."
             actionA{
               checkLastTurn()
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               powerUsed()
               def sel = my.deck.subList(0,2).select("Choose 1 card to put into your hand")
               my.deck.subList(0,2).getExcludedList(sel).moveTo(suppressLog: true, my.deck)
@@ -3370,7 +3370,7 @@ public enum TeamUp implements LogicCardInfo {
           }
           playRequirement{
             assert opp.active.stage2 : "The opponent's Active Pokémon is not a Stage 2 Pokémon"
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case DANGEROUS_DRILL_138:
@@ -3436,7 +3436,7 @@ public enum TeamUp implements LogicCardInfo {
           }
           playRequirement{
             assert opp.active.stage1 : "Your opponent's Active Pokémon is not a Stage 1 Pokémon"
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case FAIRY_CHARM_UB_142:
@@ -3500,7 +3500,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
           playRequirement{
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case JASMINE_145:
@@ -3511,7 +3511,7 @@ public enum TeamUp implements LogicCardInfo {
             shuffleDeck()
           }
           playRequirement{
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case JUDGE_WHISTLE_146:
@@ -3609,7 +3609,7 @@ public enum TeamUp implements LogicCardInfo {
             assert my.hand.find{it.name == "Dana"} : "You don't have Dana in your hand"
             assert my.hand.find{it.name == "Evelyn"} : "You don't have Evelyn in your hand"
             assert my.hand.find{it.name == "Nita"} : "You don't have Nita in your hand"
-            assert my.deck : "There are no more cards in your deck"
+            assert my.deck : "There are no more cards in your deck."
           }
         };
       case NANU_150:
@@ -3623,7 +3623,7 @@ public enum TeamUp implements LogicCardInfo {
             list.discard()
           }
           playRequirement{
-            assert my.discard.filterByType(BASIC).findAll{it.asPokemonCard().types.contains(D)} : "There are no more cards in your deck"
+            assert my.discard.filterByType(BASIC).findAll{it.asPokemonCard().types.contains(D)} : "There are no more cards in your deck."
           }
         };
       case NITA_151:
@@ -3688,7 +3688,7 @@ public enum TeamUp implements LogicCardInfo {
           def actions=[]
           onPlay {
             actions=action("Stadium: Viridian Forest") {
-              assert my.deck : "There are no more cards in your deck"
+              assert my.deck : "There are no more cards in your deck."
               assert my.hand : "You don't have cards in your hand"
               assert lastTurn != bg().turnCount : "Already used"
               bc "Used Viridian Forest effect"

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -490,7 +490,7 @@ public enum UltraPrism implements LogicCardInfo {
             text "If this Pokémon is your Active Pokémon, once during your turn (before your attack), you may heal 50 damage from 1 of your Pokémon that has any Energy attached to it."
             actionA {
               checkLastTurn() // check whether it has already been used this turn
-              assert self.active : "Leafeon GX is not your active pokemon"
+              assert self.active : "Leafeon GX is not your active Pokémon."
               def tar = my.all.findAll{it.numberOfDamageCounters && it.cards.energyCount(C)}
               assert tar
 
@@ -514,7 +514,7 @@ public enum UltraPrism implements LogicCardInfo {
             energyCost G
             attackRequirement {
               gxCheck()
-              assert my.bench.notEmpty : "This is your only pokemon"
+              assert my.bench.notEmpty : "This is your only Pokémon."
               assert my.deck.notEmpty
             }
             onAttack {
@@ -2291,7 +2291,7 @@ public enum UltraPrism implements LogicCardInfo {
               checkLastTurn()
               assert my.deck
               powerUsed()
-              my.deck.search(count: 1, "Search for a fairy pokemon", {it.cardTypes.pokemon && it.types.contains(Y)}).moveTo(my.hand)
+              my.deck.search(count: 1, "Search for a fairy Pokémon.", {it.cardTypes.pokemon && it.types.contains(Y)}).moveTo(my.hand)
               shuffleDeck()
             }
           }
@@ -2939,7 +2939,7 @@ public enum UltraPrism implements LogicCardInfo {
           }
           playRequirement{
             assert my.active.types.contains(W) || my.active.types.contains(M) : "Your Active Pokémon needs to be [W] or [M]. (The card text was officially changed)"
-            assert opp.bench.size() > 2 : "Opponent needs to have more than 2 benched Pokemon"
+            assert opp.bench.size() > 2 : "Opponent needs to have more than 2 benched Pokémon"
           }
         };
       case ELECTRIC_MEMORY_121:

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1141,7 +1141,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               while (1) {
                 def tar = my.all.findAll {it.cards.filterByEnergyType(W).findAll {!toBeMoved.contains(it)}.notEmpty()}
                 if (!tar) break
-                def pcs = tar.select("Pokemon that has [W] energy to be shuffled to deck. Cancel to stop", false)
+                def pcs = tar.select("Pokémon that has [W] energy to be shuffled to deck. Cancel to stop", false)
                 if (!pcs) break
                 def dd = pcs.cards.filterByEnergyType(W).findAll {!toBeMoved.contains(it)}.select("[W] Energy to shuffle into your deck")
                 toBeMoved.addAll(dd)
@@ -1957,7 +1957,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                 if(kef.pokemonToBeKnockedOut.owner != self.owner && kef.pokemonToBeKnockedOut.active && kef.pokemonToBeKnockedOut.owner.pbg.bench.notEmpty){
                   powerUsed()
                   flip "Hypnotic Pendulum", {
-                    kef.nextActive = kef.pokemonToBeKnockedOut.owner.pbg.bench.select("Hypnotic Pendulum: select new active pokemon", self.owner)
+                    kef.nextActive = kef.pokemonToBeKnockedOut.owner.pbg.bench.select("Hypnotic Pendulum: select new active Pokémon.", self.owner)
                   }
                 }
               }
@@ -2713,7 +2713,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             def cl1 = {my.discard.findAll{it.cardTypes.isIn(POKEMON_GX, POKEMON_EX) && it.asPokemonCard().types.contains(D)}}
             attackRequirement {
               gxCheck()
-              assert cl1() : "No [D] Pokemon-GX or Pokemon-EX in your discard pile"
+              assert cl1() : "No [D] Pokémon-GX or Pokémon-EX in your discard pile"
               assert my.bench.notFull : "Bench full"
             }
             onAttack {
@@ -4069,7 +4069,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
         return itemCard (this) {
           text "Devolve 1 of your evolved Pokémon by shuffling any number of Evolution cards on it into your deck. (That Pokémon can't evolve this turn.)"
           onPlay {
-            def pcs = my.all.findAll{it.evolution}.select("Pokemon to devolve")
+            def pcs = my.all.findAll{it.evolution}.select("Pokémon to devolve")
             def top = pcs.topPokemonCard
             devolve(pcs, top, my.deck)
             while(pcs.evolution && confirm("$top was devolved. Devolve the next evolution?")){

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1210,7 +1210,7 @@ public enum UnifiedMinds implements LogicCardInfo {
         return evolution (this, from:"Tirtouga", hp:HP160, type:W, retreatCost:3) {
           weakness G
           bwAbility "Ancient Custom", {
-            text "Pokemon Tool cards attached to your opponent's Pokemon have no effect"
+            text "Pokémon Tool cards attached to your opponent's Pokémon have no effect"
             def eff
             onActivate {
               eff = delayed {
@@ -3139,7 +3139,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             text "Discard a Pokémon Tool card from 1 of your opponent's Pokémon."
             energyCost C
             attackRequirement {
-              assertOppAll(overrideText: true, info: "There are no Pokémon Tool cards attached to your opponent's Pokemon.", {it.cards.filterByType(POKEMON_TOOL)})
+              assertOppAll(overrideText: true, info: "There are no Pokémon Tool cards attached to your opponent's Pokémon.", {it.cards.filterByType(POKEMON_TOOL)})
             }
             onAttack {
               def target = opp.all.findAll{ it.cards.filterByType(POKEMON_TOOL) }.select("Choose the Pokémon to discard a Pokémon Tool from.")
@@ -4559,7 +4559,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           def lastTurn=0
           def actions=[]
           onPlay {
-            actions=action("Stadium: Pokemon Research Lab") {
+            actions=action("Stadium: Pokémon Research Lab") {
               assert my.deck : "Your deck is empty."
               assert my.bench.notFull : "You have no space in your bench"
               assert lastTurn != bg().turnCount : "You've already used Pokémon Research Lab this turn."

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -2100,7 +2100,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           if (bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.name == "Wyndon Stadium") draw 2
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case NESSA_96:

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -184,7 +184,7 @@ public enum ChampionsPath implements LogicCardInfo {
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
         move "Call for Family", {
-          text "Search your deck for a Basic Pokemon and put it on your Bench. Then, shuffle your deck."
+          text "Search your deck for a Basic Pokémon and put it on your Bench. Then, shuffle your deck."
           energyCost C
           callForFamily basic:true, 1, delegate
         }
@@ -204,7 +204,7 @@ public enum ChampionsPath implements LogicCardInfo {
       return evolution (this, from:"Kakuna", hp:HP140, type:G, retreatCost:1) {
         weakness R
         move "Poison Jab", {
-          text "80 damage. Your opponent’s Active Pokemon is now Poisoned."
+          text "80 damage. Your opponent’s Active Pokémon is now Poisoned."
           energyCost G
           onAttack {
             damage 80
@@ -242,7 +242,7 @@ public enum ChampionsPath implements LogicCardInfo {
           text "Draw a card."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             draw 1
@@ -673,7 +673,7 @@ public enum ChampionsPath implements LogicCardInfo {
           text "Draw a card."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             draw 1
@@ -932,7 +932,7 @@ public enum ChampionsPath implements LogicCardInfo {
           text "Draw a card."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             draw 1
@@ -1052,14 +1052,14 @@ public enum ChampionsPath implements LogicCardInfo {
           my.deck.add(0, card)
         }
         playRequirement{
-          assert my.deck.notEmpty : "Your deck is empty"
+          assert my.deck.notEmpty : "Your deck is empty!"
         }
       };
       case SONIA_65:
       return copy (RebelClash.SONIA_167, this);
       case STRANGE_CANNED_FOOD_66:
       return itemCard (this) {
-        text "Heal 80 damage from 1 of your Pokemon with a [P] Energy attached to it. Then, discard a [P] Energy from that Pokemon."
+        text "Heal 80 damage from 1 of your Pokémon with a [P] Energy attached to it. Then, discard a [P] Energy from that Pokémon."
         onPlay {
           def pcs = my.all.findAll{it.cards.energyCount(P) && it.numberOfDamageCounters}.select("Choose which Pokémon to heal 80 damage from")
           def prevented = heal 80, pcs

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -536,7 +536,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Search your deck for a [G] Energy card and attach it to 1 of your Pokémon. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             attachEnergyFrom type:G, my.deck, my.all
@@ -999,7 +999,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Once during your turn, you may switch 1 of your opponent’s face-down Prize cards with the top card of their deck. (The cards stay face down.)"
           actionA {
             checkLastTurn()
-            assert opp.deck : "Your opponent's deck is empty"
+            assert opp.deck : "Your opponent's deck is empty!"
             assert opp.prizeCardSet.faceDownCards : "Your opponent has no face down Prize cards"
             powerUsed()
 
@@ -1104,7 +1104,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Search your deck for up to 2 Rare Fossil cards and put them onto your Bench. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             def info = "Select up to 2 Rare Fossil cards to put on your bench."
@@ -1534,7 +1534,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Draw 2 cards."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             draw 2
@@ -1996,7 +1996,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "You must discard a Pokémon that has the Mad Party attack from your hand in order to use this Ability. Once during your turn, you may draw 2 cards."
           actionA {
             assert my.hand.any{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} } : "You have no Pokémon with Mad Party in your hand"
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
             checkLastTurn()
             powerUsed()
             my.hand.findAll{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} }.select("Choose a Pokémon with Mad Party to discard").discard()
@@ -2343,7 +2343,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Discard the top card of your opponent’s deck."
           energyCost D
           attackRequirement {
-            assert opp.deck : "Your opponent's deck is empty"
+            assert opp.deck : "Your opponent's deck is empty!"
           }
           onAttack {
             if (opp.deck) {
@@ -2623,7 +2623,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck."
           energyCost D
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             if (my.deck) {
@@ -2809,31 +2809,31 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
             before PLAY_BASIC_POKEMON, {
               if (!isPokemonPlayable(ef)) {
-                wcu "Cannot play non-Darkness Pokemon"
+                wcu "Cannot play non-Darkness Pokémon"
                 prevent()
               }
             }
             before PLAY_EVOLUTION, {
               if (!isPokemonPlayable(ef)) {
-                wcu "Cannot play non-Darkness Pokemon"
+                wcu "Cannot play non-Darkness Pokémon"
                 prevent()
               }
             }
             before EVOLVE_STANDARD, {
               if (bg.em().retrieveObject("Infinity_Zone_" + self.hashCode()) && ef.evolutionCard.player == self.owner && !ef.evolutionCard.types.contains(D)) {
-                wcu "Cannot play non-Darkness Pokemon"
+                wcu "Cannot play non-Darkness Pokémon"
                 prevent()
               }
             }
             before EVOLVE, {
               if (bg.em().retrieveObject("Infinity_Zone_" + self.hashCode()) && ef.evolutionCard.player == self.owner  && !ef.evolutionCard.types.contains(D)) {
-                wcu "Cannot play non-Darkness Pokemon"
+                wcu "Cannot play non-Darkness Pokémon"
                 prevent()
               }
             }
             before PUT_ON_BENCH, {
               if (!isPokemonPlayable(ef)) {
-                wcu "Cannot play non-Darkness Pokemon"
+                wcu "Cannot play non-Darkness Pokémon"
                 prevent()
               }
             }
@@ -3957,9 +3957,9 @@ public enum DarknessAblaze implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement{
-          assert my.deck : "Your deck is empty."
+          assert my.deck : "Your deck is empty!."
           assert bg.turnCount > 2 : "Cannot use this card during your first turn."
-          assert my.all.any{bg().gm().hasEvolution(it.name)} : "No Pokemon with evolutions in play"
+          assert my.all.any{bg().gm().hasEvolution(it.name)} : "No Pokémon with evolutions in play"
           assert my.all.any{it.turnCount < bg.turnCount && it.lastEvolved < bg.turnCount && bg().gm().hasEvolution(it.name)} : "Cannot use this on Pokémon put into play this turn"
         }
       };

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -194,7 +194,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           text "Search your deck for up to 2 [G] Pokémon, reveal them, and put them into your hand. Then, shuffle your deck."
           energyCost G
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             def info = "Opponent chose the following Pokémon from their deck using $thisMove."
@@ -518,7 +518,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           text " Draw a card."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             draw 1
@@ -1143,7 +1143,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert self.active : "$self is not your active Pokémon"
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
             powerUsed()
             my.deck.subList(0, 2).select("Card to add to hand?").moveTo hidden:true, my.hand
           }
@@ -1152,7 +1152,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           text " Search your deck for up to 7 Basic Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck."
           energyCost P, F, M
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             def energies = my.deck.search max:7, cardTypeFilter(BASIC_ENERGY)
@@ -1312,7 +1312,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           text " Search your deck for up to 2 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty"
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             deck.search(max:2, cardTypeFilter(BASIC_ENERGY))
@@ -1532,7 +1532,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           draw 2
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case ALLISTER_71:
@@ -1544,7 +1544,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           my.hand.select(min:1, max:3, "Card(s) to discard?").discard()
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case OPAL_72:
@@ -1560,7 +1560,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case MARNIE_73:

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -292,7 +292,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
         bwAbility "Adaptive Evolution", {
-          text "This Pokemon can evolve during your first turn or the turn you play it."
+          text "This Pokémon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
               if (bg.currentTurn == self.owner){
@@ -314,7 +314,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Caterpie", hp:HP080, type:G, retreatCost:3) {
         weakness R
         bwAbility "Adaptive Evolution", {
-          text "This Pokemon can evolve during your first turn or the turn you play it."
+          text "This Pokémon can evolve during your first turn or the turn you play it."
           delayedA {
             before PREVENT_EVOLVE, self, null, EVOLVE_STANDARD, {
               if (bg.currentTurn == self.owner){
@@ -336,7 +336,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Metapod", hp:HP140, type:G, retreatCost:1) {
         weakness R
         move "Panic Poison", {
-          text "30 damage. Your opponent’s Active Pokemon is now Burned, Confused, and Poisoned."
+          text "30 damage. Your opponent’s Active Pokémon is now Burned, Confused, and Poisoned."
           energyCost G
           onAttack {
             damage 30
@@ -357,7 +357,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
         move "Swords Dance", {
-          text "During your next turn, this Pokemon’s Blinding Scythe attack does 70 more damage (before applying Weakness and Resistance)."
+          text "During your next turn, this Pokémon’s Blinding Scythe attack does 70 more damage (before applying Weakness and Resistance)."
           energyCost C
           onAttack {
             increasedBaseDamageNextTurn("Blinding Scythe", hp(70))
@@ -389,7 +389,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Bind", {
-          text "50 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "50 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost G, C, C
           onAttack {
             damage 50
@@ -401,7 +401,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP130, type:G, retreatCost:2) {
         weakness R
         move "Push Down", {
-          text "30 damage. Your opponent switches their Active Pokemon with 1 of their Benched Pokemon."
+          text "30 damage. Your opponent switches their Active Pokémon with 1 of their Benched Pokémon."
           energyCost C, C
           onAttack {
             damage 30
@@ -424,7 +424,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
         move "Mini Drain", {
-          text "10 damage. Heal 10 damage from this Pokemon."
+          text "10 damage. Heal 10 damage from this Pokémon."
           energyCost C
           onAttack {
             damage 10
@@ -475,7 +475,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Mega Drain", {
-          text "120 damage. Heal 30 damage from this Pokemon."
+          text "120 damage. Heal 30 damage from this Pokémon."
           energyCost G, C, C
           onAttack {
             damage 120
@@ -558,7 +558,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Snover", hp:HP140, type:G, retreatCost:3) {
         weakness R
         move "Soothing Scent", {
-          text "80 damage. Your opponent’s Active Pokemon is now Asleep."
+          text "80 damage. Your opponent’s Active Pokémon is now Asleep."
           energyCost G, C, C
           onAttack {
             damage 80
@@ -630,12 +630,12 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP220, type:G, retreatCost:3) {
         weakness R
         move "Forest Feast", {
-          text "Search your deck for up to 2 Basic [G] Pokemon and put them onto your Bench. Then, shuffle your deck."
+          text "Search your deck for up to 2 Basic [G] Pokémon and put them onto your Bench. Then, shuffle your deck."
           energyCost G
           callForFamily([basic:true, type:G], 2, delegate)
         }
         move "Wood Hammer", {
-          text "220 damage. This Pokemon also does 30 damage to itself."
+          text "220 damage. This Pokémon also does 30 damage to itself."
           energyCost G, G, G, C
           onAttack {
             damage 220
@@ -654,7 +654,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Max Beating", {
-          text "130+ damage. You may discard up to 3 [G] Energy from this Pokemon. If you do, this attack does 50 more damage for each Energy you discarded in this way."
+          text "130+ damage. You may discard up to 3 [G] Energy from this Pokémon. If you do, this attack does 50 more damage for each Energy you discarded in this way."
           energyCost G, G, G, C
           onAttack {
             def grassEnergies = self.cards.filterByEnergyType(G).select(min: 0, max: 3, "Discard up to 3 [G] Energy.")
@@ -678,7 +678,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Float Up", {
-          text "50 damage. You may shuffle this Pokemon and all cards attached to it into your deck."
+          text "50 damage. You may shuffle this Pokémon and all cards attached to it into your deck."
           energyCost C, C
           onAttack {
             damage 50
@@ -719,7 +719,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Applin", hp:HP080, type:G, retreatCost:1) {
         weakness R
         bwAbility "Apple Drop", {
-          text "Once during your turn, you may put 2 damage counters on 1 of your opponent’s Pokemon. If you placed any damage counters in this way, shuffle this Pokemon and all attached cards into your deck."
+          text "Once during your turn, you may put 2 damage counters on 1 of your opponent’s Pokémon. If you placed any damage counters in this way, shuffle this Pokémon and all attached cards into your deck."
           actionA {
             if(confirm("Use Apple Drop?")){
               checkLastTurn()
@@ -736,7 +736,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Acid Spray", {
-          text "60 damage. Flip a coin. If heads, discard an Energy from your opponent’s Active Pokemon."
+          text "60 damage. Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon."
           energyCost C, C
           onAttack {
             damage 60
@@ -776,7 +776,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
         move "Confuse Ray", {
-          text "Your opponent’s Active Pokemon is now Confused."
+          text "Your opponent’s Active Pokémon is now Confused."
           energyCost R
           onAttack {
             apply CONFUSED
@@ -794,7 +794,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Vulpix", hp:HP120, type:R, retreatCost:1) {
         weakness W
         move "Hex", {
-          text "30+ damage. If your opponent's Active Pokemon is affected by a Special Condition, this attack does 90 more damage."
+          text "30+ damage. If your opponent's Active Pokémon is affected by a Special Condition, this attack does 90 more damage."
           energyCost R
           onAttack {
             damage 30
@@ -804,7 +804,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Flickering Flames", {
-          text "90 damage. Your opponent’s Active Pokemon is now Asleep."
+          text "90 damage. Your opponent’s Active Pokémon is now Asleep."
           energyCost R, C, C
           onAttack {
             damage 90
@@ -816,7 +816,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP200, type:R, retreatCost:2) {
         weakness W
         move "Nine-Tailed Shapeshifter", {
-          text "Choose 1 of your opponent’s Active Pokemon’s attacks and use it as this attack."
+          text "Choose 1 of your opponent’s Active Pokémon’s attacks and use it as this attack."
           energyCost R, C, C
           attackRequirement {
             assert opp.active.topPokemonCard.moves : "No moves to use."
@@ -836,7 +836,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Flamethrower", {
-          text "180 damage. Discard an Energy from this Pokemon."
+          text "180 damage. Discard an Energy from this Pokémon."
           energyCost R, C, C, C
           onAttack {
             damage 180
@@ -871,7 +871,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Growlithe", hp:HP130, type:R, retreatCost:2) {
         weakness W
         bwAbility "Warming Up", {
-          text "If this Pokemon has Burning Scarf attached to it, it get +100 HP."
+          text "If this Pokémon has Burning Scarf attached to it, it get +100 HP."
           getterA (GET_FULL_HP, self) {h->
             if (self.cards.findAll { it.name == "Burning Scarf" }) {
               h.object += hp(100)
@@ -909,7 +909,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Magmar", hp:HP140, type:R, retreatCost:3) {
         weakness W
         move "Burst Punch", {
-          text "30 damage. Your opponent’s Active Pokemon is now Burned."
+          text "30 damage. Your opponent’s Active Pokémon is now Burned."
           energyCost R, C
           onAttack {
             damage 30
@@ -936,7 +936,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
         move "Scorch", {
-          text "Your opponent’s Active Pokemon is now Burned."
+          text "Your opponent’s Active Pokémon is now Burned."
           energyCost R
           onAttack {
             apply BURNED
@@ -961,7 +961,7 @@ public enum RebelClash implements LogicCardInfo {
           text "If you draw this card from your deck at the beginning of your turn and there is room on your Bench, instead of putting it into your hand, you may play it directly onto your Bench."
         }
         move "Reignite", {
-          text "20 damage. Attach a [R] Energy card from your discard pile to one of your Pokemon."
+          text "20 damage. Attach a [R] Energy card from your discard pile to one of your Pokémon."
           energyCost R
           onAttack {
             damage 20
@@ -975,7 +975,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Lampent", hp:HP140, type:R, retreatCost:2) {
         weakness W
         bwAbility "Protective Glow", {
-          text "Each of your Pokemon that has any Energy attached to it has no Weakness."
+          text "Each of your Pokémon that has any Energy attached to it has no Weakness."
           getterA (GET_WEAKNESSES) { h->
             if (h.effect.target.owner == self.owner && h.effect.target.cards.energyCount(C)) {
               def list = h.object as List<Weakness>
@@ -984,7 +984,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Mirage Flare", {
-          text "110 damage. Your opponent’s Active Pokemon is now Confused."
+          text "110 damage. Your opponent’s Active Pokémon is now Confused."
           energyCost R, C
           onAttack {
             damage 110
@@ -996,7 +996,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP120, type:R, retreatCost:2) {
         weakness W
         move "Lick", {
-          text "20 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "20 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost C
           onAttack {
             damage 20
@@ -1004,7 +1004,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Flamethrower", {
-          text "120 damage. Discard an Energy from this Pokemon."
+          text "120 damage. Discard an Energy from this Pokémon."
           energyCost R, R, C
           onAttack {
             damage 120
@@ -1016,7 +1016,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:R, retreatCost:2) {
         weakness W
         bwAbility "Field Runner", {
-          text "If there is a Stadium card in play, this Pokemon has no Retreat Cost."
+          text "If there is a Stadium card in play, this Pokémon has no Retreat Cost."
           getterA (GET_RETREAT_COST, BEFORE_LAST, self) { h->
             if (bg.stadiumInfoStruct) {
               h.object = 0
@@ -1047,7 +1047,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Counter", {
-          text "30+ damage. This attack does additional damage equal to the amount of damage done to this Pokemon by attacks from your opponent’s Pokemon during your opponent’s last turn."
+          text "30+ damage. This attack does additional damage equal to the amount of damage done to this Pokémon by attacks from your opponent’s Pokémon during your opponent’s last turn."
           energyCost R, C
           onAttack {
             damage 30
@@ -1057,7 +1057,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Max Pyro Ball", {
-          text "170 damage. Your opponent’s Active Pokemon is now Burned."
+          text "170 damage. Your opponent’s Active Pokémon is now Burned."
           energyCost R, R, C
           onAttack {
             damage 170
@@ -1069,7 +1069,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness M
         move "Icy Wind", {
-          text "10 damage. Your opponent’s Active Pokemon is now Asleep."
+          text "10 damage. Your opponent’s Active Pokémon is now Asleep."
           energyCost C
           onAttack {
             damage 10
@@ -1088,7 +1088,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Galarian Mr. Mime", hp:HP110, type:W, retreatCost:1) {
         weakness M
         bwAbility "Screen Cleaner", {
-          text "As long as this Pokemon is in play, prevent effects of opponent’s attacks done to all of your Pokemon with Energy attached to them. (This does not remove existing effects.)"
+          text "As long as this Pokémon is in play, prevent effects of opponent’s attacks done to all of your Pokémon with Energy attached to them. (This does not remove existing effects.)"
           delayedA {
             before null, null, Source.ATTACK, {
               def pcs = (ef as TargetedEffect).getResolvedTarget(bg, e)
@@ -1111,7 +1111,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
         move "Leap Out", {
-          text "Switch This Pokemon with 1 of your Benched Pokemon."
+          text "Switch This Pokémon with 1 of your Benched Pokémon."
           energyCost C
           attackRequirement {
             assertMyBench()
@@ -1173,7 +1173,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Power Cyclone", {
-          text "110 damage. Move an Energy from this Pokemon to 1 of your Benched Pokemon."
+          text "110 damage. Move an Energy from this Pokémon to 1 of your Benched Pokémon."
           energyCost W, C, C
           onAttack {
             damage 110
@@ -1188,14 +1188,14 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness L
         move "Aqua Impact", {
-          text "10+ damage. This attack does 50 more damage for each [C] in your opponent’s Active Pokemon’s Retreat Cost."
+          text "10+ damage. This attack does 50 more damage for each [C] in your opponent’s Active Pokémon’s Retreat Cost."
           energyCost W, C, C
           onAttack {
             damage 10+50*defending.retreatCost
           }
         }
         move "Hypno Splash", {
-          text "150 damage. Your opponent’s Active Pokemon is now Asleep."
+          text "150 damage. Your opponent’s Active Pokémon is now Asleep."
           energyCost W, C, C, C
           onAttack {
             damage 150
@@ -1207,7 +1207,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
         move "Spiral Attack", {
-          text "Your opponent’s Active Pokemon is now Confused."
+          text "Your opponent’s Active Pokémon is now Confused."
           energyCost C
           onAttack {
             apply CONFUSED
@@ -1218,7 +1218,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Tympole", hp:HP090, type:W, retreatCost:2) {
         weakness L
         move "Twirling Sign", {
-          text "30 damage. Your opponent’s Active Pokemon is now Confused."
+          text "30 damage. Your opponent’s Active Pokémon is now Confused."
           energyCost C, C
           onAttack {
             damage 30
@@ -1230,7 +1230,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Palpitoad", hp:HP170, type:W, retreatCost:3) {
         weakness L
         move "Split Spiral Punch", {
-          text "30 damage. Your opponent’s Active Pokemon is now Confused."
+          text "30 damage. Your opponent’s Active Pokémon is now Confused."
           energyCost W
           onAttack {
             damage 30
@@ -1238,7 +1238,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Resonance", {
-          text "120 damage. If your opponent’s Active Pokemon is Confused, this attack does 120 more damage."
+          text "120 damage. If your opponent’s Active Pokémon is Confused, this attack does 120 more damage."
           energyCost W, C, C, C
           onAttack {
             damage 120
@@ -1250,7 +1250,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
         move "Ice Punch", {
-          text "30 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "30 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost W, C
           onAttack {
             damage 30
@@ -1262,7 +1262,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Galarian Darumaka", hp:HP140, type:W, retreatCost:3) {
         weakness M
         move "Blizzard", {
-          text "80 damage. This attack does 10 damage to each of your opponent’s Benched Pokemon. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "80 damage. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, C, C
           onAttack {
             damage 80
@@ -1272,7 +1272,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Crushing Headbutt", {
-          text "170 damage. This Pokemon can’t use Crushed Ice Head during your next turn."
+          text "170 damage. This Pokémon can’t use Crushed Ice Head during your next turn."
           energyCost W, W, C, C
           onAttack {
             damage 170
@@ -1284,7 +1284,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP200, type:W, retreatCost:2) {
         weakness L
         move "Snipe Shot", {
-          text "This attack does 40 damage to 1 of your opponent’s Pokemon. (Don’t apply Weakness or Resistance for Benched Pokemon.)"
+          text "This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness or Resistance for Benched Pokémon.)"
           energyCost W
           onAttack {
             damage 40, opp.all.select()
@@ -1318,7 +1318,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Max Bullet", {
-          text "160 damage. This attack does 60 damage to 1 of your opponent’s Benched Pokemon. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "160 damage. This attack does 60 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, W, C
           onAttack {
             damage 160
@@ -1333,7 +1333,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         move "Dive", {
-          text "20 damage. Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokemon during your opponent’s next turn."
+          text "20 damage. Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn."
           energyCost W
           onAttack {
             damage 20
@@ -1341,7 +1341,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Hydro Pump", {
-          text "50+ damage. This attack does 20 more damage for each [W] Energy attached to this Pokemon."
+          text "50+ damage. This attack does 20 more damage for each [W] Energy attached to this Pokémon."
           energyCost C, C, C
           onAttack {
             damage 50+20*self.cards.energyCount(W)
@@ -1385,7 +1385,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP120, type:W, retreatCost:2) {
         weakness M
         bwAbility "Ice Face", {
-          text "If this Pokemon’s HP is at max, any damage done to it by opponent’s attacks is reduced by 60."
+          text "If this Pokémon’s HP is at max, any damage done to it by opponent’s attacks is reduced by 60."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               if (ef.attacker.owner != self.owner) {
@@ -1400,7 +1400,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Blizzard", {
-          text "70 damage. This attack does 10 damage to each of your opponent’s Benched Pokemon. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "70 damage. This attack does 10 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, C, C
           onAttack {
             damage 70
@@ -1414,7 +1414,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness M
         bwAbility "Cold Absorption", {
-          text "Whenever you attach a [W] Energy card from your hand to this Pokemon during your turn, heal 30 damage from it."
+          text "Whenever you attach a [W] Energy card from your hand to this Pokémon during your turn, heal 30 damage from it."
           delayedA {
             before ATTACH_ENERGY, {
               if (ef.reason == PLAY_FROM_HAND && ef.card.asEnergyCard().containsType(W) && bg.currentTurn == self.owner && ef.resolvedTarget == self) {
@@ -1425,7 +1425,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Blizzard", {
-          text "120 damage. This attack also does 10 damage to each of your opponent's Benched Pokemon. (Don't apply Weakness and Resistance for Benched Pokemon.)"
+          text "120 damage. This attack also does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W, W, C
           onAttack {
             damage 120
@@ -1453,7 +1453,7 @@ public enum RebelClash implements LogicCardInfo {
           text "Search your deck for up to 3 Energy cards, reveal them, and put them in your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             deck.search(min: 0, max: 3, cardTypeFilter(ENERGY)).moveTo(hand)
@@ -1490,7 +1490,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Electabuzz", hp:HP140, type:L, retreatCost:3) {
         weakness F
         move "Thunder Shock", {
-          text "50 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "50 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost L, C
           onAttack {
             damage 50
@@ -1498,7 +1498,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Electrified Bolt", {
-          text "90 damage. If this Pokemon has a Special Energy card attached to it, this attack does 90 more damage."
+          text "90 damage. If this Pokémon has a Special Energy card attached to it, this attack does 90 more damage."
           energyCost L, L, C
           onAttack {
             damage 90
@@ -1549,7 +1549,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Luxio", hp:HP160, type:L, retreatCost:1) {
         weakness F
         move "Raid", {
-          text "60 damage. If this Pokemon evolved from Luxio during your turn, this attack does 100 more damage."
+          text "60 damage. If this Pokémon evolved from Luxio during your turn, this attack does 100 more damage."
           energyCost L
           onAttack {
             damage 60
@@ -1571,7 +1571,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
         move "Thunder Jolt", {
-          text "30 damage. This Pokemon does 10 damage to itself."
+          text "30 damage. This Pokémon does 10 damage to itself."
           energyCost L
           onAttack {
             damage 30
@@ -1583,7 +1583,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Helioptile", hp:HP110, type:L, retreatCost:1) {
         weakness F
         move "Eerie Impulse", {
-          text "Flip a coin. If heads, discard an Energy from 1 of your opponent’s Pokemon."
+          text "Flip a coin. If heads, discard an Energy from 1 of your opponent’s Pokémon."
           energyCost L
           attackRequirement {
             assertOppAll(info: "with Energy attached to them", {it.cards.energyCount(C)})
@@ -1597,7 +1597,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Thunder", {
-          text "120 damage. This Pokemon does 30 damage to itself."
+          text "120 damage. This Pokémon does 30 damage to itself."
           energyCost L, C
           onAttack {
             damage 120
@@ -1609,10 +1609,10 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Grubbin", hp:HP090, type:L, retreatCost:2) {
         weakness F
         move "Charge", {
-          text "Search your deck for up to 2 [L] Energy cards and attach them to this Pokemon. Then, shuffle your deck."
+          text "Search your deck for up to 2 [L] Energy cards and attach them to this Pokémon. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             attachEnergyFrom(basic: true, max: 2, type: L, my.deck, self)
@@ -1631,7 +1631,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Charjabug", hp:HP150, type:L, retreatCost:2) {
         weakness F
         move "Powerful Storm", {
-          text "60+ damage. This attack does 20 more damage times the amount of Energy attached to all of your Pokemon."
+          text "60+ damage. This attack does 20 more damage times the amount of Energy attached to all of your Pokémon."
           energyCost L, C, C
           onAttack {
             damage 60
@@ -1639,7 +1639,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Thunder Jolt Beam", {
-          text "170 damage. This Pokemon does 30 damage to itself."
+          text "170 damage. This Pokémon does 30 damage to itself."
           energyCost L, C, C, C
           onAttack {
             damage 170
@@ -1651,7 +1651,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP200, type:L, retreatCost:2) {
         weakness F
         move "Electrify", {
-          text "Search your deck for up to 2 [L] Energy and attach them to your Benched Pokemon in any way you like. Then, shuffle your deck."
+          text "Search your deck for up to 2 [L] Energy and attach them to your Benched Pokémon in any way you like. Then, shuffle your deck."
           energyCost L
           attackRequirement {
             assertMyBench()
@@ -1663,7 +1663,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Bolt Storm", {
-          text "10+ damage. This attack does 30 more damage for each [L] Energy attached to your Pokemon in play."
+          text "10+ damage. This attack does 30 more damage for each [L] Energy attached to your Pokémon in play."
           energyCost L, C
           onAttack {
             damage 10
@@ -1675,7 +1675,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
         move "Tight Jaw", {
-          text "10 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "10 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost L
           onAttack {
             damage 10
@@ -1687,7 +1687,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Toxel", hp:HP130, type:L, retreatCost:2) {
         weakness F
         move "Poison Shout", {
-          text "This attack does 20 damage to each of your opponent’s Pokemon. Your opponent’s Active Pokemon is now Poisoned. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "This attack does 20 damage to each of your opponent’s Pokémon. Your opponent’s Active Pokémon is now Poisoned. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost L
           onAttack {
             opp.all.each {
@@ -1708,7 +1708,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:L, retreatCost:2) {
         weakness F
         move "Poison Jab", {
-          text "20 damage. Your opponent’s Active Pokemon is now Poisoned."
+          text "20 damage. Your opponent’s Active Pokémon is now Poisoned."
           energyCost L
           onAttack {
             damage 20
@@ -1716,7 +1716,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Electric Riot", {
-          text "90+ damage. This attack does 90 more damage if your opponent’s Active Pokemon is Poisoned."
+          text "90+ damage. This attack does 90 more damage if your opponent’s Active Pokémon is Poisoned."
           energyCost L, L, C
           onAttack {
             damage 90
@@ -1728,7 +1728,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Toxtricity V", hp:HP320, type:L, retreatCost:2) {
         weakness F
         move "G-Max Riot", {
-          text "160+ damage. This attack does 80 more damage if your opponent’s Active Pokemon is Poisoned."
+          text "160+ damage. This attack does 80 more damage if your opponent’s Active Pokémon is Poisoned."
           energyCost L, L, C
           onAttack {
             damage 160
@@ -1740,7 +1740,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP170, type:L, retreatCost:2) {
         weakness F
         bwAbility "Counterattack Kerzap", {
-          text "If this Pokemon is your Active Pokemon and is damaged by an opponent’s attack, flip 3 coins. For each heads, put 3 damage counters on the Attacking Pokemon."
+          text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, flip 3 coins. For each heads, put 3 damage counters on the Attacking Pokémon."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               if (ef.attacker.owner != self.owner) {
@@ -1768,7 +1768,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
         move "Torment", {
-          text "20 damage. Choose 1 of your opponent’s Active Pokemon’s attacks. The Defending Pokemon can’t use that attack during your opponent’s next turn."
+          text "20 damage. Choose 1 of your opponent’s Active Pokémon’s attacks. The Defending Pokémon can’t use that attack during your opponent’s next turn."
           energyCost C
           onAttack {
             damage 20
@@ -1778,7 +1778,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Spark", {
-          text "50 damage. This attack does 20 damage to 1 of your opponent’s Benched Pokemon. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "50 damage. This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost L, C
           onAttack {
             damage 50
@@ -1792,7 +1792,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
         move "Shining Fingers", {
-          text "Your opponent’s Active Pokemon is now Asleep."
+          text "Your opponent’s Active Pokémon is now Asleep."
           energyCost C
           onAttack {
             apply ASLEEP
@@ -1845,7 +1845,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Energy Warp", {
-          text "Move an Energy from 1 of your opponent’s Benched Pokemon to their Active Pokemon."
+          text "Move an Energy from 1 of your opponent’s Benched Pokémon to their Active Pokémon."
           energyCost C
           attackRequirement {
             assertOppBench(info: "with Energy attached to them", {it.cards.filterByType(ENERGY)})
@@ -1860,7 +1860,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Psychic", {
-          text "10+ damage. This attack does 30 more damage for each Energy attached to the opponent’s Active Pokemon."
+          text "10+ damage. This attack does 30 more damage for each Energy attached to the opponent’s Active Pokémon."
           energyCost P
           onAttack {
             damage 10+30*opp.active.cards.filterByType(ENERGY).size()
@@ -1872,7 +1872,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Cursed Drop", {
-          text "Put 3 damage counters on your opponent’s Pokemon in any way you like."
+          text "Put 3 damage counters on your opponent’s Pokémon in any way you like."
           energyCost P
           onAttack {
             putDamageCountersOnOpponentsPokemon(3)
@@ -1884,7 +1884,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         bwAbility "Perish Body", {
-          text "If this Pokemon is your Active Pokemon and is Knocked Out by damage from an opponent’s attack, flip a coin. If heads, the Attacking Pokemon is Knocked Out."
+          text "If this Pokémon is your Active Pokémon and is Knocked Out by damage from an opponent’s attack, flip a coin. If heads, the Attacking Pokémon is Knocked Out."
           delayedA (priority: LAST) {
             before (KNOCKOUT, self) {
               if ((ef as Knockout).byDamageFromAttack && self.active && bg.currentTurn==self.owner.opposite && self.owner.opposite.pbg.active != null && self.owner.opposite.pbg.active.inPlay) {
@@ -1898,7 +1898,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Corner", {
-          text "60 damage. The Defending Pokemon can’t retreat during your opponent’s next turn."
+          text "60 damage. The Defending Pokémon can’t retreat during your opponent’s next turn."
           energyCost P, C
           onAttack {
             damage 60
@@ -1911,7 +1911,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         bwAbility "Counterattack", {
-          text "If this Pokemon is your Active Pokemon and is damaged by an opponent’s attack, place 3 damage counters on the attacking Pokemon."
+          text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, place 3 damage counters on the attacking Pokémon."
           delayedA (priority: LAST) {
             before APPLY_ATTACK_DAMAGES, {
               if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
@@ -1922,7 +1922,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Psychic Assault", {
-          text "Does 30 damage plus 10 damage for each damage counter on the opponent’s Active Pokemon."
+          text "Does 30 damage plus 10 damage for each damage counter on the opponent’s Active Pokémon."
           energyCost P, C
           onAttack {
             damage 30+10*opp.active.numberOfDamageCounters
@@ -1934,7 +1934,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Sneaky Placement", {
-          text "Put a damage counter on 1 of your opponent’s Pokemon."
+          text "Put a damage counter on 1 of your opponent’s Pokémon."
           energyCost P
           onAttack {
             directDamage 10, opp.all.select()
@@ -1946,7 +1946,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Sand Sink", {
-          text "Discard a card from the top of your opponent’s deck. If this Pokemon has Cursed Shovel attached to it, discard 2 more cards."
+          text "Discard a card from the top of your opponent’s deck. If this Pokémon has Cursed Shovel attached to it, discard 2 more cards."
           energyCost C, C
           attackRequirement {
             assert opp.deck : "Opponent's deck is empty."
@@ -1959,7 +1959,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Super Absorption", {
-          text "90 damage. Heal 30 damage from this Pokemon."
+          text "90 damage. Heal 30 damage from this Pokémon."
           energyCost P, C, C
           onAttack {
             damage 90
@@ -1972,10 +1972,10 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Find a Friend", {
-          text "Search your deck for a Pokemon, reveal it, and put it into your hand. Then, shuffle your deck."
+          text "Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             my.deck.search(max: 1, cardTypeFilter(POKEMON)).moveTo(my.hand)
@@ -1995,7 +1995,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Calm Mind", {
-          text "Heal 30 damage from this Pokemon."
+          text "Heal 30 damage from this Pokémon."
           energyCost C
           onAttack {
             heal 30, self
@@ -2041,7 +2041,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Dripping Grudge", {
-          text "Put damage counters on your opponent’s Active Pokemon equal to the number of Pokemon in your discard pile."
+          text "Put damage counters on your opponent’s Active Pokémon equal to the number of Pokémon in your discard pile."
           energyCost P
           attackRequirement {
             assert my.discard.filterByType(POKEMON) : "There are no Pokémon in your discard pile."
@@ -2055,7 +2055,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness M
         move "Aromatherapy", {
-          text "Heal 10 damage from each of your Pokemon."
+          text "Heal 10 damage from each of your Pokémon."
           energyCost C
           onAttack {
             my.all.each {
@@ -2075,7 +2075,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Milcery", hp:HP110, type:P, retreatCost:1) {
         weakness M
         move "Decorate", {
-          text "Attach any number of Basic Energy from your hand to your Pokemon in any way you like."
+          text "Attach any number of Basic Energy from your hand to your Pokémon in any way you like."
           energyCost C
           attackRequirement {
             assert my.hand.filterByType(BASIC_ENERGY) : "There is no basic Energy in your hand."
@@ -2090,7 +2090,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Draining Kiss", {
-          text "50 damage. Heal 30 damage from this Pokemon."
+          text "50 damage. Heal 30 damage from this Pokémon."
           energyCost P, C
           onAttack {
             damage 50
@@ -2103,7 +2103,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Replenish Time", {
-          text "Heal 30 damage from to each of your Pokemon."
+          text "Heal 30 damage from to each of your Pokémon."
           energyCost C
           onAttack {
             my.all.each {
@@ -2112,7 +2112,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Psybeam", {
-          text "30 damage. Your opponent’s Active Pokemon is now Confused."
+          text "30 damage. Your opponent’s Active Pokémon is now Confused."
           energyCost P, C
           onAttack {
             damage 30
@@ -2141,7 +2141,7 @@ public enum RebelClash implements LogicCardInfo {
           text "Search your deck for a Dreepy and put it on your Bench. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             deck.search (count: 1, {it.name == "Dreepy"}).each {
@@ -2163,7 +2163,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         bwAbility "Infiltrator", {
-          text "If this Pokemon would be damaged by an attack, flip a coin. If heads, prevent all damage done to this Pokemon."
+          text "If this Pokémon would be damaged by an attack, flip a coin. If heads, prevent all damage done to this Pokémon."
           delayedA (priority: BEFORE_LAST) {
             before APPLY_ATTACK_DAMAGES, {
               def entry=bg.dm().find({it.to==self && it.dmg.value && it.notNoEffect})
@@ -2176,7 +2176,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Phantom Force", {
-          text "120 damage. Put 3 damage counters on your opponent’s Benched Pokemon in any way you like."
+          text "120 damage. Put 3 damage counters on your opponent’s Benched Pokémon in any way you like."
           energyCost P, P
           onAttack {
             damage 120
@@ -2198,7 +2198,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Jet Assault", {
-          text "60+ damage. If this Pokemon was on your Bench and became your Active Pokemon during this turn, this attack does 80 more damage."
+          text "60+ damage. If this Pokémon was on your Bench and became your Active Pokémon during this turn, this attack does 80 more damage."
           energyCost P, P
           onAttack {
             damage 60
@@ -2213,14 +2213,14 @@ public enum RebelClash implements LogicCardInfo {
         weakness D
         resistance F, MINUS30
         move "Shred", {
-          text "60 damage. This attack’s damage isn’t affected by effects on your opponents Active Pokemon."
+          text "60 damage. This attack’s damage isn’t affected by effects on your opponents Active Pokémon."
           energyCost P
           onAttack {
             shredDamage 60
           }
         }
         move "Max Phantom", {
-          text "130 damage. Put 5 damage counters on your opponent’s Benched Pokemon in any way you like."
+          text "130 damage. Put 5 damage counters on your opponent’s Benched Pokémon in any way you like."
           energyCost P, P
           onAttack {
             damage 130
@@ -2260,12 +2260,12 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Meteor Assault", {
-          text "180 damage. This Pokemon can’t use Meteor Assault again as long as it is the Active Pokemon."
+          text "180 damage. This Pokémon can’t use Meteor Assault again as long as it is the Active Pokémon."
           energyCost F, C, C
           onAttack {
             damage 180
             afterDamage {
-              bc "Meteor Assault cannot be used until this Pokemon leaves the Active Spot"
+              bc "Meteor Assault cannot be used until this Pokémon leaves the Active Spot"
               delayed (priority: BEFORE_LAST) {
                 before CHECK_ATTACK_REQUIREMENTS, {
                   if (ef.attacker == self && ef.move.name == "Meteor Assault") {
@@ -2304,7 +2304,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness P
         move "Yoga Shock", {
-          text "10 damage. Flip a coin. If heads, your opponent’s Active Pokemon is now Paralyzed."
+          text "10 damage. Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed."
           energyCost C
           onAttack {
             damage 10
@@ -2323,7 +2323,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Psychic", {
-          text "60+ damage. This attack does 20 more damage for each Energy attached to your opponent’s Active Pokemon."
+          text "60+ damage. This attack does 20 more damage for each Energy attached to your opponent’s Active Pokémon."
           energyCost C, C, C
           onAttack {
             damage 60+20*opp.active.cards.filterByType(ENERGY).size()
@@ -2345,7 +2345,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Barboach", hp:HP140, type:F, retreatCost:3) {
         weakness G
         bwAbility "Submerge", {
-          text "As long as this Pokemon is on your Bench, it takes no damage from attacks."
+          text "As long as this Pokémon is on your Bench, it takes no damage from attacks."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each{
@@ -2358,7 +2358,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Earthquake", {
-          text "140 damage. This attack does 20 damage to each of your Benched Pokemon. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "140 damage. This attack does 20 damage to each of your Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost F, F
           onAttack {
             damage 140
@@ -2372,7 +2372,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
         move "Reckless Charge", {
-          text "50 damage. This Pokemon does 30 damage to itself."
+          text "50 damage. This Pokémon does 30 damage to itself."
           energyCost C, C
           onAttack {
             damage 50
@@ -2384,7 +2384,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Galarian Yamask", hp:HP100, type:F, retreatCost:2) {
         weakness G
         move "Spreading Spite", {
-          text "For each damage counter on this Galarian Runerigus, put 2 damage counters on your opponent's Pokemon in any way you like."
+          text "For each damage counter on this Galarian Runerigus, put 2 damage counters on your opponent's Pokémon in any way you like."
           energyCost C, C
           attackRequirement{
             assert self.numberOfDamageCounters : "$self has no damage counters on itself."
@@ -2396,7 +2396,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Mad Hammer", {
-          text "120 damage. This Pokemon does 30 damage to itself."
+          text "120 damage. This Pokémon does 30 damage to itself."
           energyCost F, C, C
           onAttack {
             damage 120
@@ -2470,7 +2470,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Carkoal", hp:HP160, type:F, retreatCost:4) {
         weakness G
         bwAbility "Tar Generator", {
-          text "Once during your turn, you may search your discard pile for up to 1 [R] Energy and 1 [F] Energy and attach them to your Pokemon in any way you like."
+          text "Once during your turn, you may search your discard pile for up to 1 [R] Energy and 1 [F] Energy and attach them to your Pokémon in any way you like."
           actionA {
             checkLastTurn()
             assert (my.discard.filterByEnergyType(R) || my.discard.filterByEnergyType(F)) : "No [R] or [F] Energy cards in your discard pile."
@@ -2501,7 +2501,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP220, type:F, retreatCost:3) {
         weakness G
         move "Sand Eater", {
-          text "30 damage. Attach a [F] Energy from your discard pile to this Pokemon."
+          text "30 damage. Attach a [F] Energy from your discard pile to this Pokémon."
           energyCost F
           onAttack {
             damage 30
@@ -2511,7 +2511,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Sand Breath", {
-          text "220 damage. Discard 2 Energy from this Pokemon."
+          text "220 damage. Discard 2 Energy from this Pokémon."
           energyCost F, F, C
           onAttack {
             damage 220
@@ -2523,12 +2523,12 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP090, type:F, retreatCost:1) {
         weakness P
         move "Call for Family", {
-          text "Search your deck for up to 2 Basic Pokemon and put them on your Bench. Then, shuffle your deck."
+          text "Search your deck for up to 2 Basic Pokémon and put them on your Bench. Then, shuffle your deck."
           energyCost C
           callForFamily(basic:true, 2, delegate)
         }
         move "Team Attack", {
-          text "This attack does 30 damage for each Pokemon on your Bench with 'Falinks' in it's name."
+          text "This attack does 30 damage for each Pokémon on your Bench with 'Falinks' in it's name."
           energyCost C, C
           onAttack {
             damage 30*my.bench.findAll { it.name.contains "Falinks" }.size()
@@ -2539,7 +2539,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP160, type:F, retreatCost:2) {
         weakness P
         bwAbility "Iron Defense Formation", {
-          text "As long as this Pokemon is in play, damage done to any of your Pokemon with Falinks in its name by your opponent’s atacks is reduced by 20."
+          text "As long as this Pokémon is in play, damage done to any of your Pokémon with Falinks in its name by your opponent’s atacks is reduced by 20."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
@@ -2552,7 +2552,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Giga Impact", {
-          text "210 damage. This Pokemon can’t attack during your next turn."
+          text "210 damage. This Pokémon can’t attack during your next turn."
           energyCost F, F, C
           onAttack {
             damage 210
@@ -2571,7 +2571,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Power Press", {
-          text "120+ damage. If you have 1 more Energy attached to this Pokemon (but not used to pay for this attack), this attack does 60 more damage."
+          text "120+ damage. If you have 1 more Energy attached to this Pokémon (but not used to pay for this attack), this attack does 60 more damage."
           energyCost F, C, C, C
           onAttack {
             damage 120
@@ -2596,7 +2596,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Koffing", hp:HP130, type:D, retreatCost:3) {
         weakness F
         bwAbility "Neutralizing Gas", {
-          text "As long as this Pokemon is in the Active Spot, your opponent's Pokemon in play have no Abilities, except for Neutralizing Gas."
+          text "As long as this Pokémon is in the Active Spot, your opponent's Pokémon in play have no Abilities, except for Neutralizing Gas."
           getterA IS_ABILITY_BLOCKED, { Holder h ->
             if (self.active && h.effect.ability.name != "Neutralizing Gas" && h.effect.ability instanceof BwAbility && h.effect.target.owner != self.owner) {
               targeted(h.effect.target, SRC_ABILITY) {
@@ -2612,7 +2612,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Severe Poison", {
-          text "Your opponent's Active Pokemon is now Poisoned. Put 4 damage counters instead of 1 on that Pokemon during Pokemon Checkup."
+          text "Your opponent's Active Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon during Pokémon Checkup."
           energyCost D
           onAttack {
             apply POISONED
@@ -2624,7 +2624,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP070, type:D, retreatCost:2) {
         weakness F
         move "Poison Gas", {
-          text "10 damage. Your opponent’s Active Pokemon is now Poisoned."
+          text "10 damage. Your opponent’s Active Pokémon is now Poisoned."
           energyCost C, C
           onAttack {
             damage 10
@@ -2643,7 +2643,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Poison Ring", {
-          text "80 damage. Your opponent’s Active Pokemon is now Poisoned. The Defending Pokemon can’t retreat during your opponent’s next turn."
+          text "80 damage. Your opponent’s Active Pokémon is now Poisoned. The Defending Pokémon can’t retreat during your opponent’s next turn."
           energyCost D, C, C
           onAttack {
             damage 80
@@ -2664,7 +2664,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Dripping Grudge", {
-          text "Put damage counters on your opponent’s Active Pokemon equal to the number of Pokemon in your discard pile."
+          text "Put damage counters on your opponent’s Active Pokémon equal to the number of Pokémon in your discard pile."
           energyCost D, C
           attackRequirement {
             assert my.discard.filterByType(POKEMON) : "There are no Pokémon in your discard pile."
@@ -2678,7 +2678,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
         move "Venoshock", {
-          text "20+ damage. If your opponent’s Active Pokemon is Poisoned, this attack does 50 more damage."
+          text "20+ damage. If your opponent’s Active Pokémon is Poisoned, this attack does 50 more damage."
           energyCost C, C
           onAttack {
             damage 20
@@ -2690,7 +2690,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Trubbish", hp:HP120, type:D, retreatCost:2) {
         weakness F
         bwAbility "Poisonous Puddle", {
-          text "Once during your turn, if there is a Stadium in play, you may leave your opponents Active Pokemon Poisoned."
+          text "Once during your turn, if there is a Stadium in play, you may leave your opponents Active Pokémon Poisoned."
           actionA {
             assert bg.stadiumInfoStruct : "There is no Stadium in play."
             checkLastTurn()
@@ -2712,7 +2712,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         move "Pluck", {
-          text "10 damage. Before doing damage, discard all Pokemon Tools attached to your opponent’s Active Pokemon."
+          text "10 damage. Before doing damage, discard all Pokémon Tools attached to your opponent’s Active Pokémon."
           energyCost C
           onAttack {
             targeted(defending) {
@@ -2734,7 +2734,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Blindside", {
-          text "This attack does 100 damage to 1 of your opponent’s Pokemon that already has damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokemon.)"
+          text "This attack does 100 damage to 1 of your opponent’s Pokémon that already has damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
           energyCost D, D
           attackRequirement {
             assertOppAll(info: "with damage on them", {it.numberOfDamageCounters})
@@ -2748,7 +2748,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:D, retreatCost:2) {
         weakness G
         move "Drag Off", {
-          text "Choose 1 of your opponent’s Benched Pokemon and switch it with their Active Pokemon. This attack does 30 damage to the new Active Pokemon."
+          text "Choose 1 of your opponent’s Benched Pokémon and switch it with their Active Pokémon. This attack does 30 damage to the new Active Pokémon."
           energyCost D, C
           attackRequirement {
             assertOppBench()
@@ -2759,7 +2759,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Brain Shake", {
-          text "130 damage. Your opponent’s Active Pokemon is now Confused."
+          text "130 damage. Your opponent’s Active Pokémon is now Confused."
           energyCost D, D, C
           onAttack {
             damage 130
@@ -2813,7 +2813,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "False Surrender", {
-          text "60 damage. This damage isn’t affected by any effects on your opponent’s Active Pokemon."
+          text "60 damage. This damage isn’t affected by any effects on your opponent’s Active Pokémon."
           energyCost D, C, C
           onAttack {
             swiftDamage(60, defending)
@@ -2824,7 +2824,7 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Morgrem", hp:HP170, type:D, retreatCost:3) {
         weakness G
         bwAbility "Dark Oath", {
-          text "As long as this Pokemon is your Active Pokemon, your opponent’s Active Pokemon pays [C] more to use its attacks."
+          text "As long as this Pokémon is your Active Pokémon, your opponent’s Active Pokémon pays [C] more to use its attacks."
           getterA GET_MOVE_LIST, { h ->
             if (self.active && h.effect.target.active && h.effect.target.owner == self.owner.opposite) {
               def list = []
@@ -2838,7 +2838,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Energy Press", {
-          text "100+ damage. This attack does 30 more damage for each Energy attached to your opponent’s Active Pokemon."
+          text "100+ damage. This attack does 30 more damage for each Energy attached to your opponent’s Active Pokémon."
           energyCost D, C, C
           onAttack {
             damage 100+30*opp.active.cards.energyCount(C)
@@ -2854,7 +2854,7 @@ public enum RebelClash implements LogicCardInfo {
           actionA {
             checkLastTurn()
             powerUsed()
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
             assert my.hand.size() >= 2 : "You need 2 or more cards in your hand."
 
             my.hand.select(count: 2, "Choose 2 cards to discard.").discard()
@@ -2896,7 +2896,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Raid", {
-          text "30+ damage. If this Pokemon evolved from Scyther during your turn, this attack does 90 more damage."
+          text "30+ damage. If this Pokémon evolved from Scyther during your turn, this attack does 90 more damage."
           energyCost M
           onAttack {
             damage 30
@@ -2907,7 +2907,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Guard Claw", {
-          text "90 damage. During your opponent’s next turn, any damage done to this Pokemon by attacks is reduced by 30."
+          text "90 damage. During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 30."
           energyCost M, C, C
           onAttack {
             damage 90
@@ -2946,7 +2946,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Gyro Ball", {
-          text "70 damage. Switch this Pokemon with 1 of your Benched Pokemon. If you do, your opponent switches their Active Pokemon with 1 of their Benched Pokemon."
+          text "70 damage. Switch this Pokémon with 1 of your Benched Pokémon. If you do, your opponent switches their Active Pokémon with 1 of their Benched Pokémon."
           energyCost M, C, C
           onAttack {
             def pcs = opp.active
@@ -2968,7 +2968,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Gravitational Drop", {
-          text "10+ damage. This attack does 30 more damage for each [C] in your opponent’s Active Pokemon’s Retreat Cost."
+          text "10+ damage. This attack does 30 more damage for each [C] in your opponent’s Active Pokémon’s Retreat Cost."
           energyCost M
           onAttack {
             damage 10+30*defending.retreatCost
@@ -2987,7 +2987,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Gathering Food", {
-          text "For each Energy attached to this Pokemon, search your deck for a Trainer card, reveal it, and put it into your hand. Then, shuffle your deck."
+          text "For each Energy attached to this Pokémon, search your deck for a Trainer card, reveal it, and put it into your hand. Then, shuffle your deck."
           energyCost C
           onAttack {
             def energyCount = self.cards.energyCount(C)
@@ -3039,7 +3039,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         bwAbility "Big Shield", {
-          text "As long as this Pokemon is in play, any damage done to your Pokemon by opponent’s attacks is reduced by 30. You can’t use more than 1 Big Shield Ability."
+          text "As long as this Pokémon is in play, any damage done to your Pokémon by opponent’s attacks is reduced by 30. You can’t use more than 1 Big Shield Ability."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               if(bg.em().retrieveObject("Big_Shield") != bg.turnCount) {
@@ -3067,7 +3067,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Adamantine Press", {
-          text "90 damage. During your opponent’s next turn, this Pokemon takes 30 less damage from attacks."
+          text "90 damage. During your opponent’s next turn, this Pokémon takes 30 less damage from attacks."
           energyCost M, M, C
           onAttack {
             damage 90
@@ -3087,7 +3087,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Dangerous Nose", {
-          text "100+ damage. If your opponent’s Active Pokemon is a Basic Pokemon, this attack does 100 more damage."
+          text "100+ damage. If your opponent’s Active Pokémon is a Basic Pokémon, this attack does 100 more damage."
           energyCost M, M, C
           onAttack {
             damage 100
@@ -3109,7 +3109,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Metal Sharpener", {
-          text "30 damage. Attach a [M] Energy from your discard pile to 1 of your Pokemon."
+          text "30 damage. Attach a [M] Energy from your discard pile to 1 of your Pokémon."
           energyCost C
           onAttack {
             damage 30
@@ -3131,7 +3131,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Energy Stream", {
-          text "30 damage. Attach a [M] Energy from your discard pile to this Pokemon."
+          text "30 damage. Attach a [M] Energy from your discard pile to this Pokémon."
           energyCost M, C
           onAttack {
             damage 30
@@ -3141,7 +3141,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Smashing Edge", {
-          text "120 damage. Flip a coin. If tails, discard 2 Energy from this Pokemon"
+          text "120 damage. Flip a coin. If tails, discard 2 Energy from this Pokémon"
           energyCost M, M, C
           onAttack {
             damage 120
@@ -3156,7 +3156,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness R
         resistance G, MINUS30
         move "Guard Press", {
-          text "30 Damage. During your opponent's next turn, this Pokemon takes 20 less damage from attacks (after applying Weakness and Resistance)."
+          text "30 Damage. During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance)."
           energyCost M, C
           onAttack {
             damage 30
@@ -3164,7 +3164,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Power Rush", {
-          text "120 damage. Flip a coin. If tails, during your next turn, this Pokemon can't attack."
+          text "120 damage. Flip a coin. If tails, during your next turn, this Pokémon can't attack."
           energyCost M, M, C
           onAttack {
             damage 120
@@ -3185,7 +3185,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Collapse", {
-          text "120 damage. This Pokemon is now Asleep."
+          text "120 damage. This Pokémon is now Asleep."
           energyCost C, C, C
           onAttack {
             damage 120
@@ -3198,7 +3198,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         bwAbility "Lucky Match", {
-          text "When you play this Pokemon from your hand onto your Bench during your turn you may flip a coin. If heads put a Supporter card from your discard pile into your hand."
+          text "When you play this Pokémon from your hand onto your Bench during your turn you may flip a coin. If heads put a Supporter card from your discard pile into your hand."
           onActivate { r->
             if (r==PLAY_FROM_HAND && my.discard.filterByType(SUPPORTER) && confirm("Use Lucky Match?")) {
               powerUsed()
@@ -3221,10 +3221,10 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         move "Chirp", {
-          text "Search your deck for up to 2 Pokemon with a [F] Resistance, reveal them, and put them into your hand. Then, shuffle your deck."
+          text "Search your deck for up to 2 Pokémon with a [F] Resistance, reveal them, and put them into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             my.deck.search (max: 2, {
@@ -3265,7 +3265,7 @@ public enum RebelClash implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         move "Daunt", {
-          text "50 damage. The attacks of the Defending Pokemon do 50 less damage during your opponent’s next turn."
+          text "50 damage. The attacks of the Defending Pokémon do 50 less damage during your opponent’s next turn."
           energyCost C, C
           onAttack {
             damage 50
@@ -3273,7 +3273,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Air Slash", {
-          text "150 damage. Discard an Energy from this Pokemon."
+          text "150 damage. Discard an Energy from this Pokémon."
           energyCost C, C, C
           onAttack {
             damage 150
@@ -3309,7 +3309,7 @@ public enum RebelClash implements LogicCardInfo {
           text "Discard up to 6 cards from the top of your deck. This attack does 30 damage for each card discarded in this way."
           energyCost C, C, C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             def n = 0
@@ -3385,7 +3385,7 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         move "Big Throw", {
-          text "Flip a coin. If heads, discard your opponent’s Active Pokemon and all cards attached to it."
+          text "Flip a coin. If heads, discard your opponent’s Active Pokémon and all cards attached to it."
           energyCost C, C, C, C
           onAttack {
             flip {
@@ -3419,10 +3419,10 @@ public enum RebelClash implements LogicCardInfo {
       return evolution (this, from:"Skwovet", hp:HP120, type:C, retreatCost:1) {
         weakness F
         bwAbility "Greedy Tail", {
-          text "Once during your turn, you may search your deck for a Pokemon Tool card, reveal it, and put it into your hand. Then, shuffle your deck."
+          text "Once during your turn, you may search your deck for a Pokémon Tool card, reveal it, and put it into your hand. Then, shuffle your deck."
           actionA {
             checkLastTurn()
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
             powerUsed()
             my.deck.search(count:1, "Choose a Pokémon Tool card.", cardTypeFilter(POKEMON_TOOL)).moveTo(my.hand)
             shuffleDeck()
@@ -3440,7 +3440,7 @@ public enum RebelClash implements LogicCardInfo {
       return basic (this, hp:HP210, type:C, retreatCost:2) {
         weakness F
         bwAbility "Soft Wool", {
-          text "Damage done to this Pokemon by attacks is reduced by 30."
+          text "Damage done to this Pokémon by attacks is reduced by 30."
           delayedA {
             before APPLY_ATTACK_DAMAGES, {
               bg.dm().each {
@@ -3462,7 +3462,7 @@ public enum RebelClash implements LogicCardInfo {
       };
       case BOSS_S_ORDERS_154:
       return supporter (this) {
-        text "Choose 1 of your opponent’s Benched Pokemon and switch it with their Active Pokemon. You may play only 1 Supporter card during your turn (before your attack)."
+        text "Choose 1 of your opponent’s Benched Pokémon and switch it with their Active Pokémon. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
           switchYourOpponentsBenchedWithActive(TRAINER_CARD)
         }
@@ -3472,7 +3472,7 @@ public enum RebelClash implements LogicCardInfo {
       };
       case BURNING_SCARF_155:
       return pokemonTool (this) {
-        text "Attach a Pokemon Tool to 1 of your Pokemon that doesn’t already have a Pokemon Tool attached to it. If the [R] Pokemon this card is attached to is your Active Pokemon and is damaged by an opponent’s attack, the Attacking Pokemon is now Burned. You may play as many Item cards as you like during your turn (before your attack)."
+        text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the [R] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack, the Attacking Pokémon is now Burned. You may play as many Item cards as you like during your turn (before your attack)."
         def eff
         onPlay {reason->
           eff = delayed(priority: LAST) {
@@ -3498,12 +3498,12 @@ public enum RebelClash implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement{
-          assert my.deck : "Your deck is empty."
+          assert my.deck : "Your deck is empty!."
         }
       };
       case CURSED_SHOVEL_157:
       return pokemonTool (this) {
-        text "Attach a Pokemon Tool to 1 of your Pokemon that doesn’t already have a Pokemon Tool attached to it. If the Pokemon this Tool is attached to is Knocked Out by damage from an opponent’s attack, discard the top 2 cards of your opponent’s deck. You may play as many Item cards as you like during your turn (before your attack)."
+        text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the Pokémon this Tool is attached to is Knocked Out by damage from an opponent’s attack, discard the top 2 cards of your opponent’s deck. You may play as many Item cards as you like during your turn (before your attack)."
         def eff
         onPlay {reason->
           eff = delayed (priority: BEFORE_LAST) {
@@ -3541,14 +3541,14 @@ public enum RebelClash implements LogicCardInfo {
           }
         }
         playRequirement {
-          assert my.deck : "Your deck is empty."
+          assert my.deck : "Your deck is empty!."
         }
       };
       case FULL_HEAL_159:
       return copy(HeartgoldSoulsilver.FULL_HEAL_93, this);
       case GALAR_MINE_160:
       return stadium (this) {
-        text "The Retreat Cost of each Active Pokemon (both yours and your opponent’s) is [C][C] more. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
+        text "The Retreat Cost of each Active Pokémon (both yours and your opponent’s) is [C][C] more. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
         def eff
         onPlay {
           eff = getter (GET_RETREAT_COST) { Holder h->
@@ -3633,12 +3633,12 @@ public enum RebelClash implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement {
-          assert my.deck : "Your deck is empty."
+          assert my.deck : "Your deck is empty!."
         }
       };
       case SONIA_167:
       return supporter (this) {
-        text "Search your deck for up to 2 Basic Pokemon or up to 2 Basic Energy, reveal them, and put them into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn (before your attack)."
+        text "Search your deck for up to 2 Basic Pokémon or up to 2 Basic Energy, reveal them, and put them into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn (before your attack)."
         onPlay {
           def choice = choose([0,1],["Search deck for up to 2 Basic Pokémon","Search deck for up to 2 Basic Energy"],"What do you want to do?")
           if (choice == 0) {
@@ -3649,12 +3649,12 @@ public enum RebelClash implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement {
-          assert my.deck : "Your deck is empty."
+          assert my.deck : "Your deck is empty!."
         }
       };
       case TOOL_SCRAPPER_168:
       return itemCard (this) {
-        text "Discard up to 2 Pokemon Tools from either player’s Pokemon. You may play as many Item cards during your turn as you like (before your attack)."
+        text "Discard up to 2 Pokémon Tools from either player’s Pokémon. You may play as many Item cards during your turn as you like (before your attack)."
         onPlay {
           def i = 2
           while (true) {
@@ -3683,7 +3683,7 @@ public enum RebelClash implements LogicCardInfo {
                 break
               }
               if (tar) {
-                def sel = tar.select("Select a Pokémon to discard a Pokemon Tool from (cancel to stop).", false)
+                def sel = tar.select("Select a Pokémon to discard a Pokémon Tool from (cancel to stop).", false)
                 if (sel) {
                   def list = sel.cards.filterByType(POKEMON_TOOL).select("Discard a Pokémon Tool from $sel.")
                   targeted (sel, TRAINER_CARD) {
@@ -3721,12 +3721,12 @@ public enum RebelClash implements LogicCardInfo {
       };
       case TURRFIELD_170:
       return stadium (this) {
-        text "Once during each player’s turn, that player may search their deck for a [G] Evolution Pokemon, reveal it, and put it into their hand. Then, that player shuffles their deck. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
+        text "Once during each player’s turn, that player may search their deck for a [G] Evolution Pokémon, reveal it, and put it into their hand. Then, that player shuffles their deck. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
         def lastTurn=0
         def actions=[]
         onPlay {
           actions=action("Stadium: Turffield Stadium") {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
             assert lastTurn != bg().turnCount : "Already used this turn."
             bc "Used Turffield Stadium effect."
             lastTurn = bg().turnCount
@@ -3742,7 +3742,7 @@ public enum RebelClash implements LogicCardInfo {
       };
       case CAPTURE_ENERGY_171:
       return specialEnergy (this, [[]]) {
-        text "This card provides [C] Energy only while attached to a Pokemon. When attaching this card from your hand to 1 of your Pokemon, search your deck for a Basic Pokemon and put it on your Bench. Then, shuffle your deck."
+        text "This card provides [C] Energy only while attached to a Pokémon. When attaching this card from your hand to 1 of your Pokémon, search your deck for a Basic Pokémon and put it on your Bench. Then, shuffle your deck."
         onPlay {reason->
           if (reason == PLAY_FROM_HAND && my.deck && my.bench.notFull) {
             my.deck.search (count: 1, { it.cardTypes.is(BASIC) }).each {
@@ -3758,7 +3758,7 @@ public enum RebelClash implements LogicCardInfo {
       };
       case HORROR_PSYCHIC_ENERGY_172:
       return specialEnergy (this, [[]]) {
-        text "This card provides 1 [P] Energy while it’s attached to a Pokemon. When the [P] Pokemon this card is attached to is your Active Pokemon and is damaged by an opponents attack, put 2 damage counters on the Attacking Pokemon."
+        text "This card provides 1 [P] Energy while it’s attached to a Pokémon. When the [P] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponents attack, put 2 damage counters on the Attacking Pokémon."
         def eff
         onPlay { reason->
           eff = delayed(priority: BEFORE_LAST) {
@@ -3790,7 +3790,7 @@ public enum RebelClash implements LogicCardInfo {
       };
       case SPEED_LIGHTNING_ENERGY_173:
       return specialEnergy (this, [[]]) {
-        text "This card provides 1 [L] Energy while it’s attached to a Pokemon. When you attach this card from your hand to an [L] Pokemon, draw 2 cards"
+        text "This card provides 1 [L] Energy while it’s attached to a Pokémon. When you attach this card from your hand to an [L] Pokémon, draw 2 cards"
         onPlay {reason->
           if (reason == PLAY_FROM_HAND && self.types.contains(L)) {
             draw 2

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -561,7 +561,7 @@ public enum SwordShield implements LogicCardInfo {
           text "Once during your turn, you may search your deck for up to 2 [G] Energy cards and attach them to 1 of your Pokémon. Then, shuffle your deck."
           actionA {
             checkLastTurn()
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
             powerUsed()
             def list = my.deck.search (max: 2, basicEnergyFilter(G))
             def pcs = my.all.select("Attach to?")
@@ -1025,7 +1025,7 @@ public enum SwordShield implements LogicCardInfo {
             opp.deck.subList(0, self.cards.energyCount(R)).discard()
           }
           attackRequirement {
-            assert opp.deck : "Your opponent's deck is empty"
+            assert opp.deck : "Your opponent's deck is empty!"
           }
         }
         move "Searing Flame", {
@@ -2151,7 +2151,7 @@ public enum SwordShield implements LogicCardInfo {
             opp.deck.subList(0, 2).discard()
           }
           attackRequirement {
-            assert opp.deck : "Your opponent's deck is empty"
+            assert opp.deck : "Your opponent's deck is empty!"
           }
         }
         move "Land Crush", {
@@ -2791,7 +2791,7 @@ public enum SwordShield implements LogicCardInfo {
           text "Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             my.deck.search(max: 1, cardTypeFilter(POKEMON)).moveTo(my.hand)
@@ -3339,7 +3339,7 @@ public enum SwordShield implements LogicCardInfo {
           text "Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck."
           energyCost C
           attackRequirement {
-            assert my.deck : "Your deck is empty."
+            assert my.deck : "Your deck is empty!."
           }
           onAttack {
             my.deck.search(min:1, max:2,"Choose 2 cards to put in your hand.",{true}).moveTo(hidden: true, my.hand)

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -253,7 +253,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           actionA {
             checkNoSPC()
             assert my.hand.filterByBasicEnergyType(W) : "No [W] in hand"
-            assert my.all.find{it.types.contains(W) && !it.EX} : "No [W] pokemon"
+            assert my.all.find{it.types.contains(W) && !it.EX} : "No [W] Pokémon."
 
             powerUsed()
             def card = my.hand.filterByBasicEnergyType(W).first()
@@ -684,7 +684,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert my.bench.notEmpty : "$self is your last pokemon"
+            assert my.bench.notEmpty : "$self is your last Pokémon."
             powerUsed()
             new Knockout(self).run(bg)
             def type = choose([R, W, G, L, F, P, M, D, Y],["Fire","Water","Grass","Lightning","Fighting","Psychic","Metal","Darkness","Fairy"],"What type of energy?")
@@ -1612,7 +1612,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
       return basicTrainer (this) {
         text "Choose 1 of your own Pokémon in play and a Stage of Evolution. Discard all Evolution cards of that Stage or higher attached to that Pokémon. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
         onPlay {
-          def pcs = my.all.findAll{it.evolution}.select("Pokemon to devolve")
+          def pcs = my.all.findAll{it.evolution}.select("Pokémon to devolve")
           def pkmn = []
           pkmn.addAll(pcs.pokemonCards)
           pkmn.remove(pcs.topPokemonCard)
@@ -1694,7 +1694,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
       return basicTrainer (this) {
         text "Trade 1 of the Basic Pokémon or Evolution cards in your hand for 1 of the Basic Pokémon or Evolution cards from your deck. Show both cards to your opponent. Shuffle your deck afterward."
         onPlay {
-          my.hand.select("Choose a Pokemon", cardTypeFilter(POKEMON)).select().moveTo(my.deck)
+          my.hand.select("Choose a Pokémon", cardTypeFilter(POKEMON)).select().moveTo(my.deck)
           my.deck.search (max: 1, cardTypeFilter(POKEMON)).moveTo(hand)
           shuffleDeck()
         }
@@ -1755,7 +1755,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
       };
       case FULL_HEAL_82:
       return basicTrainer (this) {
-        text "Remove all Special Conditions from your Active Pokemon"
+        text "Remove all Special Conditions from your Active Pokémon"
         onPlay {
           clearSpecialCondition(my.active, TRAINER_CARD)
         }
@@ -1818,7 +1818,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           my.deck.setSubList(0, list)
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case PROFESSOR_OAK_88:
@@ -1851,7 +1851,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         onPlay {
           def tar = my.all.findAll { it.cards.energyCount(C) && it.numberOfDamageCounters && !it.EX }
           if(tar) {
-            def pcs = tar.select("Heal which Pokemon?")
+            def pcs = tar.select("Heal which Pokémon?")
             targeted (pcs, TRAINER_CARD) {
               pcs.cards.filterByType(ENERGY).select("Discard which Energy?").discard()
               heal 40, pcs
@@ -1958,7 +1958,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           }
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case ENERGY_SWITCH_104:
@@ -1970,7 +1970,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           src.cards.filterByType(BASIC_ENERGY).select("Select a Basic Energy card to move to the target.").each{energySwitch(src,tar,it)}
         }
         playRequirement{
-          assert my.all.findAll{it.cards.filterByType(BASIC_ENERGY)} : "You have no basic Energy attached to your pokemon"
+          assert my.all.findAll{it.cards.filterByType(BASIC_ENERGY)} : "You have no basic Energy attached to your Pokémon."
           assert my.all.size() >= 2 : "You only have one Pokémon in play."
         }
       };
@@ -2015,8 +2015,8 @@ public enum PokemodBaseSet implements LogicCardInfo {
         }
         playRequirement{
           assert !bg.em().retrieveObject("G_SPEC_"+thisCard.player) : "You have already used your G-SPEC card"
-          assert my.all.findAll{it.cards.filterByType(ENERGY)} : "You have no energy attached to your pokemon"
-          assert opp.all.findAll{it.cards.filterByType(ENERGY)} : "Your opponent has no energy attached to their pokemon"
+          assert my.all.findAll{it.cards.filterByType(ENERGY)} : "You have no energy attached to your Pokémon."
+          assert opp.all.findAll{it.cards.filterByType(ENERGY)} : "Your opponent has no energy attached to their Pokémon."
         }
       };
       case DOWSING_MACHINE_108:
@@ -2147,7 +2147,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           text "As often as you like during your turn (before your attack), move a [G] Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Venusaur ex is affected by a Special Condition."
           actionA {
             checkNoSPC()
-            assert my.all.findAll{it.cards.filterByEnergyType(G)} : "You have no [G] Energy attached to your pokemon"
+            assert my.all.findAll{it.cards.filterByEnergyType(G)} : "You have no [G] Energy attached to your Pokémon."
             assert my.all.size() >= 2 : "You only have one Pokémon in play."
             powerUsed()
             def src = my.all.findAll{it.cards.filterByEnergyType(G)}.select("Move Energy from which pokemon?")

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
@@ -306,8 +306,8 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert my.deck : "You have no cards in your deck"
-            assert bg.em().retrieveObject("Quick_Search") != bg.turnCount : "You can't use more than one Quick Search Pokémon Power each turn"
+            assert my.deck : "Your deck is empty!"
+            assert bg.em().retrieveObject("Quick_Search") != bg.turnCount : "You can't use more than one Quick Search Pokémon Power each turn."
             bg.em().storeObject("Quick_Search", bg.turnCount)
             my.deck.select(count:1).moveTo(hidden:true,my.hand)
             shuffleDeck()
@@ -419,7 +419,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
               if(ef.attacker.owner != self.owner) {
                 bg.dm().each{
                   if(it.to == self && it.notNoEffect && it.dmg.value >= 30) {
-                    bc "Invisible Wall prevents damage"
+                    bc "Invisible Wall prevents damage."
                     it.dmg = hp(0)
                   }
                 }
@@ -453,7 +453,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           }
         }
         move "Guillotine", {
-          text "50 damage. "
+          text "50 damage."
           energyCost G, G, C, C
           attackRequirement {}
           onAttack {
@@ -508,7 +508,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
                 }
               }
             }
-            assert typeList : "There is no pokemon in play with a type different than [C]"
+            assert typeList : "There is no pokemon in play with a type different than [C]!"
             powerUsed()
             def newType = choose(typeList,"Select the new type of Venomoth")
             getter GET_POKEMON_TYPE, self, {h->
@@ -539,7 +539,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            sw opp.active, opp.bench.select("Choose new active pokemon"), ATTACK
+            sw opp.active, opp.bench.select("Choose new active Pokémon."), ATTACK
           }
         }
         move "Acid", {
@@ -616,7 +616,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            sw self, my.bench.select("Choose new active pokemon"), ATTACK
+            sw self, my.bench.select("Choose new active Pokémon."), ATTACK
           }
         }
         move "Big Eggsplosion", {
@@ -719,11 +719,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           text "Search your deck for a [F] Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
           energyCost F
           attackRequirement {
-            assert my.deck : "Your deck is empty"
-            assert my.bench.notFull : "Your bench is full"
+            assert my.deck : "Your deck is empty!"
+            assert my.bench.notFull : "Your bench is full."
           }
           onAttack {
-            my.deck.search("Choose Basic [f] Pokémon",{(it.cardTypes.is(BASIC) && it.asPokemonCard().types.contains(F))}).each{
+            my.deck.search("Choose Basic [f] Pokémon.",{(it.cardTypes.is(BASIC) && it.asPokemonCard().types.contains(F))}).each{
               benchPCS(it)
             }
             shuffleDeck()
@@ -920,8 +920,8 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           text "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
           energyCost G
           attackRequirement {
-            assert my.bench.notFull : "Your bench is full"
-            assert my.deck : "Your deck is empty"
+            assert my.bench.notFull : "Your bench is full."
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             my.deck.search("Choose Basic Pokémon named Bellsprout",{(it.cardTypes.is(BASIC) && it.name.contains("Bellsprout"))}).each{
@@ -1068,8 +1068,8 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           text "Search your deck for a Basic Pokémon named Nidoran♂ or Nidoran♀ and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)"
           energyCost G
           attackRequirement {
-            assert my.bench.notFull : "Your bench is full"
-            assert my.deck : "Your deck is empty"
+            assert my.bench.notFull : "Your bench is full."
+            assert my.deck : "Your deck is empty!"
           }
           onAttack {
             my.deck.search("Choose Basic Pokémon named Nidoran♂ or Nidoran♀",{ it.cardTypes.is(BASIC) && ["Nidoran♂", "Nidoran♀"].contains(it.name) }).each{
@@ -1275,7 +1275,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
           shuffleDeck()
         }
         playRequirement{
-          assert my.deck : "Your deck is empty"
+          assert my.deck : "Your deck is empty!"
         }
       };
       case POTION_122:

--- a/src/tcgwars/logic/impl/pokemod/PokemodExpedition.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodExpedition.groovy
@@ -34,7 +34,7 @@ import tcgwars.logic.util.*;
  * @author lithogenn@gmail.com
  */
 public enum PokemodExpedition implements LogicCardInfo {
-    
+
   ALAKAZAM_1 ("Alakazam", "1", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE2, _PSYCHIC_]),
   AMPHAROS_2 ("Ampharos", "2", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE2, _LIGHTNING_]),
   ARBOK_3 ("Arbok", "3", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, _GRASS_]),
@@ -220,9 +220,9 @@ public enum PokemodExpedition implements LogicCardInfo {
   CHANSEY_EX_184 ("Chansey ex", "184", Rarity.RARE, [POKEMON, BASIC, EX, _COLORLESS_]),
   POKEMON_MASTER_KEY_185 ("Pokémon Master Key", "185", Rarity.RARE, [TRAINER]),
   POKEMON_LEGEND_BOX_186 ("Pokémon Legend Box", "186", Rarity.RARE, [TRAINER, STADIUM]);
-    
+
   static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
-  
+
   protected CardTypeSet cardTypes;
   protected String name;
   protected Rarity rarity;
@@ -283,7 +283,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         move "Syncroblast", {
           text "80 damage. If Alakazam and the Defending Pokémon don''t have the same number of Energy cards attached to them, this attack''s base damage is 20 instead of 80."
-          energyCost P, C, C, C
+          energyCost P, C, C
           attackRequirement {}
           onAttack {
             damage 80
@@ -315,7 +315,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Poison Reaction", {
@@ -572,7 +572,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost R
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -602,7 +602,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost P, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -614,7 +614,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Psychic", {
@@ -634,7 +634,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost R, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Ethereal Flame", {
@@ -653,7 +653,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost L
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -830,7 +830,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Misfire", {
@@ -1037,7 +1037,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Razor Leaf", {
@@ -1058,7 +1058,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Dogpile", {
@@ -1130,7 +1130,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Reflect Energy", {
@@ -1291,7 +1291,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Confuse Ray", {
@@ -1461,7 +1461,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1493,7 +1493,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Vine Whip", {
@@ -1574,7 +1574,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Double Scratch", {
@@ -1616,7 +1616,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Slap", {
@@ -1677,7 +1677,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost R
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Quick Attack", {
@@ -1755,7 +1755,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1825,7 +1825,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1995,7 +1995,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Tackle", {
@@ -2035,7 +2035,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost R
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Smash Kick", {
@@ -2191,7 +2191,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Bite", {
@@ -2211,7 +2211,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Flare", {
@@ -2597,7 +2597,7 @@ public enum PokemodExpedition implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Psyburn", {
@@ -2656,11 +2656,11 @@ public enum PokemodExpedition implements LogicCardInfo {
         weakness F
         resistance P, MINUS30
         move "Healing Egg", {
-          text "Remove 2 damage counters (1 if there is only 1) from each of your Pokemon. Remove no damage counters from Chansey ex."
+          text "Remove 2 damage counters (1 if there is only 1) from each of your Pokémon. Remove no damage counters from Chansey ex."
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Double-edge", {

--- a/src/tcgwars/logic/impl/pokemod/PokemodSkyridge.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodSkyridge.groovy
@@ -34,7 +34,7 @@ import tcgwars.logic.util.*;
  * @author lithogenn@gmail.com
  */
 public enum PokemodSkyridge implements LogicCardInfo {
-    
+
   AERODACTYL_1 ("Aerodactyl", "1", Rarity.RARE, [POKEMON, EVOLUTION, STAGE1, _FIGHTING_]),
   ALAKAZAM_2 ("Alakazam", "2", Rarity.RARE, [POKEMON, EVOLUTION, STAGE2, _PSYCHIC_]),
   ARCANINE_3 ("Arcanine", "3", Rarity.RARE, [POKEMON, EVOLUTION, STAGE1, _FIRE_]),
@@ -225,9 +225,9 @@ public enum PokemodSkyridge implements LogicCardInfo {
   MUK_EX_189 ("Muk ex", "189", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, EX, _GRASS_]),
   MAGCARGO_EX_190 ("Magcargo ex", "190", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, EX, _FIRE_]),
   RAYQUAZA_EX_191 ("Rayquaza ex", "191", Rarity.HOLORARE, [POKEMON, BASIC, EX, _COLORLESS_]);
-    
+
   static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
-  
+
   protected CardTypeSet cardTypes;
   protected String name;
   protected Rarity rarity;
@@ -431,7 +431,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost R
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Burn Booster", {
@@ -771,7 +771,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Frog Hop", {
@@ -816,7 +816,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Lightning Storm", {
@@ -825,6 +825,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 50
+            flip 1, {}, { directDamage 20, self }
           }
         }
       };
@@ -1036,7 +1037,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost F, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Mega Punch", {
@@ -1065,7 +1066,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost P, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1096,7 +1097,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Drag Off", {
@@ -1211,7 +1212,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1223,7 +1224,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Kick Away", {
@@ -1262,7 +1263,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1335,7 +1336,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Leek Rush", {
@@ -1393,7 +1394,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Syncroblast", {
@@ -1421,7 +1422,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost F, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1433,7 +1434,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Strength in Numbers", {
@@ -1536,7 +1537,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Eerie Light", {
@@ -1544,7 +1545,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1575,7 +1576,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1588,7 +1589,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Lullaby", {
@@ -1645,7 +1646,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Hypnoblast", {
@@ -1666,7 +1667,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Quick Turn", {
@@ -1726,7 +1727,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Splash", {
@@ -1746,7 +1747,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Magnetic Lines", {
@@ -1809,7 +1810,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -1821,7 +1822,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost P
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Removal Beam", {
@@ -1841,7 +1842,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Scratch", {
@@ -1949,7 +1950,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Double Kick", {
@@ -1991,7 +1992,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Body Slam", {
@@ -2152,7 +2153,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost R
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -2195,7 +2196,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Bite", {
@@ -2216,7 +2217,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Antler Swipe", {
@@ -2224,7 +2225,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -2236,7 +2237,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Doubleslap", {
@@ -2277,7 +2278,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost G, C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Trip Over", {
@@ -2326,7 +2327,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost W
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -2439,7 +2440,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost L
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Spin Tackle", {
@@ -2471,7 +2472,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Poison Horn", {
@@ -2479,7 +2480,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost G
           attackRequirement {}
           onAttack {
-            
+
           }
         }
       };
@@ -2513,7 +2514,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Flitter", {
@@ -2794,7 +2795,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost G, W
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Mind Bend", {
@@ -3057,7 +3058,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost W, W
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Hydrocannon", {
@@ -3172,7 +3173,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
           energyCost C
           attackRequirement {}
           onAttack {
-            
+
           }
         }
         move "Dragon Burst", {

--- a/src/tcgwars/logic/util/BenchSet.java
+++ b/src/tcgwars/logic/util/BenchSet.java
@@ -137,7 +137,7 @@ public class BenchSet extends PcsList {
   @Override
   public boolean add(PokemonCardSet e) {
     if (isFull()) {
-      throw new IllegalStateException("Bench is full");
+      throw new IllegalStateException("Bench is full.");
     }
     set(getFirstFreeIndex(), e);
     return true;

--- a/src/tcgwars/logic/util/CardList.groovy
+++ b/src/tcgwars/logic/util/CardList.groovy
@@ -493,7 +493,7 @@ public class CardList extends ArrayList<Card> {
   }
 
   public void shuffle() {
-    if (autosort) throw new IllegalStateException("Autosort is active");
+    if (autosort) throw new IllegalStateException("Autosort is active.");
     Collections.shuffle(this, Battleground.getInstance().rng);
   }
 


### PR DESCRIPTION
I went ahead and replaced all instances of "pokemon" and "Pokemon" with the proper "Pokémon" name. Additionally fixing some grammatical issues prominent in some areas.