### PR TITLE
Discard energy after damage

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -186,6 +186,59 @@ class TcgStatics {
     ef.run(bg())
     ef.getList()
   }
+  /**
+   * Select energy cards attached to a {@link PokemonCardSet} using the
+   * {@link EnergySelectUIRequestBuilder Energy Select UI}
+   * @param pcs {@link PokemonCardSet} with the Energy cards to choose
+   * @param types {@link Type}s of energy to be selected. Default: C
+   * @return {@link CardList} of the selected cards, can be empty CardList
+   */
+  static CardList selectEnergy(PokemonCardSet pcs, Type...types=C) {
+    def ef = new SelectEnergy(pcs.cards, types)
+    ef.playerType = pcs.owner
+    bg.em().activateEffect(ef)
+    return ef.selectedCards ?: []
+  }
+  /**
+   * Selects Energy of specified Type from the attacking {@link PokemonCardSet} before damage, then discards it after
+   * damage. Should only be used for {@link Move}s
+   * @param types {@link Type}s of energy to be discarded. Default: C
+   */
+  static discardSelfEnergyAfterDamage(Type...types=C) {
+    def pcs = Target.YOUR_ACTIVE.getSingleTarget(bg)
+    def cards = selectEnergy(pcs, types)
+    afterDamage {
+      def de = new DiscardEnergy(cards)
+      de.source = ATTACK
+      bg.em().activateEffect(de)
+    }
+  }
+  /**
+   * Selects Energy of specified Type from the attacking {@link PokemonCardSet} before damage, then moves it to a new
+   * location after damage. Should only be used for {@link Move}s
+   * @param types {@link Type}s of energy to be moved. Default: C
+   */
+  static moveSelfEnergyAfterDamage(CardList newLocation, Type...types=C) {
+    def pcs = Target.YOUR_ACTIVE.getSingleTarget(bg)
+    def cards = selectEnergy(pcs, types)
+    afterDamage {
+      cards.moveTo newLocation
+    }
+  }
+  /**
+   * Selects Energy of specified Type from the opponent's active {@link PokemonCardSet} before damage, then discards it
+   * after damage. Should only be used for {@link Move}s
+   * @param types (optional) {@link Type}s of energy to be discarded. Default: C
+   */
+  static discardDefendingEnergyAfterDamage(Type...types=C) {
+    def pcs = Target.OPP_ACTIVE.getSingleTarget(bg)
+    def cards = selectEnergy(pcs, types)
+    afterDamage {
+      def de = new DiscardEnergy(cards)
+      de.source = ATTACK
+      bg.em().activateEffect(de)
+    }
+  }
   static CardList hand(){
     bg().ownHand()
   }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -303,23 +303,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           energyCost D, C, C
           onAttack {
             damage 60
-            afterDamage {
-              // TODO: Make a static method to do this
-              def targetCount = Math.min self.cards.energyCount(C), 2
-              def finalCount = 0
-              while (self.cards.energyCount(C) > 0 && finalCount < targetCount) {
-                def info = "Select Energy to return to your hand."
-                def energy = self.cards.filterByType(ENERGY).select(info)
-                def energyCount = 1
-                if (energy.energyCount(C) > 1) {
-                  def choices = 1..energy.energyCount(C)
-                  def choiceInfo = "How many Energy do you want this card to count as?"
-                  energyCount = choose(choices, choiceInfo)
-                }
-                finalCount += energyCount
-                energy.moveTo my.hand
-              }
-            }
+            moveSelfEnergyAfterDamage my.hand, C, C
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1093,28 +1093,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost R, R, C
             onAttack {
               damage 160
-              afterDamage {
-                // TODO: Make a static method to do this
-                if (self.cards.energyCount(R))
-                  if (self.cards.energyCount(R) <= 2) {
-                    self.cards.filterByEnergyType(R).moveTo my.hand
-                  } else {
-                    def targetCount = Math.min self.cards.energyCount(R), 2
-                    def finalCount = 0
-                    while (self.cards.energyCount(R) > 0 && finalCount < targetCount) {
-                      def info = "Select [R] Energy to return to your hand."
-                      def energy = self.cards.filterByType(ENERGY).select(info, energyFilter(R))
-                      def energyCount = 1
-                      if (energy.energyCount(R) > 1) {
-                        def choices = 1..energy.energyCount(R)
-                        def choiceInfo = "How many Energy do you want this card to count as?"
-                        energyCount = choose(choices, choiceInfo)
-                      }
-                      finalCount += energyCount
-                      energy.moveTo my.hand
-                    }
-                  }
-              }
+              moveSelfEnergyAfterDamage my.hand, R, R
             }
           }
           move "Massive Heat Wave GX", {

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -534,7 +534,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost R, R, C, C
           onAttack {
             damage 180
-            discardSelfEnergy C, C
+            discardSelfEnergyAfterDamage C, C
           }
         }
       };
