### PR TITLE
Reorder powerUsed and bg.em().storeObject

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -768,8 +768,8 @@ public enum Deoxys implements LogicCardInfo {
               checkLastTurn()
               checkNoSPC()
               assert bg.em().retrieveObject("Happy_Dance") != bg.turnCount : "You cannot use Happy Dance more than once per turn!"
-              powerUsed()
               bg.em().storeObject("Happy_Dance",bg.turnCount)
+              powerUsed()
               my.all.each{
                 heal 10, it
               }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -228,8 +228,8 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 if (flag) {
                   PokemonCardSet pcs = ef.pokemonToBeEvolved
                   if(pcs.owner != self.owner && bg.em().retrieveObject("Darkest Impulse") != (pcs.id+bg.turnCount)){
-                    powerUsed()
                     bg.em().storeObject("Darkest Impulse", pcs.id+bg.turnCount)
+                    powerUsed()
                     directDamage(20, pcs, SRC_ABILITY)
                   }
                 }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -227,8 +227,8 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkLastTurn()
               assert bg.em().retrieveObject("Form_Change") != bg.turnCount : "You cannot use Form Change more than once per turn!"
               assert my.deck : "There is no card in your deck"
-              powerUsed()
               bg.em().storeObject("Form_Change",bg.turnCount)
+              powerUsed()
               def deoxys = self.topPokemonCard
               if (my.deck.findAll{it.name == "Deoxys"}) {
                 my.deck.search{it.name == "Deoxys"}.moveTo(self.cards)
@@ -723,8 +723,8 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkLastTurn()
               assert bg.em().retrieveObject("Form_Change") != bg.turnCount : "You cannot use Form Change more than once per turn!"
               assert my.deck : "There is no card in your deck"
-              powerUsed()
               bg.em().storeObject("Form_Change",bg.turnCount)
+              powerUsed()
               def deoxys = self.topPokemonCard
               if (my.deck.findAll{it.name == "Deoxys"}) {
                 my.deck.search{it.name == "Deoxys"}.moveTo(self.cards)
@@ -754,8 +754,8 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkLastTurn()
               assert bg.em().retrieveObject("Form_Change") != bg.turnCount : "You cannot use Form Change more than once per turn!"
               assert my.deck : "There is no card in your deck"
-              powerUsed()
               bg.em().storeObject("Form_Change",bg.turnCount)
+              powerUsed()
               def deoxys = self.topPokemonCard
               if (my.deck.findAll{it.name == "Deoxys"}) {
                 my.deck.search{it.name == "Deoxys"}.moveTo(self.cards)
@@ -785,8 +785,8 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkLastTurn()
               assert bg.em().retrieveObject("Form_Change") != bg.turnCount : "You cannot use Form Change more than once per turn!"
               assert my.deck : "There is no card in your deck"
-              powerUsed()
               bg.em().storeObject("Form_Change",bg.turnCount)
+              powerUsed()
               def deoxys = self.topPokemonCard
               if (my.deck.findAll{it.name == "Deoxys"}) {
                 my.deck.search{it.name == "Deoxys"}.moveTo(self.cards)

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1424,8 +1424,8 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 def cardName = it
                 assert my.benched.any{it.name == cardName} : "$cardName is not on your bench"
               }
-              powerUsed()
               bg.em().storeObject("DP_Unown_ITEM", bg.turnCount)
+              powerUsed()
               my.deck.search(max:1, "Choose a Trainer-Item card.", cardTypeFilter(ITEM)).showToOpponent("Opponent's chosen Trainer-Item card.").moveTo(my.hand)
               shuffleDeck()
             }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1434,7 +1434,7 @@ public enum SecretWonders implements LogicCardInfo {
             text "Once during your turn , if you have Unown S, Unown E, and Unown T on your Bench, you may flip a coin. If heads, search your discard pile for an Energy card, show it to your opponent, and put it on top of your deck."
             actionA {
               checkLastTurn()
-              assert my.bench.find{it.name = "Unown S"} : "Unown S is not on your Bench"
+              assert self.benched : "$self is not on your bench"
               assert my.bench.find{it.name = "Unown E"} : "Unown E is not on your Bench"
               assert my.bench.find{it.name = "Unown T"} : "Unown T is not on your Bench"
               powerUsed()
@@ -2222,7 +2222,7 @@ public enum SecretWonders implements LogicCardInfo {
             text "Once during your turn , if you have Unown N, Unown O, and Unown D on your Bench, you may ask your opponent to take a Prize card. If he or she does, you take a Prize card. If he or she doesn’t, draw a card."
             actionA {
               checkLastTurn()
-              assert my.bench.find{it.name = "Unown N"} : "Unown N is not on your Bench"
+              assert self.benched : "$self is not on your bench"
               assert my.bench.find{it.name = "Unown O"} : "Unown O is not on your Bench"
               assert my.bench.find{it.name = "Unown D"} : "Unown D is not on your Bench"
               powerUsed()
@@ -2254,7 +2254,7 @@ public enum SecretWonders implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert my.hand.size() == 1 : "You don't have exactly 1 card in your hand"
-              assert my.bench.find{it.name = "Unown O"} : "Unown O is not on your Bench"
+              assert self.benched : "$self is not on your bench"
               assert my.bench.find{it.name = "Unown N"} : "Unown N is not on your Bench"
               assert my.bench.find{it.name = "Unown E"} : "Unown E is not on your Bench"
               powerUsed()
@@ -2281,7 +2281,7 @@ public enum SecretWonders implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert opp.deck : "Your opponent's deck is empty"
-              assert my.bench.find{it.name = "Unown X"} : "Unown X is not on your Bench"
+              assert self.benched : "$self is not on your bench"
               powerUsed()
               opp.deck.subList(0,1).showToMe("Top card of your opponent's deck")
             }

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -2393,8 +2393,8 @@ public enum CosmicEclipse implements LogicCardInfo {
               checkLastTurn()
               assert bg.em().retrieveObject("Dance_of_Tribute") != bg.turnCount : "You can't use more than 1 Dance of Tribute Ability each turn."
               assert bg.em().retrieveObject("Dance_of_Tribute") == bg.turnCount-1 : "None of your Pokémon were Knocked Out during your opponent's last turn."
-              powerUsed()
               bg.em().storeObject("Dance_of_Tribute", bg.turnCount)
+              powerUsed()
               draw 3
             }
           }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3677,8 +3677,8 @@ public enum UnbrokenBonds implements LogicCardInfo {
               assert my.deck : "Empty deck"
               checkLastTurn()
               assert bg.em().retrieveObject("Cat Walk") != bg.turnCount : "Already used one Cat Walk ability this turn"
-              powerUsed()
               bg.em().storeObject("Cat Walk", bg.turnCount)
+              powerUsed()
               deck.select(min:1,max:2,"Put to hand").moveTo(hidden:true,hand)
               shuffleDeck()
             }


### PR DESCRIPTION
As far as understand, Alakazam's power Cancel (and power spray once its implemented), prevent all effects after powerUsed. Once either of these effects are used, powers that can only be used once per turn globally are still considered used, so no other pokemon should be able to use the power. 

I think that the reorder will fix this but it feels clunky. A better solution might include adding a parameter to powerUsed?