### PR TITLE
Use the new multiSelectPokemon Overload

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -378,8 +378,13 @@ class TcgStatics {
   static oppChoose (List choices, String info="", defaultChoice=null){
     oppChoose(choices, null, info, defaultChoice)
   }
-  static multiSelect (List pcsList, int count, String info="Select Pokémon"){
-    LUtils.selectMultiPokemon(bg().ownClient(), pcsList, info, count)
+  static multiSelect (List pcsList, Integer count, String info="Select Pokémon") {
+    // Optional parameters in the middle of a param list confuse the parser. In order to have min before max in the
+    // following definition we'll add this overload to handle "count" variations that also provide custom text
+    multiSelect(pcsList, count, count, info)
+  }
+  static multiSelect (List pcsList, Integer min, Integer max, String info="Select Pokémon"){
+    LUtils.selectMultiPokemon(bg().ownClient(), pcsList, info, min, max)
   }
   static multiDamage (List pcsList, int count, int dmg, String info="Select to deal damage"){
     def a=LUtils.selectMultiPokemon(bg().ownClient(), pcsList, info, count)

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -628,7 +628,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           text "Choose 3 of your opponent's Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost F
           onAttack {
-            multiSelect(opp.all, 3).each {
+            multiSelect(opp.all, 3, text).each {
               damage 10, it
             }
           }
@@ -1953,7 +1953,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           text "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost C, C, C
           onAttack {
-            multiSelect(opp.all, 2).each {
+            multiSelect(opp.all, 2, text).each {
               damage 30, it
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -522,7 +522,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           energyCost F, M
           onAttack {
             def maximum = Math.min(self.cards.energyCount(C), opp.all.size())
-            multiSelect(opp.all, maximum).each {
+            multiSelect(opp.all, 1, maximum, text).each {
               damage 20, it
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1567,7 +1567,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           text "Choose 2 of your opponent's Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost C, C
           onAttack {
-            multiSelect(opp.all, 2).each {
+            multiSelect(opp.all, 2, text).each {
               targeted(it) {
                 damage 10, it
               }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -289,7 +289,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
             energyCost R, C, C
             onAttack {
-              multiSelect(opp.all, 2).each{ damage 30, it }
+              multiSelect(opp.all, 2, text).each{ damage 30, it }
             }
           }
 
@@ -904,7 +904,7 @@ public enum Deoxys implements LogicCardInfo {
             text "Choose 3 of your opponent’s Pokémon. This attack does 10 damage to each of those Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
             energyCost W
             onAttack {
-              multiSelect(opp.all, 3).each{ damage 10, it }
+              multiSelect(opp.all, 3, text).each{ damage 10, it }
             }
           }
           move "Rend", {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1247,6 +1247,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           move "Tunneling", {
             text "Choose up to 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.) Onix can’t attack during your next turn."
             energyCost F, C
+            attackRequirement {
+              assertOppBench()
+            }
             onAttack {
               if (opp.bench) {
                 multiSelect(opp.bench, 1, 2, text).each{

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1249,7 +1249,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             energyCost F, C
             onAttack {
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 1, 2, text).each{
                   targeted(it){
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -981,7 +981,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           onAttack {
             damage 20
             if (opp.bench) {
-              multiSelect(opp.bench, 2).each {
+              multiSelect(opp.bench, 2, text).each {
                 damage 10, it
               }
             }
@@ -1062,7 +1062,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           onAttack {
             damage 40
             if (opp.bench) {
-              multiSelect(opp.bench, 2).each {
+              multiSelect(opp.bench, 2, text).each {
                 damage 10, it
               }
             }
@@ -1359,7 +1359,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           text "Choose 2 of your opponent's Pokémon. This attack does 30 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost F, C, C
           onAttack {
-            multiSelect(opp.all, 2).each {
+            multiSelect(opp.all, 2, text).each {
               damage 30, it
             }
           }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1310,7 +1310,7 @@ public enum LegendMaker implements LogicCardInfo {
           onAttack {
             damage 20
             if (opp.bench) {
-              multiSelect(opp.bench, 2).each{
+              multiSelect(opp.bench, 2, text).each{
                 damage 10, it
               }
             }

--- a/src/tcgwars/logic/impl/gen3/PopSeries1.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries1.groovy
@@ -339,7 +339,7 @@ public enum PopSeries1 implements LogicCardInfo {
           onAttack {
             damage 10
             if (opp.bench){
-              multiSelect(opp.bench, 2).each {
+              multiSelect(opp.bench, 2, text).each {
                 targeted(it) {
                   damage 10, it
                 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
@@ -233,7 +233,7 @@ public enum PopSeries2 implements LogicCardInfo {
           onAttack {
             damage 20
             if (opp.bench) {
-              multiSelect(opp.bench, 2).each {
+              multiSelect(opp.bench, 2, text).each {
                 targeted(it) {
                   damage 20, it
                 }

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1327,7 +1327,7 @@ public enum UnseenForces implements LogicCardInfo {
             assert opp.bench: "Opponent does not have any Benched Pokémon"
           }
           onAttack {
-            multiSelect(opp.bench, 2).each {
+            multiSelect(opp.bench, 2, text).each {
               targeted(it){ damage 10, it }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -293,7 +293,7 @@ public enum Arceus implements LogicCardInfo {
             onAttack {
               damage 60
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each {
+                multiSelect(opp.bench, 2, text).each {
                   targeted(it) {
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -2577,7 +2577,7 @@ public enum DiamondPearl implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 1, 2, text).each{
                   targeted(it){
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1707,7 +1707,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             energyCost C, C, C
             attackRequirement {}
             onAttack {
-              multiSelect(opp.all.findAll{it.evolution}, 3).each{
+              multiSelect(opp.all.findAll{it.evolution}, 3, text).each{
                 targeted(it){
                   damage 30, it
                 }
@@ -1828,7 +1828,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             onAttack {
               damage 40
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each {
+                multiSelect(opp.bench, 2, text).each {
                   targeted(it) {
                     damage 10, it
                   }
@@ -2637,7 +2637,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               assert opp.bench
             }
             onAttack {
-              multiSelect(opp.bench, 2).each{
+              multiSelect(opp.bench, 2, text).each{
                 targeted(it){
                   damage 10, it
                 }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1649,7 +1649,7 @@ public enum Platinum implements LogicCardInfo {
             onAttack {
               damage 30
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each {
+                multiSelect(opp.bench, 2, text).each {
                   targeted(it) {
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen4/PopSeries8.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries8.groovy
@@ -159,7 +159,7 @@ public enum PopSeries8 implements LogicCardInfo {
             onAttack {
               damage 20
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each {
+                multiSelect(opp.bench, 2, text).each {
                   targeted(it) {
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1749,7 +1749,7 @@ public enum Stormfront implements LogicCardInfo {
             onAttack {
               damage 20
               if (opp.bench) {
-                multiSelect(opp.bench, 2).each {
+                multiSelect(opp.bench, 2, text).each {
                   targeted(it) {
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -286,7 +286,7 @@ public enum Unleashed implements LogicCardInfo {
             energyCost P, P, P
             onAttack {
               if(opp.bench){
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 2, text).each{
                   targeted(it){
                     damage 40, it
                   }
@@ -1610,7 +1610,7 @@ public enum Unleashed implements LogicCardInfo {
             energyCost P
             onAttack {
               if(opp.bench){
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 2, text).each{
                   targeted(it){ damage 10, it }
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -1205,7 +1205,7 @@ public enum CelestialStorm implements LogicCardInfo {
             text "This attack does 30 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
             energyCost W,C
             onAttack {
-              multiSelect(opp.all, 2).each{
+              multiSelect(opp.all, 2, text).each{
                 targeted(it){
                   damage 30, it
                 }
@@ -1301,7 +1301,7 @@ public enum CelestialStorm implements LogicCardInfo {
             onAttack {
               damage 10
               if(opp.bench){
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 2, text).each{
                   targeted(it){
                     damage 10, it
                   }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -2461,7 +2461,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             text "Choose 2 of your opponent's Pokémon and put 2 damage counters on each of them."
             energyCost P
             onAttack {
-              multiSelect(opp.all, 2).each {
+              multiSelect(opp.all, 2, text).each {
                 targeted(it) { directDamage 20, it }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -718,7 +718,7 @@ public enum DragonMajesty implements LogicCardInfo {
             onAttack{
               damage 40
               if(opp.bench){
-                multiSelect(opp.bench, 2).each{
+                multiSelect(opp.bench, 2, text).each{
                   targeted(it){
                     damage 40, it
                   }

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -2377,7 +2377,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
             onAttack {
               gxPerform()
-              multiSelect(opp.bench, 2).each{
+              multiSelect(opp.bench, 2, text).each{
                 scoopUpPokemon(it, delegate)
               }
             }

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -739,7 +739,7 @@ public enum HiddenFates implements LogicCardInfo {
           onAttack {
             damage 60
             if(opp.bench){
-              multiSelect(opp.bench, 3).each{
+              multiSelect(opp.bench, 3, text).each{
                 targeted(it){ damage 20, it }
               }
             }
@@ -942,7 +942,7 @@ public enum HiddenFates implements LogicCardInfo {
           onAttack {
             gxPerform()
             if (self.cards.energySufficient(thisMove.energyCost + [R,W,L])) {
-              multiSelect(opp.all, 3).each{
+              multiSelect(opp.all, 3, text).each{
                 damage 110, it
               }
             }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -2382,7 +2382,7 @@ public enum LostThunder implements LogicCardInfo {
               bc "$thisCard used Distortion Door"
               def pcs = benchPCS(thisCard)
               if (pcs && thisCard.player.opposite.pbg.bench) {
-                multiSelect(thisCard.player.opposite.pbg.bench,2).each{
+                multiSelect(thisCard.player.opposite.pbg.bench, 2, text).each {
                   directDamage 10, it, SRC_ABILITY
                 }
               }

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2589,7 +2589,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
             onAttack {
               gxPerform()
-              def pcs = multiSelect(opp.all, 2)
+              def pcs = multiSelect(opp.all, 2, text)
               pcs.each {
                 noWrDamage 50, it
               }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1354,7 +1354,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost C, C, C
             onAttack {
               discardSelfEnergy C,C
-              multiSelect(opp.all,2).each{ damage 60, it }
+              multiSelect(opp.all, 2, text).each { damage 60, it }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2158,7 +2158,7 @@ public enum SwordShield implements LogicCardInfo {
           onAttack {
             damage 100
             if (opp.bench) {
-              multiSelect(opp.bench, 2).each {
+              multiSelect(opp.bench, 2, text).each {
                 targeted(it) {
                   damage 10, it
                 }


### PR DESCRIPTION
Uses the new overload in places where it is appropriate to use in existing code.

Also adds text to ones missing it. Was done by just using the text property of the attack that is using it, but should provide better context.