### PR TITLE
Add C to Energy cards that provide energy of Every type

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1059,7 +1059,7 @@ class TcgStatics {
               def energyEquivalent = []
               def typeImages = []
               def energyImage = (colorless) ? COLORLESS : RAINBOW
-              def energyTypes = (colorless) ? [C] : [R, D, F, G, W, L, M, P, Y, C]
+              def energyTypes = (colorless) ? [C] : valuesBasicEnergy()
 
               energyCount.times {
                 energyEquivalent.add(energyTypes)

--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -1059,7 +1059,7 @@ class TcgStatics {
               def energyEquivalent = []
               def typeImages = []
               def energyImage = (colorless) ? COLORLESS : RAINBOW
-              def energyTypes = (colorless) ? [C] : [R, D, F, G, W, L, M, P, Y]
+              def energyTypes = (colorless) ? [C] : [R, D, F, G, W, L, M, P, Y, C]
 
               energyCount.times {
                 energyEquivalent.add(energyTypes)

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -629,12 +629,16 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
         };
       case RAINBOW_ENERGY_17:
-        return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P, C]]) {
+        return specialEnergy (this, [[]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.)"
           onPlay {reason->
             if(reason == PLAY_FROM_HAND){
               directDamage(10, self)  //TODO: This one print does damage, not counters.
             }
+          }
+          getEnergyTypesOverride {
+            if (self) return bg.getGame().getRuleSet().ordinal() >= RuleSet.DPP_RULES.ordinal()?[valuesBasicEnergyNonColorless() as Set]:[[R, G, W, L, F, P] as Set];
+            else return [[] as Set]
           }
           onRemoveFromPlay {
           }

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -637,7 +637,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
           getEnergyTypesOverride {
-            if (self) return bg.getGame().getRuleSet().ordinal() >= RuleSet.DPP_RULES.ordinal()?[valuesBasicEnergyNonColorless() as Set]:[[R, G, W, L, F, P] as Set];
+            if (self) return [valuesBasicEnergyNonColorless() as Set]
             else return [[] as Set]
           }
           onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -629,7 +629,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
         };
       case RAINBOW_ENERGY_17:
-        return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P]]) {
+        return specialEnergy (this, [[R, D, F, G, W, Y, L, M, P, C]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.)"
           onPlay {reason->
             if(reason == PLAY_FROM_HAND){

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2549,7 +2549,7 @@ public enum Deoxys implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set, valuesBasicEnergy() as Set, valuesBasicEnergy() as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2549,7 +2549,7 @@ public enum Deoxys implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1883,7 +1883,7 @@ public enum Emerald implements LogicCardInfo {
             to.evolution && !to.EX
           }
           getEnergyTypesOverride{
-            if (self) return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+            if (self) return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
             else return [[] as Set]
           }
 

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1883,7 +1883,7 @@ public enum Emerald implements LogicCardInfo {
             to.evolution && !to.EX
           }
           getEnergyTypesOverride{
-            if (self) return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
+            if (self) return [valuesBasicEnergy() as Set, valuesBasicEnergy() as Set]
             else return [[] as Set]
           }
 

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2430,7 +2430,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               return [[C] as Set]
             }
             else {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set]
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2430,7 +2430,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               return [[C] as Set]
             }
             else {
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2296,7 +2296,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             return [[C] as Set]
           boolean cond1 = self.topPokemonCard.cardTypes.is(DELTA)
           if (cond1) {
-            return [[R, D, F, G, W, Y, L, M, P, N] as Set]
+            return [[R, D, F, G, W, Y, L, M, P, C] as Set]
           }
           else {
             return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2296,7 +2296,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             return [[C] as Set]
           boolean cond1 = self.topPokemonCard.cardTypes.is(DELTA)
           if (cond1) {
-            return [[R, D, F, G, W, Y, L, M, P, C] as Set]
+            return [valuesBasicEnergy() as Set]
           }
           else {
             return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -743,7 +743,7 @@ public enum LegendMaker implements LogicCardInfo {
           getterA GET_ENERGY_TYPES, { holder->
             def pcs = holder.effect.target
             if(pcs.owner == self.owner && ["Huntail", "Gorebyss"].contains(pcs.name) && holder.effect.card.name == "React Energy") {
-              holder.object = [[R, D, F, G, W, Y, L, M, P] as Set,[R, D, F, G, W, Y, L, M, P] as Set]
+              holder.object = [[R, D, F, G, W, Y, L, M, P, C] as Set,[R, D, F, G, W, Y, L, M, P, C] as Set]
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -743,7 +743,7 @@ public enum LegendMaker implements LogicCardInfo {
           getterA GET_ENERGY_TYPES, { holder->
             def pcs = holder.effect.target
             if(pcs.owner == self.owner && ["Huntail", "Gorebyss"].contains(pcs.name) && holder.effect.card.name == "React Energy") {
-              holder.object = [[R, D, F, G, W, Y, L, M, P, C] as Set,[R, D, F, G, W, Y, L, M, P, C] as Set]
+              holder.object = [valuesBasicEnergy() as Set,valuesBasicEnergy() as Set]
             }
           }
         }

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -3002,7 +3002,7 @@ public enum RisingRivals implements LogicCardInfo {
           }
           getEnergyTypesOverride {
             if (self && self.pokemonSP) {
-              return [[R, D, F, G, W, Y, L, M, P, N] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -3002,7 +3002,7 @@ public enum RisingRivals implements LogicCardInfo {
           }
           getEnergyTypesOverride {
             if (self && self.pokemonSP) {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1019,7 +1019,7 @@ public enum SecretWonders implements LogicCardInfo {
                       def pkmnCard = pcs.topPokemonCard
                       def tar = pcs.owner.pbg.all.findAll{it != self}.select("Choose a pokemon to attach $self to",pcs.owner)
                       def energyCard
-                      energyCard = specialEnergy(new CustomCardInfo(ELECTRODE_26).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P, C]]) {
+                      energyCard = specialEnergy(new CustomCardInfo(ELECTRODE_26).setCardTypes(ENERGY, SPECIAL_ENERGY), [valuesBasicEnergy()]) {
                         typeImagesOverride = [RAINBOW]
                         onPlay {}
                         onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1019,7 +1019,7 @@ public enum SecretWonders implements LogicCardInfo {
                       def pkmnCard = pcs.topPokemonCard
                       def tar = pcs.owner.pbg.all.findAll{it != self}.select("Choose a pokemon to attach $self to",pcs.owner)
                       def energyCard
-                      energyCard = specialEnergy(new CustomCardInfo(ELECTRODE_26).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P]]) {
+                      energyCard = specialEnergy(new CustomCardInfo(ELECTRODE_26).setCardTypes(ENERGY, SPECIAL_ENERGY), [[R, D, F, G, W, Y, L, M, P, C]]) {
                         typeImagesOverride = [RAINBOW]
                         onPlay {}
                         onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3327,7 +3327,7 @@ public enum CelestialStorm implements LogicCardInfo {
             }
           }
           getEnergyTypesOverride {
-            self != null ? [[R, D, F, G, W, Y, L, M, P, C] as Set] : [[C] as Set]
+            self != null ? [valuesBasicEnergy() as Set] : [[C] as Set]
           }
         };
       case SHIFTRY_GX_152:

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -3327,7 +3327,7 @@ public enum CelestialStorm implements LogicCardInfo {
             }
           }
           getEnergyTypesOverride {
-            self != null ? [[R, D, F, G, W, Y, L, M, P] as Set] : [[C] as Set]
+            self != null ? [[R, D, F, G, W, Y, L, M, P, C] as Set] : [[C] as Set]
           }
         };
       case SHIFTRY_GX_152:

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2451,7 +2451,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set, valuesBasicEnergy() as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -2451,7 +2451,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self && !self.pokemonGX && !self.pokemonEX && self.owner.pbg.prizeCardSet.size() > self.owner.opposite.pbg.prizeCardSet.size()) {
-              return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2841,7 +2841,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)) {
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -2841,7 +2841,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           }
           getEnergyTypesOverride{
             if(self != null && self.topPokemonCard.cardTypes.is(ULTRA_BEAST)) {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3170,10 +3170,10 @@ public enum UltraPrism implements LogicCardInfo {
             boolean cond1 = self.stage2
             boolean cond2 = self.owner.pbg.all.findAll{it.stage2}.size() >= 3
             if(cond1 && cond2) {
-              return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else if(cond1) {
-              return [[R, D, F, G, W, Y, L, M, P] as Set]
+              return [[R, D, F, G, W, Y, L, M, P, C] as Set]
             }
             else {
               return [[C] as Set]

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3170,7 +3170,7 @@ public enum UltraPrism implements LogicCardInfo {
             boolean cond1 = self.stage2
             boolean cond2 = self.owner.pbg.all.findAll{it.stage2}.size() >= 3
             if(cond1 && cond2) {
-              return [[R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set, [R, D, F, G, W, Y, L, M, P, C] as Set]
+              return [valuesBasicEnergy() as Set, valuesBasicEnergy() as Set, valuesBasicEnergy() as Set, valuesBasicEnergy() as Set]
             }
             else if(cond1) {
               return [[R, D, F, G, W, Y, L, M, P, C] as Set]

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -3614,7 +3614,7 @@ public enum SwordShield implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          if (self) return [[R, D, F, G, W, Y, L, M, P] as Set]
+          if (self) return [[R, D, F, G, W, Y, L, M, P, C] as Set]
           else return [[] as Set]
         }
         allowAttach {to->

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -3614,7 +3614,7 @@ public enum SwordShield implements LogicCardInfo {
           }
         }
         getEnergyTypesOverride {
-          if (self) return [[R, D, F, G, W, Y, L, M, P, C] as Set]
+          if (self) return [valuesBasicEnergy() as Set]
           else return [[] as Set]
         }
         allowAttach {to->


### PR DESCRIPTION
Q. Spinda has a Rainbow Energy attached, which counts as every type of energy, and uses its "Synchro Removal" attack. Can it discard a Call Energy from the defending Luxray [GL]?
A. Yes, Call Energy may be discarded by this attack, because the types of energy attached to Spinda includes colorless, the same type as that of Call Energy. (Sep 3, 2009 PUI Rules Team)