### PR TITLE
Retooled bugfixes2

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -195,7 +195,7 @@ class TcgStatics {
    */
   static CardList selectEnergy(PokemonCardSet pcs, Type...types=C) {
     def ef = new SelectEnergy(pcs.cards, types)
-    ef.playerType = pcs.owner
+    ef.playerType = bg.currentThreadPlayerType
     bg.em().activateEffect(ef)
     return ef.selectedCards ?: []
   }
@@ -1964,7 +1964,7 @@ class TcgStatics {
           applyEffect = bg.currentTurn == self.owner.opposite && bg.dm().find({it.to==self && it.dmg.value})
         }
         after APPLY_ATTACK_DAMAGES, {
-          if (applyEffect) {
+          if (applyEffect && ef.attacker.inPlay) {
             eff.delegate=delegate
             eff.call()
             applyEffect = false

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -620,6 +620,7 @@ public enum PowerKeepers implements LogicCardInfo {
             before KNOCKOUT, {
               if (bg.em().retrieveObject("Energy_Grounding") != bg.turnCount && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && ef.pokemonToBeKnockedOut != self && ef.pokemonToBeKnockedOut.cards.filterByType(BASIC_ENERGY).energyCount(C)) {
                 moveEnergy(basic: true, playerType: self.owner, may: true, info: "Energy Grounding : You may move an energy from ${ef.pokemonToBeKnockedOut} to $self", ef.pokemonToBeKnockedOut,self,SRC_ABILITY)
+                bg.em().storeObject("Energy_Grounding", bg.turnCount)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -619,10 +619,7 @@ public enum PowerKeepers implements LogicCardInfo {
           delayedA{
             before KNOCKOUT, {
               if (bg.em().retrieveObject("Energy_Grounding") != bg.turnCount && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && ef.pokemonToBeKnockedOut != self && ef.pokemonToBeKnockedOut.cards.filterByType(BASIC_ENERGY).energyCount(C)) {
-                if (confirm("Move an energy from ${ef.pokemonToBeKnockedOut} to $self?", self.owner)) {
-                  bg.em().storeObject("Energy_Grounding", bg.turnCount)
-                  moveEnergy(basic:true, playerType: self.owner, ef.pokemonToBeKnockedOut, self)
-                }
+                moveEnergy(basic: true, playerType: self.owner, may: true, info: "Energy Grounding : You may move an energy from ${ef.pokemonToBeKnockedOut} to $self", ef.pokemonToBeKnockedOut,self,SRC_ABILITY)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -848,7 +848,7 @@ public enum LostThunder implements LogicCardInfo {
             text "30 damage. If your opponent's Pokémon is Knocked Out by damage from this attack, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
             energyCost G
             onAttack{
-              damage 100
+              damage 30
               delayed {
                 def pcs = defending
                 after KNOCKOUT, pcs, {

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -2135,7 +2135,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-        move "Desert Geizer", {
+        move "Desert Geyser", {
           text "130 damage. If your opponent has a Stadium in play, discard it. If you discarded a Stadium in this way, during your opponent’s next turn, prevent all damage from and effects of attacks done to this Pokémon."
           energyCost F, C, C
           attackRequirement {}

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3749,7 +3749,7 @@ public enum RebelClash implements LogicCardInfo {
               }
             }
             after APPLY_ATTACK_DAMAGES, {
-              if(attackDidDamage && self.cards.contains(thisCard)) { // this energy card is still attached
+              if(attackDidDamage && self.cards.contains(thisCard) && ef.attacker.inPlay) { // this energy card is still attached
                 targeted ef.attacker as PokemonCardSet, SRC_SPENERGY, {
                   bc "Horror [P] Energy activates."
                   directDamage(20, ef.attacker as PokemonCardSet, SRC_SPENERGY)

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2971,17 +2971,16 @@ public enum SwordShield implements LogicCardInfo {
           text "Once during your turn, you may look at the top 3 cards of your deck and attach any number of [M] Energy cards you find there to this Pokémon. Put the other cards into your hand. If you use this Ability, your turn ends."
           actionA {
             if (my.deck && confirm("Use Intrepid Sword?")) {
-              def maxSize = Math.min(my.deck.size(),3)
-              def topCards = my.deck.subList(0, maxSize).showToMe("Top 3 cards of your deck.")
-              if (topCards.filterByBasicEnergyType(M)) {
-                def selectedEnergies = metalEnergies.select(min:0, max:metalEnergies.size(), "Attach any [M] Energy to $self?", basicEnergyFilter(M))
-                selectedEnergies.each {
-                  attachEnergy(self, it)
-                }
-                def nonSelectedSize = 3 - selectedEnergies.size()
-                if (nonSelectedSize) {
-                  my.deck.subList(0, nonSelectedSize).getExcludedList(selectedEnergies).moveTo(hidden: true, my.hand)
-                }
+              def maxSize = Math.min(my.deck.size(), 3)
+              def topCards = my.deck.subList(0, maxSize)
+              def selectedEnergies = topCards.select(min: 0, max: topCards.filterByBasicEnergyType(M).size(), "Attach any [M] Energy to $self?", basicEnergyFilter(M))
+              selectedEnergies.each {
+                attachEnergy(self, it)
+              }
+              def nonSelectedSize = 3 - selectedEnergies.size()
+              if (nonSelectedSize) {
+                my.deck.subList(0, nonSelectedSize).getExcludedList(selectedEnergies).moveTo(hidden: true, my.hand)
+              }
               bg.gm().betweenTurns()
             }
           }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -2973,10 +2973,8 @@ public enum SwordShield implements LogicCardInfo {
             if (my.deck && confirm("Use Intrepid Sword?")) {
               def maxSize = Math.min(my.deck.size(),3)
               def topCards = my.deck.subList(0, maxSize).showToMe("Top 3 cards of your deck.")
-              def metalEnergies = topCards.filterByBasicEnergyType(M)
-
-              if (metalEnergies) {
-                def selectedEnergies = metalEnergies.select(min:0, max:metalEnergies.size(), "Attach any [M] Energy to $self?")
+              if (topCards.filterByBasicEnergyType(M)) {
+                def selectedEnergies = metalEnergies.select(min:0, max:metalEnergies.size(), "Attach any [M] Energy to $self?", basicEnergyFilter(M))
                 selectedEnergies.each {
                   attachEnergy(self, it)
                 }
@@ -2984,9 +2982,6 @@ public enum SwordShield implements LogicCardInfo {
                 if (nonSelectedSize) {
                   my.deck.subList(0, nonSelectedSize).getExcludedList(selectedEnergies).moveTo(hidden: true, my.hand)
                 }
-              } else {
-                my.deck.subList(0,3).moveTo(hidden: true, my.hand)
-              }
               bg.gm().betweenTurns()
             }
           }


### PR DESCRIPTION
Minor fixes and optimizations

-Effects that return a pokemon to your hand no longer cause payback effects to crash the game

- discardDefendingEnergyAfterDamage now lets the attacking player select the energy instead 

- Lanturn's Energy Grounding allows the player who owns lanturn to select which energy is moved
- Zacian V allows you to select metal energies the first time it shows you your top 3 cards
- LOT beautifly only hits for 30 damage instead of 100 (kinda want to leave this one in)
- Desert Geyser is no longer spelled Desert Geizer