### PR TITLE
Use Safeguard effect for EX-era implementations

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -1,5 +1,6 @@
 package tcgwars.logic.impl.gen3
 
+import tcgwars.logic.effect.ability.custom.Safeguard
 import tcgwars.logic.impl.gen3.Deoxys;
 import tcgwars.logic.impl.gen3.Emerald;
 import tcgwars.logic.impl.gen3.FireRedLeafGreen;
@@ -203,24 +204,11 @@ public enum CrystalGuardians implements LogicCardInfo {
       return evolution (this, from:"Shuppet", hp:HP070, type:P, retreatCost:1) {
         weakness D
         resistance F, MINUS30
+
+        // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+        thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Banette by your opponents Pokémon-ex.")
         pokeBody "Safeguard", {
           text "Prevent all effects of attacks, including damage, done to Banette by your opponent's Pokémon-ex."
-          delayedA {
-            before null, self, Source.ATTACK, {
-              if (self.owner.opposite.pbg.active.EX && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE) {
-                bc "Safeguard prevents effect"
-                prevent()
-              }
-            }
-            before APPLY_ATTACK_DAMAGES, {
-              bg.dm().each {
-                if(it.to == self && it.notNoEffect && it.from.EX ) {
-                  it.dmg = hp(0)
-                  bc "Safeguard prevents damage"
-                }
-              }
-            }
-          }
         }
         move "Night Murmurs", {
           text "30 damage. If the Defending Pokémon is a Basic Pokémon, that Pokémon is now Confused."

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -207,9 +207,6 @@ public enum CrystalGuardians implements LogicCardInfo {
 
         // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
         thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Banette by your opponents Pokémon-ex.")
-        pokeBody "Safeguard", {
-          text "Prevent all effects of attacks, including damage, done to Banette by your opponent's Pokémon-ex."
-        }
         move "Night Murmurs", {
           text "30 damage. If the Defending Pokémon is a Basic Pokémon, that Pokémon is now Confused."
           energyCost P, C

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -196,9 +196,6 @@ public enum Deoxys implements LogicCardInfo {
 
           // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
           thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Altaria by your opponents Pokémon-ex.")
-          pokeBody "Safeguard", {
-            text "Prevent all effects of attacks, including damage, done to Altaria by your opponent’s Pokémon-ex."
-          }
           move "Double Wing Attack", {
             text "Does 20 Damage to each Defending Pokémon."
             energyCost L

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1,4 +1,6 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
+
+import tcgwars.logic.effect.ability.custom.Safeguard;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -191,25 +193,11 @@ public enum Deoxys implements LogicCardInfo {
         return evolution (this, from:"Swablu", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
           resistance FIGHTING, MINUS30
+
+          // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+          thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Altaria by your opponents Pokémon-ex.")
           pokeBody "Safeguard", {
             text "Prevent all effects of attacks, including damage, done to Altaria by your opponent’s Pokémon-ex."
-            //TODO: Change static safeguard so it's configurable.
-            delayedA {
-              before null, self, Source.ATTACK, {
-                if (self.owner.opposite.pbg.active.EX && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE) {
-                  bc "Safeguard prevents effect"
-                  prevent()
-                }
-              }
-              before APPLY_ATTACK_DAMAGES, {
-                bg.dm().each {
-                  if(it.to == self && it.notNoEffect && it.from.EX ) {
-                    it.dmg = hp(0)
-                    bc "Safeguard prevents damage"
-                  }
-                }
-              }
-            }
           }
           move "Double Wing Attack", {
             text "Does 20 Damage to each Defending Pokémon."

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
+import tcgwars.logic.effect.ability.custom.Safeguard;
 import tcgwars.logic.impl.gen2.Expedition;
 
 import tcgwars.logic.effect.gm.Attack
@@ -259,9 +260,11 @@ public enum FireRedLeafGreen implements LogicCardInfo {
       case DEWGONG_3:
         return evolution (this, from:"Seel", hp:HP080, type:WATER, retreatCost:2) {
           weakness METAL
+
+          // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+          thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Dewgong by your opponents Pokémon-ex.")
           pokeBody "Safeguard", {
             text "Prevent all effects of attacks, including damage, done to Dewgong by your opponent’s Pokémon-ex."
-            safeguard(self,delegate)
           }
           move "Cold Breath", {
             text "10 damage. The Defending Pokémon is now Asleep."

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -263,9 +263,6 @@ public enum FireRedLeafGreen implements LogicCardInfo {
 
           // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
           thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Dewgong by your opponents Pokémon-ex.")
-          pokeBody "Safeguard", {
-            text "Prevent all effects of attacks, including damage, done to Dewgong by your opponent’s Pokémon-ex."
-          }
           move "Cold Breath", {
             text "10 damage. The Defending Pokémon is now Asleep."
             energyCost W

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
+import tcgwars.logic.effect.ability.custom.Safeguard;
 import tcgwars.logic.impl.gen1.FossilNG;
 import tcgwars.logic.impl.gen6.Xy;
 import tcgwars.logic.impl.gen7.CelestialStorm;
@@ -2615,24 +2616,11 @@ public enum LegendMaker implements LogicCardInfo {
       return evolution (this, from:"Cascoon", hp:HP140, type:G, retreatCost:1) {
         weakness R
         weakness P
+
+        // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+        thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Dustox by your opponents Pokémon-ex.")
         pokeBody "Safeguard", {
           text "Prevent all effects of attacks, including damage, done to Dustox ex by your opponent's Pokémon-ex."
-          delayedA {
-            before null, self, Source.ATTACK, {
-              if (self.owner.opposite.pbg.active.EX && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE) {
-                bc "Safeguard prevents effect"
-                prevent()
-              }
-            }
-            before APPLY_ATTACK_DAMAGES, {
-              bg.dm().each {
-                if(it.to == self && it.from.EX && it.notNoEffect && it.dmg.value ) {
-                  it.dmg = hp(0)
-                  bc "Safeguard prevents damage"
-                }
-              }
-            }
-          }
         }
         move "Silver Wind", {
           text "40 damage. During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 30 more damage."

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2619,9 +2619,6 @@ public enum LegendMaker implements LogicCardInfo {
 
         // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
         thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Dustox by your opponents Pokémon-ex.")
-        pokeBody "Safeguard", {
-          text "Prevent all effects of attacks, including damage, done to Dustox ex by your opponent's Pokémon-ex."
-        }
         move "Silver Wind", {
           text "40 damage. During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 30 more damage."
           energyCost G, C

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1,5 +1,6 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
+import tcgwars.logic.effect.ability.custom.Safeguard;
 import tcgwars.logic.impl.gen1.FossilNG;
 import tcgwars.logic.impl.gen2.Expedition;
 import tcgwars.logic.impl.gen2.Aquapolis;
@@ -722,26 +723,11 @@ public enum PowerKeepers implements LogicCardInfo {
       case NINETALES_19:
       return evolution (this, from:"Vulpix", hp:HP070, type:R, retreatCost:1) {
         weakness W
+
+        // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+        thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Ninetales by your opponents Pokémon-ex.")
         pokeBody "Safeguard", {
           text "Prevent all effects of attacks, including damage, done to Ninetales by your opponent's Pokémon-ex."
-          delayedA {
-            before null, self, Source.ATTACK, {
-              if (self.owner.opposite.pbg.active.EX && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE) {
-                bc "Safeguard prevents effect"
-                prevent()
-              }
-            }
-            before APPLY_ATTACK_DAMAGES, {
-              if (ef.attacker.owner != self.owner && ef.attacker.EX) {
-                bg.dm().each {
-                  if(it.to == self && it.notNoEffect && it.dmg.value) {
-                    it.dmg = hp(0)
-                    bc "Safeguard prevents damage"
-                  }
-                }
-              }
-            }
-          }
         }
         move "Quick Attack", {
           text "20+ damage. Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
@@ -873,26 +859,11 @@ public enum PowerKeepers implements LogicCardInfo {
       case WOBBUFFET_24:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
+
+        // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
+        thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Wobbuffet by your opponents Pokémon-ex.")
         pokeBody "Safeguard", {
           text "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent's Pokémon-ex."
-          delayedA {
-            before null, self, Source.ATTACK, {
-              if (self.owner.opposite.pbg.active.EX && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE) {
-                bc "Safeguard prevents effect"
-                prevent()
-              }
-            }
-            before APPLY_ATTACK_DAMAGES, {
-              if (ef.attacker.EX) {
-                bg.dm().each {
-                  if(it.to == self && it.dmg.value && it.notNoEffect) {
-                    it.dmg = hp(0)
-                    bc "Safeguard prevents damage"
-                  }
-                }
-              }
-            }
-          }
         }
         move "Flip Over", {
           text "50 damage. Wobbuffet does 10 damage to itself, and don't apply Weakness and Resistance to this damage."

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -726,9 +726,6 @@ public enum PowerKeepers implements LogicCardInfo {
 
         // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
         thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Ninetales by your opponents Pokémon-ex.")
-        pokeBody "Safeguard", {
-          text "Prevent all effects of attacks, including damage, done to Ninetales by your opponent's Pokémon-ex."
-        }
         move "Quick Attack", {
           text "20+ damage. Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
           energyCost C, C
@@ -862,9 +859,6 @@ public enum PowerKeepers implements LogicCardInfo {
 
         // TODO: Replace with a static for Pokémon-ex and/or change static safeguard so it's configurable.
         thisCard.addAbility new Safeguard("Prevent all effects of attacks, including damage, done to Wobbuffet by your opponents Pokémon-ex.")
-        pokeBody "Safeguard", {
-          text "Prevent all effects of attacks, including damage, done to Wobbuffet by your opponent's Pokémon-ex."
-        }
         move "Flip Over", {
           text "50 damage. Wobbuffet does 10 damage to itself, and don't apply Weakness and Resistance to this damage."
           energyCost P, C, C


### PR DESCRIPTION
The safeguard static is for BW-era EXs. The Safeguard effect already
exists for EX-era exs, so we can use it for the relevant cards. I'm not
sure if the existing pokeBody closure should be removed?