@@ -558,7 +558,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost R, R, C
           onAttack {
             damage 160
-            discardSelfEnergy C
+            discardSelfEnergyAfterDamage C
           }
         }
       };
@@ -1600,28 +1600,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost D, C, C, C
           onAttack {
             damage 130
-            afterDamage {
-              // TODO: Make a static method to do this
-              if (self.cards.energyCount())
-                if (self.cards.energyCount() <= 2) {
-                  self.cards.filterByType(ENERGY).moveTo my.hand
-                } else {
-                  def targetCount = Math.min self.cards.energyCount(), 2
-                  def finalCount = 0
-                  while (self.cards.energyCount() > 0 && finalCount < targetCount) {
-                    def info = "Select Energy to discard."
-                    def energy = self.cards.filterByType(ENERGY).select(info)
-                    def energyCount = 1
-                    if (energy.energyCount() > 1) {
-                      def choices = 1..energy.energyCount()
-                      def choiceInfo = "How many Energy do you want this card to count as?"
-                      energyCount = choose(choices, choiceInfo)
-                    }
-                    finalCount += energyCount
-                    energy.discard()
-                  }
-                }
-            }
+            discardSelfEnergyAfterDamage C, C
             applyAfterDamage PARALYZED
             applyAfterDamage POISONED
           }
@@ -1787,7 +1766,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost M, C
           onAttack {
             damage 30
-            discardDefendingEnergy()
+            discardDefendingEnergyAfterDamage()
           }
         }
         move "Slashing Claw", {
@@ -1876,9 +1855,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost M, M, C
           onAttack {
             damage 120
-            afterDamage {
-              discardSelfEnergy C
-            }
+            discardSelfEnergyAfterDamage C
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -660,9 +660,7 @@ public enum ChampionsPath implements LogicCardInfo {
           energyCost F, F, C, C
           onAttack {
             damage 130
-            afterDamage {
-              discardSelfEnergy F
-            }
+            discardSelfEnergyAfterDamage F
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -655,9 +655,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 220
-            afterDamage {
-              discardSelfEnergy C, C
-            }
+            discardSelfEnergyAfterDamage C, C
           }
         }
       };
@@ -678,9 +676,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 300
-            afterDamage {
-              discardSelfEnergy C, C
-            }
+            discardSelfEnergyAfterDamage C, C
           }
         }
       };
@@ -938,10 +934,8 @@ public enum DarknessAblaze implements LogicCardInfo {
           onAttack {
             damage 20
             if (self.cards.energyCount(C) && confirm("Discard an Energy from $self.name to discard an energy from $defending.name?")) {
-              afterDamage {
-                discardSelfEnergy C
-                discardDefendingEnergy()
-              }
+              discardSelfEnergyAfterDamage C
+              discardDefendingEnergyAfterDamage()
             }
           }
         }
@@ -1024,7 +1018,6 @@ public enum DarknessAblaze implements LogicCardInfo {
         move "Wave Splash", {
           text "20 damage."
           energyCost W
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -1032,31 +1025,9 @@ public enum DarknessAblaze implements LogicCardInfo {
         move "Aurora Loop", {
           text "130 damage. Put 2 [W] Energy attached to this Pokémon into your hand."
           energyCost W, W, C
-          attackRequirement {}
           onAttack {
             damage 130
-            afterDamage {
-              // TODO: Make a static method to do this
-              if (self.cards.energyCount(W))
-                if (self.cards.energyCount(W) <= 2) {
-                  self.cards.filterByEnergyType(W).moveTo my.hand
-                } else {
-                  def targetCount = Math.min self.cards.energyCount(W), 2
-                  def finalCount = 0
-                  while (self.cards.energyCount(W) > 0 && finalCount < targetCount) {
-                    def info = "Select [W] Energy to return to your hand."
-                    def energy = self.cards.filterByType(ENERGY).select(info, energyFilter(W))
-                    def energyCount = 1
-                    if (energy.energyCount(W) > 1) {
-                      def choices = 1..energy.energyCount(W)
-                      def choiceInfo = "How many Energy do you want this card to count as?"
-                      energyCount = choose(choices, choiceInfo)
-                    }
-                    finalCount += energyCount
-                    energy.moveTo my.hand
-                  }
-                }
-            }
+            moveSelfEnergyAfterDamage my.hand, W, W
           }
         }
       };
@@ -1521,9 +1492,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 190
-            afterDamage {
-              discardSelfEnergy C, C
-            }
+            discardSelfEnergyAfterDamage C, C
           }
         }
       };
