### PR TITLE
Some DP-era card fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -3074,8 +3074,7 @@ public enum DiamondPearl implements LogicCardInfo {
               powerUsed()
               def cards = my.deck.subList(0,3)
               def moved = cards.select(count:1,"Choose a card to put in your hand. The rest will be discarded.").moveTo(hidden: true, my.hand)
-              cards.removeAll(moved)
-              cards.discard()
+              cards.getExcludedList(moved).discard()
             }
           }
           move "Flare Up", {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -3073,7 +3073,7 @@ public enum DiamondPearl implements LogicCardInfo {
               assert my.deck : "Your deck is empty."
               powerUsed()
               def cards = my.deck.subList(0,3)
-              def moved = cards.select(count:1,"Choose a card to put in your hand. The rest will be discarded.").moveTo(my.hand)
+              def moved = cards.select(count:1,"Choose a card to put in your hand. The rest will be discarded.").moveTo(hidden: true, my.hand)
               cards.removeAll(moved)
               cards.discard()
             }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2622,7 +2622,7 @@ public enum GreatEncounters implements LogicCardInfo {
         };
       case UNOWN_L_91:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
-          weakness P
+          weakness P, PLUS10
           pokeBody "LINK", {
             text "Unown L can use any attack from any Unown in play."
             getterA (GET_MOVE_LIST, self) { holder->

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -390,9 +390,10 @@ public enum GreatEncounters implements LogicCardInfo {
           weakness R, PLUS30
           resistance W, MINUS20
           pokeBody "Wild Growth", {
-            text "Each basic [G] Energy card attached to your Pokémon provides [G][G] Energy instead. You can't use more than 1 Wild Growth Poké-Body each turn."
+            text "Each basic [G] Energy card attached to your [G] Pokémon provides [G][G] Energy instead. You can't use more than 1 Wild Growth Poké-Body each turn."
             getterA GET_ENERGY_TYPES, { holder->
               if(holder.effect.target.owner == self.owner
+                && holder.effect.target.types.contains(G)
                 && holder.effect.card.containsTypePlain(G)
                 && holder.effect.card.cardTypes.is(BASIC_ENERGY)) {
                 holder.object = [[G] as Set,[G] as Set]

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1972,6 +1972,7 @@ public enum GreatEncounters implements LogicCardInfo {
             text "Once during your turn , if Caterpie is your Active Pokémon, you may flip a coin, if heads search your deck for a card that evolves from Caterpie and put it onto Caterpie. (This counts as evolving Caterpie.) Shuffle your deck afterward. This power can't be used if Caterpie is affected by a Special Condition."
             actionA {
               assert my.deck : "Your Deck is empty"
+              assert self.active : "$self is not your Active Pokémon"
               checkLastTurn()
               powerUsed()
               flip {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -584,17 +584,16 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                if (ef.attacker.owner == self.owner) bg.dm().each {
+                if (ef.attacker.owner == self.owner)bg.dm().each {
                   if (it.to.active && it.to.owner != self.owner && it.notZero) {
                     def attacker = it.from
                     def enthusiasm_cond = {
                       def toadNames = ["Poliwag", "Poliwhirl", "Poliwrath"]
-                      attacker.name in toadNames &&
-                        toadNames.every{toadName ->
-                          self.owner.pbg.all.any{ pcs -> pcs.name == toadName }
-                        }
+                      return (attacker.name in toadNames && toadNames.every{toadName ->
+                        self.owner.pbg.all.any{ pcs -> pcs.name == toadName }
+                      })
                     }
-                    if(enthusiasm_cond) {
+                    if(enthusiasm_cond.call()) {
                       bc "Enthusiasm +60"
                       it.dmg += hp(60)
                     }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -584,21 +584,22 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "If you have Poliwag, Poliwhirl, and Poliwrath in play, each of these Pokémon's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
-                if (ef.attacker.owner == self.owner)bg.dm().each {
-                  if (it.to.active && it.to.owner != self.owner && it.notZero) {
-                    def attacker = it.from
-                    def enthusiasm_cond = {
-                      def toadNames = ["Poliwag", "Poliwhirl", "Poliwrath"]
-                      return (attacker.name in toadNames && toadNames.every{toadName ->
-                        self.owner.pbg.all.any{ pcs -> pcs.name == toadName }
-                      })
-                    }
-                    if(enthusiasm_cond.call()) {
-                      bc "Enthusiasm +60"
-                      it.dmg += hp(60)
+                if (ef.attacker.owner == self.owner)
+                  bg.dm().each {
+                    if (it.to.active && it.to.owner != self.owner && it.notZero) {
+                      def attacker = it.from
+                      def enthusiasm_cond = {
+                        def toadNames = ["Poliwag", "Poliwhirl", "Poliwrath"]
+                        return (attacker.name in toadNames && toadNames.every{toadName ->
+                          self.owner.pbg.all.any{ pcs -> pcs.name == toadName }
+                        })
+                      }
+                      if (enthusiasm_cond.call()) {
+                        bc "Enthusiasm +60"
+                        it.dmg += hp(60)
+                      }
                     }
                   }
-                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1920,6 +1920,7 @@ public enum MajesticDawn implements LogicCardInfo {
               my.deck.search(max:my.bench.freeBenchCount,"Search your deck for as many Eevee as you like and put them onto your Bench",{it.name.contains("Eevee")}).each {
                 benchPCS(it)
               }
+              shuffleDeck()
             }
           }
           move "Lunge", {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2631,7 +2631,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
             onAttack {
               def pcs = benchPCS(my.discard.select("Choose a Pokémon to put on your bench", cardTypeFilter(POKEMON)).first())
-              if(my.discard.filterByType(BASIC_ENERGY)) {
+              if(pcs != null && my.discard.filterByType(BASIC_ENERGY)) {
                 my.discard.select(min:0, max:3, "Attach up to 3 basic Energy cards to $pcs",cardTypeFilter(BASIC_ENERGY)).each {
                   attachEnergy(pcs, it)
                 }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2725,11 +2725,11 @@ public enum MajesticDawn implements LogicCardInfo {
               checkNoSPC()
               assert my.deck : "Your deck is empty"
               powerUsed()
-              def min = Math.min(2, my.deck.size())
-              def cards = my.deck.search(min:min, max:2, "Search your deck for any 2 cards", {true})
-              rearrange(cards)
+              def list = my.deck.select(count:2)
+              list = rearrange(list)
+              my.deck.removeAll(list)
               shuffleDeck()
-              cards.moveTo(addToTop:true,hidden: true, my.deck)
+              my.deck.addAll(0, list)
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1235,7 +1235,7 @@ public enum MajesticDawn implements LogicCardInfo {
         };
       case FEAROW_36:
         return evolution (this, from:"Spearow", hp:HP080, type:COLORLESS, retreatCost:0) {
-          weakness L
+          weakness L, PLUS20
           resistance F, MINUS20
           move "Fury Attack", {
             text "20× damage. Flip 3 coins. This attack does 20 damage times the number of heads."
@@ -1355,7 +1355,7 @@ public enum MajesticDawn implements LogicCardInfo {
         };
       case MONFERNO_41:
         return evolution (this, from:"Chimchar", hp:HP070, type:FIRE, retreatCost:0) {
-          weakness W
+          weakness W, PLUS20
           move "Fire Fang", {
             text "30 damage. The Defending Pokémon is now Burned."
             energyCost R
@@ -1935,8 +1935,7 @@ public enum MajesticDawn implements LogicCardInfo {
         };
       case EEVEE_63:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
-          weakness F
-          resistance F
+          weakness F, PLUS10
           move "Gnaw", {
             text "10 damage. "
             energyCost ()

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1379,7 +1379,7 @@ public enum MajesticDawn implements LogicCardInfo {
       case MOTHIM_42:
         return evolution (this, from:["Burmy","Burmy Plant Cloak","Burmy Sandy Cloak","Burmy Trash Cloak"], hp:HP080, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
-          resistance F, MINUS30
+          resistance F, MINUS20
           pokeBody "Disturbance Scales", {
             text "Any damage done by attacks from your Pokémon to the Defending Pokémon isn’t affected by Resistance."
             delayedA {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -200,7 +200,7 @@ public enum MajesticDawn implements LogicCardInfo {
   public Card getImplementation() {
     switch (this) {
       case ARTICUNO_1:
-        return basic (this, hp:HP100, type:WATER, retreatCost:3) {
+        return basic (this, hp:HP100, type:WATER, retreatCost:2) {
           weakness M
           resistance F, MINUS20
           pokePower "Freezing Screech", {
@@ -208,7 +208,7 @@ public enum MajesticDawn implements LogicCardInfo {
             onActivate {
               if(it==PLAY_FROM_HAND && confirm("Use Freezing Screech?")) {
                 powerUsed()
-                flip {apply PARALYZED}
+                flip {apply PARALYZED, opp.active, Source.POKEPOWER}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2100,8 +2100,7 @@ public enum MajesticDawn implements LogicCardInfo {
             onAttack {
               damage 20
               if(opp.bench) {
-                multiSelect(opp.bench,2,"Does 10 damage to 2 of your opponent's benched Pokémon").each {}
-                damage 10, it
+                multiSelect(opp.bench,2,"Does 10 damage to 2 of your opponent's benched Pokémon").each{damage 10, it}
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3187,7 +3187,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             if (chosenCard)
               chosenCard.showToOpponent("Chosen card").moveTo(my.hand)
 
-            shuffleDeck()
+            if (choice == 1 && my.deck) shuffleDeck()
           }
           playRequirement {
             assert ( my.deck.notEmpty || my.discard.any{isValidFossilCard(it)}) : "You have no cards in deck, and there are no cards in your discard pile that satisfy this supporter's requirements"

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3464,16 +3464,17 @@ public enum MysteriousTreasures implements LogicCardInfo {
             onAttack {
               damage 50
               afterDamage {
-                def cardsDiscarded = 0
+                def cardsDiscarded = new CardList()
                 if (bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.player != self.owner){
-                  discard bg.stadiumInfoStruct.stadiumCard
-                  cardsDiscarded += 1
+                  cardsDiscarded.add(bg.stadiumInfoStruct.stadiumCard)
                 }
                 opp.all.findAll {it.cards.hasType(POKEMON_TOOL)}.each{
-                  it.cards.filterByType(POKEMON_TOOL).discard()
-                  cardsDiscarded += 1
+                  cardsDiscarded.addAll(it.cards.filterByType(POKEMON_TOOL))
                 }
-                if (cardsDiscarded) preventAllEffectsNextTurn()
+                if (cardsDiscarded) {
+                  cardsDiscarded.discard()
+                  preventAllEffectsNextTurn()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3463,16 +3463,18 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 50
-              def cardsDiscarded = 0
-              if (bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.player != self.owner){
-                discard bg.stadiumInfoStruct.stadiumCard
-                cardsDiscarded += 1
+              afterDamage {
+                def cardsDiscarded = 0
+                if (bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.player != self.owner){
+                  discard bg.stadiumInfoStruct.stadiumCard
+                  cardsDiscarded += 1
+                }
+                opp.all.findAll {it.cards.hasType(POKEMON_TOOL)}.each{
+                  it.cards.filterByType(POKEMON_TOOL).discard()
+                  cardsDiscarded += 1
+                }
+                if (cardsDiscarded) preventAllEffectsNextTurn()
               }
-              opp.all.findAll {it.cards.hasType(POKEMON_TOOL)}.each{
-                it.cards.filterByType(POKEMON_TOOL).discard()
-                cardsDiscarded += 1
-              }
-              if (cardsDiscarded) preventAllEffectsNextTurn()
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -238,7 +238,7 @@ public enum SecretWonders implements LogicCardInfo {
                 if(ef.cardToPlay.cardTypes.is(SUPPORTER) && bg.em().retrieveObject("Jamming")!=bg.turnCount && bg.currentThreadPlayerType == self.owner.opposite){
                   bg.em().storeObject("Jamming",bg.turnCount)
                   self.owner.opposite.pbg.all.each {
-                    directDamage(10, it, Source.POKBODY)
+                    directDamage(10, it, Source.POKEBODY)
                   }
                 }
               }
@@ -393,7 +393,7 @@ public enum SecretWonders implements LogicCardInfo {
               before BEGIN_TURN, {
                 if(self.active && !self.owner.opposite.pbg.active.types.contains(F)) {
                   bc "Irritating Buzz Activates"
-                  directDamage(10, self.owner.opposite.pbg.active, Source.POKBODY)
+                  directDamage(10, self.owner.opposite.pbg.active, Source.POKEBODY)
                 }
               }
             }
@@ -1203,7 +1203,7 @@ public enum SecretWonders implements LogicCardInfo {
             after ATTACH_ENERGY, self, {
               if (ef.reason==PLAY_FROM_HAND && ef.card.asEnergyCard().containsType(R)) {
                 bc "Flame Body removes 2 damage counters from $self"
-                heal 20, self, Source.POKBODY
+                heal 20, self, Source.POKEBODY
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -295,7 +295,7 @@ public enum SecretWonders implements LogicCardInfo {
         };
       case CHARIZARD_3:
         return evolution (this, from:"Charmeleon", hp:HP130, type:FIRE, retreatCost:3) {
-          weakness W
+          weakness W, PLUS40
           resistance F, MINUS20
           pokeBody "Fury Blaze", {
             text "If your opponent has 3 or less Prize cards left, each of Charizard’s attacks does 50 more damage to the Active Pokémon ."
@@ -412,7 +412,7 @@ public enum SecretWonders implements LogicCardInfo {
         };
       case GALLADE_6:
         return evolution (this, from:"Kirlia", hp:HP130, type:FIGHTING, retreatCost:2) {
-          weakness P
+          weakness P, PLUS30
           move "Sonic Blade", {
             text "Put damage counters on the Defending Pokémon until it is 50 HP away from being Knocked Out. If you do, your opponent switchs the Defending Pokémon with 1 of this or her Benched Pokémon."
             energyCost F, C
@@ -1129,7 +1129,7 @@ public enum SecretWonders implements LogicCardInfo {
         };
       case GOLEM_29:
         return evolution (this, from:"Graveler", hp:HP130, type:FIGHTING, retreatCost:4) {
-          weakness G
+          weakness G, PLUS30
           resistance L, MINUS20
           move "Double Throw", {
             text "Choose 2 of your opponent’s Pokémon. This attack does 30 damage to each of them."
@@ -1626,7 +1626,7 @@ f
         };
       case BRELOOM_45:
         return evolution (this, from:"Shroomish", hp:HP100, type:GRASS, retreatCost:2) {
-          weakness R
+          weakness R, PLUS30
           move "Darin Punch", {
             text "40 damage. Remove from Breloom a number of damage counters equal to the amount of Energy attached to the Defending Pokémon."
             energyCost F, C
@@ -2021,7 +2021,7 @@ f
         };
       case QUAGSIRE_60:
         return evolution (this, from:"Wooper", hp:HP090, type:WATER, retreatCost:3) {
-          weakness G
+          weakness G, PLUS30
           resistance L, MINUS20
           pokePower "Aqua Healing", {
             text "Once during your turn , if Quagsire is your Active Pokémon and the Defending Pokémon has any Energy attached to it, you may remove 3 damage counters from Quagsire."
@@ -2300,7 +2300,7 @@ f
         };
       case UNOWN_X_71:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
-          weakness P
+          weakness P, PLUS10
           pokePower "X-RAY", {
             text "Once during your turn , if you have Unown X on your Bench, you may look at the top card of your opponent’s deck and put it back on top of his or her deck."
             actionA {
@@ -2945,7 +2945,7 @@ f
         };
       case PHANPY_98:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
-          weakness W
+          weakness W, PLUS10
           resistance L, MINUS20
           move "Flail", {
             text "10× damage. Does 10 damage times the number of damage counters on Phanpy."

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -631,7 +631,7 @@ public enum SecretWonders implements LogicCardInfo {
                 before BEGIN_TURN, {
                   if (self.numberOfDamageCounters) {
                     bc "$thisAbility activates"
-                    heal 10, self, Source.POKBODY
+                    heal 10, self, Source.POKEBODY
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -3522,10 +3522,10 @@ f
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 2 cards. Then, choose a card from your opponent’s hand without looking and put it on the bottom of his or her deck."
           onPlay {
             draw 2
-            opp.hand.select(hidden: true, "Choose a card from your opponent's hand without looking").showToOpponent("Team Galactic's Mars: This card will be put on the bottom of your deck").moveTo(hidden: true, opp.deck)
+            if (opp.hand) opp.hand.shuffledCopy().select(hidden: true, "Choose a card from your opponent's hand without looking").showToOpponent("Team Galactic's Mars: This card will be put on the bottom of your deck.").moveTo(hidden: true, opp.deck)
           }
           playRequirement{
-            assert my.deck || opp.hand : "Your deck and your opponent's hand are both empty"
+            assert my.deck : "There are no cards left in your deck."
           }
         };
       case POTION_127:

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -3522,7 +3522,7 @@ f
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 2 cards. Then, choose a card from your opponent’s hand without looking and put it on the bottom of his or her deck."
           onPlay {
             draw 2
-            if (opp.hand) opp.hand.shuffledCopy().select(hidden: true, "Choose a card from your opponent's hand without looking").showToOpponent("Team Galactic's Mars: This card will be put on the bottom of your deck.").moveTo(hidden: true, opp.deck)
+            if (opp.hand) opp.hand.select(hidden: true, "Choose a card from your opponent's hand without looking").showToOpponent("Team Galactic's Mars: This card will be put on the bottom of your deck.").moveTo(hidden: true, opp.deck)
           }
           playRequirement{
             assert my.deck : "There are no cards left in your deck."


### PR DESCRIPTION
* General fixes
  - Added/corrected some Weaknesses and Resistances from several cards, matching them to the values printed in the cards.
* Legends Awakened
  - Politoed check for Enthusiasm should now work properly (and in a more efficient way).
* Secret Wonders
  - Team Galactic's Mars should now be playable even if the opponent has no hand. A check is now done in order to avoid doing that part of the card's effect were that the case (having at least 1 card in your deck is still a requirement).
  - Fixed some instances of `Source.POKEBODY` being mispelt as `Source.POKBODY`. Affects Ludicolo, Ampharos, Flygon and Magmortar.
* Great Encounters
  - Sceptile should now apply its "Wild Growth" Poké-Body to Grass type Pokémon only.
  - Caterpie should only be able to use "Pupate" when in the Active Spot.
* Majestic Dawn
  - Changed the retreat cost of Articuno, and sourced it's paralyzing Poké-Power properly.
  - When Eevee (62) uses "Call for Family", the deck will now be shuffled post-search.
  - Omanyte should now properly damage benched Pokémon.
  - Applied the logic used in Mallow for Porygon-Z Lv.X's "Decode" Poké-Power.
  - Garchomp Lv.X's "Restore" attack should no longer continue onto the "attach energy" section when no Pokémon was benched.
* Mysterious Treasures
  - Electivire Lv.X's "Pulse Barrier" should now discard the opponent's tool and stadium cards after dealing damage.
* Diamond & Pearl - Base Set
  - Infernape Lv.X should no longer show the card selected when using "Burning Hand".