### PR TITLE
Add "usingThisAbilityEndsTurn" static, make use of it in DP cards with turn-ending Poké-Powers

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -800,6 +800,10 @@ class TcgStatics {
       after FALL_BACK, self, {unregister()}
     }
   }
+  static usingThisAbilityEndsTurn(Object delegate) {
+    bc "${delegate.self.owner.getPlayerUsername(bg)}'s turn ends due to using ${delegate.thisAbility}."
+    bg.gm().betweenTurns()
+  }
 
   static preventAllEffectsFromCustomPokemonNextTurn(Move thisMove, PokemonCardSet self, Predicate<PokemonCardSet> predicate){
     delayed {

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -2295,9 +2295,9 @@ public enum CrystalGuardians implements LogicCardInfo {
             checkLastTurn()
             checkNoSPC()
             assert my.discard.filterByType(ENERGY) : "No Energies in discard"
-            powerUsed()
+            powerUsed({ usingThisAbilityEndsTurn delegate })
             3.times{attachEnergyFrom(my.discard, my.all)}
-            bg.gm().betweenTurns()
+            usingThisAbilityEndsTurn delegate
           }
         }
         move "Ultra Pump", {

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -2124,10 +2124,10 @@ public enum DragonFrontiers implements LogicCardInfo {
             checkNoSPC()
             assert my.hand.filterByType(BASIC_ENERGY) : "No Basic Energy in hand"
             assert my.all.any{ ["Latias", "Latias ex", "Latios", "Latios ex"].contains(it.name) }
-            powerUsed()
+            powerUsed({ usingThisAbilityEndsTurn delegate })
             def eligible = my.all.findAll { ["Latias", "Latias ex", "Latios", "Latios ex"].contains(it.name) }
             attachEnergyFrom(basic:true, my.hand, eligible.select("Attach to"))
-            bg.gm().betweenTurns()
+            usingThisAbilityEndsTurn delegate
           }
         }
         move "Power Crush", {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2995,7 +2995,7 @@ public enum GreatEncounters implements LogicCardInfo {
               powerUsed()
 
               flip 2, {}, {}, [
-                2: { bg().gm().betweenTurns() },
+                2: { usingThisAbilityEndsTurn delegate },
                 0: {
                   eff = delayed {
                     after DRAW_CARD, {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -2672,11 +2672,11 @@ public enum LegendsAwakened implements LogicCardInfo {
             actionA {
               checkNoSPC()
               checkLastTurn()
-              powerUsed()
+              powerUsed({ usingThisAbilityEndsTurn delegate })
               my.all.each {
                 heal 20, it
               }
-              bg.gm().betweenTurns()
+              usingThisAbilityEndsTurn delegate
             }
           }
           move "Hidden Power", {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2576,6 +2576,7 @@ public enum MajesticDawn implements LogicCardInfo {
                   benchPCS(it)
                 }
                 shuffleDeck()
+                bc "${self.owner.getPlayerUsername(bg)}'s turn ends due to using $thisCard's effect."
                 bg.gm().betweenTurns()
               }
             }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1350,12 +1350,12 @@ public enum Platinum implements LogicCardInfo {
       case LUDICOLO_34:
         return evolution (this, from:"Lombre", hp:HP120, type:GRASS, retreatCost:2) {
           weakness L, PLUS30
-          pokePower "Cheerful Voice", {// TODO: Use a stored object to end the turn if the effect is blocked https://compendium.pokegym.net/compendium-bw.html#4
+          pokePower "Cheerful Voice", {
             text "Once during your turn , you may use this power. If you do, your turn ends. During your next turn, each of Ludicolo’s attacks does 60 more damage to the Defending Pokémon . This power can’t be used if Ludicolo is affected by a Special Condition."
             actionA {
               checkLastTurn()
               checkNoSPC()
-              powerUsed()
+              powerUsed({ usingThisAbilityEndsTurn delegate })
               delayed {
                 def registeredOn=0
                 after PROCESS_ATTACK_EFFECTS, {
@@ -1372,6 +1372,7 @@ public enum Platinum implements LogicCardInfo {
                 after DEVOLVE, self, {unregister()}
                 register{registeredOn=bg.turnCount}
               }
+              usingThisAbilityEndsTurn delegate
             }
           }
           move "Mad Dance", {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -270,7 +270,7 @@ public enum SecretWonders implements LogicCardInfo {
               checkLastTurn()
               checkNoSPC()
               assert my.hand.filterByBasicEnergyType(W) : "There are no basic [W] Energys in your hand."
-              powerUsed()
+              powerUsed({ usingThisAbilityEndsTurn delegate })
               while(true){
                 if(!my.hand.filterByBasicEnergyType(W)) break
                 def tar = my.all.select("Attach energy to which Pokémon? (Cancel to stop)", false)
@@ -279,8 +279,8 @@ public enum SecretWonders implements LogicCardInfo {
                 energy.each{
                   attachEnergy(tar,it)
                 }
-                bg.gm().betweenTurns()
               }
+              usingThisAbilityEndsTurn delegate
             }
           }
           move "Hydro Pump", {

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3168,6 +3168,7 @@ public enum SupremeVictors implements LogicCardInfo {
           resistance M, MINUS20
           pokePower "Energy Recycle", {
             text "Once during your turn , you may use this power. If you do, your turn ends. Search your discard pile for up to 3 Energy cards and attach them to your Pokémon in any way you like. This power can’t be used if Electivire is affected by a Special Condition."
+            //TODO: Use "usingThisAbilityEndsTurn delegate" when implementing this card.
             actionA {
             }
           }


### PR DESCRIPTION
This should allow Alakazam (Mysterious Treasures) "Power Cancel" and Power Spray to effectively block these powers, while still ending the owner's turn (as intended, and clarified through erratas in earlier cards from the block).

Affected cards by this:

- Swampert-ex (Crystal Guardians)
- Latias-ex δ (Dragon Frontiers)
- Blastoise (Secret Wonders)
- Dialga Lv.X (Great Encounters) 
  + _Not affected by Power Spray, but can make use of this static._
- Call Energy (Majestic Dawn)
  + _No use of the static, but a bc message was added based on it._
- Unown V (Legends Awakened)
- Ludicolo (Platinum)
- Electivire E4 Lv.X (Supreme Victors)
  + _Just a TODO, not yet implemented._


Co-dependant on https://github.com/axpendix/tcgone/pull/179