### PR TITLE
UPR89: Don't show useless dialog to click through

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -2172,7 +2172,9 @@ public enum UltraPrism implements LogicCardInfo {
             }
             onAttack {
               opp.all.each{
-                attachEnergyFrom(type:M,my.discard,my.all.select())
+                if (my.discard.filterByEnergyType(METAL)) {
+                  attachEnergyFrom type: M, my.discard, my.all.select()
+                }
               }
             }
           }


### PR DESCRIPTION
If there are no more M energy in the discard pile this card would
display the player's Pokémon to choose from that would have to be
clicked through to finish the attack. Instead, this will now just
skip any remaining checks if the discard pile no longer has any M
energy in it.

This should "fix" https://forum.tcgone.net/t/bug-report-solgaleo-prism-star-upr-89-attempting-to-u/2163