### PR TITLE
Fix Cardlist Shuffle on Select

### DIFF
--- a/src/tcgwars/logic/util/CardList.groovy
+++ b/src/tcgwars/logic/util/CardList.groovy
@@ -312,7 +312,7 @@ public class CardList extends ArrayList<Card> {
     }
     CardList cards = this;
     boolean hidden = params.hidden ?: false
-    if (hidden) {
+    if (hidden && this.persistent && this.persistentName == "Hand") {
       cards = this.shuffledCopy();
     }
     if (playerType != TcgStatics.bg().currentThreadPlayerType) {


### PR DESCRIPTION
Only create shuffled copy for hands when selecting from a hidden cardlist