### PR TITLE
Phione crash fix

### DIFF
--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1595,7 +1595,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assert self.benched
               assertOppBench()
               powerUsed()
-              if(sw2(opp.bench.oppSelect("Choose a new Active Pokémon"), SRC_ABILITY)){
+              if(sw2(opp.active, opp.bench.oppSelect("Choose a new Active Pokémon"), SRC_ABILITY){
                 self.cards.getExcludedList(self.topPokemonCard).discard()
                 self.cards.moveTo(my.deck)
                 removePCS(self)

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -1595,7 +1595,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               assert self.benched
               assertOppBench()
               powerUsed()
-              if(sw2(opp.active, opp.bench.oppSelect("Choose a new Active Pokémon"), SRC_ABILITY){
+              if(sw2(opp.active, opp.bench.oppSelect("Choose a new Active Pokémon"), SRC_ABILITY)){
                 self.cards.getExcludedList(self.topPokemonCard).discard()
                 self.cards.moveTo(my.deck)
                 removePCS(self)


### PR DESCRIPTION
Fixes Phione crashes. used sw2(opp.active, opp.bench.oppSelect(...),SRC_ABILITY) rather than sw2(opp.bench.oppSelect(...), null,SRC_ABILITY) as it should target your opponent's active Pokemon. @axpendix 
[phione.txt](https://github.com/axpendix/tcgone-engine-contrib/files/5611729/phione.txt)
https://forum.tcgone.net/t/br-phione-smp-sm220-lucario-melmetal-gx-smp-sm192-phio/11188
