### PR TITLE
Attempt to fix Holon GL

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -2757,7 +2757,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           }
           eff = delayed {
             before APPLY_SPECIAL_CONDITION, self, {
-              if (!self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
+              if (self != null && !self.EX && self.cards.filterByType(BASIC_ENERGY).filterByEnergyType(G)) {
                 targeted self, SRC_SPENERGY, {
                   bc "Holon Energy GL prevents special conditions"
                   prevent()


### PR DESCRIPTION
When Holon GL gets moved from the active to the bench, it shouldn't still prevent the active from receiving special conditions.