### PR TITLE
Some more 2008 format related fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1206,19 +1206,10 @@ public enum LegendsAwakened implements LogicCardInfo {
           move "Drizzle", {
             text "Choose up to 2 basic [W] Energy cards from your hand and attach them to 1 of your Pokémon."
             attackRequirement {
-              assert my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W) : "No [W] Energy cards in your hand"
+              assert my.hand.filterByBasicEnergyType(W) : "No Basic [W] Energy cards in your hand"
             }
             onAttack {
-              def energies = my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W).select(max: 2, "Select 2 basic [F] Energy cards to attach to 1 of your Pokémon")
-              my.hand.removeAll(energies)
-              energies.each {
-                if (my.bench) {
-                  attachEnergy(my.bench.select("Attach to which?"), it)
-                } else {
-                  attachEnergy(self, it)
-                }
-              }
-              heal energies.size() * 10, self
+              attachEnergyFrom(max:2, basic: true, type:W, my.hand, my.all)
             }
           }
           move "High Tide", {

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -2369,9 +2369,12 @@ public enum LegendsAwakened implements LogicCardInfo {
             energyCost G
             attackRequirement {}
             onAttack {
-              if (opp.hand.size() > 5) {
-                def count = opp.hand.size() - 5
-                opp.hand.select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to discard").discard()
+              damage 30
+              afterDamage {
+                if (opp.hand.size() > 5) {
+                  def count = opp.hand.size() - 5
+                  opp.hand.select(hidden: true, count: count, "Choose ${count==1?'a':count} random ${count==1?'card':'cards'} from your opponent's hand to discard").discard()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -922,7 +922,7 @@ public enum SecretWonders implements LogicCardInfo {
             //Errata: Ghost Head can't cause Banette to Knock Out itself ... the attack has to leave Banette with at least 10 HP. "Put as many damage counters as you like on Banette. (You can't Knock Out Banette.) Put that many damage counters on the Defending Pokémon." (Jan 29, 2008 Pokemon Organized Play News)
             energyCost ()
             attackRequirement {
-              assert self.remainingHP.value + 10 == self.fullHP  : "You can't place any more damage counters in $self"
+              assert self.remainingHP.value == 10  : "You can't place any more damage counters in $self"
             }
             onAttack {
               def count = choose(1..((self.remainingHP.value / 10) - 1), "Put as many damage counters as you like on Banette")


### PR DESCRIPTION
* Ninjask (Legends Awakened) should now do 30 damage when using "Chip Off".
* Banette (Secret Wonders) should now only prevent attacking with Ghost Head when at 10HP (which is when no damage counters would be placeable at all)
* Kyogre (Legends Awakened) now uses the `attachEnergyFrom` static (taken from the implementation for Cosmic Eclipse's Groudon), and no longer heals based on the energy attached via this attack.