@@ -2259,9 +2228,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 80
-            afterDamage {
-              discardDefendingEnergy()
-            }
+            discardDefendingEnergyAfterDamage()
           }
         }
         move "Heavy Rock Artillery", {
@@ -2658,28 +2625,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 200
-            afterDamage {
-              // TODO: Make a static method to do this
-              if (self.cards.energyCount(D))
-                if (self.cards.energyCount(D) <= 2) {
-                  self.cards.filterByEnergyType(D).moveTo my.hand
-                } else {
-                  def targetCount = Math.min self.cards.energyCount(D), 2
-                  def finalCount = 0
-                  while (self.cards.energyCount(D) > 0 && finalCount < targetCount) {
-                    def info = "Select [D] Energy to return to your hand."
-                    def energy = self.cards.filterByType(ENERGY).select(info, energyFilter(D))
-                    def energyCount = 1
-                    if (energy.energyCount(D) > 1) {
-                      def choices = 1..energy.energyCount(D)
-                      def choiceInfo = "How many Energy do you want this card to count as?"
-                      energyCount = choose(choices, choiceInfo)
-                    }
-                    finalCount += energyCount
-                    energy.moveTo my.hand
-                  }
-                }
-            }
+            moveSelfEnergyAfterDamage my.hand, D, D
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -1206,7 +1206,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           energyCost M, M, C
           onAttack {
             damage 130
-            discardSelfEnergy C, C
+            discardSelfEnergyAfterDamage C, C
           }
         }
       };
@@ -1385,7 +1385,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           energyCost C, C, C
           onAttack {
             damage 120
-            discardSelfEnergy C
+            discardSelfEnergyAfterDamage C
           }
         }
       };
@@ -1429,11 +1429,11 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         weakness L
         resistance F, MINUS30
         move "Energy Cutoff", {
-          text "60 damage. Flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+          text "60 damage. Discard an Energy from your opponent's Active Pokémon."
           energyCost C, C
           onAttack {
             damage 60
-            discardDefendingEnergy()
+            discardDefendingEnergyAfterDamage()
           }
         }
         move "Loop Cannon", {
@@ -1441,28 +1441,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           energyCost C, C, C
           onAttack {
             damage 160
-            afterDamage {
-              // TODO: Make a static method to do this
-              if (self.cards.energyCount())
-                if (self.cards.energyCount() <= 2) {
-                  self.cards.filterByType(ENERGY).moveTo my.hand
-                } else {
-                  def targetCount = Math.min self.cards.energyCount(), 2
-                  def finalCount = 0
-                  while (self.cards.energyCount() > 0 && finalCount < targetCount) {
-                    def info = "Select Energy to return to your hand."
-                    def energy = self.cards.filterByType(ENERGY).select(info)
-                    def energyCount = 1
-                    if (energy.energyCount() > 1) {
-                      def choices = 1..energy.energyCount()
-                      def choiceInfo = "How many Energy do you want this card to count as?"
-                      energyCount = choose(choices, choiceInfo)
-                    }
-                    finalCount += energyCount
-                    energy.moveTo my.hand
-                  }
-                }
-            }
+            moveSelfEnergyAfterDamage my.hand, C, C
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -740,10 +740,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost C, C
           onAttack {
             damage 60
-
-            afterDamage {
-              flip { discardDefendingEnergy() }
-            }
+            flip { discardDefendingEnergyAfterDamage() }
           }
         }
       };
@@ -840,7 +837,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost R, C, C, C
           onAttack {
             damage 180
-            discardSelfEnergy(C)
+            discardSelfEnergyAfterDamage(C)
           }
         }
       };
@@ -1008,7 +1005,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost R, R, C
           onAttack {
             damage 120
-            discardSelfEnergy(C)
+            discardSelfEnergyAfterDamage(C)
           }
         }
       };
@@ -2515,7 +2512,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost F, F, C
           onAttack {
             damage 220
-            discardSelfEnergy(C, C)
+            discardSelfEnergyAfterDamage(C, C)
           }
         }
       };
@@ -3146,7 +3143,7 @@ public enum RebelClash implements LogicCardInfo {
           onAttack {
             damage 120
             flip 1, {}, {
-              discardSelfEnergy(C, C)
+              discardSelfEnergyAfterDamage(C, C)
             }
           }
         }
@@ -3277,7 +3274,7 @@ public enum RebelClash implements LogicCardInfo {
           energyCost C, C, C
           onAttack {
             damage 150
-            discardSelfEnergy(C)
+            discardSelfEnergyAfterDamage(C)
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -753,9 +753,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, R, R, C
           onAttack {
             damage 120
-            afterDamage{
-              2.times{ discardDefendingEnergy() }
-            }
+            discardDefendingEnergyAfterDamage C, C
           }
         }
       };
@@ -829,7 +827,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, C
           onAttack {
             damage 120
-            discardSelfEnergy(C, C)
+            discardSelfEnergyAfterDamage(C, C)
           }
         }
       };
