### PR TITLE
Light Dragonite and Dusknoir

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -2723,17 +2723,21 @@ public enum DeltaSpecies implements LogicCardInfo {
         text "Holon Energy FF provides [C] Energy. If the Pokémon that Holon Energy FF is attached to also has a basic [R] Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic [F] Energy card attached to it, damage done by that Pokémon's attack isn't affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
         def eff
         def eff2
-        onPlay {reason->
-          eff = getter (GET_WEAKNESSES, self) { h->
+        onPlay { reason ->
+          eff = getter(GET_WEAKNESSES, self) { h ->
             if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(R)) {
-              h.object.clear()
+              targeted self, SRC_SPENERGY, {
+                h.object.clear()
+              }
             }
           }
           eff2 = delayed {
             before APPLY_RESISTANCE, {
               bg.dm().each {
-                if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(F) && it.from==self) {
-                  prevent()
+                if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(F) && it.from == self) {
+                  targeted self, SRC_SPENERGY, {
+                    prevent()
+                  }
                 }
               }
             }
@@ -2743,43 +2747,45 @@ public enum DeltaSpecies implements LogicCardInfo {
           eff.unregister()
           eff2.unregister()
         }
-        onMove {to->
-        }
       };
       case HOLON_ENERGY_GL_105:
       return specialEnergy (this, [[C]]) {
         text "Holon Energy GL provides [C] Energy. If the Pokémon that Holon Energy GL is attached to also has a basic [G] Energy card attached to it, that Pokémon can't be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic [L] Energy card attached to it, damage done by your opponent's Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
         def eff
         def eff2
-        onPlay {reason->
+        onPlay { reason ->
           if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
-            clearSpecialCondition(self)
+            clearSpecialCondition(self, SRC_SPENERGY)
           }
           eff = delayed {
             before APPLY_SPECIAL_CONDITION, self, {
-              if ( !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G) ){
-                bc "Holon Energy GL prevents special conditions"
-                prevent()
+              if (!self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
+                targeted self, SRC_SPENERGY, {
+                  bc "Holon Energy GL prevents special conditions"
+                  prevent()
+                }
               }
             }
             after ATTACH_ENERGY, {
               if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
-                clearSpecialCondition(self)
+                clearSpecialCondition(self, SRC_SPENERGY)
               }
             }
             after ENERGY_SWITCH, {
               if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
-                clearSpecialCondition(self)
+                clearSpecialCondition(self, SRC_SPENERGY)
               }
             }
           }
-          eff2=delayed {
+          eff2 = delayed {
             before APPLY_ATTACK_DAMAGES, {
-              if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(L)){
+              if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(L)) {
                 bg.dm().each {
-                  if(it.to==self && it.from.owner!=self.owner && it.from.EX && it.dmg.value && it.notNoEffect){
-                    it.dmg -= hp(10)
-                    bc "Holon Energy GL -10"
+                  if (it.to == self && it.from.owner != self.owner && it.from.EX && it.dmg.value && it.notNoEffect) {
+                    targeted self, SRC_SPENERGY, {
+                      it.dmg -= hp(10)
+                      bc "Holon Energy GL -10"
+                    }
                   }
                 }
               }
@@ -2792,7 +2798,7 @@ public enum DeltaSpecies implements LogicCardInfo {
         }
         onMove {to->
           if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
-            clearSpecialCondition(self)
+            clearSpecialCondition(self, SRC_SPENERGY)
           }
         }
       };
@@ -2801,17 +2807,21 @@ public enum DeltaSpecies implements LogicCardInfo {
         text "Holon Energy WP provides [C] Energy. If the Pokémon that Holon Energy WP is attached to also has a basic [W] Energy card attached to it, prevent all effects, excluding damage, done to that Pokémon by your opponent's Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic [P] Energy card attached to it, that Pokémon's Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
         def eff
         def eff2
-        onPlay {reason->
-          eff = getter (GET_RETREAT_COST, self) {h->
+        onPlay { reason ->
+          eff = getter(GET_RETREAT_COST, self) { h ->
             if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(P)) {
-              h.object = 0
+              targeted self, SRC_SPENERGY, {
+                h.object = 0
+              }
             }
           }
           eff2 = delayed {
             before null, self, Source.ATTACK, {
-              if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(W) && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages)) {
-                bc "Holon Energy WP prevented effect"
-                prevent()
+              if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(W) && bg.currentTurn == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages)) {
+                targeted self, SRC_SPENERGY, {
+                  bc "Holon Energy WP prevented effect"
+                  prevent()
+                }
               }
             }
           }
@@ -2819,8 +2829,6 @@ public enum DeltaSpecies implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
           eff2.unregister()
-        }
-        onMove {to->
         }
       };
       case METAL_ENERGY_107:

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2500,22 +2500,34 @@ public enum Deoxys implements LogicCardInfo {
         return specialEnergy (this, [[C],[C],[C]]) {
           text "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides [C][C][C] Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
           def eff
+          def turnCount
           def check = {
-            if(!it.evolution){discard thisCard}
+            if (!it.evolution) {
+              targeted null, SRC_SPENERGY, {
+                discard thisCard
+              }
+            }
           }
-          onPlay {reason->
+          onPlay { reason ->
+            turnCount = bg.turnCount
             eff = delayed {
               before RETREAT, self, {
-                wcu "$self can't retreat due to having Boost Energy attached."
-                prevent()
+                targeted self, SRC_SPENERGY, {
+                  wcu "$self can't retreat due to having Boost Energy attached."
+                  prevent()
+                }
               }
               before BETWEEN_TURNS, {
-                discard thisCard
-                unregister()
+                if (turnCount == bg.turnCount) {
+                  targeted null, SRC_SPENERGY, {
+                    discard thisCard
+                  }
+                }
               }
-              after EVOLVE, self, {check(self)}
-              after DEVOLVE, self, {check(self)}
-              after ATTACH_ENERGY, self, {check(self)}
+              after EVOLVE, self, { check(self) }
+              after DEVOLVE, self, { check(self) }
+              after ATTACH_ENERGY, self, { check(self) }
+              after CHECK_ABILITIES, { check(self) }
             }
           }
           onRemoveFromPlay {
@@ -2531,10 +2543,10 @@ public enum Deoxys implements LogicCardInfo {
       case HEAL_ENERGY_94:
         return specialEnergy (this, [[C]]) {
           text "Heal Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter and all Special Conditions from that Pokémon. If heal Energy is attached to Pokémon-ex, Heal Energy has no effect other than providing Energy."
-          onPlay {reason->
-            if(!self.EX && reason == PLAY_FROM_HAND){
-              heal (10, self, SRC_SPENERGY)
-              clearSpecialCondition(self)
+          onPlay { reason ->
+            if (!self.EX && reason == PLAY_FROM_HAND) {
+              heal(10, self, SRC_SPENERGY)
+              clearSpecialCondition(self, SRC_SPENERGY)
             }
           }
           onRemoveFromPlay {
@@ -2545,13 +2557,18 @@ public enum Deoxys implements LogicCardInfo {
           text "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides [C] Energy. While in play, if you have more prizes left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
           def eff
           def check = {
-            if(!it.evolution || it.EX){discard thisCard}
+            if (!it.evolution || it.EX) {
+              targeted null, SRC_SPENERGY, {
+                discard thisCard
+              }
+            }
           }
           onPlay {reason->
             eff = delayed {
-              after EVOLVE, self, {check(self)}
-              after DEVOLVE, self, {check(self)}
-              after ATTACH_ENERGY, self, {check(self)}
+              after EVOLVE, self, { check(self) }
+              after DEVOLVE, self, { check(self) }
+              after ATTACH_ENERGY, self, { check(self) }
+              after CHECK_ABILITIES, { check(self) }
             }
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1824,10 +1824,13 @@ public enum Emerald implements LogicCardInfo {
           onPlay {reason->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
-                if (self.types.contains(D) || self.topPokemonCard.name.contains("Dark ")){
-                  bg.dm().each(){
-                    if(it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
-                      it.dmg += hp(10)
+                if (self.types.contains(D) || self.topPokemonCard.name.contains("Dark ")) {
+                  bg.dm().each() {
+                    if (it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value) {
+                      targeted self, Source.SRC_SPENERGY, {
+                        bc "Darkness Energy +10"
+                        it.dmg += hp(10)
+                      }
                     }
                   }
                 }
@@ -1845,22 +1848,29 @@ public enum Emerald implements LogicCardInfo {
           //TODO: Check non-groovy prints, see if they properly reduce damage before W/R (pre-errata they did so after W/R)
           def eff
           def check = {
-            if(!it.evolution || it.EX){discard thisCard}
+            if (!it.evolution || it.EX) {
+              targeted null, Source.SRC_SPENERGY, {
+                discard thisCard
+              }
+            }
           }
           typeImagesOverride = [RAINBOW, RAINBOW]
-          onPlay {reason->
+          onPlay { reason ->
             eff = delayed {
               after PROCESS_ATTACK_EFFECTS, {
-                if(ef.attacker == self) bg.dm().each {
-                  if(it.to.owner != self.owner && it.dmg.value) {
-                    bc "Double Rainbow Energy -10"
-                    it.dmg -= hp(10)
+                if (ef.attacker == self) bg.dm().each {
+                  if (it.to.owner != self.owner && it.dmg.value) {
+                    targeted self, Source.SRC_SPENERGY, {
+                      bc "Double Rainbow Energy -10"
+                      it.dmg -= hp(10)
+                    }
                   }
                 }
               }
-              after EVOLVE, self, {check(self)}
-              after DEVOLVE, self, {check(self)}
-              after ATTACH_ENERGY, self, {check(self)}
+              after EVOLVE, self, { check(self) }
+              after DEVOLVE, self, { check(self) }
+              after ATTACH_ENERGY, self, { check(self) }
+              after CHECK_ABILITIES, { check(self) }
             }
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2454,10 +2454,6 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           text "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) Multi Energy provides [C] Energy when attached to a Pokémon that already has Special Energy cards attached to it."
           onPlay {reason->
           }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
           getEnergyTypesOverride{
             if(self == null || self.cards.filterByType(SPECIAL_ENERGY).size() > 1) {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2307,8 +2307,6 @@ public enum HolonPhantoms implements LogicCardInfo {
         text "δ Rainbow Energy provides [C] Energy. While attached to a Pokémon that has δ on its card, δ Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)"
         onPlay {reason->
         }
-        onRemoveFromPlay {
-        }
         getEnergyTypesOverride {
           if (!self || !self.topPokemonCard)
             return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -2444,10 +2444,12 @@ public enum UnseenForces implements LogicCardInfo {
       case CYCLONE_ENERGY_99:
       return specialEnergy (this, [[C]]) {
         text "Cyclone Energy provides [C] Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
-        onPlay { reason->
+        onPlay { reason ->
           if (reason == PLAY_FROM_HAND && self.active) {
             if (opp.bench) {
-              sw(opp.active, opp.bench.oppSelect("Cyclone Energy was played, which Pokémon to switch with the Active?"), SRC_SPENERGY)
+              targeted null, SRC_SPENERGY, { // Don't force player choose a Pokémon when it will have no effect
+                sw(opp.active, opp.bench.oppSelect("Cyclone Energy was played, which Pokémon to switch with the Active?"), SRC_SPENERGY)
+              }
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
+++ b/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
@@ -1,5 +1,6 @@
 package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen3.RubySapphire
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -1699,17 +1700,7 @@ public enum CallOfLegends implements LogicCardInfo {
       case DARKNESS_ENERGY_86:
         return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_87:
-        return specialEnergy (this, [[C]]) {
-          text "Damage done by attacks to the Pokémon that Metal Energy attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t Metal. Metal Energy provides Metal Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (RubySapphire.METAL_ENERGY_94, this);
       case GRASS_ENERGY_88:
         return basicEnergy (this, GRASS);
       case FIRE_ENERGY_89:

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen1.BaseSet;
 import tcgwars.logic.impl.gen3.FireRedLeafGreen;
 import tcgwars.logic.impl.gen3.TeamRocketReturns;
 import tcgwars.logic.impl.gen5.BlackWhite;
@@ -2179,10 +2180,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
       case SWITCH_102:
         return copy (FireRedLeafGreen.SWITCH_102, this)
       case DOUBLE_COLORLESS_ENERGY_103:
-        return specialEnergy (this, [[C],[C]]) {
-          text "Double Colorless Energy Provides 2 Colorless Energy."
-          onPlay {}
-        };
+        return copy (BaseSet.DOUBLE_COLORLESS_ENERGY, this)
       case RAINBOW_ENERGY_104:
         return copy (CelestialStorm.RAINBOW_ENERGY_151, this)
       case AMPHAROS_105:

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1,6 +1,9 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.Action
+import tcgwars.logic.effect.Source
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.RubySapphire;
 import tcgwars.logic.impl.gen4.MysteriousTreasures;
 import tcgwars.logic.impl.gen5.PlasmaStorm;
 
@@ -2026,22 +2029,25 @@ public enum MajesticDawn implements LogicCardInfo {
               assert my.bench.notFull : "Bench full"
               assert my.deck : "Your deck is empty!"
               bc "Used Call Energy effect"
-              int count = bench.freeBenchCount>=2?2:1
-              my.deck.search (max: count,"Search your deck for up to 2 Basic Pokémon and put them onto your Bench", cardTypeFilter(BASIC)).each {
-                benchPCS(it)
+              targeted null, Source.SRC_SPENERGY, {
+                int count = bench.freeBenchCount >= 2 ? 2 : 1
+                my.deck.search(max: count, "Search your deck for up to 2 Basic Pokémon and put them onto your Bench", cardTypeFilter(BASIC)).each {
+                  benchPCS(it)
+                }
+                shuffleDeck()
+                bg.gm().betweenTurns()
               }
-              shuffleDeck()
-              bg.gm().betweenTurns()
             }
           }
           onRemoveFromPlay {
-            actions.each { bg().gm().unregisterAction(it) }
+            actions.each { bg().gm().unregisterAction(it as Action) }
           }
         };
       case DARKNESS_ENERGY_93:
         return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case HEALTH_ENERGY_94:
         return specialEnergy (this, [[C]]) {
+          // TODO: Is this just Potion Energy?
           text "Health Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter from that Pokémon."
           onPlay {reason->
           }
@@ -2053,18 +2059,9 @@ public enum MajesticDawn implements LogicCardInfo {
           }
         };
       case METAL_ENERGY_95:
-        return specialEnergy (this, [[C]]) {
-          text "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t [M]. Metal Energy provides [M] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case RECOVER_ENERGY_96:
+        // TODO: Is this just Full Heal Energy?
         return specialEnergy (this, [[C]]) {
           text "Recover Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove all Special Conditions from that Pokémon."
           onPlay {reason->

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3434,7 +3434,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
                   bg.dm().each(){
                     //Self damage appears to be increased as well, similar to PlusPower
                     if(it.to.active && it.dmg.value) {
-                      it.dmg += hp(10)
+                      targeted self, SRC_SPENERGY, {
+                        bc "Darkness Energy +10"
+                        it.dmg += hp(10)
+                      }
                     }
                   }
                 }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1,4 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
+
+import tcgwars.logic.impl.gen7.CelestialStorm;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -2689,17 +2691,7 @@ public enum Platinum implements LogicCardInfo {
           }
         };
       case RAINBOW_ENERGY_121:
-        return specialEnergy (this, [[C]]) {
-          text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but provides only 1 Energy at a time. (doesn’t count as a energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon.(don’t apply Weakness and Resistance.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (CelestialStorm.RAINBOW_ENERGY_151, this)
       case DIALGA_G_LV_X_122:
         return levelUp (this, from:"Dialga G", hp:HP120, type:METAL, retreatCost:2) {
           weakness R

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen3.RubySapphire;
 import tcgwars.logic.impl.gen4.MysteriousTreasures
 import tcgwars.logic.impl.gen7.CelestialStorm;
 
@@ -2269,17 +2270,7 @@ public enum RisingRivals implements LogicCardInfo {
       case DARKNESS_ENERGY_99:
         return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_100:
-        return specialEnergy (this, [[C]]) {
-          text "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t [M]. Metal Energy provides [M] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case SP_ENERGY_101:
         return specialEnergy (this, [[C]]) {
           text "SP Energy provides [C] Energy. While attached to a Pokémon SP, SP Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)"

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1,4 +1,7 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
+
+import tcgwars.logic.impl.gen2.Aquapolis
+import tcgwars.logic.impl.gen3.UnseenForces;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -2245,29 +2248,9 @@ public enum Stormfront implements LogicCardInfo {
           }
         };
       case CYCLONE_ENERGY_94:
-        return specialEnergy (this, [[C]]) {
-          text "Cyclone Energy provides [C] Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (UnseenForces.CYCLONE_ENERGY_99, this)
       case WARP_ENERGY_95:
-        return specialEnergy (this, [[C]]) {
-          text "Warp Energy provides [C] Energy. When you attach this card from your hand to your Active Pokémon, switch that Pokémon with 1 of your Benched Pokémon."
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (Aquapolis.WARP_ENERGY_147, this)
       case DUSKNOIR_LV_X_96:
         return levelUp (this, from:"Dusknoir", hp:HP140, type:PSYCHIC, retreatCost:3) {
           weakness D

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
+import tcgwars.logic.impl.gen3.RubySapphire;
 import tcgwars.logic.impl.gen4.MysteriousTreasures;
 
 import tcgwars.logic.effect.gm.PlayTrainer
@@ -1677,17 +1678,7 @@ public enum Undaunted implements LogicCardInfo {
       case DARKNESS_ENERGY_79:
         return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
       case METAL_ENERGY_80:
-        return specialEnergy (this, [[C]]) {
-          text "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn’t [M]. Metal Energy provides [M] Energy. (Doesn’t count as a basic Energy card.)"
-          onPlay {reason->
-          }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
-          allowAttach {to->
-          }
-        };
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case ESPEON_81:
         return evolution (this, from:"Eevee", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness P

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3329,7 +3329,9 @@ public enum CelestialStorm implements LogicCardInfo {
           typeImagesOverride = [RAINBOW]
           onPlay {reason->
             if (reason == PLAY_FROM_HAND) {
-              directDamage(10, self, Source.SRC_SPENERGY)
+              targeted null, SRC_SPENERGY, {
+                directDamage(10, self, SRC_SPENERGY)
+              }
             }
           }
           getEnergyTypesOverride {

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -5061,7 +5061,9 @@ public enum CosmicEclipse implements LogicCardInfo {
             "When you attach this card from your hand to a Pokémon, draw a card."
           onPlay {reason->
             if(reason == PLAY_FROM_HAND) {
-              draw 1
+              targeted null, SRC_SPENERGY, {
+                draw 1
+              }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2436,10 +2436,6 @@ public enum CrimsonInvasion implements LogicCardInfo {
           text "This card provides [C] Energy.\nIf you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn't a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time"
           onPlay {reason->
           }
-          onRemoveFromPlay {
-          }
-          onMove {to->
-          }
           getEnergyTypesOverride{
             if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
               return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2831,8 +2831,10 @@ public enum ForbiddenLight implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 bg.dm().each{
                   if(it.from == self && it.to.active && it.to.owner != self.owner && self.topPokemonCard.cardTypes.is(ULTRA_BEAST) && it.dmg.value) {
-                    bc "Beast Energy +30"
-                    it.dmg += hp(30)
+                    targeted self, SRC_SPENERGY, {
+                      bc "Beast Energy +30"
+                      it.dmg += hp(30)
+                    }
                   }
                 }
               }
@@ -2840,8 +2842,6 @@ public enum ForbiddenLight implements LogicCardInfo {
           }
           onRemoveFromPlay {
             eff.unregister()
-          }
-          onMove {to->
           }
           getEnergyTypesOverride{
             if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)) {
@@ -2857,8 +2857,6 @@ public enum ForbiddenLight implements LogicCardInfo {
           text "This card provides [C] Energy.\nWhile this card is attached to a Pokémon, it provides [F], [D], and [Y] Energy but provides only 1 Energy at a time."
           // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
-          }
-          onRemoveFromPlay {
           }
           getEnergyTypesOverride {
             self != null ? [[F,D,Y] as Set] : [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -4471,9 +4471,11 @@ public enum LostThunder implements LogicCardInfo {
           def eff
           onPlay {reason->
             eff = getter (GET_MOVE_LIST,self) {holder->
-              for(card in holder.effect.target.cards.filterByType(POKEMON)){
-                if(card!=holder.effect.target.topPokemonCard){
-                  holder.object.addAll(card.moves)
+              targeted self, SRC_SPENERGY, {
+                for (card in holder.effect.target.cards.filterByType(POKEMON)) {
+                  if (card != holder.effect.target.topPokemonCard) {
+                    holder.object.addAll(card.moves)
+                  }
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3173,8 +3173,6 @@ public enum UltraPrism implements LogicCardInfo {
             "While this card is attached to a Stage 2 Pokémon, it provides every type of Energy but provides only 1 Energy at a time. If you have 3 or more Stage 2 Pokémon in play, it provides every type of Energy but provides 4 Energy at a time."
           onPlay {reason->
           }
-          onRemoveFromPlay {
-          }
           getEnergyTypesOverride {
             if(!self || !self.topPokemonCard)
               return [[C] as Set]
@@ -3198,8 +3196,6 @@ public enum UltraPrism implements LogicCardInfo {
           // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
           }
-          onRemoveFromPlay {
-          }
           getEnergyTypesOverride {
             self != null ? [[G,R,W] as Set] : [[C] as Set]
           }
@@ -3209,8 +3205,6 @@ public enum UltraPrism implements LogicCardInfo {
           text "This card provides [C] Energy.\n While this card is attached to a Pokémon, it provides [L], [P], and [M] Energy but provides only 1 Energy at a time."
           // TODO: Request appropriate typeImageOverride be added
           onPlay {reason->
-          }
-          onRemoveFromPlay {
           }
           getEnergyTypesOverride {
             self != null ? [[L,P,M] as Set] : [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -4491,17 +4491,28 @@ public enum UnbrokenBonds implements LogicCardInfo {
             "This card provides [C][C][C] Energy only while it is attached to an Evolution Pokémon." +
             "If this card is attached to anything other than an Evolution Pokémon, discard this card."
           def eff
+          def turnCount
           def check = {
-            if (!it.realEvolution) discard thisCard
-          }
-          onPlay {reason->
-            eff = delayed (priority: BEFORE_LAST) {
-              before BETWEEN_TURNS, {
+            if (!it.realEvolution) {
+              targeted null, SRC_SPENERGY, {
                 discard thisCard
               }
-              after EVOLVE, self, {check(self)}
-              after DEVOLVE, self, {check(self)}
-              after ATTACH_ENERGY, self, {check(self)}
+            }
+          }
+          onPlay {reason->
+            turnCount = bg.turnCount
+            eff = delayed (priority: BEFORE_LAST) {
+              before BETWEEN_TURNS, {
+                if (bg.turnCount == turnCount) {
+                  targeted null, SRC_SPENERGY, {
+                    discard thisCard
+                  }
+                }
+              }
+              after EVOLVE, self, { check(self) }
+              after DEVOLVE, self, { check(self) }
+              after ATTACH_ENERGY, self, { check(self) }
+              after CHECK_ABILITIES, { check(self) } // Miraculous Wind (LIGHT_DRAGONITE_14) and Spectral Breach (DUSKNOIR_45)
             }
             check(self)
           }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -4678,11 +4678,13 @@ public enum UnifiedMinds implements LogicCardInfo {
               def newLocationChanged = false
               before MOVE_CARD, {
                 if (ef.cards.contains(thisCard) && ef.newLocation == self.owner.pbg.discard && !newLocationChanged) {
-                  newLocationChanged = true
-                  def res = moveCard(supresssLog: true, thisCard, thisCard.player.pbg.hand)
-                  if (!res) {
-                    prevent()
-                    bc "Recycle Energy was recycled into its owner's hand."
+                  targeted null, SRC_SPENERGY, {
+                    newLocationChanged = true
+                    def res = moveCard(supresssLog: true, thisCard, thisCard.player.pbg.hand)
+                    if (!res) {
+                      prevent()
+                      bc "Recycle Energy was recycled into its owner's hand."
+                    }
                   }
                 }
               }
@@ -4699,7 +4701,9 @@ public enum UnifiedMinds implements LogicCardInfo {
           def eff
           onPlay {reason->
             eff = getter (GET_WEAKNESSES, self) { h->
-              h.object.clear()
+              targeted self, SRC_SPENERGY, {
+                h.object.clear()
+              }
             }
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -2167,8 +2167,10 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           eff = delayed {
             before null, self, ATTACK, {
               if (self.types.contains(W) && ef.effectType != DAMAGE && bg.currentTurn == self.owner.opposite) {
-                bc "$thisCard prevents effect"
-                prevent()
+                targeted self, SRC_SPENERGY, {
+                  bc "$thisCard prevents effect"
+                  prevent()
+                }
               }
             }
           }
@@ -2188,7 +2190,11 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         def eff
         onPlay {reason->
           eff = getter GET_WEAKNESSES, self, { holder ->
-            if(self.types.contains(M)) holder.object.clear()
+            if (self.types.contains(M)) {
+              targeted self, SRC_SPENERGY, {
+                holder.object.clear()
+              }
+            }
           }
         }
         onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -1179,9 +1179,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           delayedA {
             // FIXME: Figure out the best way to deal with unsourced effects from Special Energy
             //  also applicable to LIGHT_DRAGONITE NeoDestiny Miraculous Wind
-            bc "$thisAbility is not fully implemented yet and my not work as intended."
             before null, null, SRC_SPENERGY, {
-              bc "$thisAbility"
               prevent()
             }
           }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -4132,7 +4132,9 @@ public enum DarknessAblaze implements LogicCardInfo {
         def getterRegister = {
           eff1 = getter (GET_FULL_HP, self) {h->
             if (self.types.contains(R)) {
-              h.object += hp(20)
+              targeted self, SRC_SPENERGY, {
+                h.object += hp(20)
+              }
             }
           }
         }
@@ -4161,7 +4163,9 @@ public enum DarknessAblaze implements LogicCardInfo {
         onPlay { reason->
           eff = getter (GET_RETREAT_COST, BEFORE_LAST, self) {h->
             if (self.types.contains(D)) {
-              h.object = 0
+              targeted self, SRC_SPENERGY, {
+                h.object = 0
+              }
             }
           }
         }
@@ -4182,8 +4186,10 @@ public enum DarknessAblaze implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               bg.dm().each{
                 if(it.from == self && it.to.active && it.to.owner != self.owner && self.types.contains(C) && it.dmg.value) {
-                  bc "Powerful [C] Energy +20"
-                  it.dmg += hp(20)
+                  targeted self, SRC_SPENERGY, {
+                    bc "Powerful [C] Energy +20"
+                    it.dmg += hp(20)
+                  }
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -1576,8 +1576,10 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           spcEff = delayed {
             before APPLY_SPECIAL_CONDITION, self, {
               if (!self.types.contains(G)) return
-              bc "$thisCard.name prevents ${(ef as ApplySpecialCondition).type} on $self"
-              prevent()
+              targeted self, SRC_SPENERGY, {
+                bc "$thisCard.name prevents ${(ef as ApplySpecialCondition).type} on $self"
+                prevent()
+              }
             }
             after ATTACH_ENERGY, {
               if (self == null || !self.types.contains(G)) return
@@ -1606,8 +1608,10 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             before APPLY_ATTACK_DAMAGES, {
               if (!(ef.attacker.owner != self.owner && self.types.contains(F))) return
               bg.dm().each {if(it.to == self && it.dmg.value && it.notNoEffect) {
-                bc "$thisCard.name -20"
-                it.dmg -= hp(20)
+                targeted self, SRC_SPENERGY, {
+                  bc "$thisCard.name -20"
+                  it.dmg -= hp(20)
+                }
               }}
             }
           }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3745,10 +3745,12 @@ public enum RebelClash implements LogicCardInfo {
         text "This card provides [C] Energy only while attached to a Pokémon. When attaching this card from your hand to 1 of your Pokémon, search your deck for a Basic Pokémon and put it on your Bench. Then, shuffle your deck."
         onPlay {reason->
           if (reason == PLAY_FROM_HAND && my.deck && my.bench.notFull) {
-            my.deck.search (count: 1, { it.cardTypes.is(BASIC) }).each {
-              benchPCS(it)
+            targeted null, SRC_SPENERGY, {
+              my.deck.search(count: 1, { it.cardTypes.is(BASIC) }).each {
+                benchPCS(it)
+              }
+              shuffleDeck()
             }
-            shuffleDeck()
           }
         }
         getEnergyTypesOverride {
@@ -3773,8 +3775,10 @@ public enum RebelClash implements LogicCardInfo {
             }
             after APPLY_ATTACK_DAMAGES, {
               if(attackDidDamage && self.cards.contains(thisCard)) { // this energy card is still attached
-                bc "Horror [P] Energy activates."
-                directDamage(20, ef.attacker as PokemonCardSet, SRC_SPENERGY)
+                targeted ef.attacker as PokemonCardSet, SRC_SPENERGY, {
+                  bc "Horror [P] Energy activates."
+                  directDamage(20, ef.attacker as PokemonCardSet, SRC_SPENERGY)
+                }
                 attackDidDamage = false
               }
             }
@@ -3793,7 +3797,9 @@ public enum RebelClash implements LogicCardInfo {
         text "This card provides 1 [L] Energy while it’s attached to a Pokémon. When you attach this card from your hand to an [L] Pokémon, draw 2 cards"
         onPlay {reason->
           if (reason == PLAY_FROM_HAND && self.types.contains(L)) {
-            draw 2
+            targeted null, SRC_SPENERGY, {
+              draw 2
+            }
           }
         }
         getEnergyTypesOverride {


### PR DESCRIPTION
All of the Special Energy except for Burning Energy should now be blocked by Miraculous Wind and Spectral Breach.

Relevant Rulings [all from the Japanese Q&A](https://translate.google.com/translate?sl=auto&tl=en&u=https://www.pokemon-card.com/rules/faq/search.php?freeword%3D%25E3%2582%25B4%25E3%2583%25BC%25E3%2582%25B9%25E3%2583%2588%25E3%2583%2596%25E3%2583%25AA%25E3%2583%25BC%25E3%2583%2581%26regulation_header_search_item1%3DBW) for many decisions on what should be blocked (basically everything) and what should not (costs _before_ playing) though Rainbow Energy has rulings against it working this way, I took some creative liberty with it because of how similar it is to other "do _on_ attach" abilities, especially in wording. Though I have asked for a ruling on it here: https://pokegym.net/community/index.php?threads/dusknoir-spectral-breach-and-rainbow-energy.192181/ and will adjust accordingly if needed:

> Q: When there is a Dusknoir with the Ability "Spectral Breach" on the field, if you discard "Burning Energy" using the Talonflame Attack "Bright Wing" can you reattach the "Burning Energy" to the Talonflame V?
A: No you cannot.

Note: The above will not currently function properly. Burning Energy is handled in a particular manner that will require more work.

> Q: When I had a Dusknoir with the Ability "Spectral Breach" on the field, I attached "Triple Acceleration Energy" to my "Evolved Pokémon." In the same turn, if I use the Item "Devolution Spray Z" to devolve Dusknoir to Dusclops, will the "Triple Acceleration Energy" attached this turn be discarded?
A: Yes, it will be discarded.

> Q: When I had a Dusknoir with the Ability "Spectral Breach" on the field, I attached "Triple Acceleration Eenergy" to my "Evolved Pokémon." Will "Triple Acceleration Energy" be discarded if I devolve Duscknoir to Dusclops during my next turn using the Item "Devolution Spray Z?"
A: **No it won't be discarded**. In this case, the turn that Dusknoir was devolved is not the turn "Triple Acceleration Energy" was used, so **it will not be discarded, even after the turn is over.**

> Q: If there is a Dusknoir with the Ability "Spectral Breach" on the field, and I attach "Triple Acceleration Energy" to an Evolved Pokémon, will the "Triple Acceleration Energy" be discarded at the end of the turn it was attached?
A: No, it won't be discarded.

> Q: If there is a Dusknoir with the Ability "Spectral Breach" on the field, and I use the Item "Crushing Hammer" to discard the "Recycle Energy" attached to the opponent's Pokémon, can the opponent return the "Recycle Energy" to their hand?
A: No, they cannot.

> Q: After using my Typhlosion's Ability "Blazing Energy", if I evolve my Dusclops into a Dusknoir with the Ablity "Spectral Breach" this turn, will the attached "Twin Energy" be treated as 1 [R] energy?
A: No. In this case, the Ability "Spectral Breach" worked later so "Twin Energy" is now 1 [C] energy.

> Q: If there is a Dusknoir with the Ability "Spectral Breach" on the field, and I use the Ability "Blazing Energy" of my Typhlosion, will the "Twin Energy" attached be treated as 2 flame energies?
A: No. In this case, due to the effect of the Ability "Spectral Breach," "Twin Energy" works as 1 [C] energy, so the effect of the Ability "Blazing Energy" treats it as 1 [R] energy.

> Q: When there is a Dusknoir with the Ability "Spectral Breach" in play, if I attach "Aurora Energy" from my hand to a Pokémon, do I discard 1 card from my hand?
A: Yes, discard.

> Q: If there is a Dusknoir with the Ability "Spectral Breach" on the field, and I attach "Speed Lightning Energy" from my hand  to a Lightning Pokémon, can I draw 2 cards?
A: No, you cannot.

> Q: When there is a Dusknoir with the Ability "Spectral Breach" on the field, and I use the Item "Devolution Spray Z" to devolve an Evolution Pokémon into a Basic Pokémon after adding "Triple Acceleration Energy" to that Evolution Pokémon, is "Triple Acceleration Energy" discarded?
A: No, it won't be discarded.

> Q: When there is a Dusknoir with the Ability "Spectral Breach" working on the field, I use the Supporter "Bea" and I discard a "Triple Acceleration Energy" as one of the top 5 cards discarded from my deck and attach it to a Basic benched [F] Pokémon. Is the "Triple Acceleration Energy" discarded in this case?
A: No, it won't be discarded.

Note: The above final ruling was the hardest one to understand the Google translation of, it's possible it is not completely accurate. However, I believe it is pretty accurate.

Energy have also been made to check what they are attached to after `CHECK_ABILITIES` where applicable.