### PR TITLE
Card Fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -850,7 +850,7 @@ public enum Deoxys implements LogicCardInfo {
             text "As long as Rayquaza has any basic [R] Energy cards and any basic [L] Energy cards attached to it, prevent all effects, except damage, by an opponent’s attack done to Rayquaza."
             delayedA {
               before null, self, Source.ATTACK, {
-                if(ef.attacker.owner != self && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages) && self.cards.energyCount(L) && self.cards.energyCount(R)){
+                if (bg.currentTurn == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages) && self.cards.energyCount(L) && self.cards.energyCount(R)) {
                   bc "Dragon Aura prevents effect"
                   prevent()
                 }

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -2239,7 +2239,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           onPlay {reason->
             eff = delayed {
               before KNOCKOUT, {
-                if (!self.active && (ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && self.owner.pbg.bench.notEmpty && self.owner.pbg.active.cards.filterByType(BASIC_ENERGY)) {
+                if (!self.active && bg.currentTurn==self.owner.opposite && (ef as Knockout).byDamageFromAttack && (ef as Knockout).pokemonToBeKnockedOut == self.owner.pbg.active && self.owner.pbg.active.cards.filterByType(BASIC_ENERGY)) {
                   bc "EXP.ALL activates"
                   if (oppConfirm("EXP.ALL: Move an Energy from ${self.owner.pbg.active} to $self ?")) {
                     def energy = self.owner.pbg.active.cards.filterByType(BASIC_ENERGY).oppSelect("Select an Energy from the Active Pokémon to move to the holder of EXP.ALL").first()

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1865,12 +1865,12 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
           if (my.active.types.contains(D) && my.active.specialConditions) {
-            my.active.specialConditions.removeAll([ASLEEP, CONFUSED, PARALYZED])
             bc "${my.owner.getPlayerUsername(bg)}'s $my.active was cured of status effects due to $thisCard"
+            clearSpecialCondition(my.active, TRAINER_CARD, [ASLEEP, CONFUSED, PARALYZED])
           }
           if (opp.active.types.contains(D) && opp.active.specialConditions) {
-            opp.active.specialConditions.removeAll([ASLEEP, CONFUSED, PARALYZED])
             bc "${opp.owner.getPlayerUsername(bg)}'s $opp.active was cured of status effects due to $thisCard"
+            clearSpecialCondition(opp.active, TRAINER_CARD, [ASLEEP, CONFUSED, PARALYZED])
           }
         }
         onRemoveFromPlay {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -584,16 +584,20 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                if (
-                  ef.attacker.owner == self.owner &&
-                  ef.attacker.name in ["Poliwag", "Poliwhirl", "Poliwrath"] &&
-                  ["Poliwag", "Poliwhirl", "Poliwrath"].every{
-                    toadName -> self.owner.pbg.all.any{ it.name == toadName }
-                  }
-                ) bg.dm().each {
-                  if (it.to.active && it.notZero) {
-                    bc "Enthusiasm +60"
-                    it.dmg += hp(60)
+                if (ef.attacker.owner == self.owner) bg.dm().each {
+                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
+                    def attacker = it.from
+                    def enthusiasm_cond = {
+                      def toadNames = ["Poliwag", "Poliwhirl", "Poliwrath"]
+                      attacker.name in toadNames &&
+                        toadNames.every{toadName ->
+                          self.owner.pbg.all.any{ pcs -> pcs.name == toadName }
+                        }
+                    }
+                    if(enthusiasm_cond) {
+                      bc "Enthusiasm +60"
+                      it.dmg += hp(60)
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -465,7 +465,7 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If your opponent has any Pokémon LV.X in play, each of Luxray's attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                if (ef.attacker == self && opp.all.any { it.isPokemonLevelUp() }) {
+                if (ef.attacker == self && opp.all.any { it.pokemonLevelUp }) {
                   bg.dm().each {
                     if (it.to.active && it.notZero) {
                       bc "Rivalry +50"

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -584,8 +584,14 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each {
-                  if (it.from.name in ["Poliwag", "Poliwhirl", "Poliwrath"] && it.to.active && it.to.owner != self.owner && it.dmg.value && it.notNoEffect) {
+                if (
+                  ef.attacker.owner == self.owner &&
+                  ef.attacker.name in ["Poliwag", "Poliwhirl", "Poliwrath"] &&
+                  ["Poliwag", "Poliwhirl", "Poliwrath"].every{
+                    toadName -> self.owner.pbg.all.any{ it.name == toadName }
+                  }
+                ) bg.dm().each {
+                  if (it.to.active && it.notZero) {
                     bc "Enthusiasm +60"
                     it.dmg += hp(60)
                   }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -465,11 +465,11 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If your opponent has any Pokémon LV.X in play, each of Luxray's attacks does 50 more damage to the Active Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                if (opp.all.any { it.isPokemonLevelUp() }) {
+                if (ef.attacker == self && opp.all.any { it.isPokemonLevelUp() }) {
                   bg.dm().each {
-                    if (it.from == self && it.to.active && it.to.owner != self.owner && it.dmg.value && it.notNoEffect) {
-                      bc "Rivalry +30"
-                      it.dmg += hp(30)
+                    if (it.to.active && it.notZero) {
+                      bc "Rivalry +50"
+                      it.dmg += hp(50)
                     }
                   }
                 }


### PR DESCRIPTION
* Luxray (Legends Awakened)'s Poké-Body "Rivalry" should increase damage by 50, not 30.
* Politoed (Legends Awakened)'s Poké-Body "Enthusiasm" should only work when a Poliwag, a Poliwhirl and a Poliwrath are in play (not counting pre-evolution of evolved Pokémon in this). The damage increase should also not be ignored by shred attacks, should they happen.
* Rayquaza (EX Deoxys) should now stop causing a NPE when using it's "Dragon Aura" Poké-Body.
* EXP.ALL (EX FireRed & LeafGreen) should in theory prevent activation when a benched Pokémon is KO'd (couldn't reproduce, but logic could be improved anyway)
* Sidney's Stadium (EX Power Keepers) should now properly remove pre-existing Special Conditions.