### PR TITLE
End of July batch of fixes (mostly gen 4 related)

### DIFF
--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -2286,7 +2286,7 @@ public enum Arceus implements LogicCardInfo {
                 }
               }
             }
-            effPrize = getter GET_GIVEN_PRIZES, self, {holder->
+            effPrize = getter GET_GIVEN_PRIZES, BEFORE_LAST, self, {holder->
               bc "Expert Belt increases prizes taken by one."
               holder.object += 1
             }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -357,13 +357,13 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               my.all.each {
                 predecessors.add(it.name)
               }
-              def lvX = my.deck.search("Select a Pokémon LV.X that evolves from one of your Pokémon", {
+              LevelUpPokemonCard lvX = my.deck.search("Select a Pokémon LV.X that evolves from one of your Pokémon", {
                 it.cardTypes.is(LVL_X) && it.predecessor in predecessors
-              }).first()
+              }).first() as LevelUpPokemonCard
 
               if (lvX) {
                 def target = my.all.findAll {
-                  it.topPokemonCard.name == (lvX as LevelUpPokemonCard).predecessor
+                  !it.pokemonLevelUp && it.topPokemonCard.name == lvX.predecessor
                 }.select("Which Pokémon to Level Up?")
 
                 bg().em().run(new LevelUp(target, lvX))

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2910,13 +2910,16 @@ public enum GreatEncounters implements LogicCardInfo {
               checkLastTurn()
               checkNoSPC()
               powerUsed()
-              assert my.bench && opp.bench : "Both players must have a Benched Pokémon"
+              assertMyBench()
 
-              targeted (opp.active, Source.POKEPOWER) {
-                sw opp.active, opp.bench.select("Select the new Active Pokémon"), Source.POKEPOWER
+              sw my.active, my.bench.oppSelect("$thisAbility: Select your opponent's new Active Pokémon"), Source.POKEPOWER
+
+              if (opp.bench) {
+                targeted (opp.active, Source.POKEPOWER) {
+                  sw opp.active, opp.bench.select("$thisAbility: Select your opponent's new Active Pokémon"), Source.POKEPOWER
+                }
               }
 
-              sw my.active, my.bench.oppSelect("Select new Active Pokémon"), Source.POKEPOWER
             }
           }
           move "Hydro Reflect", {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2733,6 +2733,7 @@ public enum GreatEncounters implements LogicCardInfo {
           onPlay {
             def choice = 1
             def chosenCard
+            def deckSearched = false
 
             if (my.deck && my.discard.any {it.cardTypes.is(LVL_X) }) {
               choice = choose([1,2], ['Search your deck', 'Search your discard pile'], "Choose where to search for a Pokémon LV.X card to be put it into your hand")
@@ -2741,6 +2742,7 @@ public enum GreatEncounters implements LogicCardInfo {
             if (choice == 1 && my.deck) {
               def validTargets = my.deck.findAll {it.cardTypes.is(LVL_X)}
               chosenCard = my.deck.search(count: 1, "Choose where to search for a Pokémon LV.X card to be put it into your hand", { validTargets.contains(it) })
+              deckSearched = true
             } else /*if (choice == 2 || !my.deck)*/ {
               chosenCard = my.discard.findAll { it.cardTypes.is(LVL_X) }.select()
             }
@@ -2748,7 +2750,8 @@ public enum GreatEncounters implements LogicCardInfo {
             if (chosenCard)
               chosenCard.showToOpponent("$thisCard : Chosen card").moveTo(my.hand)
 
-            shuffleDeck()
+            if (deckSearched)
+              shuffleDeck()
           }
           playRequirement{
             assert my.discard || my.deck : "Your deck or discard needs to be not empty"

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1882,30 +1882,8 @@ public enum LegendsAwakened implements LogicCardInfo {
             text "The Defending Pokémon is now Confused. Put 6 damage counters instead of 3 on the Confused Pokémon."
             attackRequirement {}
             onAttack {
-              // TODO create GET_CONFUSED_DAMAGE static
-
-//              def magicalStepRecipient = opp.active
-//              apply CONFUSED, magicalStepRecipient, SRC_ABILITY
-//              delayed {
-//                def eff
-//                register {
-//                  eff = getter (GET_CONFUSED_DAMAGE) {h->
-//                    if (h.effect.target == magicalStepRecipient && h.effect.target.active && h.object < hp(30)) {
-//                      bc "Magical Step increases confused damage on $magicalStepRecipient to 60."
-//                      h.object = hp(60)
-//                    }
-//                  }
-//                }
-//                unregister {
-//                  eff.unregister()
-//                }
-//
-//                after CLEAR_SPECIAL_CONDITION, magicalStepRecipient, {
-//                  if(ef.types.contains(CONFUSED)){
-//                    unregister()
-//                  }
-//                }
-//              }
+              apply CONFUSED
+              bg.em().storeObject("Confusion Boost"+defending.hashCode(), "Magical Step")
             }
           }
           move "Grind", {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1463,7 +1463,7 @@ public enum MajesticDawn implements LogicCardInfo {
             onAttack {
               damage 50
               if(opp.bench) {
-                multiSelect(opp.all, 2, "Does 10 damage to 2 of your opponent's Benched Pokémon").each {
+                multiSelect(opp.bench, 2, "Does 10 damage to 2 of your opponent's Benched Pokémon").each {
                   damage 10, it
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1866,9 +1866,12 @@ public enum MysteriousTreasures implements LogicCardInfo {
               assert my.discard.filterByType(ENERGY).filterByEnergyType(M) : "There is no [M] Energy card in your discard"
             }
             onAttack {
+              def metalEnergyAmt = self.cards.energyCardCount(M)
               attachEnergyFrom(type : M, my.discard, self)
-              //TODO: Make this conditional on the attach
-              heal 10, self
+              if (metalEnergyAmt < self.cards.energyCardCount(M)) {
+
+                heal 10, self
+              }
             }
           }
           move "Confront", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1188,7 +1188,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               def playerPick = choose([0, 1], ["Heads", "Tails"], "You're putting a coin next to your active Pokémon without showing your opponent. Pick which side they must guess:")
-              def oppPick = choose([0, 1], ["Heads", "Tails"], "Your opponent put a coin next to their active Pokémon without showing you. You must guess if it's Heads or Tails. If you guess incorrectly, ${self} will do 50 damage to the Defending Pokémon. If you guess correctly, ${self} will do 20 damage to itself (ignoring W/R in this case):")
+              def oppPick = oppChoose([0, 1], ["Heads", "Tails"], "Your opponent put a coin next to their active Pokémon without showing you. You must guess if it's Heads or Tails. If you guess incorrectly, ${self} will do 50 damage to the Defending Pokémon. If you guess correctly, ${self} will do 20 damage to itself (ignoring W/R in this case):")
               if (playerPick != oppPick)
                 damage 50
               else

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1870,7 +1870,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               attachEnergyFrom(type : M, my.discard, self)
               if (metalEnergyAmt < self.cards.energyCardCount(M)) {
 
-                heal 10, self
+                heal 20, self
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -591,7 +591,7 @@ public enum Platinum implements LogicCardInfo {
             text "Prevent all damage done to your Benched Pokémon (excluding any Manectric) by attacks."
             delayedA {
               before APPLY_ATTACK_DAMAGES, {
-                bg.dm().each {if(it.to.owner==self.owner && it.from.owner!=self.owner && it.to.benched && !it.to.name == "Manectric" && it.dmg.value && it.notNoEffect){
+                bg.dm().each {if(it.to.owner==self.owner && it.from.owner!=self.owner && it.to.benched && it.to.name != "Manectric" && it.dmg.value && it.notNoEffect){
                   bc "Electric Barrier reduces damage"
                   it.dmg=hp(0)
                 }}
@@ -603,7 +603,7 @@ public enum Platinum implements LogicCardInfo {
             energyCost L
             onAttack {
               all.each {
-                if(it.hasPokePower) {
+                if(it.hasPokePower()) {
                   damage 30, it
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -3185,7 +3185,7 @@ public enum Platinum implements LogicCardInfo {
               def names = my.all.collect{ it.name }
               LevelUpPokemonCard sel_1 = deck.search ("Select a Pokémon that Levels up from $names.", {it.cardTypes.is(LVL_X) && names.contains(it.predecessor)}).first() as LevelUpPokemonCard
               if (sel_1) {
-                def sel_2 = my.all.findAll{ (sel_1.predecessor == it.name) }.select("Select one of your Pokémon named ${sel_1.name}")
+                def sel_2 = my.all.findAll{ !it.pokemonLevelUp && sel_1.predecessor == it.name }.select("Select one of your Pokémon named ${sel_1.name}")
                 bg().em().run(new LevelUp(sel_2, sel_1))
               }
               shuffleDeck()

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -2823,7 +2823,8 @@ public enum RisingRivals implements LogicCardInfo {
       case WEEZING_87:
         return evolution (this, from:"Koffing", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
-          pokeBody "Camoflage Gas", {
+          pokeBody "Camouflage Gas", {
+            text "If Weezing is Confused and is Knocked Out, your opponent can’t take a Prize card."
             getterA GET_GIVEN_PRIZES, self, {holder ->
               if(self.isSPC(CONFUSED)) {
                 bc "$thisAbility prevents taking any prize card from ${self}"

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -3442,7 +3442,7 @@ f
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
             energyCost C
             onAttack {
-              sw opp.active, opp.bench.select()
+              sw2 opp.bench.select("Choose the new Defending Pokémon")
             }
             attackRequirement {
               assert opp.bench

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -3075,9 +3075,9 @@ public enum Stormfront implements LogicCardInfo {
         };
       case MACHAMP_LV_X_98:
         return levelUp (this, from:"Machamp", hp:HP150, type:FIGHTING, retreatCost:3) {
-          weakness P
+          weakness P, PLUS40
           pokeBody "No Guard", {
-            text "As long as Machamp is your Active Pokémon, each of Machamp’s attacks does 60 more damage to the Active Pokémon and any damage done to Machamp by your opponent’s Pokémon is increased by 60 ."
+            text "As long as Machamp is your Active Pokémon, each of Machamp’s attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance) and any damage done to Machamp by your opponent’s Pokémon is increased by 60 (after applying Weakness and Resistance)."
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
                 if(ef.attacker==self) bg.dm().each {
@@ -3103,19 +3103,19 @@ public enum Stormfront implements LogicCardInfo {
             onAttack {
               damage 20
               afterDamage {
-                flip{
-                  delayed {
-                    before KNOCKOUT, self, {
-                      if((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite){
+                delayed {
+                  before KNOCKOUT, self, {
+                    if((ef as Knockout).byDamageFromAttack && bg.currentTurn==self.owner.opposite){
+                      flip {
                         self.damage = self.fullHP - hp(10)
                         bc "$self endured the hit!"
                         prevent()
                       }
                     }
-                    unregisterAfter 2
-                    after CHANGE_STAGE, self, {unregister()}
-                    after FALL_BACK, self, {unregister()}
                   }
+                  unregisterAfter 2
+                  after CHANGE_STAGE, self, {unregister()}
+                  after FALL_BACK, self, {unregister()}
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -279,7 +279,7 @@ public enum Stormfront implements LogicCardInfo {
           pokePower "Emperor Aura", {
             text "Once during your turn , when you play Empoleon from your hand to evolve 1 of your Active Pokémon, you may use this power. Your opponent can’t attach any Energy cards from his or her hand to his or her Pokémon during your opponent’s next turn."
             onActivate {r->
-              if (r==PLAY_FROM_HAND && confirm("Use Emperor Aura?")) {
+              if (r==PLAY_FROM_HAND && self.active && confirm("Use Emperor Aura?")) {
                 powerUsed()
                 delayed {
                   before ATTACH_ENERGY, {

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -2131,7 +2131,7 @@ public enum Stormfront implements LogicCardInfo {
           resistance R, MINUS20
           move "Gyro Swap", {
             text "Put a number of damage counters on the Defending Pokémon equal to the number of [C] Energy in Bronzor's Retreat Cost ."
-            energyCost P, C
+            energyCost P
             attackRequirement {
               assert self.retreatCost > 0 : "$self's retreat cost is 0"
             }

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -2034,7 +2034,7 @@ public enum Stormfront implements LogicCardInfo {
       case SKARMORY_51:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness L, PLUS20
-          resistance M, MINUS20
+          resistance F, MINUS20
           move "Quick Attack", {
             text "10+ damage. Flip a coin. If heads, this attack does 10 damage plus 20 more damage."
             energyCost M

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -3368,7 +3368,7 @@ public enum Stormfront implements LogicCardInfo {
           }
           move "Charge Beam", {
             text "10 damage. Search your discard pile for a [L] Energy card and attach it to Voltorb. ."
-            energyCost L, L
+            energyCost L
             onAttack {
               damage 10
               afterDamage {

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1469,7 +1469,7 @@ public enum SupremeVictors implements LogicCardInfo {
             onAttack {
               damage 40
               flip {
-                damage 40
+                damage 20
                 heal 20, self
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3956,7 +3956,7 @@ public enum SupremeVictors implements LogicCardInfo {
             onAttack {
               damage 80, opp.all.select()
               discardSelfEnergyAfterDamage C, C
-              cantUseAttach thisMove, self
+              cantUseAttack thisMove, self
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -4061,7 +4061,7 @@ public enum SupremeVictors implements LogicCardInfo {
         };
       case ZAPDOS_150:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
-          weakness F
+          resistance F, MINUS30
           move "Lightning Burn", {
             text "30 damage. Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself. "
             energyCost L, L, L

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3897,7 +3897,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 150
               flip 1, {}, {
                 afterDamage {
-                  discardAllSelfEnergy(C)
+                  discardAllSelfEnergy(null)
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -464,8 +464,8 @@ public enum SupremeVictors implements LogicCardInfo {
             }
             onDeactivate {
               eff.unregister()
-              target = []
-              source = []
+              def target = []
+              def source = []
               bg.em().storeObject("Gravitation_target", target)
               bg.em().storeObject("Gravitation_source", source)
             }
@@ -477,7 +477,7 @@ public enum SupremeVictors implements LogicCardInfo {
             onAttack {
               damage 60
               if(bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.player == self.owner) {
-                opp.all.findAll{it.types.containsAny(defending.types)}.each {
+                opp.bench.findAll{it.types.containsAny(defending.types)}.each {
                   damage 20, it
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3757,12 +3757,12 @@ public enum SupremeVictors implements LogicCardInfo {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
             "Flip 2 coins. If either of them is heads, look at your opponent's hand. For each heads, choose 1 card from your opponent's hand and put it on the bottom of your opponent's deck in any order."
           onPlay {
-            def count
+            def count = 0
             flip 2, {
-              count ++
+              count++
             }
             if(count) {
-              rearrange(opp.hand.select(count:count,"Choose $count cards to put on the botto of your opponent's deck")).showToOpponent("Cyrus's Initiative: Selected cards").moveTo(opp.deck)
+              rearrange(opp.hand.select(count:count,"Choose $count cards to put on the botto of your opponent's deck")).showToOpponent("Cyrus's Initiative: Your opponent selected the following cards. They'll be put in the bottom of your deck in the displayed order:").moveTo(opp.deck)
             }
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -528,7 +528,7 @@ public enum SupremeVictors implements LogicCardInfo {
             onAttack {
               damage 30
               afterDamage {
-                heal 10 * defending.card.energyCount(C), self
+                heal 10 * defending.cards.energyCount(C), self
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2053,7 +2053,7 @@ public enum SupremeVictors implements LogicCardInfo {
           }
         };
       case IVYSAUR_62:
-        return evolution (this, from:"Bulbasuar", hp:HP080, type:G, retreatCost:2) {
+        return evolution (this, from:"Bulbasaur", hp:HP080, type:G, retreatCost:2) {
           weakness R, PLUS20
           pokePower "Evolutionary Pollen", {
             text "Once during your turn, when you play Ivysaur from your hand to evolve 1 of your Pokémon, you may use this power. Your opponent's Active Pokémon is now Asleep."

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2309,7 +2309,7 @@ public enum SupremeVictors implements LogicCardInfo {
                 def card = pcs.cards.filterByType(POKEMON_TOOL).select("Pokémon Tool to move").first() as PokemonToolCard
                 def pl = opp.all.findAll { canAttachPokemonTool(it, card) && it!=pcs }
                 if(!pl){wcu "No available Pokemon to move this card"; return}
-                def tar = pl.select("Move $tool to which Pokémon?")
+                def tar = pl.select("Move $card to which Pokémon?")
                 targeted (tar) {
                   attachPokemonTool(card, tar)
                 }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2281,7 +2281,7 @@ public enum SupremeVictors implements LogicCardInfo {
           move "Call for Family", {
             text "Search your deck for up to 2 Lightning Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
             energyCost ()
-            callForFamily([basic:true, type:L], 2, delegate)
+            callForFamily([basic:true, types:L], 2, delegate)
           }
           move "Trash Charge", {
             text "10 damage. Search your discard pile for a [L] Energy card and attach it to 1 of your Pokémon."

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3807,9 +3807,9 @@ public enum SupremeVictors implements LogicCardInfo {
             onActivate {r->
               if (r==PLAY_FROM_HAND && opp.deck && confirm('Use Darkness Send?')) {
                 powerUsed()
-                def count
+                def count = 0
                 flip 3, {
-                  count ++
+                  count++
                 }
                 opp.deck.subList(0,count).moveTo(opp.lostZone)
               }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1402,8 +1402,7 @@ public enum SupremeVictors implements LogicCardInfo {
                         }, 1:{
                           bc "$pcs is still asleep."
                         }, 0:{
-                          bc "$pcs is knocked out by $thisMove."
-                          new Knockout(pcs).run(bg)
+                          bc "$pcs is still asleep."
                         }]
                         prevent()
                       }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1195,15 +1195,16 @@ public enum SupremeVictors implements LogicCardInfo {
           pokeBody "Marvel Eyes", {
             text "If you have Solrock in play, prevent all effects of attacks, including damage, done to any of your Lunatone or Solrock by your opponent's Pokémon LV.X."
             delayedA {
-              before null, self, Source.ATTACK, {
-                if (self.owner.pbg.all.findAll{it.name == "Solrock"} && self.owner.opposite.pbg.active.pokemonLevelUp && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
+              before null, null, Source.ATTACK, {
+                PokemonCardSet pcs = e.getTargetPokemon()
+                if (pcs.owner == self.owner && ["Solrock", "Lunatone"].contains(pcs.name) && self.owner.pbg.all.findAll{it.name == "Solrock"} && self.owner.opposite.pbg.active.pokemonLevelUp && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
                   bc "$thisAbility prevents effect"
                   prevent()
                 }
               }
               before APPLY_ATTACK_DAMAGES, {
                 bg.dm().each {
-                  if(self.owner.pbg.all.findAll{it.name == "Solrock"} && it.to == self && it.notNoEffect && it.from.pokemonLevelUp){
+                  if(it.to.owner == self.owner && ["Solrock", "Lunatone"].contains(it.to.name) && self.owner.pbg.all.findAll{it.name == "Solrock"} && it.from.pokemonLevelUp && it.notNoEffect && it.notZero){
                     it.dmg = hp(0)
                     bc "$thisAbility prevents damage"
                   }
@@ -1211,7 +1212,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
               after ENERGY_SWITCH, {
                 def efs = (ef as EnergySwitch)
-                if(self.owner.pbg.all.findAll{it.name == "Solrock"} && efs.from.pokemonLevelUp && efs.to == self && bg.currentState == Battleground.BGState.ATTACK){
+                if(efs.to.owner == self.owner && ["Solrock", "Lunatone"].contains(efs.to.name) && self.owner.pbg.all.findAll{it.name == "Solrock"} && efs.from.pokemonLevelUp && bg.currentState == Battleground.BGState.ATTACK){
                   discard efs.card
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1867,7 +1867,7 @@ public enum SupremeVictors implements LogicCardInfo {
                 powerUsed()
                 def maxSize = Math.min(opp.deck.size(),4)
                 def list = rearrange(opp.deck.subList(0,maxSize), "Rearrange top $maxSize cards of your opponent's deck")
-                my.deck.setSubList(0, list)
+                opp.deck.setSubList(0, list)
                 bc "$thisAbility rearranged the top cards of ${self.owner.opposite.getPlayerUsername(bg)}'s deck"
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1057,8 +1057,10 @@ public enum SupremeVictors implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 20
-              if (defending.cards.energyCount(C)) {
-                moveEnergy(defending, opp.bench)
+              afterDamage {
+                if (defending.cards.energyCount(C)) {
+                  moveEnergy(defending, opp.bench)
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -829,7 +829,7 @@ public enum SupremeVictors implements LogicCardInfo {
               afterDamage {
                 if(!opp.all.find{it.types.contains(W)}) {
                   def count = 0
-                  flip 3, {
+                  flip 3, {}, {
                     count++
                   }
                   if(count) {

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3745,7 +3745,7 @@ public enum SupremeVictors implements LogicCardInfo {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
             "Look at the top 7 cards of your deck, choose 1 of them, and put it into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward."
           onPlay {
-            my.deck.subList(0,7).select("Choose a card to put into your hand").moveTo(my.hand)
+            my.deck.subList(0,7).select("Choose a card to put into your hand").moveTo(hidden: true, my.hand)
             shuffleDeck()
           }
           playRequirement{

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -4041,7 +4041,7 @@ public enum SupremeVictors implements LogicCardInfo {
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           resistance F, MINUS30
           move "Hyper Flame", {
-            text "60 damage. Flip a coin. If heads, discard a [R] Energy card attached to Moltres. If tails, discard all Energy cards attached to Moltres. If you can’t discard Energy cards, this attack does nothing."
+            text "60 damage. Flip a coin. If heads, discard a [R] Energy card attached to Moltres. If tails, discard all Energy cards attached to Moltres."
             energyCost R, R, R
             attackRequirement {
               assert self.cards.energyCount(R)
@@ -4052,7 +4052,7 @@ public enum SupremeVictors implements LogicCardInfo {
                 discardSelfEnergyAfterDamage R
               }, {
                 afterDamage {
-                  discardAllSelfEnergy C
+                  discardAllSelfEnergy(null)
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3972,8 +3972,10 @@ public enum SupremeVictors implements LogicCardInfo {
                 applyEffect = self.active && bg.currentTurn == self.owner.opposite && bg.dm().any({ it.to == self && it.dmg.value })
               }
               after APPLY_ATTACK_DAMAGES, {
-                if (applyEffect && !self.slatedToKO && my.discard.filterByType(ENERGY)) {
-                  attachEnergyFrom(my.discard,self)
+                if (applyEffect && !self.slatedToKO && self.owner.pbg.discard.filterByType(ENERGY)) {
+                  self.owner.pbg.discard.select(min:0, max: 1, "$thisAbility: Attach an Energy card to attach to ${self}?", cardTypeFilter(ENERGY), self.owner).each {
+                    attachEnergy(self, it)
+                  }
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3914,9 +3914,10 @@ public enum SupremeVictors implements LogicCardInfo {
               checkNoSPC()
               assert my.discard.filterByType(ENERGY) : "You have no Energy cards in your discard pile"
               powerUsed({ usingThisAbilityEndsTurn delegate })
-              attachEnergyFrom(my.discard,my.all)
-              attachEnergyFrom(my.discard,my.all)
-              attachEnergyFrom(my.discard,my.all)
+              def maxCards = Math.min(3,my.discard.filterByEnergyType(L).size())
+              my.discard.select(max:maxCards,"Search your discard pile for up to 3 [L] Energy cards",energyFilter(L)).each {
+                attachEnergy(my.all.select("Attach $it to"), it)
+              }
               usingThisAbilityEndsTurn delegate
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1342,8 +1342,10 @@ public enum SupremeVictors implements LogicCardInfo {
             delayedA {
               def flag
               before APPLY_ATTACK_DAMAGES, {
-                if(it.to == self && it.dmg.value >= 70) {
-                  flag = true
+                bg.dm().each {
+                  if(it.to == self && it.dmg.value >= 70) {
+                    flag = true
+                  }
                 }
               }
               after APPLY_ATTACK_DAMAGES, {

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1146,7 +1146,7 @@ public enum SupremeVictors implements LogicCardInfo {
               assert my.hand.filterByType(BASIC_ENERGY) : "You have no Basic Energy cards in your hand"
             }
             onAttack {
-              def card = my.hand.select("Choose a Basic Energy card to attach to 1 of your Pokémon").first()
+              def card = my.hand.select("Choose a Basic Energy card to attach to 1 of your Pokémon",cardTypeFilter(BASIC_ENERGY)).first()
               def tar = my.all.select("Choose a Pokémon to attach $card to")
               attachEnergy (tar,card)
               heal 20, tar

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2181,7 +2181,7 @@ public enum SupremeVictors implements LogicCardInfo {
               powerUsed()
               flip {
                 bc "$thisAbility moves all Energy cards from $my.active to $self"
-                my.active.filterByType(ENERGY).each {
+                my.active.cards.filterByType(ENERGY).each {
                   energySwitch(my.active,self,it,true)
                   sw(my.active,self,POKEPOWER)
                 }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -4080,7 +4080,7 @@ public enum SupremeVictors implements LogicCardInfo {
         };
       case MILOTIC_SH7:
         return evolution (this, from:"Feebas", hp:HP080, type:W, retreatCost:1) {
-          weakness L
+          weakness L, PLUS20
           pokeBody "Aqua Mirage", {
             text "If you have no cards in your hand, prevent all damage done to Milotic by attacks from your opponent’s Pokémon."
             delayedA {
@@ -4108,7 +4108,7 @@ public enum SupremeVictors implements LogicCardInfo {
         };
       case RELICANTH_SH8:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
-          weakness G
+          weakness G, PLUS20
           move "Deep Sea Pressure", {
             text "20 damage. During your opponent's next turn, the Defending Pokémon's retreat cost is [C][C] more."
             energyCost F, C
@@ -4133,7 +4133,7 @@ public enum SupremeVictors implements LogicCardInfo {
         };
       case YANMA_SH9:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
-          weakness L
+          weakness L, PLUS20
           resistance F, MINUS20
           move "Sonicboom", {
             text "10 damage. This attack’s damage isn’t affected by Weakness or Resistance."

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1683,7 +1683,7 @@ public enum SupremeVictors implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               clearSpecialCondition(self)
-              heal 50, self
+              heal 40, self
               apply ASLEEP, self
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3969,7 +3969,7 @@ public enum SupremeVictors implements LogicCardInfo {
             delayedA {
               def applyEffect = false
               before APPLY_ATTACK_DAMAGES, {
-                applyEffect = bg.currentTurn == self.owner.opposite && self.active && bg.dm().find({ it.to == self && it.dmg.value })
+                applyEffect = self.active && bg.currentTurn == self.owner.opposite && bg.dm().any({ it.to == self && it.dmg.value })
               }
               after APPLY_ATTACK_DAMAGES, {
                 if (applyEffect && !self.slatedToKO && my.discard.filterByType(ENERGY)) {
@@ -3984,9 +3984,9 @@ public enum SupremeVictors implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 200
-              if(!my.hand) {
+              if(my.hand) {
                 afterDamage {
-                  discardAllSelfEnergy C
+                  discardAllSelfEnergy()
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3789,7 +3789,8 @@ public enum SupremeVictors implements LogicCardInfo {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
             "Search your discard pile for up to 5 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck."
           onPlay {
-            my.discard.select(max:5,"Search your discard pile for up to 5 Pokémon and basic Energy cards",{it.cardTypes.is(POKEMON)||it.cardTypes.is(BASIC_ENERGY)})
+            my.discard.findAll{it.cardTypes.contains(BASIC_ENERGY) || it.cardTypes.contains(POKEMON)}.select(count: 5).moveTo(my.deck)
+            shuffleDeck()
           }
           playRequirement{
             assert my.discard.filterByType(POKEMON) || my.discard.filterByType(BASIC_ENERGY) : "You have no Pokémon or basic Energy cards in your discard pile"

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -645,7 +645,8 @@ public enum SupremeVictors implements LogicCardInfo {
             text "Remove all Special Conditions from each of your [G] Pokémon. Each of your [G] Pokémon can't be affected by any Special Conditions."
             delayedA {
               before APPLY_SPECIAL_CONDITION, {
-                if (ef.target.owner == self.owner && ef.target.types.contains(G)) {
+                def pcs = ef.getTargetPokemon()
+                if (pcs.owner == self.owner && pcs.types.contains(G)) {
                   bc "$thisAbility prevents special conditions on $self."
                   prevent()
                 }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -782,7 +782,7 @@ public enum SupremeVictors implements LogicCardInfo {
             delayedA {
               after PROCESS_ATTACK_EFFECTS, {
                 if(ef.attacker==self) bg.dm().each {
-                  if(it.from==self && it.to.active && it.to.hasPokePower() && it.to.owner!=self.owner && it.dmg.value){
+                  if(it.from==self && it.to.active && it.to.owner!=self.owner && it.dmg.value && it.to.hasPokeBody()){
                     bc "$thisAbility +30"
                     it.dmg += hp(30)
                   }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2586,7 +2586,7 @@ public enum SupremeVictors implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               opp.all.each {
-                damage 10
+                damage 10, it
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -1620,8 +1620,13 @@ public enum Triumphant implements LogicCardInfo {
           move "Inviting Scent", {
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon."
             energyCost C
+            attackRequirement {
+              assert opp.bench
+            }
             onAttack {
-              whirlwind()
+              targeted (defending) {
+                sw defending, opp.bench.select()
+              }
             }
           }
           move "Careless Tackle", {

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -1591,7 +1591,7 @@ public enum Triumphant implements LogicCardInfo {
 
         };
       case ARON_56:
-        return basic (this, hp:HP060, type:METAL, retreatCost:1) {
+        return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness R
           resistance P, MINUS20
           move "Mountain Eater", {

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -1467,8 +1467,10 @@ public enum Triumphant implements LogicCardInfo {
             energyCost C, C, C
             onAttack {
               damage 50
-              flip {
-                discardDefendingEnergy()
+              afterDamage {
+                flip {
+                  discardDefendingEnergy()
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -1844,9 +1844,9 @@ public enum Undaunted implements LogicCardInfo {
             my.hand.remove(thisCard)
 
             eff = delayed {
-              after PROCESS_ATTACK_EFFECTS, {
-                bg.dm().each {
-                  if (it.to == pcs && it.dmg.value && it.notNoEffect) {
+              before APPLY_ATTACK_DAMAGES, {
+                bg.dm().each{
+                  if(it.to == pcs && it.notNoEffect && it.dmg.value) {
                     bc "Defender -20"
                     it.dmg -= hp(20)
                   }


### PR DESCRIPTION
This PR depends on https://github.com/axpendix/tcgone/pull/214

## Dependencies

Requires https://github.com/axpendix/tcgone/pull/214 to be merged first.

## Pushed fixes

* Rework confusion boost for Aromatisse (BKT 106) and Grumpig (LA 56)
  - Now it should use the same override for confusion damage in both attacks, as only one would apply (since it's an override, 6 instead of 3).

* Implement "Mend" on Lairon (Mysterious Treasures 53)
  - Added some logic for making the heal conditional.

* Further fix Lairon (Mysterious Treasures 53)
  - Should now heal 2 damage counters instead of only 1.

* Partial Fix for Porygon-Z (DP Promo DP35) and Fix for Level Max (PL 107)
  - "Learning" and "Level Max" should no longer allow leveling up a Leveled-Up pokémon.

* Fix Defender (Undaunted 72)
  - Should now be applied after W&R, not before.

* Fix Expert Belt (Arceus 87)
  - Should increase prizes taken before "reduce to zero" effects kick in (such as Weezing from Rising Rivals)

* Fix attempt at Metagross (Supreme Victors 7)
  - Should fix a crash, and stop doing extra damage when using "Geo Impact with a stadium in play.

* Fix a typo in Regigigas FB (Supreme Victors 9)
  - Should make Drain Punch work correctly.

* Fix attempt for Venusaur (Supreme Victors 13)
  - Should solve both Green Aroma, and a potentially related issue caused by it when attacking with Desperate Pollen.

* Fix Butterfree FB (Supreme Victors 17)
  - "Compound Eyes" should boost damage when the opponent's active has a Poké-Body, not a Poké-Power.

* Fix Camerupt (Supreme Victors 18)
  - Volcanic Crash should now discard energies on each tails flipped, not each heads.

* Fix Empoleon FB (Supreme Victors 27)
  - Should now move the energy after damage is dealt.

* Fix attempt at Lickylicky C (Supreme Victors 30)
  - Should now allow the player to select basic energy cards only.

* Fix attempt at Lunatone (Supreme Victors 32)
  - Should now properly protect your Solrock and Lunatone, not just this one Lunatone.

* Fix Mr. Mime (Supreme Victors 37)
  - Focus Wall should no longer cause an Engine Error.

* Fix Parasect (Supreme Victors 38)
  - Hibernation Spore shouldn't KO the opponent's pokemon on double tails (copied from Darkrai Lv.X's variant of the attack)

* Fix Roserade C (Supreme Victors 40)
  - Magical Leaf should now do 60 on heads, not 80.

* Fix Wailord (Supreme Victors 47)
  - Rest now heals 4 damage counters, not 5.

* Fix Chatot G (Supreme Victors 54)
  - Disrupting Spy should now properly rearrange the opponent's deck.

* Fix Ivysaur (Supreme Victors 62)
  - Typo in the pre-evolution name.

* Fix Marshtomp (Supreme Victors 67)
  - Plunge should no longer cause an Engine Error.

* Fix Minun (Supreme Victors 71)
  - Call for Family should now properly fetch only Lightning Basic Pokémon.

* Fix Murkrow (Supreme Victors 72)
  - Should no longer crash.

* Fix Mr. Mime (Mysterious Treasures 30)
  - Should now properly show the opponent the second Heads/Tails call.

* Fix Rotom (Supreme Victors 82)
  - Should now do 10 damage to each of the opponent's Pokémon, not 10 times the amount of them to the active.

* Fix Cynthia's Guidance (Supreme Victors 136)
  - Should not display the chosen card in the game log.

* Fix Cyrus' Initiative (Supreme Victors 137)
  - Should no longer throw an Engine Error. Should also be clearer to the opponent in the cards being put in the bottom of the deck, in the shown order.

* Fix Palmer's Contribution (Supreme Victors 139)
  - Should now properly shuffle cards into the deck from the discard pile.

* Fix Weakness of Milotic (SH7) ,Relicant (SH8) and Yanma (SH9)
  - All should be +20, not x2

* Fix Zapdos (Supreme Victors 150)
  - Should resist fighting (-30), not be weak to it.

* Fix Moltres (Supreme Victors 149)
  - Should discard all energy cards, not just colorless when flipping tails.

* Fix Absol G Lv.X (Supreme Victors 141)
  - Darkness Send should no longer cause an Engine Error.

* Fix Charizard G Lv.X (Supreme Victors 143)
  - Tails on Malevolent Fire should discard all energy cards, not just colorless ones.

* Fix Electivire FB Lv.X (Supreme Victors 144)
  - Should now allow to attach as many energy cards from the discard pile as one wants, not forcing to attach all 3.

* Fix Garchomp C Lv.X (Supreme Victors 145)
  - Fixed a typo, shouldn't cause an Engine Error anymore.

* Fix Final Blowout in Rayquaza C Lv.X (Supreme Victors 146)
  - Should now properly prevent energies being discarded if you don't have cards in hand. It should also discard all energies and not only colorless ones.

* Fix Palkia Lv.X (Great Encounters 106)
  - Restructure should now work when only the Palkia's owner has a bench (do as much as you can), and also work in the correct order (your pokémon, then your opponent's if they have bench)

* Fix Tentacruel (Triumphant 50)
  - Hyper Beam should now discard after damage is dealt.

* Fix Bellsprout (Triumphant 57)
  - Inviting Scent should now be a choice of the attacking player on who to switch in, not the opponent's.

* Fix Rayquaza C Lv.X (Supreme Victor 146)
  - Should now offer the correct player to attach an energy from its own discard pile, and also the ability to skip the use of Dragon Spirit.

* Fix Empoleon (Stormfront 2)
  - Should now only activate Emperor Aura when it's active as it evolves.

* Fix Aron (Triumphant 56)
  - Retreat cost should be 2, not 1.

* Fix Prinplup (Majestic Dawn 44)
  - Wash Over should now ping bench pokémon, not including the active as an option.

* Fix Trapinch (Secret Wonders 115)
  - Inviting Trap should now target the benched Pokémon, not the active (thus not blocked by abilities on it, such as an active Glaceon MD 5)

* Fix Manectric (Platinum 11)
  - "Electric Barrier" should now properly protct non-Manectric benched Pokémon. And "Power Wave" should no longer cause an Engine Error.

* Fix Voltorb (Stormfront SH3)
  - Charge Beam should cost L, not LL.

* Fix Machamp Lv.X (Stormfront 98)
  - Weakness is now +40, and Strong-Willed now does the flip when about to be knocked out (not as a condition for getting the anti-ko effect)

* Fix Premier Ball (Great Encounters 101, Stormfront 91)
  - Should now only shuffle the deck if it was searched.

* Fix Bronzor (Stormfront 55)
  - Gyro Swap should cost P, not P and C.

* Fix Skarmory (Stormfront 51)
  - Should resist fighting, not metal.
