### PR TITLE
Corrections for July 23rd's fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -2313,10 +2313,10 @@ public enum CrystalGuardians implements LogicCardInfo {
                 bc "$self - Time Travel activated"
                 flip 1, {
                   bc "$self is not knocked out and is moved to bottom of deck."
-                  prevent()
                   self.cards.getExcludedList(self.topPokemonCard).discard()
                   moveCard(self.topPokemonCard, my.deck)
                   removePCS(self)
+                  prevent()
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1890,11 +1890,11 @@ public enum UnifiedMinds implements LogicCardInfo {
               powerUsed()
               def source = my.all.findAll { it.numberOfDamageCounters > 0 }.select("Select a source for a damage counter.")
               def target = my.all
-              my.all.remove(source)
+              target.remove(source)
               target = target.select("Select a Pokémon to move the damage counter to.")
               source.damage-=hp(10)
-              target.damage+=hp(10)
               bc "Ominous Posture moved a damage counter from $source to $target."
+              directDamage 10, target
               checkFaint()
             }
           }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1874,8 +1874,8 @@ public enum SwordShield implements LogicCardInfo {
             target.remove(source)
             target = target.select("Target for the damage counter?")
             source.damage-=hp(10)
-            target.damage+=hp(10)
             bc "Swapped a damage counter from $source to $target."
+            directDamage 10, target
             checkFaint()
           }
         }


### PR DESCRIPTION
* Jynx (Unified Minds 76) and Gengar (Sword & Shield 85) should now properly move damage counters (using directDamage instead of modifying the health directly, so it can be partially prevented). Jynx will also now exclude the source Pokémon from the list of potential targets for the counter being moved.
* Celebi Star (Crystal Guardians 100) should now do everything intended prior to preventing the Knockout.