### PR TITLE
Some EX/DP Era fixes (EM, CG, PK, SW, PL)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -662,12 +662,10 @@ public enum CrystalGuardians implements LogicCardInfo {
         pokeBody "Cursed Glare", {
           text "As long as Dusclops is your Active Pokémon, your opponent can't attach any Special Energy cards (except for [D] and [M] Energy cards) from his or her hand to his or her Active Pokémon."
           delayedA {
-            before PLAY_ENERGY, {
-              if (self.active && ef.cardToPlay.cardTypes.is(SPECIAL_ENERGY) && bg.currentTurn == self.owner.opposite) {
-                if ( !( ["Metal Energy", "Darkness Energy"].contains(ef.cardToPlay.name) ) ) {
-                  wcu "Cursed Glare prevents playing this card"
-                  prevent()
-                }
+            before ATTACH_ENERGY, self.owner.opposite.pbg.active, {
+              if(ef.reason == PLAY_FROM_HAND && self.active && (ef.card.cardTypes.is(SPECIAL_ENERGY) && ef.card.name != "Darkness Energy" && ef.card.name != "Metal Energy")) {
+                wcu "$thisAbility: Can't attach special energies to your Active Pokémon"
+                prevent()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -455,7 +455,7 @@ public enum Emerald implements LogicCardInfo {
             onActivate {
               if(my.active.cards.energyCount(G) && my.active.specialConditions){
                 bc "Green Essence clears existing Special Conditions in the Active ${my.active}."
-                clearSpecialCondition(my.active, SRC_ABILITY)
+                clearSpecialCondition(my.active, Source.POKEBODY)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1930,8 +1930,8 @@ public enum Emerald implements LogicCardInfo {
             text "As long as Cacturne ex is your Active Pokémon, your opponent can’t attach any Special Energy cards (except for [D] and [M] Energy cards) from his or her hand to his or her Active Pokémon."
             delayedA {
               before ATTACH_ENERGY, self.owner.opposite.pbg.active, {
-                if(ef.reason == PLAY_FROM_HAND && ef.resolvedTarget.owner == self.owner.opposite && ef.resolvedTarget.active && self.active && (ef.card.cardTypes.is(SPECIAL_ENERGY) && ef.card.name != "Darkness Energy" && ef.card.name != "Metal Energy")) {
-                  wcu "Cursed Glare: Can't attach energy"
+                if(ef.reason == PLAY_FROM_HAND && self.active && (ef.card.cardTypes.is(SPECIAL_ENERGY) && ef.card.name != "Darkness Energy" && ef.card.name != "Metal Energy")) {
+                  wcu "$thisAbility: Can't attach special energies to your Active Pokémon"
                   prevent()
                 }
               }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -212,7 +212,7 @@ public enum Emerald implements LogicCardInfo {
           }
           move "Damage Burn", {
             text "50+ damage. If the Defending Pokémon already has any damage counters on it, this attack does 50 damage plus 20 more damage."
-            energyCost F, F, C
+            energyCost R, R, C
             onAttack {
               damage 50
               if(defending.numberOfDamageCounters) damage 20

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1930,7 +1930,7 @@ public enum Emerald implements LogicCardInfo {
             text "As long as Cacturne ex is your Active Pokémon, your opponent can’t attach any Special Energy cards (except for [D] and [M] Energy cards) from his or her hand to his or her Active Pokémon."
             delayedA {
               before ATTACH_ENERGY, self.owner.opposite.pbg.active, {
-                if(ef.reason == PLAY_FROM_HAND && ef.resolvedTarget.owner == self.owner.opposite && ef.resolvedTarget.active && self.active && (ef.card instanceof SpecialEnergyCard && ef.card.name != "Darkness Energy" && ef.card.name != "Metal Energy")) {
+                if(ef.reason == PLAY_FROM_HAND && ef.resolvedTarget.owner == self.owner.opposite && ef.resolvedTarget.active && self.active && (ef.card.cardTypes.is(SPECIAL_ENERGY) && ef.card.name != "Darkness Energy" && ef.card.name != "Metal Energy")) {
                   wcu "Cursed Glare: Can't attach energy"
                   prevent()
                 }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1356,7 +1356,8 @@ public enum PowerKeepers implements LogicCardInfo {
         pokeBody "Rough Skin", {
           text "If Carvanha is your Active Pokémon and is damaged by an opponent's attack (even if Carvanha is Knocked Out), put 1 damage counter on the Attacking Pokémon."
           ifActiveAndDamagedByAttackBody(delegate) {
-            directDamage(10, ef.attacker, Source.SRC_ABILITY)
+            bc "$thisAbility activates"
+            directDamage(10, ef.attacker, Source.POKEBODY)
           }
         }
         move "Gnaw", {

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1846,7 +1846,7 @@ public enum Platinum implements LogicCardInfo {
             energyCost D, C, C
             onAttack {
               damage 40
-              if(confirm("Discard a [D] Energy attached to Houndoom G?")) {
+              if(self.cards.energyCardCount(D) && confirm("Discard a [D] Energy attached to $self?")) {
                 damage 20
                 discardSelfEnergyAfterDamage D
               }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1396,8 +1396,8 @@ f
           pokeBody "Rough Skin", {
             text "If Sharpedo is your Active Pokémon and is damaged by an opponent’s attack , put 2 damage counter on the Attacking Pokémon."
             ifActiveAndDamagedByAttackBody(delegate) {
-              bc "Rough Skin activates"
-              directDamage(20, ef.attacker)
+              bc "$thisAbility activates"
+              directDamage(20, ef.attacker, Source.POKEBODY)
             }
           }
           move "Strike Wound", {


### PR DESCRIPTION
- Cacturne-ex (Emerald) and Dusclops (Crystal Guardians) should now properly block attaching Special Energy other than [D]/[M] Energy to the opponent's Active Pokémon when in the Active Position.
- Blaziken (Emerald) should now ask for Fire energy instead of Fighting energy for its "Damage Burn" attack.
- Sceptile (Emerald) should no longer cause an Engine Error when removing special conditions (also changed said effect's source from SRC_ABILITY to POKEBODY)
- Carvanha (Power Keepers) and Sharpedo (Secret Wonders) should now apply Poke-Body-sourced damage with their "Rough Skin" Poke-Body.
- Houndoom G (Platinum) should now only ask about discarding a [D] Energy for extra damage when attacking with "Dark Slash" if any [D] Energy is actually attached to them.