### PR TITLE
Merge some card fixes from the pre-rpc branch

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -1810,7 +1810,7 @@ public enum CrystalGuardians implements LogicCardInfo {
         def eff, eff2
         def flag = false
         onPlay { reason ->
-          eff = getter (GET_MOVE_LIST) { holder->
+          eff = getter (GET_MOVE_LIST, self) { holder->
             if(holder.effect.target.active && holder.effect.target.evolution) {
               for(card in holder.effect.target.cards.filterByType(STAGE1, BASIC)) {
                 if(card!=holder.effect.target.topPokemonCard){

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -423,11 +423,10 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           def eff
           pokeBody "Family Bonds", {
             text "As long as Nidoqueen is in play, the Retreat Cost for Nidoran♀, Nidorina, Nidoran♂, Nidorino and Nidoking is 0."
-            delayedA {
-              eff = getter (GET_RETREAT_COST, BEFORE_LAST) {
-                if (it.effect.target.name == "Nidoran♂" || it.effect.target.name == "Nidoran♀" || it.effect.target.name == "Nidorino" || it.effect.target.name == "Nidorina" || it.effect.target.name == "Nidoking") {
-                  it.object = 0
-                }
+            getterA (GET_RETREAT_COST, BEFORE_LAST) { holder ->
+              def pcs = holder.effect.target
+              if (["Nidoran♂", "Nidoran♀", "Nidorino", "Nidorina", "Nidoking"].contains(pcs.name)) {
+                holder.object = 0
               }
             }
           }
@@ -1856,20 +1855,26 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
             onAttack {
               def revealCard = new CardList();
+              def foundBasic = false
               def ind = 0
               def curCard
               while(ind < my.deck.size()){
                 curCard = my.deck.get(ind)
                 ind+=1
                 revealCard.add(curCard)
-                if(curCard.cardTypes.is(BASIC))
+                if(curCard.cardTypes.is(BASIC)) {
+                  foundBasic = true
                   break
+                }
               }
+              bc "${self.owner.getPlayerUsername(bg)} revealed $ind cards from the top of the deck " + (foundBasic ? "and found $curCard" : "without finding any Basic Pokémon")
               revealCard.showToMe("Drawn cards")
-              revealCard.showToOpponent("revealed cards")
+              revealCard.showToOpponent("Revealed cards")
               revealCard.clear()
-              revealCard.add(curCard)
-              revealCard.moveTo(my.hand)
+              if (foundBasic) {
+                revealCard.add(curCard)
+                revealCard.moveTo(my.hand)
+              }
               shuffleDeck()
             }
           }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -227,6 +227,7 @@ public enum LegendMaker implements LogicCardInfo {
                   prevent()
                 }
               }
+              unregisterAfter 2
             }
             afterDamage{
               preventAllEffectsFromCustomPokemonNextTurn(thisMove, self, {it.EX})


### PR DESCRIPTION
This should've been commited through a PR to master, then merged individually into pre-rpc. My bad on that, shouldn't happen in the future.

Summary of the merged fixes:

* Fix "Family Bonds" Poké-Body in Nidoqueen (FRLG 9)
  - Use getterA instead of delayedA, so it stops when the PCS leaves play.

* Fix Nidoran Female (FRLG 70)

* Fix Memory Berry (CG 80)
  - Only check moves for self

* Fix "Speed Stroke" in Aerodactyl (LM 1)
  - Should no longer prevent effects from ex Pokémon