### PR TITLE
Bug fixing

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1535,7 +1535,7 @@ public enum Deoxys implements LogicCardInfo {
             delayedA {
               before APPLY_ATTACK_DAMAGES, {
                 bg.dm().each{
-                  if(it.to == self && self.cards.energyCount(P)) {
+                  if(it.to == self && self.cards.energyCount(P) && it.notNoEffect) {
                     bc "Core Guard -10"
                     it.dmg -= hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -1466,17 +1466,15 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
             onAttack {
               def targets = my.discard.findAll { it.cardTypes.is(POKEMON_TOOL) || it.cardTypes.is(ROCKETS_SECRET_MACHINE) }
-              def choice = 1
-              if (targets.size() >= 3)
-                choice = choose([1, 3], ["Select 1 card: put it in your hand", "Select 3 cards: shuffle them in your deck"], "What do you want to do?")
+              def choice = choose([1, 3], ["Select 1 card: put it in your hand", "Select 3 cards: shuffle them in your deck"], "What do you want to do?")
               def info = choice == 1 ? "Select 1 Pokémon Tool or Rocket’s Secret Machine card" : "Select a combination of 3 Pokémon Tool and Rocket’s Secret Machine cards"
-              def tar = my.discard.select count: choice, info, { targets.contains(it) }
+              def tar = my.discard.select count: Math.min(choice as Integer, targets.size()), info, { targets.contains(it) }
               tar.showToOpponent("Opponent's selected cards.")
-              if (choice == 3) {
+              if (choice == 1) {
+                tar.moveTo my.hand
+              } else {
                 tar.moveTo my.deck
                 shuffleDeck()
-              } else {
-                tar.moveTo my.hand
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -3413,17 +3413,14 @@ public enum UnseenForces implements LogicCardInfo {
             assert opp.hand : "Your opponent has no cards in their hand"
           }
           onAttack {
-            def basics = opp.hand.shuffledCopy().showToMe("Opponent's hand.").filterByType(BASIC)
-            if (basics) {
-              def tar = basics.select("Choose a pokemon to bench")
-              if (tar) {
-                def card = tar.first()
-                def benched = benchPCS(card, OTHER)
-                if (benched) {
-                  sw2 (benched)
-                }
-              }
-            }
+            def count = opp.hand.shuffledCopy().filterByType(BASIC) ? 1 : 0
+            def info = count ? "Choose a Pokémon to bench." : "No basics found in Opponent's hand."
+            def tar = opp.hand.shuffledCopy().select min: count, max: count, info, cardTypeFilter(BASIC)
+            if (!tar)
+              return
+            def benched = benchPCS(tar.first(), OTHER)
+            if (benched)
+              sw2 benched
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -3596,10 +3596,10 @@ public enum CosmicEclipse implements LogicCardInfo {
                   bg.em().run(new PlayCard(doll))
                   def pcs = self.owner.pbg.all.find{it.name=="Lillie's Poké Doll" && !tmp.contains(it)}
                   sw(self, pcs)
+                  scoopUpPokemon(self, delegate)
                   eff.unregister()
                   self.owner.pbg.triggerBenchSizeCheck()
                 }
-                scoopUpPokemon(self, delegate)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -254,7 +254,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
               if (self.owner.opposite.pbg.hand.contains(ef.cardToPlay)) playedFromOppHand = true
             }
             before PLAY_TRAINER, {
-              if (!ef.supporter || !playedFromOppHand) return
+              if (!ef.supporter || !playedFromOppHand || !self.active) return
               oldImpl = ef.cardToPlay
               newImpl = supporter(new CustomCardInfo(ef.cardToPlay.customInfo).setCardTypes(TRAINER, SUPPORTER)) {
                 onPlay { draw 3 }

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -251,6 +251,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             def oldImpl = null
             def newImpl = null
             before PLAY_CARD, {
+              playedFromOppHand = false
               if (self.owner.opposite.pbg.hand.contains(ef.cardToPlay)) playedFromOppHand = true
             }
             before PLAY_TRAINER, {

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -1114,9 +1114,8 @@ public enum AmazingVoltTackle implements LogicCardInfo {
       return basic (this, hp:HP030, type:P, retreatCost:1) {
         globalAbility {
           delayed {
-            def abilityUsed = false
             before PLAY_CARD, {
-              if (ef.cardToPlay == thisCard) {
+              if (ef.cardToPlay == thisCard && checkGlobalAbility(thisCard)) {
                 def abilityName = "Shell Bind"
                 wcu("$abilityName prevents playing $thisCard")
                 prevent()


### PR DESCRIPTION
Shiftry's Ability Only While Active

Simplify Unown E (UF) Hidden Power attack
* Should no longer double prompt the player. Will show the full hand
whether there is a Basic in hand or not. Message changes based on
whether a Basic is available or not as well.

Rocket's Wobb (TRR) Simplify and fix Dark Aid
* Simplified some repetitive code. Fixed Dark Aid not checking for
Rocket's Secret Machine cards. Fixed Dark Aid not always allowing
you to shuffle the cards to deck.

Clefairy (CEC) fix scoop up timing

Shedinja (VIV) playable with ability turned off