### PR TITLE
HP-MD related fixes, fix for Noctowl (SSH)

### DIFF
--- a/src/tcgwars/logic/groovy/TcgStatics.groovy
+++ b/src/tcgwars/logic/groovy/TcgStatics.groovy
@@ -852,8 +852,8 @@ class TcgStatics {
       if(params.name){
         pkmnName = params.name
       }
-      if(params.type){
-        deck.search (max: maxSpace,{it.name.contains(pkmnName) && it.cardTypes.is(basicFilter) && it.asPokemonCard().types.contains(params.type)}).each {
+      if(params.types){
+        deck.search (max: maxSpace,{it.name.contains(pkmnName) && it.cardTypes.is(basicFilter) && params.types.any{ty -> it.asPokemonCard().types.contains(ty)}}).each {
           benchPCS(it)
         }
       }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -521,9 +521,11 @@ public enum DiamondPearl implements LogicCardInfo {
                 if(confirm ("You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent’s deck. Your opponent shuffles his or her deck afterward.")) {
                   flip {
                     discardAllSelfEnergy()
-                    defending.cards.moveTo(opp.deck)
-                    removePCS(defending)
-                    shuffleDeck(null, TargetPlayer.OPPONENT)
+                    targeted (defending) {
+                      defending.cards.moveTo(opp.deck)
+                      removePCS(defending)
+                      shuffleDeck(null, TargetPlayer.OPPONENT)
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -443,13 +443,14 @@ public enum GreatEncounters implements LogicCardInfo {
           weakness R, PLUS30
           resistance W, MINUS20
           move "Power Whip", {
-            text "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each basic Energy card attached to Tangrowth to that Pokémon."
+            text "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Energy from basic Energy cards attached to Tangrowth to that Pokemon."
+            //Errata'd. Original text: "This attack does 10 damage for each basic Energy card attached to Tangrowth to that Pokémon."
             energyCost G
             attackRequirement {
               assert self.cards.filterByType(BASIC_ENERGY) : "$self has no basic Energy cards attached to it"
             }
             onAttack {
-              damage 10 * self.cards.filterByType(BASIC_ENERGY).size(), opp.all.select()
+              damage 10 * self.cards.filterByType(BASIC_ENERGY).energyCount(), opp.all.select()
             }
           }
           move "Stick and Absorb", {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1008,6 +1008,7 @@ public enum GreatEncounters implements LogicCardInfo {
               assert my.bench.find{it.name == "Unown E"} : "Unown E is not on your Bench"
               assert my.bench.find{it.name == "Unown A"} : "Unown A is not on your Bench"
               assert my.bench.find{it.name == "Unown L"} : "Unown L is not on your Bench"
+              assert !my.active.getSpecialConditions().isEmpty() : "Your Active Pokémon needs to have at least 1 Special Condition applied"
               powerUsed()
               clearSpecialCondition(my.active, Source.POKEPOWER)
             }
@@ -1021,7 +1022,9 @@ public enum GreatEncounters implements LogicCardInfo {
             onAttack {
               if (my.hand) {
                 damage 30
-                my.hand.select("Discard a card").discard()
+                afterDamage{
+                  my.hand.select("Discard a card").discard()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1511,7 +1511,7 @@ public enum GreatEncounters implements LogicCardInfo {
             energyCost W, C, C
             attackRequirement {}
             onAttack {
-              damage 30 * self.cards.energyCount(C)
+              damage 30 * self.cards.energyCardCount()
               afterDamage {
                 self.cards.filterByType(ENERGY).moveTo(my.deck)
                 shuffleDeck()

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -615,33 +615,7 @@ public enum GreatEncounters implements LogicCardInfo {
           }
         };
       case DIALGA_16:
-        return basic (this, hp:HP090, type:METAL, retreatCost:2) {
-          weakness R, PLUS20
-          resistance P, MINUS20
-          move "Time Bellow", {
-            text "10 damage. Draw a Card."
-            energyCost M
-            onAttack {
-              damage 10
-              afterDamage {
-                draw 1
-              }
-            }
-          }
-          move "Flash Cannon", {
-            text "40 damage. You may return all Energy cards attached to Dialga to your hand. If you do, remove the highest Stage Evolution card from the Defending Pokémon and shuffle that card into your opponent's deck."
-            energyCost M, M, C
-            onAttack {
-              damage 40
-              afterDamage {
-                if (defending.evolution && !defending.slatedToKO && confirm("Return all Energy cards attached to $self to your hand?")) {
-                  devolve(defending, defending.topPokemonCard, opp.deck)
-                  shuffleDeck null, TargetPlayer.OPPONENT
-                }
-              }
-            }
-          }
-        };
+        return copy(DiamondPearl.DIALGA_1, this);
       case EXPLOUD_17:
         return evolution (this, from:"Loudred", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS30
@@ -958,42 +932,7 @@ public enum GreatEncounters implements LogicCardInfo {
           }
         };
       case PALKIA_26:
-        return basic (this, hp:HP090, type:WATER, retreatCost:2) {
-          weakness L, PLUS20
-          move "Spacial Rend", {
-            text "10 damage. Search your deck for a Stadium card, show it to your opponent, and put it into your hand. Shuffle your deck afterward. If there is any Stadium card in play, discard it."
-            energyCost W
-            onAttack {
-              damage 10
-              afterDamage {
-                if (my.deck) {
-                  my.deck.search(cardTypeFilter(STADIUM)).showToOpponent("Selected cards").moveTo(hand)
-                  shuffleDeck()
-                }
-                if (bg.stadiumInfoStruct) {
-                  discard bg.stadiumInfoStruct.stadiumCard
-                }
-              }
-            }
-          }
-          move "Transback", {
-            text "40 damage. You may flip a coin. If heads, discard all energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck aftward."
-            energyCost W, W, C
-            onAttack {
-              damage 40
-              afterDamage {
-                if (!defending.slatedToKO && confirm("Flip for $thisMove?")) {
-                  flip {
-                    discardAllSelfEnergy()
-                    defending.cards.moveTo(opp.deck)
-                    removePCS(defending)
-                    shuffleDeck null, TargetPlayer.OPPONENT
-                  }
-                }
-              }
-            }
-          }
-        };
+        return copy(DiamondPearl.PALKIA_11, this);
       case PRIMEAPE_27:
         return evolution (this, from:"Mankey", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1478,10 +1478,18 @@ public enum LegendsAwakened implements LogicCardInfo {
           pokePower "Resent", {
             text "Once during your opponent's turn, if Shedinja would be Knocked Out by damage from an attack, you may put 4 damage counters on the Attacking Pokémon and each of your opponent's Pokémon that has the same name as the Attacking Pokémon."
             delayedA {
+              def attackerName = null
+              before APPLY_ATTACK_DAMAGES, {
+                bg.dm().each {
+                  if (it.to==self && it.dmg.value) {
+                    attackerName = it.from.name
+                  }
+                }
+              }
               before (KNOCKOUT, self) {
                 if ((ef as Knockout).byDamageFromAttack && bg.currentTurn == self.owner.opposite && confirm("Use Resent?", self.owner)) {
                   self.owner.opposite.pbg.all.each {
-                    if (it.name == self.owner.opposite.pbg.active.name) {
+                    if (it.name == attackerName) {
                       directDamage 40, it, Source.POKEPOWER
                     }
                   }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -2358,8 +2358,9 @@ public enum LegendsAwakened implements LogicCardInfo {
             energyCost G
             attackRequirement {}
             onAttack {
-              while(opp.hand.size() >= 6) {
-                opp.hand.select(hidden: true, "Opponent's hand, select 1 to discard").discard()
+              if (opp.hand.size() > 5) {
+                def count = opp.hand.size() - 5
+                opp.hand.select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to discard").discard()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1929,7 +1929,7 @@ public enum LegendsAwakened implements LogicCardInfo {
         return evolution (this, from:"Exeggcute", hp:HP080, type:P, retreatCost:1) {
           weakness P, '+20'
           move "Psychic Strategy", {
-            text "Each player counts the number of cards in his or her opponent's hand. Each player shuffles his or her hand into his or her deck. Then, each player draws a number of cards equal to the number of cards his or her opponent had."
+            text "Each player counts the number of cards in his or her opponent’s hand. Each player shuffles his or her hand into his or her deck. Then, each player draws a number of cards up to the number of cards his or her opponent had. (You draw your cards first.)"
             attackRequirement {}
             onAttack {
               def toDraw = opp.hand.size()
@@ -1939,13 +1939,13 @@ public enum LegendsAwakened implements LogicCardInfo {
                 my.hand.moveTo(hidden:true, my.deck)
                 shuffleDeck()
               }
-              draw toDraw
-
               if (opp.hand) {
                 opp.hand.moveTo(hidden:true, my.deck)
                 shuffleDeck(null, TargetPlayer.OPPONENT)
               }
-              draw oppToDraw, TargetPlayer.OPPONENT
+
+              if (toDraw) draw( choose(1..toDraw,"How many cards would you like to draw?") as int )
+              if (oppToDraw) draw( oppChoose(1..oppToDraw, "How many cards would you like to draw?") as int, TargetPlayer.OPPONENT )
             }
           }
           move "Super Eggsplosion", {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -171,7 +171,7 @@ public enum LegendsAwakened implements LogicCardInfo {
   ENERGY_PICKUP_132 ("Energy Pickup", "132", Rarity.UNCOMMON, [TRAINER, ITEM]),
   POKE_RADAR_133 ("Poké Radar", "133", Rarity.UNCOMMON, [TRAINER, ITEM]),
   SNOWPOINT_TEMPLE_134 ("Snowpoint Temple", "134", Rarity.UNCOMMON, [TRAINER, STADIUM]),
-  STARK_MOUNTAIN_135 ("Stark Mountain", "135", Rarity.UNCOMMON, [TRAINER]),
+  STARK_MOUNTAIN_135 ("Stark Mountain", "135", Rarity.UNCOMMON, [TRAINER, STADIUM]),
   TECHNICAL_MACHINE_TS_1_136 ("Technical Machine TS-1", "136", Rarity.UNCOMMON, [TRAINER, ITEM, TECHNICAL_MACHINE]),
   TECHNICAL_MACHINE_TS_2_137 ("Technical Machine TS-2", "137", Rarity.UNCOMMON, [TRAINER, ITEM, TECHNICAL_MACHINE]),
   CLAW_FOSSIL_138 ("Claw Fossil", "138", Rarity.COMMON, [TRAINER]),

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1227,10 +1227,10 @@ public enum LegendsAwakened implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 60
-              discardSelfEnergy(W, W)
               opp.bench.each {
-                damage 20
+                damage 20, it
               }
+              discardSelfEnergyAfterDamage W, W
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -3042,7 +3042,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           move "Call for Family", {
             text "Search your deck for up to 2 in any combination of Grass Basic Pokémon and Psychic Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
             energyCost C
-            callForFamily([basic:true, type:[G, P]], 2, delegate)
+            callForFamily([basic:true, types:[G, P]], 2, delegate)
           }
           move "Hypnosis", {
             text "10 damage. The Defending Pokémon is now Asleep."

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1367,13 +1367,16 @@ public enum LegendsAwakened implements LogicCardInfo {
             actionA {
               checkNoSPC()
               checkLastTurn()
-              assert opp.bench : "Opponent has no Benched Pokémon"
-              assert !opp.active.evolution : "Opponent's Active Pokemon is Evolved"
+              // No assert for bench or not being evolved
+              // Q. Can you discard 2 cards from your hand with Regice's "Regi Move" Poke-POWER even if the opponent's Defending Pokemon is not a Basic [read: unevolved] Pokemon? Or what if they have no Benched Pokemon?
+              //A. Yes, but then you cannot switch the opponent's Defending Pokemon. (Sep 4, 2008 PUI Rules Team; Jan 22, 2009 PUI Rules Team)
               assert my.hand.size() >= 2 : "Hand is less than 2 cards"
               powerUsed()
 
               my.hand.select(count: 2, "Select 2 cards to discard").discard()
-              sw opp.active, opp.bench.oppSelect("New active")
+              if (!opp.active.evolution && opp.bench) {
+                sw opp.active, opp.bench.oppSelect("New active")
+              }
             }
           }
           move "Ice Reflect", {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1384,9 +1384,13 @@ public enum MajesticDawn implements LogicCardInfo {
             text "Any damage done by attacks from your Pokémon to the Defending Pokémon isn’t affected by Resistance."
             delayedA {
               before APPLY_RESISTANCE, {
-                bg.dm().each {
-                  if (it.from.owner == self.owner && it.to.owner == self.owner.opposite && it.to.active) {
-                    prevent()
+                if (ef.attacker.owner == self.owner) {
+                  bg.dm().each {
+                    if (it.to.owner == self.owner.opposite && it.to.active) {
+                      // TODO: For below line, add Additional if? " && it.from.types.any{ty -> it.to.resistances.contains(ty)}"
+                      // bc "$thisAbility ignores resistance" // This shouldn't always print.
+                      prevent()
+                    }
                   }
                 }
               }
@@ -1396,18 +1400,21 @@ public enum MajesticDawn implements LogicCardInfo {
             text "30× damage. Does 30 damage times the number of different types of Wormadam on your Bench."
             energyCost G
             attackRequirement {
-              assert my.bench.find{it.name.contains("Wormadam")} : "You have no Wormadam on your Bench"
+              assertMyBench(info: "with Wormadam in their name", {it.name.contains("Wormadam")})
             }
             onAttack {
-              def worms = []
-              def count = 0
+              def wormTypes = []
               my.bench.each {
-                if(it.name.contains("Wormadam") && !worms.contains(it.name)) {
-                  worms.add(it.name)
-                  count ++
+                if(it.name.contains("Wormadam")) {
+                  for (Type ty : it.getTypes()) {
+                    if (!wormTypes.contains(ty)) {
+                      wormTypes.add(ty)
+                      break
+                    }
+                  }
                 }
               }
-              damage 30 * count
+              damage 30 * wormTypes.size()
             }
           }
           move "Quick Touch", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3245,7 +3245,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               revealCard.clear()
               revealCard.add(curCard)
               revealCard.moveTo(my.hand)
-              shuffleDeck()
+              if (ind > 1) shuffleDeck()
           }
           playRequirement{
             assert my.deck

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -962,13 +962,15 @@ public enum MysteriousTreasures implements LogicCardInfo {
         return evolution (this, from:"Exeggcute", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
           move "String Bomb", {
-            text "30× damage. Flip a coin for each basic Energy card attached to Exeggutor and to the Defending Pokémon. This attack does 30 damage times the number of heads."
+            text "30× damage. Flip a coin for each Energy from basic Energy cards attached to Exeggutor and to the Defending Pokémon. This attack does 30 damage times the number of heads."
+            // Used to say "Flip a coin for each basic Energy card attached to Exeggutor and to the Defending Pokémon."
+            // * Exeggutor's "String Bomb" attack should say, "Flip a coin for each Energy from basic Energy cards attached to Exeggutor and to the Defending Pokémon." (Feb 28, 2008 Pokemon Organized Play News)
             energyCost C
             attackRequirement {
               assert ( [self, defending].any{it.cards.filterByType(BASIC_ENERGY)} ) : "Neither $self nor the Defending Pokémon have any basic Energy cards attached"
             }
             onAttack {
-              def basicEnergies = self.cards.filterByType(BASIC_ENERGY).size() + defending.cards.filterByType(BASIC_ENERGY).size()
+              def basicEnergies = self.cards.filterByType(BASIC_ENERGY).energyCount() + defending.cards.filterByType(BASIC_ENERGY).energyCount()
               flip basicEnergies, { damage 30 }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1107,13 +1107,14 @@ public enum MysteriousTreasures implements LogicCardInfo {
           weakness F, PLUS20
           resistance M, MINUS20
           move "Lightning Twister", {
-            text "20× damage. Does 20 damage times the number of basic Energy cards attached to Manectric."
+            text "20× damage. Does 20 damage times the amount of Energy from basic Energy cards attached to Manectric."
+            // Erratad. Original Text: "Does 20 damage times the number of basic Energy cards attached to Manectric."
             energyCost C
             attackRequirement {
               assert self.cards.filterByType(BASIC_ENERGY) : "$self has no basic Energy cards attached."
             }
             onAttack {
-              damage 20 * self.cards.filterByType(BASIC_ENERGY).size()
+              damage 20 * self.cards.filterByType(BASIC_ENERGY).energyCount()
             }
           }
           move "Chain Lightning", {

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1982,7 +1982,7 @@ public enum Platinum implements LogicCardInfo {
           weakness W, PLUS20
           move "Fire Tail Slap", {
             text "40 damage. Flip a coin. If tails, discard a [R] Energy attached to Monferno."
-            energyCost R, R
+            energyCost R
             onAttack {
               damage 40
               flip 1, {}, { discardSelfEnergyAfterDamage R }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -1762,7 +1762,7 @@ public enum Platinum implements LogicCardInfo {
           }
         };
       case FLAAFFY_48:
-        return evolution (this, from:"Flaaffy", hp:HP080, type:LIGHTNING, retreatCost:1) {
+        return evolution (this, from:"Mareep", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
           resistance M, MINUS20
           move "Spark", {

--- a/src/tcgwars/logic/impl/gen4/PopSeries6.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries6.groovy
@@ -111,7 +111,7 @@ public enum PopSeries6 implements LogicCardInfo {
             // Oran Berry: Remove 1 damage counter from Gible at the end of your turn.
             delayedA {
               before BETWEEN_TURNS,{
-                if (self.numberOfDamageCounters >= 1) {
+                if (bg.currentTurn == self.owner && self.numberOfDamageCounters >= 1) {
                   bc "Oran Berry activates"
                   heal 10, self
                 }
@@ -137,7 +137,7 @@ public enum PopSeries6 implements LogicCardInfo {
             // Oran Berry: Remove 1 damage counter from Gible at the end of your turn.
             delayedA {
               before BETWEEN_TURNS,{
-                if (self.numberOfDamageCounters >= 1) {
+                if (bg.currentTurn == self.owner && self.numberOfDamageCounters >= 1) {
                   bc "Oran Berry activates"
                   heal 10, self
                 }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -228,7 +228,7 @@ public enum SecretWonders implements LogicCardInfo {
   public Card getImplementation() {
     switch (this) {
       case AMPHAROS_1:
-        return evolution (this, from:"Flaffy", hp:HP130, type:LIGHTNING, retreatCost:3) {
+        return evolution (this, from:"Flaaffy", hp:HP130, type:LIGHTNING, retreatCost:3) {
           weakness F, PLUS30
           resistance M, MINUS20
           pokeBody "Jamming", {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -3106,8 +3106,8 @@ f
             }
             onAttack {
               def top = my.deck.subList(0,2)
-              def choice = top.select("Choose a card to put into your hand").moveTo(my.hand)
-              top.getExcludedList(choice).moveTo(my.deck)
+              def choice = top.select("Choose a card to put into your hand").moveTo(hidden: true, my.hand)
+              top.getExcludedList(choice).moveTo(hidden: true, my.deck)
             }
           }
           move "Scratch", {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -915,10 +915,15 @@ public enum SecretWonders implements LogicCardInfo {
           weakness D, PLUS20
           resistance C, MINUS20
           move "Ghost Head", {
-            text "Put as many damage counters as you like on Banette. (You can’t put more than Banette’s remaining HP.) Put that many damage counters on the Defending Pokémon."
+            text "Put as many damage counters as you like on Banette. (You can't Knock Out Banette.) Put that many damage counters on the Defending Pokémon."
+            //Old text: "Put as many damage counters as you like on Banette. (You can’t put more than Banette’s remaining HP.) Put that many damage counters on the Defending Pokémon."
+            //Errata: Ghost Head can't cause Banette to Knock Out itself ... the attack has to leave Banette with at least 10 HP. "Put as many damage counters as you like on Banette. (You can't Knock Out Banette.) Put that many damage counters on the Defending Pokémon." (Jan 29, 2008 Pokemon Organized Play News)
             energyCost ()
+            attackRequirement {
+              assert self.remainingHP.value + 10 == self.fullHP  : "You can't place any more damage counters in $self"
+            }
             onAttack {
-              def count = choose(1..self.remainingHP.value / 10, "Put as many damage counters as you like on Banette")
+              def count = choose(1..((self.remainingHP.value / 10) - 1), "Put as many damage counters as you like on Banette")
               directDamage 10 * count, self
               directDamage 10 * count, defending
             }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -2983,7 +2983,7 @@ f
             text "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20."
             energyCost C
             onAttack {
-              reduceDamageFromDefendingNextTurn(hp(50), thisMove, defending)
+              reduceDamageFromDefendingNextTurn(hp(20), thisMove, defending)
             }
           }
           move "Peck", {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1559,7 +1559,8 @@ f
           weakness R, PLUS20
           resistance L, MINUS20
           pokeBody "Sandy Cloak", {
-            text "Prevent all effects of attacks, excluding damage, done to Wormadam Sandy Cloak."
+            text "Prevent all effects of attacks, excluding damage, done to Wormadam Sandy Cloak by your opponent's Pokemon."
+            //Errata'd. Original text: "Prevent all effects of attacks, excluding damage, done to Wormadam Sandy Cloak."
             delayedA {
               before null, self, Source.ATTACK, {
                 if(bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages)){

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -1404,7 +1404,7 @@ f
             text "60+ damage. If the Defending Pokémon has 2 or more damage counters on it, this attack does 60 damage plus 20 more damage. This attack damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects of that Pokémon."
             energyCost W, C, C
             onAttack {
-              swiftDamage (60 + (defending.numberOfDamageCounters > 2 ? 20 : 0), defending)
+              swiftDamage (60 + (defending.numberOfDamageCounters >= 2 ? 20 : 0), defending)
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -359,7 +359,9 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
           move "Blaze Roar", {
-            text "60 damage. Does 20 damage to 1 of your opponent's Benched Pokémon. Filp a coin. If tails, discard 2 [R] Energy attached to Entei."
+            text "60 damage. Does 20 damage to 1 of your opponent's Benched Pokémon. Filp a coin. If tails, discard 2 [R] Energy cards attached to Entei."
+            //Original Text: "Filp a coin. If tails, discard 2 [R] Energy attached to Entei."
+            //Errata: Entei's "Blaze Roar" attack should say "discard 2 Fire Energy CARDS" rather than just "discard 2 Fire Energy". (Nov 16, 2007 Pokemon Organized Play News)
             energyCost R, R, R
             onAttack {
               damage 60

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -632,7 +632,7 @@ public enum RebelClash implements LogicCardInfo {
         move "Forest Feast", {
           text "Search your deck for up to 2 Basic [G] Pokémon and put them onto your Bench. Then, shuffle your deck."
           energyCost G
-          callForFamily([basic:true, type:G], 2, delegate)
+          callForFamily([basic:true, types:G], 2, delegate)
         }
         move "Wood Hammer", {
           text "220 damage. This Pokémon also does 30 damage to itself."

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -3110,10 +3110,11 @@ public enum SwordShield implements LogicCardInfo {
           }
           onAttack {
             def tar = opp.bench.select("Choose a Benched Pokémon to shuffle back into the deck.")
-            tar.cards.moveTo(opp.deck)
-            removePCS(tar)
-            shuffleDeck(null, TargetPlayer.OPPONENT)
-
+            targeted (tar) {
+              tar.cards.moveTo(opp.deck)
+              removePCS(tar)
+              shuffleDeck(null, TargetPlayer.OPPONENT)
+            }
             self.cards.moveTo(my.deck)
             shuffleDeck()
             removePCS(self)


### PR DESCRIPTION
- Mothim (Majestic Dawn) should now properly calculate its attack damage based on each type of Wormadam its owner has in play. Crystal Shard interaction should also work correctly now.
- Quick Ball (Mysterious Treasures, Majestic Dawn) should no longer shuffle the deck if the first card revealed is a Pokémon card (since there's no "other revealed cards" in that instance).
- Flaaffy (Platinum) should now be able to properly evolve from a Mareep.
- Monferno (Platinum) should now have the correct attack cost for "Fire Tail Slap" ([R] instead of [R][R])
- Dialga and Palkia (both Great Encounters) should now work as copies of their original DP-Base Set prints. This should work some issues with the GE prints.
- Palkia (DP-Base Set, reprint in Great Encounters) should now use a targeted effect on transback. Should become blockable by cards like Wormadam Sandy Cloak.
- Unown H (Great Encounters) should now only be able to use "HEAL" when the owner's Active Pokémon has at least one Special Condition applied. And Hidden Power now discards the hand card after dealing damage.
- Pelipper (Great Encounters) now counts energy Cards, instead of the pure energy count.
- Exeggutor (Legends Awakened) now offers "up to" draw when using "Psychic Strategy".
- Stark Mountain (Legends Awakened) should now work as a stadium properly (was missing a CardType).
- Exeggcute (Legends Awakened) should now properly search with Call for Family. This was achieved by updating the used static.
- Ampharos (Secret Wonders) now properly evolves from Flaaffy (there was a typo in the pre-evolution name field)
- Sharpedo (Secret Wonders) now properly checks for damage counters being 2 or more, not more than 2 when using "Strike Wound".
- Gible and Pikachu (POP Series 6)'s Oran Berry should now only heal at the end of their owner's turn, not the opponent's.
- Added errata for Entei (Secret Wonders)
- Applied an errata to Manectric (Mysterious Treasures), should count total Energy given by basic Energy cards, not the number of cards itself.
- Similar energy-related errata for Tangrowth (Great Encounters).
- Wormadam Sandy Cloak (Secret Wonders) has its text updated with an errata. Effect should already be working properly prior to this.
- Pidgey (Secret Wonders) should only reduce damage by 20, not 50, when using Growl.
- Sentret (Secret Wonders) should no longer print the moved cards when using Grope.

---

Changes not related to the format specifically:

- Noctowl (Sword & Shield - Base Set) should now do a targeted effect when attacking with Carry Off. Based on japanese FAQs, if the opponent's scoop is blocked, Noctowl still gets shuffled.
- Rillaboom V (Rebel Clash) was updated to accomodate for the `callForFamily` static change made for Exeggcute (Legends Awakened).