### PR TITLE
Blastoise ex (FRLG): Fix Energy Rain

### DIFF
--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2453,7 +2453,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             powerUsed()
             def card = my.hand.filterByBasicEnergyType(W).first()
             def tar = my.all.select("To?")
-            attachEnergy(tar, card)
+            attachEnergy(tar, card, PLAY_FROM_HAND)
             directDamage 10, tar, SRC_ABILITY
           }
           }


### PR DESCRIPTION
Should use the PLAY_FROM_HAND activation reason so that cards that rely on checking if
an energy was attached from the hand trigger properly.