### PR TITLE
Fix "Dragon Aura" in Rayquaza (DX)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -850,7 +850,7 @@ public enum Deoxys implements LogicCardInfo {
             text "As long as Rayquaza has any basic [R] Energy cards and any basic [L] Energy cards attached to it, prevent all effects, except damage, by an opponent’s attack done to Rayquaza."
             delayedA {
               before null, self, Source.ATTACK, {
-                if (bg.currentTurn == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages) && self.cards.energyCount(L) && self.cards.energyCount(R)) {
+                if (bg.currentTurn == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages) && self.cards.basicEnergyCardCount(L) && self.cards.basicEnergyCardCount(R)) {
                   bc "Dragon Aura prevents effect"
                   prevent()
                 }


### PR DESCRIPTION
Should only check for basic Energy cards, not any. This should fix some issues with it regarding this ability.