### PR TITLE
Groovy re-implementation for "Ruby & Sapphire - Base Set" (Cards 1-22)

### DIFF
--- a/src/tcgwars/logic/card/Collection.java
+++ b/src/tcgwars/logic/card/Collection.java
@@ -181,6 +181,8 @@ public enum Collection {
   WIZARDS_BLACK_STAR_PROMOS_NG(111, "WBSP", "gen1.WizardsBlackStarPromosNG"),
   SHINY_STAR_V(1012, "JS4A", "gen8.ShinyStarV"),
 
+  RUBY_SAPPHIRE_NG(1301, "Ruby & Sapphire", "RS", "gen3.RubySapphireNG"),
+
   ;
 
   int id;

--- a/src/tcgwars/logic/impl/gen3/PopSeries4.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries4.groovy
@@ -181,33 +181,7 @@ public enum PopSeries4 implements LogicCardInfo {
         }
       };
       case SCEPTILE_5:
-      return evolution (this, from:"Grovyle", hp:HP100, type:G, retreatCost:3) {
-        weakness R
-        resistance W, MINUS30
-        pokePower "Energy Trans", {
-          text "As often as you like during your turn (before your attack), move a [G] Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition."
-          actionA {
-            checkNoSPC()
-            assert my.all.findAll {it.cards.energyCount(G)>0} : "There are no Pokémon with [G] Energy cards"
-            assert my.all.size()>=2 : "There is only one Pokémon on the field"
-
-            powerUsed()
-            def src=my.all.findAll {it.cards.energyCount(G)>0}.select("Source for [G]")
-            def card=src.cards.filterByEnergyType(G).select("Card to move").first()
-            def tar=my.all
-            tar.remove(src)
-            tar=tar.select("Target for [G]")
-            energySwitch(src, tar, card)
-          }
-        }
-        move "Tail Rap", {
-          text "50x damage. Flip 2 coins. This attack does 50 damage times the number of heads."
-          energyCost G, C, C
-          onAttack {
-            flip 2, { damage 50 }
-          }
-        }
-      };
+      return copy(RubySapphireNG.SCEPTILE_20, this);
       case COMBUSKEN_6:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -327,34 +327,7 @@ public enum PowerKeepers implements LogicCardInfo {
         }
       };
       case BLAZIKEN_5:
-      return evolution (this, from:"Combusken", hp:HP100, type:R, retreatCost:2) {
-        weakness W
-        pokePower "Firestarter", {
-          text "Once during your turn (before your attack), you may attach a [R] Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition."
-          actionA {
-            checkLastTurn()
-            checkNoSPC()
-            assert my.bench : "No benched Pokémon"
-            assert my.discard.filterByEnergyType(R) : "You have no [R] Energy cards in your discard pile"
-            powerUsed()
-
-            attachEnergyFrom(type: R, my.discard, my.bench)
-          }
-        }
-        move "Fire Stream", {
-          text "50 damage. Discard a [R] Energy card attached to Blaziken. This attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
-          energyCost R, C, C
-          onAttack {
-            damage 50
-            opp.bench.each {
-              damage 10, it
-            }
-            afterDamage {
-              discardSelfEnergy(R)
-            }
-          }
-        }
-      };
+      return copy (RubySapphire.BLAZIKEN_3, this);
       case CHARIZARD_6:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -400,59 +373,9 @@ public enum PowerKeepers implements LogicCardInfo {
         }
       };
       case DELCATTY_8:
-      return evolution (this, from:"Skitty", hp:HP070, type:C, retreatCost:1) {
-        weakness F
-        pokePower "Energy Draw", {
-          text "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can't be used if Delcatty is affected by a Special Condition."
-          actionA {
-            checkNoSPC()
-            checkLastTurn()
-            assert my.hand.filterByType(ENERGY) : "No Energy in hand"
-            //Using LV.X Compendium Ruling instead of the EX: You can discard even if you don't have cards in deck.
-            powerUsed()
-
-            my.hand.filterByType(ENERGY).select("Discard").discard()
-            if (my.deck){
-              def maxDraw = Math.min(3, my.deck.size())
-              draw choose(1..maxDraw, "Draw how many cards?")
-            }
-          }
-        }
-        move "Max Energy Source", {
-          text "10x damage. Does 10 damage times the amount of Energy attached to all of your Active Pokémon."
-          energyCost C
-          onAttack {
-            damage 10*self.cards.energyCount(C)
-          }
-        }
-      };
+      return copy(RubySapphireNG.DELCATTY_5, this);
       case GARDEVOIR_9:
