### PR TITLE
Fix timing of effects that trigger when pokemon is damaged by an attack

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1859,19 +1859,24 @@ class TcgStatics {
   /* Effects that trigger when a Pokémon is active and damaged by an opposing attack, can be called by either a Poké-Body / Ability, an attack, or a card attached to the Pokémon. */
 
   // poke bodies and abilities
-  static ifActiveAndDamagedByAttackBody (Closure eff, PokemonCardSet self, Object delegate) {
-    delegate.delayedA (priority: BEFORE_LAST) {
-      def applyEffect = false
-      before APPLY_ATTACK_DAMAGES, {
-          applyEffect = bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value})
-      }
-      after APPLY_ATTACK_DAMAGES, {
-        if (applyEffect) {
-          eff()
-          applyEffect = false
+  static ifActiveAndDamagedByAttackBody (Object delegate1, Closure eff) {
+    def c1 = {
+      delayedA(priority: BEFORE_LAST) {
+        def applyEffect = false
+        before APPLY_ATTACK_DAMAGES, {
+          applyEffect = bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to == self && it.dmg.value })
+        }
+        after APPLY_ATTACK_DAMAGES, {
+          if (applyEffect) {
+            eff.call()
+            applyEffect = false
+          }
         }
       }
     }
+    c1.resolveStrategy=Closure.DELEGATE_FIRST
+    c1.delegate=delegate1
+    c1.call()
   }
 
   // tools and special energy

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1863,7 +1863,7 @@ class TcgStatics {
     delegate.delayedA (priority: BEFORE_LAST) {
       def applyEffect = false
       before APPLY_ATTACK_DAMAGES, {
-          applyEffect = bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value}))
+          applyEffect = bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value})
       }
       after APPLY_ATTACK_DAMAGES, {
         if (applyEffect) {
@@ -1875,7 +1875,7 @@ class TcgStatics {
   }
 
   // tools and special energy
-  static ifActiveAndDamagedByAttackAttached (Closure c, PokemonCardSet self, Object delegate, Card thisCard) {
+  static ifActiveAndDamagedByAttackAttached (Closure c, Object delegate, Card thisCard) {
     def eff
     delegate.onPlay {reason->
       eff = delayed(priority: BEFORE_LAST) {

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -557,10 +557,10 @@ public enum CrystalGuardians implements LogicCardInfo {
         weakness F
         pokeBody "Fluffy Fur", {
           text "If Wigglytuff is your Active Pokémon and is damaged by an opponent's attack (even if Wigglytuff is Knocked Out), the Attacking Pokémon is now Asleep."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "Fluffy Fur"
             apply ASLEEP, (ef.attacker as PokemonCardSet)
-          }, self, delegate)
+          }
         }
         move "Collect", {
           text "Draw 3 cards."

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -557,14 +557,10 @@ public enum CrystalGuardians implements LogicCardInfo {
         weakness F
         pokeBody "Fluffy Fur", {
           text "If Wigglytuff is your Active Pokémon and is damaged by an opponent's attack (even if Wigglytuff is Knocked Out), the Attacking Pokémon is now Asleep."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({it.to==self && it.dmg.value})) {
-                bc "Fluffy Fur"
-                apply ASLEEP, (ef.attacker as PokemonCardSet)
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "Fluffy Fur"
+            apply ASLEEP, (ef.attacker as PokemonCardSet)
+          }, self, delegate)
         }
         move "Collect", {
           text "Draw 3 cards."

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1104,18 +1104,10 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           weakness FIRE
           pokeBody "Poison Payback", {
             text "If Kakuna is your Active Pokémon and is damaged by an opponent’s attack (even if Kakuna is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA {
-              before APPLY_ATTACK_DAMAGES, {
-                if(ef.attacker.owner != self.owner) {
-                  bg.dm().each{
-                    if(it.to == self && self.active && it.notNoEffect && it.dmg.value) {
-                      bc "Kakuna's Poison Payback poison your Pokémon!"
-                      apply POISONED,ef.attacker
-                    }
-                  }
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Kakuna's Poison Payback poison your Pokémon!"
+              apply POISONED, ef.attacker
+            }, self, delegate)
           }
           move "Headbutt", {
             text "10 damage."

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1104,10 +1104,10 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           weakness FIRE
           pokeBody "Poison Payback", {
             text "If Kakuna is your Active Pokémon and is damaged by an opponent’s attack (even if Kakuna is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Kakuna's Poison Payback poison your Pokémon!"
               apply POISONED, ef.attacker
-            }, self, delegate)
+            }
           }
           move "Headbutt", {
             text "10 damage."

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2112,10 +2112,10 @@ public enum LegendMaker implements LogicCardInfo {
         weakness R
         pokeBody "Poison Payback", {
           text "If Wurmple is your Active Pokémon and is damaged by an opponent's attack (even if Wurmple is Knocked Out), the Attacking Pokémon is now Poisoned."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "Poison Payback"
             apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-          }, self, delegate)
+          }
         }
         move "String Pull", {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
@@ -2288,9 +2288,9 @@ public enum LegendMaker implements LogicCardInfo {
           Card pokemonCard, trainerCard = thisCard
           pokemonCard = basic (new CustomCardInfo(CLAW_FOSSIL_78).setCardTypes(BASIC, POKEMON), hp:HP040, type:COLORLESS, retreatCost:0) {
             pokeBody "Jagged Stone", {
-              ifActiveAndDamagedByAttackBody({
+              ifActiveAndDamagedByAttackBody(delegate) {
                 directDamage(10, ef.attacker, Source.SRC_ABILITY)
-              }, self, delegate)
+              }
             }
             customAbility {
               def eff, acl

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -2112,14 +2112,10 @@ public enum LegendMaker implements LogicCardInfo {
         weakness R
         pokeBody "Poison Payback", {
           text "If Wurmple is your Active Pokémon and is damaged by an opponent's attack (even if Wurmple is Knocked Out), the Attacking Pokémon is now Poisoned."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                bc "Poison Payback"
-                apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "Poison Payback"
+            apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+          }, self, delegate)
         }
         move "String Pull", {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
@@ -2292,13 +2288,9 @@ public enum LegendMaker implements LogicCardInfo {
           Card pokemonCard, trainerCard = thisCard
           pokemonCard = basic (new CustomCardInfo(CLAW_FOSSIL_78).setCardTypes(BASIC, POKEMON), hp:HP040, type:COLORLESS, retreatCost:0) {
             pokeBody "Jagged Stone", {
-              delayedA{
-                before APPLY_ATTACK_DAMAGES, {
-                  if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
-                    directDamage(10, ef.attacker, Source.SRC_ABILITY)
-                  }
-                }
-              }
+              ifActiveAndDamagedByAttackBody({
+                directDamage(10, ef.attacker, Source.SRC_ABILITY)
+              }, self, delegate)
             }
             customAbility {
               def eff, acl

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1251,13 +1251,9 @@ public enum PowerKeepers implements LogicCardInfo {
         weakness F
         pokeBody "Strikes Back", {
           text "If Vigoroth is your Active Pokémon and is damaged by an opponent's attack (even if Vigoroth is Knocked Out), put 1 damage counter on the Attacking Pokémon."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value })) {
-                directDamage(10, ef.attacker, Source.SRC_ABILITY)
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            directDamage(10, ef.attacker, Source.SRC_ABILITY)
+          }, self, delegate)
         }
         move "Ambush", {
           text "20+ damage. Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
@@ -1361,13 +1357,9 @@ public enum PowerKeepers implements LogicCardInfo {
         resistance P, MINUS30
         pokeBody "Rough Skin", {
           text "If Carvanha is your Active Pokémon and is damaged by an opponent's attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value })) {
-                directDamage(10, ef.attacker, Source.SRC_ABILITY)
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            directDamage(10, ef.attacker, Source.SRC_ABILITY)
+          }, self, delegate)
         }
         move "Gnaw", {
           text "20 damage."

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1251,9 +1251,9 @@ public enum PowerKeepers implements LogicCardInfo {
         weakness F
         pokeBody "Strikes Back", {
           text "If Vigoroth is your Active Pokémon and is damaged by an opponent's attack (even if Vigoroth is Knocked Out), put 1 damage counter on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             directDamage(10, ef.attacker, Source.SRC_ABILITY)
-          }, self, delegate)
+          }
         }
         move "Ambush", {
           text "20+ damage. Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
@@ -1357,9 +1357,9 @@ public enum PowerKeepers implements LogicCardInfo {
         resistance P, MINUS30
         pokeBody "Rough Skin", {
           text "If Carvanha is your Active Pokémon and is damaged by an opponent's attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             directDamage(10, ef.attacker, Source.SRC_ABILITY)
-          }, self, delegate)
+          }
         }
         move "Gnaw", {
           text "20 damage."

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -725,10 +725,10 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness GRASS
           pokeBody "Poison Payback", {
             text "If Dark Sandslash is your Active Pokémon and is damaged by an opponent’s attack (even if Dark Sandslash is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Poison Payback"
               apply POISONED, (ef.attacker as PokemonCardSet)
-            }, self, delegate)
+            }
           }
           move "Swift", {
             text "50 damage. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
@@ -959,12 +959,12 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness LIGHTNING
           pokeBody "Spiny", {
             text "If Qwilfish is your Active Pokémon and is damaged by an opponent’s attack (even if Qwilfish is Knocked Out), flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Spiny"
               def counterDmg = 0
               flipUntilTails {counterDmg += 10}
               directDamage(counterDmg, ef.attacker, Source.SRC_ABILITY)
-            }, self, delegate)
+            }
           }
           move "Stun Poison", {
             text "10 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned."
@@ -2577,10 +2577,10 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness PSYCHIC
           pokeBody "Strikes Back", {
             text "If Rocket’s Hitmonchan ex is your Active Pokémon and is damaged by an opponent’s attack (even if Rocket’s Hitmonchan ex is Knocked Out), put 2 damage counters on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "$self Strikes Back!"
               directDamage 20, (ef.attacker as PokemonCardSet)
-            }, self, delegate)
+            }
           }
           move "Mach Punch", {
             text "10 damage. Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -725,14 +725,10 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness GRASS
           pokeBody "Poison Payback", {
             text "If Dark Sandslash is your Active Pokémon and is damaged by an opponent’s attack (even if Dark Sandslash is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Poison Payback"
-                  apply POISONED, (ef.attacker as PokemonCardSet)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Poison Payback"
+              apply POISONED, (ef.attacker as PokemonCardSet)
+            }, self, delegate)
           }
           move "Swift", {
             text "50 damage. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
@@ -963,22 +959,12 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness LIGHTNING
           pokeBody "Spiny", {
             text "If Qwilfish is your Active Pokémon and is damaged by an opponent’s attack (even if Qwilfish is Knocked Out), flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if (self.active) {
-                  def pcs = self.owner.opposite.pbg.active
-                  def counterDmg = 0
-                  bg.dm().each{
-                    if(it.to == self && it.notNoEffect && it.dmg.value) {
-                      bc "Spiny"
-                      pcs = it.from
-                      flipUntilTails {counterDmg += 10}
-                    }
-                  }
-                  directDamage counterDmg, pcs
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Spiny"
+              def counterDmg = 0
+              flipUntilTails {counterDmg += 10}
+              directDamage(counterDmg, ef.attacker, Source.SRC_ABILITY)
+            }, self, delegate)
           }
           move "Stun Poison", {
             text "10 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned."
@@ -2589,14 +2575,10 @@ public enum TeamRocketReturns implements LogicCardInfo {
           weakness PSYCHIC
           pokeBody "Strikes Back", {
             text "If Rocket’s Hitmonchan ex is your Active Pokémon and is damaged by an opponent’s attack (even if Rocket’s Hitmonchan ex is Knocked Out), put 2 damage counters on the Attacking Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "$self Strikes Back!"
-                  directDamage 20, (ef.attacker as PokemonCardSet)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "$self Strikes Back!"
+              directDamage 20, (ef.attacker as PokemonCardSet)
+            }, self, delegate)
           }
           move "Mach Punch", {
             text "10 damage. Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1049,12 +1049,12 @@ public enum UnseenForces implements LogicCardInfo {
         weakness P
         pokeBody "Stages of Evolution", {
           text "As long as Hitmontop is an Evolved Pokémon, is your Active Pokémon, and is damaged by an opponent's attack (even if Hitmontop is Knocked Out), put 2 damage counters on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             if (self.evolution) {
               bc "Stages of Evolution Activates"
               directDamage 20, (ef.attacker as PokemonCardSet)
             }
-          }, self, delegate)
+          }
         }
         move "Upward Kick", {
           text "20+ damage. If the Defending Pokémon already has at least 2 damage counters on it, this attack does 20 damage plus 30 more damage."
@@ -2623,14 +2623,14 @@ public enum UnseenForces implements LogicCardInfo {
         resistance F, MINUS30
         pokeBody "Silver Sparkle", {
           text "If Lugia ex is your Active Pokémon and is damaged by an opponent's attack (even if Lugia ex is Knocked Out), flip a coin. If heads, choose an Energy card attached to the Attacking Pokémon and return it to your opponent's hand."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             if (ef.attacker.cards.filterByType(ENERGY)) {
               bc "Silver Sparkle Activates"
               flip {
                 ef.attacker.cards.filterByType(ENERGY).select("Select an Energy to move to the Opponent's hand", {true}, self.owner).moveTo(ef.attacker.owner.pbg.hand)
               }
             }
-          }, self, delegate)
+          }
         }
         move "Elemental Blast", {
           text "200 damage. Discard a [R] Energy, [W] Energy, and [L] Energy attached to Lugia ex."

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1049,14 +1049,12 @@ public enum UnseenForces implements LogicCardInfo {
         weakness P
         pokeBody "Stages of Evolution", {
           text "As long as Hitmontop is an Evolved Pokémon, is your Active Pokémon, and is damaged by an opponent's attack (even if Hitmontop is Knocked Out), put 2 damage counters on the Attacking Pokémon."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if(bg.currentTurn == self.owner.opposite && self.evolution && self.active && bg.dm().find({it.to==self && it.dmg.value})){
-                bc "Stages of Evolution Activates"
-                directDamage 20, (ef.attacker as PokemonCardSet)
-              }
+          ifActiveAndDamagedByAttackBody({
+            if (self.evolution) {
+              bc "Stages of Evolution Activates"
+              directDamage 20, (ef.attacker as PokemonCardSet)
             }
-          }
+          }, self, delegate)
         }
         move "Upward Kick", {
           text "20+ damage. If the Defending Pokémon already has at least 2 damage counters on it, this attack does 20 damage plus 30 more damage."
@@ -2625,18 +2623,14 @@ public enum UnseenForces implements LogicCardInfo {
         resistance F, MINUS30
         pokeBody "Silver Sparkle", {
           text "If Lugia ex is your Active Pokémon and is damaged by an opponent's attack (even if Lugia ex is Knocked Out), flip a coin. If heads, choose an Energy card attached to the Attacking Pokémon and return it to your opponent's hand."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to==self && it.dmg.value})) {
-                if (ef.attacker.cards.filterByType(ENERGY)) {
-                  bc "Silver Sparkle Activates"
-                  flip {
-                    ef.attacker.cards.filterByType(ENERGY).select("Select an Energy to move to the Opponent's hand", {true}, self.owner).moveTo(ef.attacker.owner.pbg.hand)
-                  }
-                }
+          ifActiveAndDamagedByAttackBody({
+            if (ef.attacker.cards.filterByType(ENERGY)) {
+              bc "Silver Sparkle Activates"
+              flip {
+                ef.attacker.cards.filterByType(ENERGY).select("Select an Energy to move to the Opponent's hand", {true}, self.owner).moveTo(ef.attacker.owner.pbg.hand)
               }
             }
-          }
+          }, self, delegate)
         }
         move "Elemental Blast", {
           text "200 damage. Discard a [R] Energy, [W] Energy, and [L] Energy attached to Lugia ex."

--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -1360,14 +1360,10 @@ public enum Arceus implements LogicCardInfo {
           resistance C, MINUS20
           pokeBody "Hidden Poison", {
             text "If Haunter is your Active Pokémon and is damaged by an opponent’s attack (even if Haunter is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "$thisAbility"
-                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "$thisAbility"
+              apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+            }, self, delegate)
           }
           move "Tongue Spring", {
             text "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon."

--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -1360,10 +1360,10 @@ public enum Arceus implements LogicCardInfo {
           resistance C, MINUS20
           pokeBody "Hidden Poison", {
             text "If Haunter is your Active Pokémon and is damaged by an opponent’s attack (even if Haunter is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "$thisAbility"
               apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Tongue Spring", {
             text "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon."

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -3163,10 +3163,10 @@ public enum LegendsAwakened implements LogicCardInfo {
             energyCost F
             attackRequirement {}
             onAttack {
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Counter Punch activates"
                 directDamage(40, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
           move "Gut Strike", {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -906,17 +906,12 @@ public enum LegendsAwakened implements LogicCardInfo {
           weakness F, '+20'
           pokeBody "Attracting Body", {
             text "If Delcatty is your Active Pokémon and is damaged by an opponent's attack (even if Delcatty is Knocked Out), flip a coin. If heads, the Attacking Pokémon is now Confused."
-            delayedA(priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && it.dmg.value > 0 && bg.currentTurn==self.owner.opposite
-                    && self.active) {
-                    bc "Attracting Body activates"
-                    apply CONFUSED, it.from, SRC_ABILITY
-                  }
-                }
+            ifActiveAndDamagedByAttackBody({
+              bc "Attracting Body activates"
+              flip {
+                apply CONFUSED, ef.attacker, SRC_ABILITY
               }
-            }
+            }, self, delegate)
           }
           move "Energy Assist", {
             text "30 damage. Search your discard pile for a basic Energy card and attach it to 1 of your Benched Pokémon."
@@ -3168,18 +3163,10 @@ public enum LegendsAwakened implements LogicCardInfo {
             energyCost F
             attackRequirement {}
             onAttack {
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                    bc "Counter Punch activates"
-                    directDamage(40, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after FALL_BACK, self, {unregister()}
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Counter Punch activates"
+                directDamage(40, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
           move "Gut Strike", {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -906,12 +906,12 @@ public enum LegendsAwakened implements LogicCardInfo {
           weakness F, '+20'
           pokeBody "Attracting Body", {
             text "If Delcatty is your Active Pokémon and is damaged by an opponent's attack (even if Delcatty is Knocked Out), flip a coin. If heads, the Attacking Pokémon is now Confused."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Attracting Body activates"
               flip {
                 apply CONFUSED, ef.attacker, SRC_ABILITY
               }
-            }, self, delegate)
+            }
           }
           move "Energy Assist", {
             text "30 damage. Search your discard pile for a basic Energy card and attach it to 1 of your Benched Pokémon."

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -820,14 +820,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
           weakness R, PLUS30
           pokeBody "Glacier Snow", {
             text "If Abomasnow is your Active Pokémon and is damaged by an opponent’s attack (even if Abomasnow is Knocked Out), the Attacking Pokémon is now Asleep."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({it.to==self && it.dmg.value})) {
-                  bc "Glacier Snow triggers"
-                  apply ASLEEP, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Glacier Snow triggers"
+              apply ASLEEP, (ef.attacker as PokemonCardSet), SRC_ABILITY
+            }, self, delegate)
           }
           move "Heavy Blizzard", {
             text "60 damage. Flip a coin. If heads, put 1 damage counter on each of your opponent’s Benched Pokémon."
@@ -2064,18 +2060,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
             energyCost C
             attackRequirement {}
             onAttack {
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                    bc "Spike Armor activates"
-                    directDamage(40, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-                after FALL_BACK, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Spike Armor activates"
+                directDamage(40, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
           move "Poison Spike", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -820,10 +820,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
           weakness R, PLUS30
           pokeBody "Glacier Snow", {
             text "If Abomasnow is your Active Pokémon and is damaged by an opponent’s attack (even if Abomasnow is Knocked Out), the Attacking Pokémon is now Asleep."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Glacier Snow triggers"
               apply ASLEEP, (ef.attacker as PokemonCardSet), SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Heavy Blizzard", {
             text "60 damage. Flip a coin. If heads, put 1 damage counter on each of your opponent’s Benched Pokémon."

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -2060,10 +2060,10 @@ public enum MysteriousTreasures implements LogicCardInfo {
             energyCost C
             attackRequirement {}
             onAttack {
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Spike Armor activates"
                 directDamage(40, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
           move "Poison Spike", {

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -410,7 +410,7 @@ public enum Platinum implements LogicCardInfo {
         };
       case DIALGA_6:
         return basic (this, hp:HP100, type:METAL, retreatCost:2) {
-          weakness R
+          weakness R, PLUS20
           resistance P, MINUS20
           pokeBody "Time Aura", {
             text "As long as Dialga is your Active Pokémon, your opponent can’t play any Pokémon from his or her hand to evolve his or her Active Pokémon."
@@ -851,7 +851,7 @@ public enum Platinum implements LogicCardInfo {
                 unregisterAfter 3
                 after FALL_BACK, pcs, {
                   pokeFlag = false
-                  unregister() 
+                  unregister()
                 }
                 after EVOLVE, pcs, {
                   pokeFlag = false
@@ -3420,7 +3420,7 @@ public enum Platinum implements LogicCardInfo {
                 }
                 if(
                   (once) &&
-                  (!ignoreList.contains(ability.name) && 
+                  (!ignoreList.contains(ability.name) &&
                   (thisCard.player.pbg.hand.find{it.name == "Team Galactic's Invention G-103 Power Spray"} || bluffing)) &&
                   (thisCard.player.pbg.all.findAll{it.topPokemonCard.cardTypes.is(POKEMON_SP)}.size() >= 3) &&
                   (ability instanceof PokePower) &&

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1390,14 +1390,10 @@ public enum SecretWonders implements LogicCardInfo {
           weakness L, PLUS20
           resistance P, MINUS20
           pokeBody "Rough Skin", {
-            text "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack , put 2 damage counter on the Attacking Pokémon."
-            delayedA{
-                before APPLY_ATTACK_DAMAGES, {
-                  if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
-                    directDamage(20, ef.attacker, Source.SRC_ABILITY)
-                  }
-                }
-              }
+            text "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack, put 2 damage counter on the Attacking Pokémon."
+            ifActiveAndDamagedByAttackBody({
+              directDamage(20, ef.attacker, Source.SRC_ABILITY)
+            }, self, delegate)
           }
           move "Strike Wound", {
             text "60+ damage. If the Defending Pokémon has 2 or more damage counters on it, this attack does 60 damage plus 20 more damage. This attack damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects of that Pokémon."
@@ -2318,7 +2314,7 @@ public enum SecretWonders implements LogicCardInfo {
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
           pokePower "ZERO", {
-            text "Once during your turn , if Unown Z is on your Bench and you have no cards in you deck, you may discard all cards attached to Unown Z and put Unown Z on top of your deck."
+            text "Once during your turn, if Unown Z is on your Bench and you have no cards in you deck, you may discard all cards attached to Unown Z and put Unown Z on top of your deck."
             actionA {
               checkLastTurn()
               assert my.deck.size() == 0 : "Your deck is not empty"
@@ -2343,7 +2339,7 @@ public enum SecretWonders implements LogicCardInfo {
                 count += choice
               }
               if(count > 0) {
-                directDamage 10 * count, defending 
+                directDamage 10 * count, defending
               }
             }
           }
@@ -2355,15 +2351,11 @@ public enum SecretWonders implements LogicCardInfo {
           resistance F, MINUS20
           pokeBody "Dangerous Scales", {
             text "If Venomoth is your Active Pokémon and is damaged by an opponent’s attack (even is Venomoth is Knocked Out), the Attacking Pokémon is now Asleep and Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if (bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({it.to==self && it.dmg.value})) {
-                  bc "Dangerous Scales"
-                  apply ASLEEP, (ef.attacker as PokemonCardSet)
-                  apply POISONED, (ef.attacker as PokemonCardSet)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Dangerous Scales"
+              apply ASLEEP, (ef.attacker as PokemonCardSet)
+              apply POISONED, (ef.attacker as PokemonCardSet)
+            }, self, delegate)
           }
           move "Disturbance Dive", {
             text "50 damage. Prevent all effects of an attack, excluding damage, done to Venomoth during your opponent’s next turn."
@@ -3012,19 +3004,17 @@ public enum SecretWonders implements LogicCardInfo {
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
           pokePower "Balloon Sting", {
-            text "Once during your opponent’s turn, if Qwilfish is your Active Pokémon and is damage by an attack (even if Qwilfish is Knocked Out), you may flip a coin. If heads, the Attacking Pokémon is now Poisoned. Put 2 damage counter instead of 1 on that Pokémon between turns."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value}) && confirm ("Use Balloon Sting?")){
-                  powerUsed()
-                  bc "Balloon Sting activates"
-                  flip {
-                    apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                    extraPoison 1
-                  }
+            text "Once during your opponent’s turn, if Qwilfish is your Active Pokémon and is damaged by an attack (even if Qwilfish is Knocked Out), you may flip a coin. If heads, the Attacking Pokémon is now Poisoned. Put 2 damage counter instead of 1 on that Pokémon between turns."
+            ifActiveAndDamagedByAttackBody({
+              if (confirm("Use Balloon Sting?")) {
+                powerUsed()
+                bc "Balloon Sting activates"
+                flip {
+                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+                  extraPoison 1
                 }
               }
-            }
+            }, self, delegate)
           }
           move "Nerve Shot", {
             text "20 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1390,9 +1390,9 @@ public enum SecretWonders implements LogicCardInfo {
           resistance P, MINUS20
           pokeBody "Rough Skin", {
             text "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack, put 2 damage counter on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               directDamage(20, ef.attacker, Source.SRC_ABILITY)
-            }, self, delegate)
+            }
           }
           move "Strike Wound", {
             text "60+ damage. If the Defending Pokémon has 2 or more damage counters on it, this attack does 60 damage plus 20 more damage. This attack damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects of that Pokémon."
@@ -2350,11 +2350,11 @@ public enum SecretWonders implements LogicCardInfo {
           resistance F, MINUS20
           pokeBody "Dangerous Scales", {
             text "If Venomoth is your Active Pokémon and is damaged by an opponent’s attack (even is Venomoth is Knocked Out), the Attacking Pokémon is now Asleep and Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Dangerous Scales"
               apply ASLEEP, (ef.attacker as PokemonCardSet)
               apply POISONED, (ef.attacker as PokemonCardSet)
-            }, self, delegate)
+            }
           }
           move "Disturbance Dive", {
             text "50 damage. Prevent all effects of an attack, excluding damage, done to Venomoth during your opponent’s next turn."
@@ -3004,7 +3004,7 @@ public enum SecretWonders implements LogicCardInfo {
           weakness L, PLUS20
           pokePower "Balloon Sting", {
             text "Once during your opponent’s turn, if Qwilfish is your Active Pokémon and is damaged by an attack (even if Qwilfish is Knocked Out), you may flip a coin. If heads, the Attacking Pokémon is now Poisoned. Put 2 damage counter instead of 1 on that Pokémon between turns."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               if (confirm("Use Balloon Sting?")) {
                 powerUsed()
                 bc "Balloon Sting activates"
@@ -3013,7 +3013,7 @@ public enum SecretWonders implements LogicCardInfo {
                   extraPoison 1
                 }
               }
-            }, self, delegate)
+            }
           }
           move "Nerve Shot", {
             text "20 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1096,16 +1096,10 @@ public enum Stormfront implements LogicCardInfo {
           weakness W, PLUS20
           pokeBody "Burning Mane", {
             text "If Rapidash is your Active Pokémon and is damaged by an opponent’s attack (even if Rapidash is Knocked Out), the Attacking Pokémon is now Burned."
-            delayedA {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && self.active && it.dmg.value && bg.currentTurn==self.owner.opposite) {
-                    bc "Burning Mane activates."
-                    apply BURNED, it.from, SRC_ABILITY
-                  }
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Burning Mane activates."
+              apply BURNED, ef.attacker, SRC_ABILITY
+            }, self, delegate)
           }
           move "Rear Kick", {
             text "30 damage. "
@@ -1129,16 +1123,10 @@ public enum Stormfront implements LogicCardInfo {
           weakness R, PLUS20
           pokeBody "Hidden Poison", {
             text "If Roserade is your Active Pokémon and is damaged by an opponent’s attack (even if Roserade is Knocked Out), the Defending Pokémon is now Poisoned."
-            delayedA {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && self.active && it.dmg.value && bg.currentTurn==self.owner.opposite) {
-                    bc "Hidden Poison activates."
-                    apply POISONED, it.from, SRC_ABILITY
-                  }
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Hidden Poison activates."
+              apply POISONED, ef.attacker, SRC_ABILITY
+            }, self, delegate)
           }
           move "Bowed Whip", {
             text "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, discard an Energy card attached to that Pokémon."
@@ -1613,18 +1601,12 @@ public enum Stormfront implements LogicCardInfo {
           resistance M, MINUS20
           pokeBody "Radiance", {
             text "If Electrode is your Active Pokémon and is damaged by an opponent’s attack (even if Electrode is Knocked Out), put 1 damage counter on each of your opponent’s Pokémon."
-            delayedA {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && self.active && it.dmg.value && bg.currentTurn==self.owner.opposite) {
-                    bc "Radiance activates."
-                    self.owner.opposite.pbg.all.each {
-                      directDamage 10, it, SRC_ABILITY
-                    }
-                  }
-                }
+            ifActiveAndDamagedByAttackBody({
+              bc "Radiance activates."
+              self.owner.opposite.pbg.all.each {
+                directDamage 10, it, SRC_ABILITY
               }
-            }
+            }, self, delegate)
           }
           def turnCount=-1
           HP lastDamage=null
@@ -1949,7 +1931,7 @@ public enum Stormfront implements LogicCardInfo {
           pokeBody "Overeager", {
             text "If Sableye is your Active Pokémon at the beginning of the game, you go first. (If each player’s Active Pokémon has the Overeager Poké-Body, this power does nothing.)"
             delayedA {
-              //TODO : I think this has to be engine level? 
+              //TODO : I think this has to be engine level?
             }
           }
           move "Impersonate", {

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1096,10 +1096,10 @@ public enum Stormfront implements LogicCardInfo {
           weakness W, PLUS20
           pokeBody "Burning Mane", {
             text "If Rapidash is your Active Pokémon and is damaged by an opponent’s attack (even if Rapidash is Knocked Out), the Attacking Pokémon is now Burned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Burning Mane activates."
               apply BURNED, ef.attacker, SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Rear Kick", {
             text "30 damage. "
@@ -1123,10 +1123,10 @@ public enum Stormfront implements LogicCardInfo {
           weakness R, PLUS20
           pokeBody "Hidden Poison", {
             text "If Roserade is your Active Pokémon and is damaged by an opponent’s attack (even if Roserade is Knocked Out), the Defending Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Hidden Poison activates."
               apply POISONED, ef.attacker, SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Bowed Whip", {
             text "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, discard an Energy card attached to that Pokémon."
@@ -1601,12 +1601,12 @@ public enum Stormfront implements LogicCardInfo {
           resistance M, MINUS20
           pokeBody "Radiance", {
             text "If Electrode is your Active Pokémon and is damaged by an opponent’s attack (even if Electrode is Knocked Out), put 1 damage counter on each of your opponent’s Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Radiance activates."
               self.owner.opposite.pbg.all.each {
                 directDamage 10, it, SRC_ABILITY
               }
-            }, self, delegate)
+            }
           }
           def turnCount=-1
           HP lastDamage=null

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -12,6 +12,7 @@ import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
+import tcgwars.logic.effect.basic.Knockout;
 
 import tcgwars.logic.card.*
 import tcgwars.logic.util.*;

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -234,17 +234,32 @@ public enum SupremeVictors implements LogicCardInfo {
           move "Feint Attack", {
             text "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon."
             energyCost D
-            attackRequirement {}
             onAttack {
               swiftDamage(20, opp.all.select())
             }
           }
           move "Doom News", {
-            text "to your hand. The Defending Pokémon is Knocked Out at the end of your opponent’s next turn."
+            text "Return all Energy cards attached to this Pokémon to your hand. The Defending Pokémon is Knocked Out at the end of your opponent’s next turn."
             energyCost D, C, C
-            attackRequirement {}
             onAttack {
-              damage 0
+              self.cards.filterByType(ENERGY).each { it.moveTo(my.hand) }
+
+              def pcs = defending
+              targeted(pcs) {
+                bc "At the end of ${self.owner.opposite}'s next turn, the Defending ${defending} will be Knocked Out. (This effect can be removed by benching/evolving ${defending}.)"
+                delayed {
+                  before BETWEEN_TURNS, {
+                    if (bg.currentTurn == self.owner.opposite && all.contains(pcs)) {
+                      bc "Doom News' effect occurs."
+                      new Knockout(pcs).run(bg)
+                    }
+                  }
+                  unregisterAfter 2
+                  after FALL_BACK, pcs, {unregister()}
+                  after EVOLVE, pcs, {unregister()}
+                  after DEVOLVE, pcs, {unregister()}
+                }
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -625,14 +625,10 @@ public enum CelestialStorm implements LogicCardInfo {
           weakness FIRE
           bwAbility "Poison Payback" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Poison Payback"
+              apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+            }, self, delegate)
           }
           move "Light Punch" , {
             text "10 damage."
@@ -647,14 +643,10 @@ public enum CelestialStorm implements LogicCardInfo {
           weakness FIRE
           bwAbility "Poison Payback" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Poison Payback"
+              apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+            }, self, delegate)
           }
           move "Feint Attack" , {
             text "This attack does 50 damage to 1 of your opponent's Pokémon. This damage isn't affected by Weakness, Resistance, or any other effects on that Pokémon."

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -625,10 +625,10 @@ public enum CelestialStorm implements LogicCardInfo {
           weakness FIRE
           bwAbility "Poison Payback" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Poison Payback"
               apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Light Punch" , {
             text "10 damage."
@@ -643,10 +643,10 @@ public enum CelestialStorm implements LogicCardInfo {
           weakness FIRE
           bwAbility "Poison Payback" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Poison Payback"
               apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Feint Attack" , {
             text "This attack does 50 damage to 1 of your opponent's Pokémon. This damage isn't affected by Weakness, Resistance, or any other effects on that Pokémon."

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1350,12 +1350,12 @@ public enum DragonMajesty implements LogicCardInfo {
       case DRAGON_TALON_59:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the [N] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
-          ifActiveAndDamagedByAttackAttached({
+          ifActiveAndDamagedByAttackAttached(delegate) {
             if (self.types.contains(N)) {
               bc "Dragon Talon activates"
               directDamage(30, ef.attacker, TRAINER_CARD)
             }
-          }, delegate, thisCard)
+          }
         };
       case FIERY_FLINT_60:
         return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -528,14 +528,10 @@ public enum DragonMajesty implements LogicCardInfo {
           weakness LIGHTNING
           bwAbility "Commotion" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on each of your Benched Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Commotion activates"
-                  self.owner.pbg.bench.each {directDamage(20, it)}
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Commotion activates"
+              self.owner.pbg.bench.each {directDamage(20, it)}
+            }, self, delegate)
           }
           move "Wild Tail" , {
             text "160 damage. You may discard any Stadium card in play."
@@ -1072,14 +1068,10 @@ public enum DragonMajesty implements LogicCardInfo {
           weakness FAIRY
           bwAbility "Rough Skin" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Rough Skin activates"
-                  directDamage(30, ef.attacker, SRC_ABILITY)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Rough Skin activates"
+              directDamage(30, ef.attacker, SRC_ABILITY)
+            }, self, delegate)
           }
           move "Dragon Claw" , {
             text "100 damage."
@@ -1358,20 +1350,12 @@ public enum DragonMajesty implements LogicCardInfo {
       case DRAGON_TALON_59:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the [N] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
-          def eff
-          onPlay {reason->
-            eff = delayed (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value}) && self.active && self.types.contains(N)){
-                  bc "Dragon Talon activates"
-                  directDamage(30, ef.attacker, TRAINER_CARD)
-                }
-              }
+          ifActiveAndDamagedByAttackAttached({
+            if (self.types.contains(N)) {
+              bc "Dragon Talon activates"
+              directDamage(30, ef.attacker, TRAINER_CARD)
             }
-          }
-          onRemoveFromPlay {
-            eff.unregister()
-          }
+          }, self, delegate, thisCard)
         };
       case FIERY_FLINT_60:
         return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -528,10 +528,10 @@ public enum DragonMajesty implements LogicCardInfo {
           weakness LIGHTNING
           bwAbility "Commotion" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 2 damage counters on each of your Benched Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Commotion activates"
               self.owner.pbg.bench.each {directDamage(20, it)}
-            }, self, delegate)
+            }
           }
           move "Wild Tail" , {
             text "160 damage. You may discard any Stadium card in play."
@@ -1068,10 +1068,10 @@ public enum DragonMajesty implements LogicCardInfo {
           weakness FAIRY
           bwAbility "Rough Skin" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Rough Skin activates"
               directDamage(30, ef.attacker, SRC_ABILITY)
-            }, self, delegate)
+            }
           }
           move "Dragon Claw" , {
             text "100 damage."

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1355,7 +1355,7 @@ public enum DragonMajesty implements LogicCardInfo {
               bc "Dragon Talon activates"
               directDamage(30, ef.attacker, TRAINER_CARD)
             }
-          }, self, delegate, thisCard)
+          }, delegate, thisCard)
         };
       case FIERY_FLINT_60:
         return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1358,14 +1358,10 @@ public enum ForbiddenLight implements LogicCardInfo {
           weakness PSYCHIC
           bwAbility "Poison Point", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Poison Point"
-                  apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Poison Point"
+              apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
+            }, self, delegate)
           }
           move "Twister", {
             text "60 damage. Flip 2 coins. For each heads, discard an Energy from your opponent’s Active Pokémon. If both of them are tails, this attack does nothing."

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1358,10 +1358,10 @@ public enum ForbiddenLight implements LogicCardInfo {
           weakness PSYCHIC
           bwAbility "Poison Point", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Poison Point"
               apply POISONED, (ef.attacker as PokemonCardSet), SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Twister", {
             text "60 damage. Flip 2 coins. For each heads, discard an Energy from your opponent’s Active Pokémon. If both of them are tails, this attack does nothing."

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -624,18 +624,10 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 20
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                    bc "Counter Head activates"
-                    directDamage(80, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after FALL_BACK, self, {unregister()}
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Shell Trap activates"
+                directDamage(80, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
           move "Bright Flame", {

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -624,10 +624,10 @@ public enum GuardiansRising implements LogicCardInfo {
             energyCost C, C
             onAttack {
               damage 20
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Shell Trap activates"
                 directDamage(80, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
           move "Bright Flame", {

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -3566,10 +3566,10 @@ public enum LostThunder implements LogicCardInfo {
           resistance DARKNESS, MINUS20
           bwAbility "Effect Spore" , {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Asleep."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Effect Spore"
               apply ASLEEP, (ef.attacker as PokemonCardSet)
-            }, self, delegate)
+            }
           }
           move "Dream's Touch" , {
             text "50 damage. If your opponent's Active Pokémon is Asleep, your opponent shuffles all Energy from it into their deck."

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1978,10 +1978,10 @@ public enum SunMoon implements LogicCardInfo {
           resistance PSYCHIC, MINUS20
           bwAbility "Rough Skin", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Rough Skin activates"
               directDamage(30, ef.attacker)
-            }, self, delegate)
+            }
           }
           move "Aqua Impact", {
             text "60+ damage. This attack does 20 more damage for each [C] in your opponent's Active Pokémon's Retreat Cost."

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -1978,14 +1978,10 @@ public enum SunMoon implements LogicCardInfo {
           resistance PSYCHIC, MINUS20
           bwAbility "Rough Skin", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Rough Skin activates"
-                  directDamage(30, ef.attacker)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Rough Skin activates"
+              directDamage(30, ef.attacker)
+            }, self, delegate)
           }
           move "Aqua Impact", {
             text "60+ damage. This attack does 20 more damage for each [C] in your opponent's Active Pokémon's Retreat Cost."
@@ -2774,23 +2770,10 @@ public enum SunMoon implements LogicCardInfo {
       case POISON_BARB_124:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.\nYou may play as many Item cards as you like during your turn (before your attack)."
-          def eff
-          onPlay {reason->
-            eff = delayed(priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && it.dmg.value > 0 && bg.currentTurn==self.owner.opposite
-                    && self.active) {
-                    bc "Poison Barb activates"
-                    apply POISONED, it.from, SRC_ABILITY
-                  }
-                }
-              }
-            }
-          }
-          onRemoveFromPlay {
-            eff.unregister()
-          }
+          ifActiveAndDamagedByAttackAttached({
+            bc "Poison Barb activates"
+            apply POISONED, ef.attacker, TRAINER_CARD
+          }, self, delegate, thisCard)
         }
       case POKE_BALL_125:
         return copy(BlackWhite.POKE_BALL_97, this)

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2770,10 +2770,10 @@ public enum SunMoon implements LogicCardInfo {
       case POISON_BARB_124:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.\nYou may play as many Item cards as you like during your turn (before your attack)."
-          ifActiveAndDamagedByAttackAttached({
+          ifActiveAndDamagedByAttackAttached(delegate) {
             bc "Poison Barb activates"
             apply POISONED, ef.attacker, TRAINER_CARD
-          }, delegate, thisCard)
+          }
         }
       case POKE_BALL_125:
         return copy(BlackWhite.POKE_BALL_97, this)

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -2773,7 +2773,7 @@ public enum SunMoon implements LogicCardInfo {
           ifActiveAndDamagedByAttackAttached({
             bc "Poison Barb activates"
             apply POISONED, ef.attacker, TRAINER_CARD
-          }, self, delegate, thisCard)
+          }, delegate, thisCard)
         }
       case POKE_BALL_125:
         return copy(BlackWhite.POKE_BALL_97, this)

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2563,10 +2563,10 @@ public enum SunMoonPromos implements LogicCardInfo {
           weakness W
           bwAbility "Cursed Body", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Cursed Body activates."
               apply CONFUSED, ef.attacker, SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Fiery Bone", {
             text "90 damage. Your opponent's Active Pokémon is now Burned."
@@ -3179,9 +3179,9 @@ public enum SunMoonPromos implements LogicCardInfo {
         weakness M
         bwAbility "Spiky Shield", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             directDamage(30, ef.attacker, Source.SRC_ABILITY)
-          }, self, delegate)
+          }
         }
         move "Frost Breath", {
           text "120 damage."

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -2563,16 +2563,10 @@ public enum SunMoonPromos implements LogicCardInfo {
           weakness W
           bwAbility "Cursed Body", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-            delayedA {
-              before APPLY_ATTACK_DAMAGES, {
-                bg.dm().each {
-                  if (it.to == self && self.active && it.dmg.value && bg.currentTurn == self.owner.opposite) {
-                    bc "Cursed Body activates."
-                    apply CONFUSED, it.from, SRC_ABILITY
-                  }
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Cursed Body activates."
+              apply CONFUSED, ef.attacker, SRC_ABILITY
+            }, self, delegate)
           }
           move "Fiery Bone", {
             text "90 damage. Your opponent's Active Pokémon is now Burned."
@@ -3185,13 +3179,9 @@ public enum SunMoonPromos implements LogicCardInfo {
         weakness M
         bwAbility "Spiky Shield", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
-                directDamage(30, ef.attacker, Source.SRC_ABILITY)
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            directDamage(30, ef.attacker, Source.SRC_ABILITY)
+          }, self, delegate)
         }
         move "Frost Breath", {
           text "120 damage."

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -851,10 +851,10 @@ public enum UltraPrism implements LogicCardInfo {
             text "30 damage. During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
             onAttack {
               damage 30
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Spike Armor activates"
                 directDamage(60, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
           move "Frost Breath", {

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -664,10 +664,10 @@ public enum UltraPrism implements LogicCardInfo {
           weakness WATER
           bwAbility "Incandescent Body", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Burned."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Incandescent Body burns attacker"
               apply BURNED, ef.attacker, SRC_ABILITY
-            }, self, delegate)
+            }
           }
           move "Fire Blaster", {
             text "80+ damage. You may discard 2 Energy from this Pokémon. If you do, this attack does 80 more damage."

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -664,15 +664,10 @@ public enum UltraPrism implements LogicCardInfo {
           weakness WATER
           bwAbility "Incandescent Body", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Burned."
-            damage 20
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Incandescent Body burns attacker"
-                  bg.dm().each{apply BURNED, it.from}
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Incandescent Body burns attacker"
+              apply BURNED, ef.attacker, SRC_ABILITY
+            }, self, delegate)
           }
           move "Fire Blaster", {
             text "80+ damage. You may discard 2 Energy from this Pokémon. If you do, this attack does 80 more damage."
@@ -856,18 +851,10 @@ public enum UltraPrism implements LogicCardInfo {
             text "30 damage. During your opponent’s next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 6 damage counters on the Attacking Pokémon."
             onAttack {
               damage 30
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                    bc "Spike Armor activates"
-                    directDamage(60, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-                after FALL_BACK, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Spike Armor activates"
+                directDamage(60, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
           move "Frost Breath", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3151,10 +3151,10 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost M, C, C
             onAttack {
               damage 80
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Extra-Tight activates"
                 directDamage(80, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
           move "Giga Impact", {

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -3151,18 +3151,10 @@ public enum UnbrokenBonds implements LogicCardInfo {
             energyCost M, C, C
             onAttack {
               damage 80
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                    bc "Extra-Tight activates"
-                    directDamage(80, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after FALL_BACK, self, {unregister()}
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Extra-Tight activates"
+                directDamage(80, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
           move "Giga Impact", {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -4332,10 +4332,10 @@ public enum UnifiedMinds implements LogicCardInfo {
       case EAR_RINGING_BELL_194:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-          ifActiveAndDamagedByAttackAttached({
+          ifActiveAndDamagedByAttackAttached(delegate) {
             bc "Ear-Ringing Bell activates."
             apply CONFUSED, ef.attacker, TRAINER_CARD
-          }, delegate, thisCard)
+          }
         };
       case FLYINIUM_Z_AIR_SLASH_195:
         return pokemonTool (this) {

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3083,19 +3083,10 @@ public enum UnifiedMinds implements LogicCardInfo {
             energyCost D
             onAttack {
               damage 10
-
-              delayed (priority: LAST) {
-                before APPLY_ATTACK_DAMAGES, {
-                  if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})) {
-                    bc "Mirror Gem activates."
-                    directDamage(80, ef.attacker as PokemonCardSet)
-                  }
-                }
-                unregisterAfter 2
-                after FALL_BACK, self, {unregister()}
-                after EVOLVE, self, {unregister()}
-                after DEVOLVE, self, {unregister()}
-              }
+              ifDamagedByAttackNextTurn({
+                bc "Mirror Gem activates."
+                directDamage(80, ef.attacker as PokemonCardSet)
+              }, self)
             }
           }
         };
@@ -3909,14 +3900,10 @@ public enum UnifiedMinds implements LogicCardInfo {
           weakness F
           bwAbility "Counterattack", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 4 damage counters on the Attacking Pokémon."
-            delayedA (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if (self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to == self && it.dmg.value })) {
-                  bc "Counterattack activates."
-                  directDamage(40, ef.attacker)
-                }
-              }
-            }
+            ifActiveAndDamagedByAttackBody({
+              bc "Counterattack activates."
+              directDamage(40, ef.attacker)
+            }, self, delegate)
           }
           move "Dynamic Swing", {
             text "100+ damage. You may do 100 more damage. If you do, during your opponent's next turn, this Pokémon takes 100 more damage from attacks (after applying Weakness and Resistance)."
@@ -4345,23 +4332,10 @@ public enum UnifiedMinds implements LogicCardInfo {
       case EAR_RINGING_BELL_194:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-          def eff
-          onPlay {reason->
-            eff = delayed(priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                bg().dm().each {
-                  if (it.to == self && it.dmg.value > 0 && bg.currentTurn==self.owner.opposite
-                    && self.active) {
-                    bc "Ear-Ringing Bell activates."
-                    apply CONFUSED, it.from, SRC_ABILITY
-                  }
-                }
-              }
-            }
-          }
-          onRemoveFromPlay {
-            eff.unregister()
-          }
+          ifActiveAndDamagedByAttackAttached({
+            bc "Ear-Ringing Bell activates."
+            apply CONFUSED, ef.attacker, TRAINER_CARD
+          }, self, delegate, thisCard)
         };
       case FLYINIUM_Z_AIR_SLASH_195:
         return pokemonTool (this) {
@@ -4398,10 +4372,19 @@ public enum UnifiedMinds implements LogicCardInfo {
           def eff
           onPlay {reason->
             eff=delayed (priority: LAST){
+              def applyEffect = false
               before APPLY_ATTACK_DAMAGES,{
                 if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value >= 180}) && self.active){
-                  bc "Giant Bomb explodes."
-                  directDamage(100, ef.attacker, TRAINER_CARD)
+                  applyEffect = true
+                }
+              }
+              after APPLY_ATTACK_DAMAGES, {
+                if (applyEffect) {
+                  if (self.cards.contains(thisCard)) {
+                    bc "Giant Bomb activates."
+                    directDamage(100, ef.attacker, TRAINER_CARD)
+                  }
+                  applyEffect = false
                 }
               }
               unregister {discard thisCard}

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3900,10 +3900,10 @@ public enum UnifiedMinds implements LogicCardInfo {
           weakness F
           bwAbility "Counterattack", {
             text "If this Pokémon is your Active Pokémon and is damaged by an opponent's attack (even if this Pokémon is Knocked Out), put 4 damage counters on the Attacking Pokémon."
-            ifActiveAndDamagedByAttackBody({
+            ifActiveAndDamagedByAttackBody(delegate) {
               bc "Counterattack activates."
               directDamage(40, ef.attacker)
-            }, self, delegate)
+            }
           }
           move "Dynamic Swing", {
             text "100+ damage. You may do 100 more damage. If you do, during your opponent's next turn, this Pokémon takes 100 more damage from attacks (after applying Weakness and Resistance)."

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -3083,10 +3083,10 @@ public enum UnifiedMinds implements LogicCardInfo {
             energyCost D
             onAttack {
               damage 10
-              ifDamagedByAttackNextTurn({
+              ifDamagedByAttackNextTurn(delegate) {
                 bc "Mirror Gem activates."
                 directDamage(80, ef.attacker as PokemonCardSet)
-              }, self)
+              }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -4335,7 +4335,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           ifActiveAndDamagedByAttackAttached({
             bc "Ear-Ringing Bell activates."
             apply CONFUSED, ef.attacker, TRAINER_CARD
-          }, self, delegate, thisCard)
+          }, delegate, thisCard)
         };
       case FLYINIUM_Z_AIR_SLASH_195:
         return pokemonTool (this) {

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -473,10 +473,10 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Hazard Sensor", {
           text "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "$thisAbility activates"
             apply CONFUSED, ef.attacker, SRC_ABILITY
-          }, self, delegate)
+          }
         }
         move "Life Sucker", {
           text "100 damage. Heal 30 damage from this Pokémon."

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -473,14 +473,10 @@ public enum ChampionsPath implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Hazard Sensor", {
           text "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})) {
-                bc "$thisAbility activates"
-                apply CONFUSED, ef.attacker, SRC_ABILITY
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "$thisAbility activates"
+            apply CONFUSED, ef.attacker, SRC_ABILITY
+          }, self, delegate)
         }
         move "Life Sucker", {
           text "100 damage. Heal 30 damage from this Pokémon."

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3044,10 +3044,10 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 60
-            ifDamagedByAttackNextTurn({
+            ifDamagedByAttackNextTurn(delegate) {
               bc "Trap Bite activates"
               directDamage(120, ef.attacker as PokemonCardSet)
-            }, self)
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -905,14 +905,10 @@ public enum DarknessAblaze implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Scorching Feathers", {
           text "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent’s Pokémon (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Burned."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (self.active && bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})) {
-                bc "$thisAbility activates"
-                apply BURNED, ef.attacker, SRC_ABILITY
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "$thisAbility activates"
+            apply BURNED, ef.attacker, SRC_ABILITY
+          }, self, delegate)
         }
         move "Mach Flight", {
           text "120 damage. During your opponent’s next turn, the Defending Pokémon can’t retreat."
@@ -3048,18 +3044,10 @@ public enum DarknessAblaze implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 60
-            delayed (priority: LAST) {
-              before APPLY_ATTACK_DAMAGES, {
-                if(bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})){
-                  bc "Trap Bite activates"
-                  directDamage(120, ef.attacker as PokemonCardSet)
-                }
-              }
-              unregisterAfter 2
-              after FALL_BACK, self, {unregister()}
-              after EVOLVE, self, {unregister()}
-              after DEVOLVE, self, {unregister()}
-            }
+            ifDamagedByAttackNextTurn({
+              bc "Trap Bite activates"
+              directDamage(120, ef.attacker as PokemonCardSet)
+            }, self)
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -905,10 +905,10 @@ public enum DarknessAblaze implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Scorching Feathers", {
           text "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent’s Pokémon (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Burned."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "$thisAbility activates"
             apply BURNED, ef.attacker, SRC_ABILITY
-          }, self, delegate)
+          }
         }
         move "Mach Flight", {
           text "120 damage. During your opponent’s next turn, the Defending Pokémon can’t retreat."

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -1218,10 +1218,10 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         resistance G, MINUS30
         bwAbility "Counterattack", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent's attack (even if it is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "$thisAbility activates"
             directDamage 30, ef.attacker
-          }, self, delegate)
+          }
         }
         move "Grip and Squeeze", {
           text "90 damage. During your opponent's next turn, the Defending Pokémon can't retreat."

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -1218,14 +1218,10 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         resistance G, MINUS30
         bwAbility "Counterattack", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent's attack (even if it is Knocked Out), put 3 damage counters on the Attacking Pokémon."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if (!(self.active && ef.attacker.owner != self.owner)) return
-              if(!bg.dm().find({it.to==self && it.dmg.value})) return
-              bc "$thisAbility activates"
-              directDamage 30, ef.attacker
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "$thisAbility activates"
+            directDamage 30, ef.attacker
+          }, self, delegate)
         }
         move "Grip and Squeeze", {
           text "90 damage. During your opponent's next turn, the Defending Pokémon can't retreat."

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3463,7 +3463,7 @@ public enum RebelClash implements LogicCardInfo {
             bc "Burning Scarf activates"
             apply BURNED, ef.attacker, TRAINER_CARD
           }
-        }, self, delegate, thisCard)
+        }, delegate, thisCard)
       };
       case CAPACIOUS_BUCKET_156:
       return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1738,12 +1738,12 @@ public enum RebelClash implements LogicCardInfo {
         weakness F
         bwAbility "Counterattack Kerzap", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, flip 3 coins. For each heads, put 3 damage counters on the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "Counterattack Kerzap activates."
             flip 3, {
               directDamage 30, ef.attacker
             }
-          }, self, delegate)
+          }
         }
         move "Sparking Strike", {
           text "120 damage."
@@ -1901,10 +1901,10 @@ public enum RebelClash implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Counterattack", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, place 3 damage counters on the attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             bc "Counterattack activates"
             directDamage(30, ef.attacker, Source.SRC_ABILITY)
-          }, self, delegate)
+          }
         }
         move "Psychic Assault", {
           text "Does 30 damage plus 10 damage for each damage counter on the opponent’s Active Pokémon."

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1738,20 +1738,12 @@ public enum RebelClash implements LogicCardInfo {
         weakness F
         bwAbility "Counterattack Kerzap", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, flip 3 coins. For each heads, put 3 damage counters on the Attacking Pokémon."
-          delayedA {
-            before APPLY_ATTACK_DAMAGES, {
-              if (ef.attacker.owner != self.owner) {
-                bg.dm().each {
-                  if (it.to == self && self.active && it.notNoEffect && it.dmg.value) {
-                    bc "Counterattack Kerzap activates."
-                    flip 3, {
-                      directDamage 30, ef.attacker
-                    }
-                  }
-                }
-              }
+          ifActiveAndDamagedByAttackBody({
+            bc "Counterattack Kerzap activates."
+            flip 3, {
+              directDamage 30, ef.attacker
             }
-          }
+          }, self, delegate)
         }
         move "Sparking Strike", {
           text "120 damage."
@@ -1909,14 +1901,10 @@ public enum RebelClash implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Counterattack", {
           text "If this Pokémon is your Active Pokémon and is damaged by an opponent’s attack, place 3 damage counters on the attacking Pokémon."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              if (bg.currentTurn == self.owner.opposite && bg.dm().find({ it.to==self && it.dmg.value }) && self.active) {
-                bc "Counterattack activates"
-                directDamage(30, ef.attacker, Source.SRC_ABILITY)
-              }
-            }
-          }
+          ifActiveAndDamagedByAttackBody({
+            bc "Counterattack activates"
+            directDamage(30, ef.attacker, Source.SRC_ABILITY)
+          }, self, delegate)
         }
         move "Psychic Assault", {
           text "Does 30 damage plus 10 damage for each damage counter on the opponent’s Active Pokémon."
@@ -3470,22 +3458,12 @@ public enum RebelClash implements LogicCardInfo {
       case BURNING_SCARF_155:
       return pokemonTool (this) {
         text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the [R] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack, the Attacking Pokémon is now Burned. You may play as many Item cards as you like during your turn (before your attack)."
-        def eff
-        onPlay {reason->
-          eff = delayed(priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              bg().dm().each {
-                if (it.to == self && self.active && self.types.contains(R) && it.dmg.value && bg.currentTurn==self.owner.opposite) {
-                  bc "Burning Scarf activates."
-                  apply BURNED, it.from, Source.TRAINER_CARD
-                }
-              }
-            }
+        ifActiveAndDamagedByAttackAttached({
+          if (self.types.contains(R)) {
+            bc "Burning Scarf activates"
+            apply BURNED, ef.attacker, TRAINER_CARD
           }
-        }
-        onRemoveFromPlay {
-          eff.unregister()
-        }
+        }, self, delegate, thisCard)
       };
       case CAPACIOUS_BUCKET_156:
       return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3458,12 +3458,12 @@ public enum RebelClash implements LogicCardInfo {
       case BURNING_SCARF_155:
       return pokemonTool (this) {
         text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the [R] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack, the Attacking Pokémon is now Burned. You may play as many Item cards as you like during your turn (before your attack)."
-        ifActiveAndDamagedByAttackAttached({
+        ifActiveAndDamagedByAttackAttached(delegate) {
           if (self.types.contains(R)) {
             bc "Burning Scarf activates"
             apply BURNED, ef.attacker, TRAINER_CARD
           }
-        }, delegate, thisCard)
+        }
       };
       case CAPACIOUS_BUCKET_156:
       return itemCard (this) {

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2830,7 +2830,7 @@ public enum SwordShield implements LogicCardInfo {
         resistance G, MINUS30
         bwAbility "Snap Trap", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent’s attack (even if it is Knocked Out), discard an Energy from the Attacking Pokémon."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
               PokemonCardSet pcs = ef.attacker
               targeted (pcs, SRC_ABILITY) {
                 if (pcs.cards.filterByType(ENERGY)){
@@ -2838,7 +2838,7 @@ public enum SwordShield implements LogicCardInfo {
                   pcs.cards.filterByType(ENERGY).select("Discard",{true},self.owner).discard()
                 }
               }
-          }, self, delegate)
+          }
         }
         move "Damage Rush", {
           text "30+ damage. Flip a coin until you get tails. This attack does 30 more damage for each heads."

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2830,23 +2830,15 @@ public enum SwordShield implements LogicCardInfo {
         resistance G, MINUS30
         bwAbility "Snap Trap", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent’s attack (even if it is Knocked Out), discard an Energy from the Attacking Pokémon."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
+          ifActiveAndDamagedByAttackBody({
               PokemonCardSet pcs = ef.attacker
-              if (pcs.owner != self.owner) {
-                bg.dm().each{
-                  if (it.to == self && self.active && it.dmg.value) {
-                    targeted (pcs, SRC_ABILITY) {
-                      if(pcs.cards.filterByType(ENERGY)){
-                        bc "Galarian Stunfisk's Snap Trap activates."
-                        pcs.cards.filterByType(ENERGY).select("Discard",{true},self.owner).discard()
-                      }
-                    }
-                  }
+              targeted (pcs, SRC_ABILITY) {
+                if (pcs.cards.filterByType(ENERGY)){
+                  bc "Galarian Stunfisk's Snap Trap activates."
+                  pcs.cards.filterByType(ENERGY).select("Discard",{true},self.owner).discard()
                 }
               }
-            }
-          }
+          }, self, delegate)
         }
         move "Damage Rush", {
           text "30+ damage. Flip a coin until you get tails. This attack does 30 more damage for each heads."

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -337,22 +337,13 @@ public enum SwordShieldPromos implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Teapot of Surprises", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent's attack (even if it is Knocked Out), choose a random card from your opponent's hand. Your opponent reveals that card and puts it on the bottom of their deck."
-          delayedA (priority: LAST) {
-            before APPLY_ATTACK_DAMAGES, {
-              PokemonCardSet pcs = ef.attacker
-              if (pcs.owner != self.owner) {
-                bg.dm().each{
-                  if (it.to == self && self.active && it.dmg.value) {
-                    def opponent = self.owner.opposite.pbg
-                    if (opponent.hand.size() > 0) {
-                      bc "Teapot of Surprises activates"
-                      opponent.hand.select(hidden: true, count:1).showToOpponent("Chosen card").showToMe("Teapot of Surprises: this card will be put on the bottom of your deck").moveTo(opponent.deck) //Inverted showTo effects, but should work fine now
-                    }
-                  }
-                }
-              }
+          ifActiveAndDamagedByAttackBody({
+            def opponent = self.owner.opposite.pbg
+            if (opponent.hand.size() > 0) {
+              bc "Teapot of Surprises activates"
+              opponent.hand.select(hidden: true, count:1).showToOpponent("Chosen card").showToMe("Teapot of Surprises: this card will be put on the bottom of your deck").moveTo(opponent.deck) //Inverted showTo effects, but should work fine now
             }
-          }
+          }, self, delegate)
         }
         move "Mind Bend", {
           text "100 damage. Your opponent's Active Pokémon is now Confused."

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -337,13 +337,13 @@ public enum SwordShieldPromos implements LogicCardInfo {
         resistance F, MINUS30
         bwAbility "Teapot of Surprises", {
           text "If this Pokémon is in the Active Spot and is damaged by an opponent's attack (even if it is Knocked Out), choose a random card from your opponent's hand. Your opponent reveals that card and puts it on the bottom of their deck."
-          ifActiveAndDamagedByAttackBody({
+          ifActiveAndDamagedByAttackBody(delegate) {
             def opponent = self.owner.opposite.pbg
             if (opponent.hand.size() > 0) {
               bc "Teapot of Surprises activates"
               opponent.hand.select(hidden: true, count:1).showToOpponent("Chosen card").showToMe("Teapot of Surprises: this card will be put on the bottom of your deck").moveTo(opponent.deck) //Inverted showTo effects, but should work fine now
             }
-          }, self, delegate)
+          }
         }
         move "Mind Bend", {
           text "100 damage. Your opponent's Active Pokémon is now Confused."


### PR DESCRIPTION
See #dev channel in the discord server. Currently effects that trigger when a Pokémon is damaged by an attack are activated before the damage and effects of that attack are applied. 
This is problematic if for example an attack heals the attacking Pokémon, that effect should resolve before an effect of an Ability that places damage on the attacking Pokémon. With the current implementation, a Pokémon with previously zero damage would be able to immediately heal the damage it shouldn't yet have during the resolution of the attack effect. Another relevant example is when an attack that discards an Energy faces against a triggered effect that sends back an Energy to the hand. The attacking player should choose the discard first, and only after that the defending players makes the choice on what to return, but currently it's the other way around.

I have no prior experience with this engine or the language, so not sure if this PR solves the issue completely, but based on other card implementations it should help I think, and at least provide a solid basis for changing all those same effects in one shared function.