### PR TITLE
Refactor Holon-Energy Pokemon Global Ability

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1016,7 +1016,9 @@ class TcgStatics {
                     def returningEnergy = pcs.cards.filterByType(ENERGY).select(count: 1)
 
                     bg.em().run(new ChangeImplementation(energyCard, thisCard))
-                    def cannotPlayEnergy = bg.em().run(new PlayEnergy(energyCard, pcs))
+                    def playEnergy = new PlayEnergy(energyCard)
+                    bg.em().run(playEnergy)
+                    def cannotPlayEnergy = !playEnergy.attached
                     if (cannotPlayEnergy) {
                       bg.em().run(new ChangeImplementation(thisCard, energyCard))
                     } else {

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1013,7 +1013,7 @@ class TcgStatics {
                     def pcs = validPokemon.select("Attach to?")
 
                     // Select an energy before attachment so that thisCard doesn't show up as an option
-                    def returningEnergy = pcs.cards.filterByType(ENERGY).select(count: 1)
+                    def returningEnergy = pcs.cards.select cardTypeFilter(ENERGY)
 
                     bg.em().run(new ChangeImplementation(energyCard, thisCard))
                     def playEnergy = new PlayEnergy(energyCard)

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1012,7 +1012,7 @@ class TcgStatics {
 
                     def pcs = validPokemon.select("Attach to?")
 
-                    // Return an energy back to the hand
+                    // Select an energy before attachment so that thisCard doesn't show up as an option
                     def returningEnergy = pcs.cards.filterByType(ENERGY).select(count: 1)
 
                     bg.em().run(new ChangeImplementation(energyCard, thisCard))

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -853,58 +853,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       case HOLON_S_ELECTRODE_21:
       return evolution (this, from:"Holon's Voltorb", hp:HP070, type:L, retreatCost:0) {
         weakness F
-        globalAbility {Card thisCard->
-          delayed {
-            before PLAY_CARD, {
-              def validPokemon = thisCard.player.pbg.all.findAll {it.cards.energyCount()}
-              if(ef.cardToPlay == thisCard){
-                if(choose([1,2], ["Pokémon", "Energy"], "Play this card as a Pokémon or as an energy?") == 2){
-                  if(bg.em().retrieveObject("Holon_Pokemon_Energy") != bg.turnCount){
-                    if(validPokemon){
-                      def pcs = validPokemon.select("Attach to?")
-                      bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-
-                      // Return an energy back to the hand
-                      pcs.cards.filterByType(ENERGY).select(count:1).moveTo(thisCard.player.pbg.hand)
-
-                      def pkmnCard = thisCard
-                      def energyCard
-                      energyCard = specialEnergy(new CustomCardInfo(HOLON_S_ELECTRODE_21).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P],[R, D, F, G, W, Y, L, M, P]]) {
-                        typeImagesOverride = [RAINBOW,RAINBOW]
-                        onPlay {}
-                        onRemoveFromPlay {
-                          bg.em().run(new ChangeImplementation(pkmnCard, energyCard))
-                        }
-                      }
-                      energyCard.player = thisCard.player
-                      bg.em().run(new ChangeImplementation(energyCard, pkmnCard))
-                      bc "$energyCard is now a Special Energy Card"
-                      attachEnergy(pcs, energyCard, PLAY_FROM_HAND)
-                      prevent()
-                    } else {
-                      prevent()
-                      wcu "You have no energy attached to your Pokémon"
-                    }
-                  } else {
-                    prevent()
-                    wcu "You have already played an Energy"
-                  }
-                }
-              } //If the user chooses Pokémon, play the card normally
-            }
-            before PLAY_ENERGY, {
-              if(bg.em().retrieveObject("Holon_Pokemon_Energy") == bg.turnCount){
-                wcu "Cannot play any more energy this turn."
-                prevent()
-              }
-            }
-            after ATTACH_ENERGY, {
-              if(ef.reason==PLAY_FROM_HAND){
-                bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-              }
-            }
-          }
-        }
+        holon_pokemon_energy(delegate, 2)
         move "Dazzle Blast", {
           text "30 damage. The Defending Pokémon is now Confused."
           energyCost L, C
@@ -918,58 +867,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       return evolution (this, from:"Holon's Magnemite", hp:HP070, type:M, retreatCost:1) {
         weakness R
         resistance G, MINUS30
-        globalAbility {Card thisCard->
-          delayed {
-            before PLAY_CARD, {
-              def validPokemon = thisCard.player.pbg.all.findAll {it.cards.energyCount()}
-              if(ef.cardToPlay == thisCard){
-                if(choose([1,2], ["Pokémon", "Energy"], "Play this card as a Pokémon or as an energy?") == 2){
-                  if(bg.em().retrieveObject("Holon_Pokemon_Energy") != bg.turnCount){
-                    if(validPokemon){
-                      def pcs = validPokemon.select("Attach to?")
-                      bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-
-                      // Return an energy back to the hand
-                      pcs.cards.filterByType(ENERGY).select(count:1).moveTo(thisCard.player.pbg.hand)
-
-                      def pkmnCard = thisCard
-                      def energyCard
-                      energyCard = specialEnergy(new CustomCardInfo(HOLON_S_MAGNETON_22).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P],[R, D, F, G, W, Y, L, M, P]]) {
-                        typeImagesOverride = [RAINBOW,RAINBOW]
-                        onPlay {}
-                        onRemoveFromPlay {
-                          bg.em().run(new ChangeImplementation(pkmnCard, energyCard))
-                        }
-                      }
-                      energyCard.player = thisCard.player
-                      bg.em().run(new ChangeImplementation(energyCard, pkmnCard))
-                      bc "$energyCard is now a Special Energy Card"
-                      attachEnergy(pcs, energyCard)
-                      prevent()
-                    } else {
-                      prevent()
-                      wcu "You have no energy attached to your Pokémon"
-                    }
-                  } else {
-                    prevent()
-                    wcu "You have already played an Energy"
-                  }
-                }
-              } //If the user chooses Pokémon, play the card normally
-            }
-            before PLAY_ENERGY, {
-              if(bg.em().retrieveObject("Holon_Pokemon_Energy") == bg.turnCount){
-                wcu "Cannot play any more energy this turn."
-                prevent()
-              }
-            }
-            after ATTACH_ENERGY, {
-              if(ef.reason==PLAY_FROM_HAND){
-                bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-              }
-            }
-          }
-        }
+        holon_pokemon_energy(delegate, 2)
         move "Extra Ball", {
           text "30+ damage. If the Defending Pokémon is Pokémon-ex, this attack does 30 damage plus 20 more damage."
           energyCost M, C
@@ -2313,47 +2211,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
         resistance G, MINUS30
-        globalAbility {Card thisCard->
-          delayed {
-            before PLAY_CARD, {
-              if(ef.cardToPlay == thisCard){
-                if(choose([1,2], ["Pokémon", "Energy"], "Play this card as a Pokémon or as an energy?") == 2){
-                  if(bg.em().retrieveObject("Holon_Pokemon_Energy") != bg.turnCount){
-                    def pcs = thisCard.player.pbg.all.select("Attach to?")
-                    bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-                    def pkmnCard = thisCard
-                    def energyCard
-                    energyCard = specialEnergy(new CustomCardInfo(HOLON_S_MAGNEMITE_70).setCardTypes(ENERGY, SPECIAL_ENERGY), [[C]]) {
-                      onPlay {}
-                      onRemoveFromPlay {
-                        bg.em().run(new ChangeImplementation(pkmnCard, energyCard))
-                      }
-                    }
-                    energyCard.player = thisCard.player
-                    bg.em().run(new ChangeImplementation(energyCard, pkmnCard))
-                    bc "$energyCard is now a Special Energy Card"
-                    attachEnergy(pcs, energyCard)
-                    prevent()
-                  } else {
-                    prevent()
-                    wcu "You have already played an energy"
-                  }
-                }
-              } //If the user chooses Pokémon, play the card normally
-            }
-            before PLAY_ENERGY, {
-              if(bg.em().retrieveObject("Holon_Pokemon_Energy") == bg.turnCount){
-                wcu "Cannot play any more energy this turn."
-                prevent()
-              }
-            }
-            after ATTACH_ENERGY, {
-              if(ef.reason==PLAY_FROM_HAND){
-                bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-              }
-            }
-          }
-        }
+        holon_pokemon_energy(delegate, 1)
         move "Linear Attack", {
           text "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost M
@@ -2365,47 +2223,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       case HOLON_S_VOLTORB_71:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
-        globalAbility {Card thisCard->
-          delayed {
-            before PLAY_CARD, {
-              if(ef.cardToPlay == thisCard){
-                if(choose([1,2], ["Pokémon", "Energy"], "Play this card as a Pokémon or as an energy?") == 2){
-                  if(bg.em().retrieveObject("Holon_Pokemon_Energy") != bg.turnCount){
-                    def pcs = thisCard.player.pbg.all.select("Attach to?")
-                    bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-                    def pkmnCard = thisCard
-                    def energyCard
-                    energyCard = specialEnergy(new CustomCardInfo(HOLON_S_VOLTORB_71).setCardTypes(ENERGY, SPECIAL_ENERGY), [[C]]) {
-                      onPlay {}
-                      onRemoveFromPlay {
-                        bg.em().run(new ChangeImplementation(pkmnCard, energyCard))
-                      }
-                    }
-                    energyCard.player = thisCard.player
-                    bg.em().run(new ChangeImplementation(energyCard, pkmnCard))
-                    bc "$energyCard is now a Special Energy Card"
-                    attachEnergy(pcs, energyCard)
-                    prevent()
-                  } else {
-                    prevent()
-                    wcu "You have already played an energy"
-                  }
-                }
-              } //If the user chooses Pokémon, play the card normally
-            }
-            before PLAY_ENERGY, {
-              if(bg.em().retrieveObject("Holon_Pokemon_Energy") == bg.turnCount){
-                wcu "Cannot play any more energy this turn."
-                prevent()
-              }
-            }
-            after ATTACH_ENERGY, {
-              if(ef.reason==PLAY_FROM_HAND){
-                bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-              }
-            }
-          }
-        }
+        holon_pokemon_energy(delegate, 1)
         move "Thundershock", {
           text "10 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
           energyCost L

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -2211,7 +2211,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
         resistance G, MINUS30
-        holon_pokemon_energy(delegate, 1)
+        holon_pokemon_energy(delegate, 1, true)
         move "Linear Attack", {
           text "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost M
@@ -2223,7 +2223,7 @@ public enum DeltaSpecies implements LogicCardInfo {
       case HOLON_S_VOLTORB_71:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
-        holon_pokemon_energy(delegate, 1)
+        holon_pokemon_energy(delegate, 1, true)
         move "Thundershock", {
           text "10 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
           energyCost L

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2263,7 +2263,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           def moveBody = {
             text "Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost C
-            attackRequirement { assert my.deck : "Deck is empty!" }
+            attackRequirement { assert my.deck : "Deck is empty" }
             onAttack {
               deck.search("Search your deck for a δ Pokémon.", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -229,7 +229,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             def fossilInHand = my.hand.any{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }
-            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokemon?")) {
+            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokémon?")) {
               my.hand.findAll{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }.select().discard()
               damage 30, opp.bench.select()
             }
@@ -279,7 +279,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             assert bg.em().retrieveObject("Form_Change") != bg.turnCount : "You can’t use more than 1 Form Change Poké-Power each turn"
             checkLastTurn()
-            assert my.deck : "Deck is empty"
+            assert my.deck : "Deck is empty!"
             bg.em().storeObject("Form_Change",bg.turnCount)
             powerUsed()
 
@@ -461,7 +461,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokémon in play"
             //TODO: Handle Cursed Glare, shouldn't be allowed to attach in that case.
             powerUsed()
-            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokemon").first()
+            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokémon").first()
             def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokémon to attach the Energy to.")
             attachEnergy(tar, energy)
           }
@@ -2242,14 +2242,14 @@ public enum HolonPhantoms implements LogicCardInfo {
           },{
             def eligible = my.hand.findAll { ["Omanyte", "Kabuto", "Aerodactyl", "Aerodactyl ex", "Lileep", "Anorith"].contains(it.name) }
             if(eligible){
-              eligible.select("Select which Pokémon to bench").each {
+              eligible.select("Select which Pokémon to bench.").each {
                 benchPCS(it)
               }
             }
           }
         }
         playRequirement{
-          assert my.bench.notFull : "Your bench is full"
+          assert my.bench.notFull : "Your bench is full."
           assert my.deck || my.hand.getExcludedList(thisCard) : "You cannot play this card if its your only card in hand, and you have no more cards in deck"
         }
       };
@@ -2331,7 +2331,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             checkNoSPC()
             assert opp.bench.size() >= 4 : "Opponent needs to have 4 or more Benched Pokémon"
             powerUsed()
-            def tar = opp.bench.select("Choose a pokemon to return to your opponent's hand.")
+            def tar = opp.bench.select("Choose a Pokémon to return to your opponent's hand.")
             scoopUpPokemon([:], tar, delegate, SRC_ABILITY)
           }
         }
@@ -2370,7 +2370,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             afterDamage {
-              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve Defending?")) {
+              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve the Defending Pokémon?")) {
                 discardSelfEnergy(C, C)
                 def top=defending.topPokemonCard
                 devolve(defending, top, opp.deck)
@@ -2389,9 +2389,9 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert opp.bench : "Opponent has no Benched"
+            assert opp.bench : "Opponent has no Benched Pokémon"
             powerUsed()
-            sw(opp.active, opp.bench.oppSelect("New Active Pokemon"))
+            sw(opp.active, opp.bench.oppSelect("New Active Pokémon"))
           }
         }
         move "Sharp Fang", {

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -461,7 +461,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokémon in play"
             //TODO: Handle Cursed Glare, shouldn't be allowed to attach in that case.
             powerUsed()
-            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokémon").first()
+            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokémon.").first()
             def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokémon to attach the Energy to.")
             attachEnergy(tar, energy)
           }
@@ -2263,9 +2263,9 @@ public enum HolonPhantoms implements LogicCardInfo {
           def moveBody = {
             text "Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost C
-            attackRequirement { assert my.deck : "Deck is empty" }
+            attackRequirement { assert my.deck : "Deck is empty!" }
             onAttack {
-              deck.search("Search your deck for a δ Pokémon", {
+              deck.search("Search your deck for a δ Pokémon.", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)
             }).moveTo(my.hand)
               shuffleDeck()
@@ -2389,7 +2389,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert opp.bench : "Opponent has no Benched Pokémon"
+            assert opp.bench : "Opponent has no Benched Pokémon."
             powerUsed()
             sw(opp.active, opp.bench.oppSelect("New Active Pokémon"))
           }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -458,11 +458,11 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert my.hand.filterByType(BASIC_ENERGY) || my.hand.any{it.name.contains("δ Rainbow Energy")}: "No Basic Energy or δ Rainbow Energy in Hand"
-            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokemon in play"
+            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokémon in play"
             //TODO: Handle Cursed Glare, shouldn't be allowed to attach in that case.
             powerUsed()
             def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokemon").first()
-            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokemon to attach the Energy to.")
+            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokémon to attach the Energy to.")
             attachEnergy(tar, energy)
           }
         }
@@ -1533,7 +1533,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Your opponent chooses 1 of his or her Pokémon. Put 4 damage counters on that Pokémon."
           energyCost M, C
           onAttack {
-            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokemon?")
+            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokémon?")
           }
         }
       };
@@ -2242,7 +2242,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           },{
             def eligible = my.hand.findAll { ["Omanyte", "Kabuto", "Aerodactyl", "Aerodactyl ex", "Lileep", "Anorith"].contains(it.name) }
             if(eligible){
-              eligible.select("Select which Pokemon to bench").each {
+              eligible.select("Select which Pokémon to bench").each {
                 benchPCS(it)
               }
             }
@@ -2257,15 +2257,15 @@ public enum HolonPhantoms implements LogicCardInfo {
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
           "Each player's Pokémon that has δ on its card can use attacks on this card instead of its own." +
-          "[C] Delta Call - Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+          "[C] Delta Call - Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
         def eff
         onPlay {
           def moveBody = {
-            text "Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+            text "Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost C
             attackRequirement { assert my.deck : "Deck is empty" }
             onAttack {
-              deck.search("Search your deck for a δ Pokemon", {
+              deck.search("Search your deck for a δ Pokémon", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)
             }).moveTo(my.hand)
               shuffleDeck()
@@ -2350,8 +2350,8 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Once during your turn (before your attack), if Mew ex is on your Bench, you may look at your opponent's hand."
           actionA {
             checkLastTurn()
-            assert self.benched : "This Pokemon is not benched"
-            assert opp.hand : "Opponent's hand is empty"
+            assert self.benched : "This Pokémon is not benched"
+            assert opp.hand : "Opponent's hand is empty!"
             powerUsed()
             opp.hand.shuffledCopy().showToMe("Your opponent's hand")
           }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -1,5 +1,8 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
+import tcgwars.logic.effect.gm.AttachEnergy
+import tcgwars.logic.effect.gm.PlayEnergy
+import tcgwars.logic.effect.gm.PlayTrainer;
 import tcgwars.logic.impl.gen1.FossilNG;
 import tcgwars.logic.impl.gen3.TeamRocketReturns;
 import tcgwars.logic.impl.gen3.LegendMaker;
@@ -226,7 +229,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             def fossilInHand = my.hand.any{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }
-            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokémon?")) {
+            if (opp.bench && fossilInHand && confirm("Discard a Fossil from hand to do 30 damage to a Benched Pokemon?")) {
               my.hand.findAll{ ["Claw Fossil", "Mysterious Fossil", "Root Fossil", "Holon Fossil"].contains(it.name) }.select().discard()
               damage 30, opp.bench.select()
             }
@@ -455,11 +458,11 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             assert my.hand.filterByType(BASIC_ENERGY) || my.hand.any{it.name.contains("δ Rainbow Energy")}: "No Basic Energy or δ Rainbow Energy in Hand"
-            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokémon in play"
+            assert my.all.any{ it.topPokemonCard.cardTypes.is(DELTA) } : "No Delta Pokemon in play"
             //TODO: Handle Cursed Glare, shouldn't be allowed to attach in that case.
             powerUsed()
-            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokémon").first()
-            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokémon to attach the Energy to.")
+            def energy = my.hand.findAll({it.cardTypes.is(BASIC_ENERGY) || it.name == "δ Rainbow Energy"}).select("Select an energy to attach to one of your δ Pokemon").first()
+            def tar = my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Select a δ Pokemon to attach the Energy to.")
             attachEnergy(tar, energy)
           }
         }
@@ -1437,58 +1440,7 @@ public enum HolonPhantoms implements LogicCardInfo {
       case HOLON_S_CASTFORM_44:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
-        globalAbility {Card thisCard->
-          delayed {
-            before PLAY_CARD, {
-              def validPokemon = thisCard.player.pbg.all.findAll {it.cards.energyCount()}
-              if(ef.cardToPlay == thisCard){
-                if(choose([1,2], ["Pokémon", "Energy"], "Play this card as a Pokémon or as an energy?") == 2){
-                  if(bg.em().retrieveObject("Holon_Pokemon_Energy") != bg.turnCount){
-                    if(validPokemon){
-                      def pcs = validPokemon.select("Attach to?")
-                      bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-
-                      // Return an energy back to the hand
-                      pcs.cards.filterByType(ENERGY).select(count:1).moveTo(thisCard.player.pbg.hand)
-
-                      def pkmnCard = thisCard
-                      def energyCard
-                      energyCard = specialEnergy(new CustomCardInfo(HOLON_S_CASTFORM_44).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P],[R, D, F, G, W, Y, L, M, P]]) {
-                        typeImagesOverride = [RAINBOW,RAINBOW]
-                        onPlay {}
-                        onRemoveFromPlay {
-                          bg.em().run(new ChangeImplementation(pkmnCard, energyCard))
-                        }
-                      }
-                      energyCard.player = thisCard.player
-                      bg.em().run(new ChangeImplementation(energyCard, pkmnCard))
-                      bc "$energyCard is now a Special Energy Card"
-                      attachEnergy(pcs, energyCard)
-                      prevent()
-                    } else {
-                      prevent()
-                      wcu "You have no energy attached to your Pokémon"
-                    }
-                  } else {
-                    prevent()
-                    wcu "You have already played an Energy"
-                  }
-                }
-              } //If the user chooses Pokémon, play the card normally
-            }
-            before PLAY_ENERGY, {
-              if(bg.em().retrieveObject("Holon_Pokemon_Energy") == bg.turnCount){
-                wcu "Cannot play any more energy this turn."
-                prevent()
-              }
-            }
-            after ATTACH_ENERGY, {
-              if(ef.reason==PLAY_FROM_HAND){
-                bg.em().storeObject("Holon_Pokemon_Energy", bg.turnCount)
-              }
-            }
-          }
-        }
+        holon_pokemon_energy(delegate, 2)
         move "Delta Draw", {
           text "Count the number of Pokémon you have in play that has δ on its card. Draw up to that many cards."
           energyCost C
@@ -1581,7 +1533,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Your opponent chooses 1 of his or her Pokémon. Put 4 damage counters on that Pokémon."
           energyCost M, C
           onAttack {
-            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokémon?")
+            directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokemon?")
           }
         }
       };
@@ -2290,14 +2242,14 @@ public enum HolonPhantoms implements LogicCardInfo {
           },{
             def eligible = my.hand.findAll { ["Omanyte", "Kabuto", "Aerodactyl", "Aerodactyl ex", "Lileep", "Anorith"].contains(it.name) }
             if(eligible){
-              eligible.select("Select which Pokémon to bench.").each {
+              eligible.select("Select which Pokemon to bench").each {
                 benchPCS(it)
               }
             }
           }
         }
         playRequirement{
-          assert my.bench.notFull : "Your bench is full."
+          assert my.bench.notFull : "Your bench is full"
           assert my.deck || my.hand.getExcludedList(thisCard) : "You cannot play this card if its your only card in hand, and you have no more cards in deck"
         }
       };
@@ -2305,15 +2257,15 @@ public enum HolonPhantoms implements LogicCardInfo {
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
           "Each player's Pokémon that has δ on its card can use attacks on this card instead of its own." +
-          "[C] Delta Call - Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+          "[C] Delta Call - Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
         def eff
         onPlay {
           def moveBody = {
-            text "Search your deck for a Pokémon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+            text "Search your deck for a Pokemon that has δ on its card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
             energyCost C
-            attackRequirement { assert my.deck : "Deck is empty!" }
+            attackRequirement { assert my.deck : "Deck is empty" }
             onAttack {
-              deck.search("Search your deck for a δ Pokémon.", {
+              deck.search("Search your deck for a δ Pokemon", {
               it.cardTypes.pokemon && it.cardTypes.is(DELTA)
             }).moveTo(my.hand)
               shuffleDeck()
@@ -2379,7 +2331,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             checkNoSPC()
             assert opp.bench.size() >= 4 : "Opponent needs to have 4 or more Benched Pokémon"
             powerUsed()
-            def tar = opp.bench.select("Choose a Pokémon to return to your opponent's hand.")
+            def tar = opp.bench.select("Choose a pokemon to return to your opponent's hand.")
             scoopUpPokemon([:], tar, delegate, SRC_ABILITY)
           }
         }
@@ -2398,8 +2350,8 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Once during your turn (before your attack), if Mew ex is on your Bench, you may look at your opponent's hand."
           actionA {
             checkLastTurn()
-            assert self.benched : "This Pokémon is not benched"
-            assert opp.hand : "Opponent's hand is empty!"
+            assert self.benched : "This Pokemon is not benched"
+            assert opp.hand : "Opponent's hand is empty"
             powerUsed()
             opp.hand.shuffledCopy().showToMe("Your opponent's hand")
           }
@@ -2418,7 +2370,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
 
             afterDamage {
-              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve the Defending Pokémon?")) {
+              if (defending.evolution && !defending.slatedToKO && confirm("Discard 2 Energy to devolve Defending?")) {
                 discardSelfEnergy(C, C)
                 def top=defending.topPokemonCard
                 devolve(defending, top, opp.deck)
@@ -2437,9 +2389,9 @@ public enum HolonPhantoms implements LogicCardInfo {
           actionA {
             checkLastTurn()
             checkNoSPC()
-            assert opp.bench : "Opponent has no Benched Pokémon."
+            assert opp.bench : "Opponent has no Benched"
             powerUsed()
-            sw(opp.active, opp.bench.oppSelect("New Active Pokémon"))
+            sw(opp.active, opp.bench.oppSelect("New Active Pokemon"))
           }
         }
         move "Sharp Fang", {


### PR DESCRIPTION
This PR introduces the changes to move the GlobalAbility for holon energy-pokmon (Holon's Voltorb, Holon's Castform, etc) into something more reusable inside TcgStatics.

These changes also update the logic of how attachment works so that it will not interfere with other Ability-based energy attachments such as Meganium Ex's `Nurture and Heal` ability.



This PR is dependent on PR https://github.com/axpendix/tcgone/pull/109 which allows the PlayEnergy effect to have the energy attachment target defined by the caller.  

It is used in these changes to determine if the Holon's Energy-Pokemon can be attached or not.  (clarification: it should not be allowed if an energy has already been played for the turn)