-      return evolution (this, from:"Kirlia", hp:HP100, type:P, retreatCost:2) {
-        weakness P
-        pokePower "Psy Shadow", {
-          text "Once during your turn (before your attack), you may search your deck for a [P] Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can't be used if Gardevoir is affected by a Special Condition."
-          actionA {
-            checkLastTurn()
-            checkNoSPC()
-            assert my.deck : "Deck is empty"
-            powerUsed()
-
-            my.deck.search("Search for a [P] Energy card to attach to one of your Pokémon.", energyFilter(P)).each {
-              def tar = my.all.select("Attach $it to? That Pokémon will receive 2 damage counters.")
-              attachEnergy(tar, it)
-              directDamage 20, tar, SRC_ABILITY
-            }
-            shuffleDeck()
-          }
-        }
-        move "Energy Burst", {
-          text "10x damage. Does 10 damage times the total amount of Energy attached to Gardevoir and the Defending Pokémon."
-          energyCost P
-          onAttack {
-            damage 10 * (self.cards.energyCount(C) + defending.cards.energyCount(C))
-          }
-        }
-      };
+      return copy(RubySapphireNG.GARDEVOIR_7, this);
       case KABUTOPS_10:
       return evolution (this, from:"Kabuto", hp:HP110, type:F, retreatCost:2) {
         weakness G
@@ -547,45 +470,7 @@ public enum PowerKeepers implements LogicCardInfo {
         }
       };
       case SLAKING_13:
