### PR TITLE
Multiple Card Fixes (TR, Neo Genesis, Aquapolis, CG, DS, MD, UNM, DAA, RCL)

### DIFF
--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -620,10 +620,14 @@ public enum TeamRocketNG implements LogicCardInfo {
           text "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
           onPlay {
             def list = opp.hand.shuffledCopy()
-            list = list.select(count: list.hasTrainer() ? 1 : 0, "Opponent's hand. If there is a Trainer card, choose 1 of them to have your opponent shuffle that card into their deck", cardTypeFilter(TRAINER))
-            if(list) {
-              list.showToOpponent("Opponent played Rocket's Sneak Attack and this card from your hand will be shuffled into your deck").moveTo(opp.deck)
-              shuffleOppDeck()
+            if (list.filterByType(TRAINER).empty) {
+              list.showToMe("Your opponent's hand. No trainers found in it.")
+            } else {
+              list = list.select(count: 1, "Opponent's hand. If there is a Trainer card, choose 1 of them to have your opponent shuffle that card into their deck", cardTypeFilter(TRAINER))
+              if(list) {
+                list.showToOpponent("Opponent played Rocket's Sneak Attack and this card from your hand will be shuffled into your deck").moveTo(opp.deck)
+                shuffleOppDeck()
+              }
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -454,7 +454,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           }
           onAttack {
             def trainer = my.deck.search("Select an Trainer card",cardTypeFilter(TRAINER)).showToOpponent("Mining - This is the Trainer card your opponent picked.").moveTo(my.hand)
-            if (trainer && confirm("Do you wish to attach $trainer too?")) {
+            if (trainer && trainer.hasType(POKEMON_TOOL) && confirm("Do you wish to attach $trainer too?")) {
               bg.em().run(new PlayCard(trainer.first()))
             }
             shuffleDeck()

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1677,7 +1677,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             assert my.deck : "Deck is empty"
           }
           onAttack {
-            my.deck.search("Search your dekc for a [M] Pokémon (excluding Pokémon-ex)", {it.asPokemonCard().types.contains(M) && !it.asPokemonCard().cardTypes.is(EX)}).showToOpponent("Cry for Help: Selected Cards").moveTo(my.hand)
+            my.deck.search("Search your deck for a [M] Pokémon (excluding Pokémon-ex)", {Card card -> card.asPokemonCard().types.contains(M) && !card.asPokemonCard().cardTypes.is(EX)}).showToOpponent("Cry for Help: Selected Cards").moveTo(my.hand)
             shuffleDeck()
           }
         }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1161,7 +1161,7 @@ public enum MajesticDawn implements LogicCardInfo {
 
         };
       case VAPOREON_34:
-        return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:2) {
+        return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:1) {
           weakness L, PLUS20
           move "Cleanse Away", {
             text "30 damage. Remove 2 damage counters from each of your Benched Pokémon."

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -561,7 +561,6 @@ public enum MajesticDawn implements LogicCardInfo {
               if(sel) {
                 def pcs = my.all.findAll{it.name == sel.predecessor}.select("Put $sel onto...")
                 evolve(pcs, sel)
-                directDamage 10, self
               }
               shuffleDeck()
             }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -4086,14 +4086,13 @@ public enum UnbrokenBonds implements LogicCardInfo {
               boolean flag = false
               int extraPoisonCount = 0
               before SWITCH, null, TRAINER_CARD, {
-                PokemonCardSet fb = (ef as Switch).fallenBack
-                flag = ( fb & fb.isSPC(POISONED) )
+                flag = ef.fallenBack?.isSPC(POISONED)
                 if(flag) {
-                  extraPoisonCount = bg.em().retrieveObject("extra_poison_counter_"+fb.hashCode()) ?: 0
+                  extraPoisonCount = bg.em().retrieveObject("extra_poison_counter_"+ef.fallenBack.hashCode()) ?: 0
                 }
               }
               after SWITCH, null, TRAINER_CARD, {
-                if(flag) {apply(POISONED, (ef as Switch).switchedOut, TRAINER_CARD)}
+                if(flag) {apply(POISONED, ef.switchedOut, TRAINER_CARD)}
                 if(extraPoisonCount) extraPoison(extraPoisonCount)
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -4086,13 +4086,14 @@ public enum UnbrokenBonds implements LogicCardInfo {
               boolean flag = false
               int extraPoisonCount = 0
               before SWITCH, null, TRAINER_CARD, {
-                flag = ef.fallenBack?.isSPC(POISONED)
+                PokemonCardSet fb = (ef as Switch).fallenBack
+                flag = ( fb & fb.isSPC(POISONED) )
                 if(flag) {
-                  extraPoisonCount = bg.em().retrieveObject("extra_poison_counter_"+ef.fallenBack.hashCode()) ?: 0
+                  extraPoisonCount = bg.em().retrieveObject("extra_poison_counter_"+fb.hashCode()) ?: 0
                 }
               }
               after SWITCH, null, TRAINER_CARD, {
-                if(flag) {apply(POISONED, ef.switchedOut, TRAINER_CARD)}
+                if(flag) {apply(POISONED, (ef as Switch).switchedOut, TRAINER_CARD)}
                 if(extraPoisonCount) extraPoison(extraPoisonCount)
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1884,6 +1884,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           bwAbility "Ominous Posture", {
             text "Once during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon to another of your Pokémon."
             actionA {
+              assertMyBench()
               assert all.find({ it.numberOfDamageCounters > 0 }) : "None of your Pokémon have damage counters."
               checkLastTurn()
               powerUsed()

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3195,7 +3195,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           text "If this Pokémon is Knocked Out by damage from an attack from your opponent’s Pokémon, discard the top 2 cards of your opponent’s deck."
           delayedA (priority: LAST) {
             before (KNOCKOUT, self) {
-              if ((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && opp.deck) {
+              if ((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite && self.owner.opposite.pbg.deck) {
                 bc "One Last Dig - 2 cards will be discarded from the top of the opponent's deck"
                 self.owner.opposite.pbg.deck.subList(0,2).discard()
               }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -3539,8 +3539,8 @@ public enum RebelClash implements LogicCardInfo {
           draw num*2
         }
         playRequirement {
-          def hand = my.hand.getExcludedList(thisCard).size() >= 1
-          assert (hand || my.deck) : "Not enough cards in your hand or your deck is empty."
+          assert my.hand.getExcludedList(thisCard) : "Not enough cards in your hand"
+          assert my.deck : "Your deck is empty"
         }
       };
       case NUGGET_162:


### PR DESCRIPTION
From the contrib repo sets:

* Fixed Rocket's Sneak Attack (Team Rocket 72): Should no longer crash if no trainers are found. Will just show the opponent's hand and finish.
* Fixed Jynx (Unified Minds 76): Ominous Posture should not be useable when there's no bench (so no two pokemon to move counters from and into).
* Fixed Retreat cost of Vaporeon (Majestic Dawn 34): Reduced from 2 to 1, as it's meant to be.
* Fixed Phione (Majestic Dawn 12): Should not take damage from using its first attack.
* Fixed Mawile (Crystal Guardians 9): Should now check for the selected trainer being a tool before offering to attach it.
* Fix attempt for Skarmory (Delta Species 55): "Cry For Help" should now properly filter in the selection popup. Also fixed a typo.
* Fixed Milo (Rebel Clash 161): The discard is a cost, not an effect. Thus, you need to have both cards in your deck and at least one card in hand to discard for Milo.
* Fixed Dunsparce (Darkness Ablaze 137): Should now properly check for the opponent's deck.

and from https://github.com/axpendix/tcgone/pull/212:

* Fix Professor Elm (Neo Genesis 96)
  - Should now hide the cards being shuffled into the deck.
* Add new validation to Umbreon (Aquapolis 41)
  - Should now prevent use of its pokepower if the opponent has no hand, preventing an exception.