@@ -848,7 +846,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, R, R, C
           onAttack {
             damage 150
-            discardSelfEnergy(C, C)
+            discardSelfEnergyAfterDamage(C, C)
           }
         }
       };
@@ -860,7 +858,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R
           onAttack {
             damage 30
-            discardSelfEnergy(C)
+            discardSelfEnergyAfterDamage(C)
           }
         }
       };
@@ -940,7 +938,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, R, C
           onAttack {
             damage 190
-            discardSelfEnergy(C, C)
+            discardSelfEnergyAfterDamage(C, C)
           }
         }
       };
@@ -982,7 +980,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost R, R, C
           onAttack {
             damage 160
-            flip 1, {}, { discardSelfEnergy(C, C) }
+            flip 1, {}, { discardSelfEnergyAfterDamage(C, C) }
           }
         }
       };
@@ -1156,7 +1154,10 @@ public enum SwordShield implements LogicCardInfo {
           text "Flip 3 coins. For each heads, discard an Energy from your opponent’s Active Pokémon."
           energyCost W
           onAttack {
-            flip 3, { discardDefendingEnergy() }
+            def count = 0
+            flip 3, { count++ }
+            def types = (1..count).collect {C} as Type[]
+            discardDefendingEnergyAfterDamage types
           }
         }
         move "Pierce", {
@@ -1205,28 +1206,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost W, W, W, C
           onAttack {
             damage 210
-            afterDamage {
-              // TODO: Make a static method to do this
-              if (self.cards.energyCount(W))
-                if (self.cards.energyCount(W) <= 2) {
-                  self.cards.filterByEnergyType(W).moveTo my.hand
-                } else {
-                  def targetCount = Math.min self.cards.energyCount(W), 2
-                  def finalCount = 0
-                  while (self.cards.energyCount(W) > 0 && finalCount < targetCount) {
-                    def info = "Select [W] Energy to return to your hand."
-                    def energy = self.cards.filterByType(ENERGY).select(info, energyFilter(W))
-                    def energyCount = 1
-                    if (energy.energyCount(W) > 1) {
-                      def choices = 1..energy.energyCount(W)
-                      def choiceInfo = "How many Energy do you want this card to count as?"
-                      energyCount = choose(choices, choiceInfo)
-                    }
-                    finalCount += energyCount
-                    energy.moveTo my.hand
-                  }
-                }
-            }
+            moveSelfEnergyAfterDamage my.hand, W, W
           }
         }
       };
@@ -1775,8 +1755,8 @@ public enum SwordShield implements LogicCardInfo {
           onAttack {
             damage 150
 
+            discardSelfEnergyAfterDamage C
             afterDamage {
-              discardSelfEnergy C
               if (my.bench) {
                 sw self, my.bench.select()
               }
@@ -2803,7 +2783,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost M, C
           onAttack {
             damage 40
-            discardDefendingEnergy()
+            discardDefendingEnergyAfterDamage()
           }
         }
       };
@@ -2935,7 +2915,7 @@ public enum SwordShield implements LogicCardInfo {
           onAttack {
             damage 130
             if (confirm("Discard 2 Energies to take 100 less damage next turn?")) {
-              discardSelfEnergy(C, C)
+              discardSelfEnergyAfterDamage(C, C)
 
               afterDamage {
                 delayed {

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -407,7 +407,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
           energyCost C, C, C
           onAttack {
             damage 120
-            discardSelfEnergy C
+            discardSelfEnergyAfterDamage C
           }
         }
       };
@@ -443,7 +443,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
           energyCost C, C, C
           onAttack {
             damage 60
-            flip{ afterDamage{ discardDefendingEnergy() } }
+            flip{ discardDefendingEnergyAfterDamage() }
           }
         }
         move "Metal Blade", {
@@ -452,7 +452,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
           onAttack {
             damage 190
             afterDamage{
-              discardSelfEnergy(C,C,C)
+              discardSelfEnergyAfterDamage(C,C,C)
             }
           }
         }
@@ -530,10 +530,8 @@ public enum SwordShieldPromos implements LogicCardInfo {
           onAttack {
             damage 120
             if (self.cards.energyCount(C)) {
-              afterDamage {
-                discardSelfEnergy C
-              }
-              discardDefendingEnergy()
+              discardSelfEnergyAfterDamage C
+              discardDefendingEnergyAfterDamage()
             }
           }
         }


### PR DESCRIPTION
Implements the new SelectEnergy effect to handle discarding/moving Energy after damage properly. Energy is selected before damage, damage is applied, then energy is discarded/moved when these statics are used.

Implemented primarily in the gen8 sets for now, and replacing some TODO's left from a former non-static, non-SelectEnergy implementation in other sets. If all seems well, another PR will be made to try to massively replace existing improperly handled Energy discards/moves.