-      return evolution (this, from:"Vigoroth", hp:HP120, type:C, retreatCost:3) {
-        weakness F
-        pokeBody "Lazy", {
-          text "As long as Slaking is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers."
-          getterA IS_ABILITY_BLOCKED, { Holder h->
-            if (self.active && h.effect.target.owner == self.owner.opposite && h.effect.ability instanceof PokePower) {
-              h.object=true
-            }
-          }
-          //TODO: Is this needed here?
-          getterA IS_GLOBAL_ABILITY_BLOCKED, {Holder h->
-            if (self.active && h.effect.target.owner == self.owner.opposite) {
-              h.object=true
-            }
-          }
-          onActivate {
-            new CheckAbilities().run(bg)
-          }
-          onDeactivate {
-            new CheckAbilities().run(bg)
-          }
-        }
-        move "Critical Move", {
-          text "100 damage. Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can't attack during your next turn."
-          energyCost C, C, C, C
-          attackRequirement {
-            assert self.cards.filterByType(BASIC_ENERGY) : "$self has no Basic Energy attached"
-          }
-          onAttack {
-            if(self.cards.filterByType(BASIC_ENERGY)){
-              damage 100
-              afterDamage {
-                self.cards.filterByType(BASIC_ENERGY).select("Discard a basic energy from $self.").discard()
-                cantAttackNextTurn(self)
-              }
-            }
-          }
-        }
-      };
+      return copy(RubySapphireNG.SLAKING_12, this);
       case DUSCLOPS_14:
       return evolution (this, from:"Duskull", hp:HP080, type:P, retreatCost:2) {
         weakness D

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -407,17 +407,16 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Super Slap Push", {
           text "Does 20 damage to each Defending Pokémon."
           energyCost F
-          attackRequirement {}
           onAttack {
-
+            damage 20
           }
         }
         move "Mega Throw", {
           text "40+ damage. If the Defending Pokémon is a Pokémon-ex, this attack does 40 damage plus 40 more damage."
           energyCost F, C, C
-          attackRequirement {}
           onAttack {
             damage 40
+            if (defending.EX) damage 40
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -541,14 +541,21 @@ public enum RubySapphireNG implements LogicCardInfo {
         pokePower "Water Call", {
           text "Once during your turn (before your attack), you may attach a [W] Energy card from your hand to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition."
           actionA {
+            checkNoSPC()
+            checkLastTurn()
+            assert my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W) : "You have no [W] Energy cards in your hand"
+
+            powerUsed()
+            def pcs = my.all.select()
+            attachEnergyFrom(type:W, my.hand, pcs)
           }
         }
         move "Hypno Splash", {
           text "50 damage. The Defending Pokémon is now Asleep."
           energyCost W, W, C, C
-          attackRequirement {}
           onAttack {
             damage 50
+            applyAfterDamage(ASLEEP)
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -645,17 +645,23 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Invisible Hand", {
           text "If any of your opponent's Active Pokémon are Evolved Pokémon, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
           energyCost C
-          attackRequirement {}
+          attackRequirement {
+            assert my.deck : "There are no more cards in your deck."
+            assert opp.active.evolution : "Your opponent's Active Pokémon isn't an Evolved Pokémon"
+          }
           onAttack {
-
+            my.deck.select().moveTo(hidden: true, my.hand)
+            shuffleDeck()
           }
         }
         move "Repulsion", {
           text "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn't have any Benched Pokémon or other Active Pokémon, this attack does nothing.)"
           energyCost C, C
-          attackRequirement {}
+          attackRequirement { assert opp.bench: "Opponent's bench is empty" }
           onAttack {
-
+            flip {
+              scoopUpPokemon(defending, delegate)
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -565,15 +565,14 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Take Down", {
           text "50 damage. Wailord does 20 damage to itself."
           energyCost C, C, C
-          attackRequirement {}
           onAttack {
             damage 50
+            damage 20, self
           }
         }
         move "Surf", {
           text "70 damage."
           energyCost W, W, W, C, C
-          attackRequirement {}
           onAttack {
             damage 70
           }

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -206,15 +206,16 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Retaliate", {
           text "10x damage. Flip a coin. If heads, this attack does 10 damage times the number of damage counters on Aggron."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
+            flip {
+              damage 10 * self.numberOfDamageCounters
+            }
           }
         }
         move "Mega Punch", {
           text "40 damage."
           energyCost C, C, C
-          attackRequirement {}
           onAttack {
             damage 40
           }
@@ -222,9 +223,8 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Double Lariat", {
           text "70x damage. Flip 2 coins. This attack does 70 damage times the number of heads."
           energyCost M, M, C, C, C
-          attackRequirement {}
           onAttack {
-            damage 70
+            flip 2, {damage 70}
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -427,17 +427,17 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Attract Current", {
           text "10 damage. Search your deck for a [L] Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 10
+            attachEnergyFrom(type:L, my.deck, my.all)
           }
         }
         move "Thunder Jolt", {
           text "50 damage. Flip a coin. If tails, Manectric does 10 damage to itself."
           energyCost L, L, C
-          attackRequirement {}
           onAttack {
             damage 50
+            flip 1, {}, {damage 10, self}
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -207,7 +207,6 @@ public enum RubySapphireNG implements LogicCardInfo {
           text "10x damage. Flip a coin. If heads, this attack does 10 damage times the number of damage counters on Aggron."
           energyCost C
           onAttack {
-            damage 10
             flip {
               damage 10 * self.numberOfDamageCounters
             }
@@ -249,7 +248,7 @@ public enum RubySapphireNG implements LogicCardInfo {
           energyCost G
           onAttack {
             damage 20
-            flip {applyAfterDamage PARALYZED}
+            flipThenApplySC PARALYZED
           }
         }
         move "Parallel Gain", {
@@ -285,9 +284,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             opp.bench.each {
               damage 10, it
             }
-            afterDamage {
-              discardSelfEnergy(R)
-            }
+            discardSelfEnergyAfterDamage R
           }
         }
       };
@@ -388,7 +385,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             my.deck.search("Search for a [P] Energy card to attach to one of your Pokémon.", energyFilter(P)).each {
               def tar = my.all.select("Attach $it to? That Pokémon will receive 2 damage counters.")
               attachEnergy(tar, it)
-              directDamage 20, tar, SRC_ABILITY
+              directDamage 20, tar, POKEPOWER
             }
             shuffleDeck()
           }
@@ -543,7 +540,7 @@ public enum RubySapphireNG implements LogicCardInfo {
           actionA {
             checkNoSPC()
             checkLastTurn()
-            assert my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W) : "You have no [W] Energy cards in your hand"
+            assert my.hand.filterByEnergyType(W) : "You have no [W] Energy cards in your hand"
 
             powerUsed()
             def pcs = my.all.select()
@@ -594,9 +591,7 @@ public enum RubySapphireNG implements LogicCardInfo {
           energyCost R, C, C, C
           onAttack {
             damage 80
-            afterDamage{
-              discardSelfEnergy(R)
-            }
+            discardSelfEnergyAfterDamage R
           }
         }
       };
@@ -701,7 +696,7 @@ public enum RubySapphireNG implements LogicCardInfo {
           text "As often as you like during your turn (before your attack), move a [G] Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition."
           actionA {
             checkNoSPC()
-            assert my.all.findAll {it.cards.energyCount(G)>0} : "There are no Pokémon with [G] Energy cards"
+            assert my.all.find{it.cards.energyCount(G)>0} : "There are no Pokémon with [G] Energy cards"
             assert my.all.size()>=2 : "There is only one Pokémon on the field"
 
             powerUsed()

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -478,15 +478,18 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Lizard Poison", {
           text "20 damage. If 1 Energy is attached to Sceptile, the Defending Pokémon is now Asleep. If 2 Energy is attached to Sceptile, the Defending Pokémon is now Poisoned. If 3 Energy is attached to Sceptile, the Defending Pokémon is now Asleep and Poisoned. If 4 or more Energy is attached to Sceptile, the Defending Pokémon is now Asleep, Burned, and Poisoned."
           energyCost C
-          attackRequirement {}
           onAttack {
             damage 20
+            def energyAttached = self.cards.energyCount()
+            if (energyAttached >= 3 || energyAttached == 1) applyAfterDamage(ASLEEP)
+            if (energyAttached >= 2) applyAfterDamage(POISONED)
+            if (energyAttached >= 4) applyAfterDamage(BURNED)
+
           }
         }
         move "Solarbeam", {
           text "70 damage."
           energyCost G, G, C, C, C
-          attackRequirement {}
           onAttack {
             damage 70
           }

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -300,14 +300,20 @@ public enum RubySapphireNG implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 20
+            if (opp.bench) damage 10, opp.bench.select()
           }
         }
         move "Fire Spin", {
           text "100 damage. Discard 2 basic Energy cards attached to Camerupt or this attack does nothing."
           energyCost R, R, C, C
-          attackRequirement {}
+          attackRequirement {
+            assert self.cards.filterByType(BASIC_ENERGY).size() >= 2 : "$self needs 2 or more Basic Energies attached"
+          }
           onAttack {
             damage 100
+            afterDamage {
+              self.cards.filterByType(BASIC_ENERGY).select(count: 2, "Select 2 Basic Energies to discard.").discard()
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -234,22 +234,30 @@ public enum RubySapphireNG implements LogicCardInfo {
         pokeBody "Withering Dust", {
           text "As long as Beautifly is in play, do not apply Resistance for all Active Pokémon."
           delayedA {
+            before APPLY_RESISTANCE, {
+              bg.dm().each{
+                if(it.to.active){
+                  bc "Resistance isn't applied due to $thisAbility"
+                  prevent()
+                }
+              }
+            }
           }
         }
         move "Stun Spore", {
           text "20 damage. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
           energyCost G
-          attackRequirement {}
           onAttack {
             damage 20
+            flip {applyAfterDamage PARALYZED}
           }
         }
         move "Parallel Gain", {
           text "50 damage. Remove 1 damage counter from each of your Pokémon, including Beautifly."
           energyCost G, C, C
-          attackRequirement {}
           onAttack {
             damage 50
+            my.all.each {heal 10, it}
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -183,7 +183,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.RUBY_SAPPHIRE;
+    return tcgwars.logic.card.Collection.RUBY_SAPPHIRE_NG;
   }
 
   @Override

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -584,17 +584,19 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Clutch", {
           text "20 damage. The Defending Pokémon can't retreat until the end of your opponent's next turn."
           energyCost C, C
-          attackRequirement {}
           onAttack {
             damage 20
+            cantRetreat defending
           }
         }
         move "Flamethrower", {
           text "80 damage. Discard a [R] Energy card attached to Blaziken."
           energyCost R, C, C, C
-          attackRequirement {}
           onAttack {
             damage 80
+            afterDamage{
+              discardSelfEnergy(R)
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -448,14 +448,26 @@ public enum RubySapphireNG implements LogicCardInfo {
         pokeBody "Intimidating Fang", {
           text "As long as Mightyena is your Active Pokémon, any damage done to your Pokémon done by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
+            after PROCESS_ATTACK_EFFECTS, {
+              if (self.active && ef.attacker.owner != self.owner) {
+                bg.dm().each {
+                  if(it.to.owner==self.owner && it.notZero) {
+                    bc "$thisPower -10"
+                    it.dmg-=hp(10)
+                  }
+                }
+              }
+            }
           }
         }
         move "Shakedown", {
           text "40 damage. Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
           energyCost D, C, C
-          attackRequirement {}
           onAttack {
             damage 40
+            afterDamage {
+              flip {discardRandomCardFromOpponentsHand()}
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -746,7 +746,9 @@ public enum RubySapphireNG implements LogicCardInfo {
         weakness L
         pokeBody "Rough Skin", {
           text "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon."
-          delayedA {
+          ifActiveAndDamagedByAttackBody(delegate) {
+            bc "$thisAbility activates"
+            directDamage(10, ef.attacker, Source.POKEBODY)
           }
         }
         move "Dark Slash", {
@@ -755,6 +757,10 @@ public enum RubySapphireNG implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 40
+            if(self.cards.energyCardCount(D) && confirm("Discard a [D] Energy attached to $self?")) {
+              damage 30
+              discardSelfEnergyAfterDamage D
+            }
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -727,9 +727,8 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Water Arrow", {
           text "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
           energyCost W
-          attackRequirement {}
           onAttack {
-
+            damage 20, opp.all.select()
           }
         }
         move "Fast Stream", {
@@ -738,6 +737,7 @@ public enum RubySapphireNG implements LogicCardInfo {
           attackRequirement {}
           onAttack {
             damage 30
+            // Only one defending Pokémon in single battles, so the effect is ignored.
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -350,20 +350,25 @@ public enum RubySapphireNG implements LogicCardInfo {
         pokeBody "Protective Dust", {
           text "Prevent all effects of attacks, except damage, done to Dustox by the Attacking Pokémon."
           delayedA {
+            before null, null, ATTACK, {
+              if (ef instanceof TargetedEffect && ef.effectType != DAMAGE && (ef as TargetedEffect).getResolvedTarget(bg, e) == self) {
+                bc "$thisAbility prevents all effects done to $self."
+                prevent()
+              }
+            }
           }
         }
         move "Toxic", {
           text "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns."
           energyCost G, C
-          attackRequirement {}
           onAttack {
-
+            apply POISONED
+            extraPoison 1
           }
         }
         move "Gust", {
           text "50 damage."
           energyCost G, C, C
-          attackRequirement {}
           onAttack {
             damage 50
           }

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -606,7 +606,6 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Headbutt", {
           text "20 damage."
           energyCost C, C
-          attackRequirement {}
           onAttack {
             damage 20
           }
@@ -614,9 +613,8 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Battle Blast", {
           text "40+ damage. Does 40 damage plus 10 more damage for each [F] Energy attached to Breloom."
           energyCost G, C, C
-          attackRequirement {}
           onAttack {
-            damage 40
+            damage 40 + 10 * self.cards.energyCount(F)
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -385,7 +385,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             my.deck.search("Search for a [P] Energy card to attach to one of your Pokémon.", energyFilter(P)).each {
               def tar = my.all.select("Attach $it to? That Pokémon will receive 2 damage counters.")
               attachEnergy(tar, it)
-              directDamage 20, tar, POKEPOWER
+              directDamage 20, tar, Source.POKEPOWER
             }
             shuffleDeck()
           }

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -672,15 +672,14 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Stockpile", {
           text "During your next turn, Spit Up's base damage is 70 instead of 30, and Swallow's base damage is 60 instead of 20."
           energyCost C
-          attackRequirement {}
           onAttack {
-
+            increasedBaseDamageNextTurn("Spit Up", hp(40))
+            increasedBaseDamageNextTurn("Swallow", hp(40))
           }
         }
         move "Spit Up", {
           text "30 damage."
           energyCost W, C
-          attackRequirement {}
           onAttack {
             damage 30
           }
@@ -688,9 +687,9 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Swallow", {
           text "20 damage. After your attack, remove from Pelipper the number of damage counters equal to the damage you did to the Defending Pokémon. If Pelipper has fewer damage counters than that, remove all of them."
           energyCost W, C, C
-          attackRequirement {}
           onAttack {
             damage 20
+            removeDamageCounterEqualToDamageDone()
           }
         }
       };

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -624,17 +624,18 @@ public enum RubySapphireNG implements LogicCardInfo {
         move "Rend", {
           text "20+ damage. If the Defending Pokémon has any damage counters on it, this attack does 20 damage plus 20 more damage."
           energyCost F, C
-          attackRequirement {}
           onAttack {
             damage 20
+            if(defending.numberOfDamageCounters) {
+              damage 20
+            }
           }
         }
         move "Double Spin", {
           text "60x damage. Flip 2 coins. This attack does 60 damage times the number of heads."
           energyCost F, C, C, C
-          attackRequirement {}
           onAttack {
-            damage 60
+            flip 2, {damage 60}
           }
         }
       };


### PR DESCRIPTION
* Relocated some cards already implemented in Groovy, and redirected to the RubySapphireNG print. Affects:
  - Blaziken (RS 3, PK 5)
  - Delcatty (RS 5, PK 8)
  - Gardevoir (RS 7, PK 9)
  - Slaking (RS 12, PK 13)
  - Sceptile (RS 20, POP4 5)
* Besides that, this PR implements cards 1 through 22.