### PR TITLE
Start of massive refactor to set targets and source properly

### DIFF
--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1,4 +1,6 @@
-package tcgwars.logic.impl.gen7;
+package tcgwars.logic.impl.gen7
+
+import tcgwars.logic.groovy.TcgStatics;
 
 import static tcgwars.logic.card.HP.*;
 import static tcgwars.logic.card.Type.*;
@@ -4415,11 +4417,17 @@ public enum UnbrokenBonds implements LogicCardInfo {
           text "Prevent all effects of your opponent's Abilities done to the Pokémon this card is attached to. Remove any such existing effects."
           def eff
           onPlay {reason->
-            // TODO implement properly after source refactoring and/or RichSource captivation
-            eff = delayed {
+            eff = delayed target:self, source:TRAINER_CARD, {
               before null, self, SRC_ABILITY, {
-                bc "Stealthy Hood prevents effect"
-                prevent()
+                def abilityEffect = bg.em().getNearestEffectType(USE_ABILITY)
+                def abilityUser = abilityEffect.getResolvedTarget(bg, e)
+                if (abilityUser == null) {
+                  abilityUser = abilityEffect.thisPokemon
+                }
+                if (abilityUser.owner == self.owner.opposite) {
+                  bc "Stealthy Hood prevents effect"
+                  prevent()
+                }
               }
             }
             new CheckAbilities().run(bg)


### PR DESCRIPTION
TcgStatics changes show the  changes that should be made to `delayed` effects to set targets and sources properly. I haven't really thought much about setting EffectTypes yet, but will probably work well in addition to the new event management.

The Unbroken Bonds STEALTHY_HOOD change shows how the new event management in the sister PR in the engine can be used to ensure we only block effects from abilities used by the opponent's Pokémon. Currently both `resolvedTarget` and `thisPokemon` are checked (all Groovy delayed checks extend AbstractDelayed**Move**Effect so currently thisPokemon will work on more abilities this way for now, but once all abilities set their target