### PR TITLE
BST110: Invert original ability check

### DIFF
--- a/src/tcgwars/logic/impl/gen8/BattleStyles.groovy
+++ b/src/tcgwars/logic/impl/gen8/BattleStyles.groovy
@@ -2617,11 +2617,22 @@ public enum BattleStyles implements LogicCardInfo {
         resistance GRASS, MINUS30
         bwAbility "Lustrous Body", {
           text "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon."
-          // TODO implement properly after source refactoring and/or RichSource captivation
+          // Unsure of how this will work if Ability effects are chained
+          def fromSelf = false
           delayedA {
+            before BW_ABILITY, {
+              fromSelf = ef.self.owner == self.owner
+            }
             before null, self, SRC_ABILITY, {
+              if (fromSelf) {
+                fromSelf = false
+                return
+              }
               bc "$thisAbility prevents effect"
               prevent()
+            }
+            after BW_ABILITY, {
+              fromSelf = false
             }
           }
         }


### PR DESCRIPTION
Invert the check that was originally used. Check if an ability being used
is from Corviknight's player, if so, explicitly allow it, else block.