### PR TITLE
Fixes batch (August 5)

### DIFF
--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -353,10 +353,9 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               assert my.deck : "Deck is empty"
             }
             onAttack {
-              def predecessors = []
-              my.all.each {
-                predecessors.add(it.name)
-              }
+              def predecessors = my.all
+                .findAll { !it.pokemonLevelUp }
+                .collect { it.name }
               LevelUpPokemonCard lvX = my.deck.search("Select a Pokémon LV.X that evolves from one of your Pokémon", {
                 it.cardTypes.is(LVL_X) && it.predecessor in predecessors
               }).first() as LevelUpPokemonCard

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -952,7 +952,7 @@ public enum GreatEncounters implements LogicCardInfo {
               assert bg.em().retrieveObject("Trump Card") == bg.turnCount-1 : "None of your Pokémon were Knocked Out during your opponent's last turn."
               bg.em().storeObject("Trump Card", bg.turnCount)
               powerUsed()
-              my.deck.search("Search your deck for 1 card",{true}).moveTo(hidden:true,my.hand)
+              my.deck.search(count:1,"Search your deck for 1 card",{true}).moveTo(hidden:true,my.hand)
             }
           }
           move "Psych Up", {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2039,15 +2039,16 @@ public enum GreatEncounters implements LogicCardInfo {
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
           pokePower "Scent Conduct", {
-            text "Once during your turn , you may flip a coin. If heads, search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Illumise is affected by a Special Condition."
+            text "Once during your turn , you may flip a coin. If heads, search your deck for a [G] Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Illumise is affected by a Special Condition."
             actionA {
               checkLastTurn()
+              checkNoSPC()
               assert my.deck : "Deck is empty"
               assert bench.notFull : "Bench is full"
               checkNoSPCForClassic()
               powerUsed()
               flip {
-                my.deck.search { it.cardTypes.is(BASIC) }.each {
+                my.deck.search { it.cardTypes.is(BASIC) && it.asPokemonCard().types.contains(G) }.each {
                   benchPCS(it)
                 }
                 shuffleDeck()
@@ -2064,7 +2065,8 @@ public enum GreatEncounters implements LogicCardInfo {
               for (Ability ability : defending.getAbilities().keySet()) {
                 if (ability instanceof PokeBody) hasPokeBody = true;
               }
-              if (hasPokeBody) apply ASLEEP
+              if (hasPokeBody)
+                applyAfterDamage ASLEEP
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1047,12 +1047,12 @@ public enum GreatEncounters implements LogicCardInfo {
         return evolution (this, from:"Jigglypuff", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
           pokePower "Good Night Melody", {
-            text "Once during your turn , you may use this power. Each Active Pokémon (both your and your opponent's is now Asleep. This power can't be use if Wigglytuff is affected by a Special Condition."
+            text "Once during your turn , you may use this power. Each Active Pokémon (both your and your opponent's) is now Asleep. This power can't be used if Wigglytuff is affected by a Special Condition."
             actionA {
               checkLastTurn()
               checkNoSPC()
               powerUsed()
-              apply ASLEEP, self, Source.POKEPOWER
+              apply ASLEEP, my.active, Source.POKEPOWER
               apply ASLEEP, opp.active, Source.POKEPOWER
             }
           }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1151,7 +1151,7 @@ public enum GreatEncounters implements LogicCardInfo {
             }
             onAttack {
               flip {
-                my.deck.search("Search your deck for 1 card",{true}).moveTo(hidden:true,my.hand)
+                my.deck.search(count:1, "Search your deck for 1 card",{true}).moveTo(hidden:true,my.hand)
                 shuffleDeck()
               }
             }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2229,7 +2229,7 @@ public enum GreatEncounters implements LogicCardInfo {
             onAttack {
               flip {
                 damage 40
-                discardDefendingEnergy()
+                discardDefendingEnergyAfterDamage()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2176,7 +2176,9 @@ public enum GreatEncounters implements LogicCardInfo {
             onAttack {
               damage 20
               if (bg.stadiumInfoStruct && confirm ("Discard ${bg.stadiumInfoStruct.stadiumCard}?")) {
-                discard bg.stadiumInfoStruct.stadiumCard
+                afterDamage {
+                  discard bg.stadiumInfoStruct.stadiumCard
+                }
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2767,6 +2767,7 @@ public enum GreatEncounters implements LogicCardInfo {
             actionA {
               assert all.find({ it.numberOfDamageCounters > 0 }) : "None of either player's Pokémon have damage counters."
               checkLastTurn()
+              checkNoSPC()
               powerUsed()
               def source = all.findAll { it.numberOfDamageCounters > 0 }.select("Select a source for a damage counter.")
               def target = all

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2561,6 +2561,7 @@ public enum GreatEncounters implements LogicCardInfo {
               assert my.all.find { it.name == "Illumise" } : "Illumise is not in play"
               assert my.discard.filterByType(SUPPORTER) : "No Supporter card in your discard pile"
               checkLastTurn()
+              checkNoSPC()
               powerUsed()
               def card = my.discard.filterByType(SUPPORTER).select("Which card should be place on top of your deck?")
               card.showToOpponent("Selected card").moveTo(addToTop: true, my.deck)

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1599,7 +1599,7 @@ public enum GreatEncounters implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 20
-              flip { discardDefendingEnergy() }
+              flip { discardDefendingEnergyAfterDamage() }
             }
           }
           move "Steel Wing", {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1818,7 +1818,7 @@ public enum MajesticDawn implements LogicCardInfo {
           }
           move "Uproar", {
             text "Flip a coin. If heads, this attack does 10 damage to each of your opponent’s Pokémon."
-            energyCost P
+            energyCost ()
             onAttack {
               flip {
                 opp.all.each {

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -416,10 +416,12 @@ public enum MajesticDawn implements LogicCardInfo {
           move "Chase Up", {
             text "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
             energyCost C
-            onAttack {
+            attackRequirement {
               assert my.deck : "Your deck is empty."
+            }
+            onAttack {
               flip {
-                my.deck.search(max:1,"Select 1 card",{true}).moveTo(my.hand)
+                my.deck.search(count:1,"Select 1 card",{true}).moveTo(my.hand)
                 shuffleDeck()
               }
             }
@@ -431,7 +433,7 @@ public enum MajesticDawn implements LogicCardInfo {
               damage 30
               if(my.hand.filterByBasicEnergyType(W) && my.bench) {
                 my.hand.select(min:0, max:2, "Choose up to 2 basic [W] Energy cards to attach to your Benched Pokémon",basicEnergyFilter(W)).each {
-                  attachEnergy(my.bench.select("Attach $it to"), it)
+                  attachEnergy(my.bench.select("Attach $it to"), it, PLAY_FROM_HAND)
                 }
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -1004,7 +1004,7 @@ public enum MajesticDawn implements LogicCardInfo {
             onAttack {
               damage 30
               flip {
-                discardDefendingEnergy()
+                discardDefendingEnergyAfterDamage()
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -421,7 +421,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
             onAttack {
               flip {
-                my.deck.search(count:1,"Select 1 card",{true}).moveTo(my.hand)
+                my.deck.search(count:1,"Select 1 card",{true}).moveTo(hidden:true, my.hand)
                 shuffleDeck()
               }
             }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -530,7 +530,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 60
-              discardRandomCardFromOpponentsHand()
+              afterDamage {
+                discardRandomCardFromOpponentsHand()
+              }
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -3182,8 +3182,10 @@ public enum Platinum implements LogicCardInfo {
           text "Flip a coin. If heads, search your deck for a Pokémon LV.X that levels up from 1 of your Pokémon, and put it onto that Pokémon (this counts as leveling up that Pokémon). Shuffle your deck afterward."
           onPlay {
             flip {
-              def names = my.all.collect{ it.name }
-              LevelUpPokemonCard sel_1 = deck.search ("Select a Pokémon that Levels up from $names.", {it.cardTypes.is(LVL_X) && names.contains(it.predecessor)}).first() as LevelUpPokemonCard
+              def names = my.all
+                .findAll { !it.pokemonLevelUp }
+                .collect { it.name }
+              LevelUpPokemonCard sel_1 = deck.search ("Select a Pokémon that Levels up from $names.", {it.cardTypes.is(LVL_X) && it.predecessor in names}).first() as LevelUpPokemonCard
               if (sel_1) {
                 def sel_2 = my.all.findAll{ !it.pokemonLevelUp && sel_1.predecessor == it.name }.select("Select one of your Pokémon named ${sel_1.name}")
                 bg().em().run(new LevelUp(sel_2, sel_1))

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1140,10 +1140,12 @@ public enum Stormfront implements LogicCardInfo {
             onAttack {
               def tar = opp.all.select("Choose 1 of your opponent's Pokémon")
               damage 30, tar
-              flip {
-                if(tar.cards.filterByType(ENERGY)) {
-                  targeted(tar){
-                    tar.cards.select("Choose an energy to discard from $tar",cardTypeFilter(ENERGY)).discard()
+              afterDamage{
+                flip {
+                  if(tar.cards.filterByType(ENERGY)) {
+                    targeted(tar){
+                      tar.cards.select("Choose an energy to discard from $tar",cardTypeFilter(ENERGY)).discard()
+                    }
                   }
                 }
               }

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1613,7 +1613,7 @@ public enum Stormfront implements LogicCardInfo {
 
         };
       case ELECTRODE_36:
-        return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
+        return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
           resistance M, MINUS20
           pokeBody "Radiance", {

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -1828,7 +1828,7 @@ public enum Stormfront implements LogicCardInfo {
         };
       case MILTANK_44:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
-          weakness F
+          weakness F, PLUS20
           move "Collect", {
             text "Draw a card."
             energyCost C

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -2178,13 +2178,14 @@ public enum SupremeVictors implements LogicCardInfo {
             actionA {
               checkLastTurn()
               assert self.benched : "$self is not on your Bench"
+              assert my.active.energyCards : "Your Active Pokémon must have Energy cards attached"
               powerUsed()
               flip {
                 bc "$thisAbility moves all Energy cards from $my.active to $self"
                 my.active.cards.filterByType(ENERGY).each {
-                  energySwitch(my.active,self,it,true)
-                  sw(my.active,self,POKEPOWER)
+                  energySwitch(my.active,self,it)
                 }
+                sw(my.active,self)
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -1197,7 +1197,7 @@ public enum SupremeVictors implements LogicCardInfo {
             delayedA {
               before null, null, Source.ATTACK, {
                 PokemonCardSet pcs = e.getTargetPokemon()
-                if (pcs.owner == self.owner && ["Solrock", "Lunatone"].contains(pcs.name) && self.owner.pbg.all.findAll{it.name == "Solrock"} && self.owner.opposite.pbg.active.pokemonLevelUp && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
+                if (pcs && pcs.owner == self.owner && ["Solrock", "Lunatone"].contains(pcs.name) && self.owner.pbg.all.findAll{it.name == "Solrock"} && self.owner.opposite.pbg.active.pokemonLevelUp && bg.currentTurn==self.owner.opposite && ef.effectType != DAMAGE){
                   bc "$thisAbility prevents effect"
                   prevent()
                 }

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -3790,11 +3790,14 @@ public enum SupremeVictors implements LogicCardInfo {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
             "Search your discard pile for up to 5 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck."
           onPlay {
-            my.discard.findAll{it.cardTypes.contains(BASIC_ENERGY) || it.cardTypes.contains(POKEMON)}.select(count: 5).moveTo(my.deck)
+            my.discard
+              .findAll{it.cardTypes.contains(BASIC_ENERGY) || it.cardTypes.contains(POKEMON)}
+              .select(min:1, max: 5, "Choose up to 5 in any combination of Pokémon and Supporter cards to put back into your deck")
+              .moveTo(my.deck)
             shuffleDeck()
           }
           playRequirement{
-            assert my.discard.filterByType(POKEMON) || my.discard.filterByType(BASIC_ENERGY) : "You have no Pokémon or basic Energy cards in your discard pile"
+            assert my.discard.filterByType(POKEMON, BASIC_ENERGY) : "You have no Pokémon or basic Energy cards in your discard pile"
           }
         };
       case VS_SEEKER_140:

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -1715,7 +1715,7 @@ public enum Triumphant implements LogicCardInfo {
           resistance L, MINUS20
           move "Sand Veil", {
             text "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Diglett during your opponent’s next turn."
-            energyCost ()
+            energyCost C
             onAttack {
               flip {
                 preventAllEffectsNextTurn()

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -2229,11 +2229,12 @@ public enum Triumphant implements LogicCardInfo {
         return basicTrainer (this) {
           text "Discard 2 cards from you hand. Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand. You can’t choose Junk Arm with the effect of this card."
           onPlay {
-            my.hand.select(count:2,"Discard 2 cards").discard()
+            my.hand.getExcludedList(thisCard).select(count:2,"Discard 2 cards").discard()
             my.discard.select("Choose a Trainer card to return to your hand", {it.cardTypes.is(ITEM) && it.name != "Junk Arm"}).showToOpponent("Selected Cards").moveTo(my.hand)
           }
           playRequirement{
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "You don't have 2 other cards to discard"
+            assert my.discard.filterByType(ITEM).any{it.name != "Junk Arm"} : "You don't have any Trainer-Item cards not named \"Junk Arm\""
           }
         };
       case SEEKER_88:

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -2206,6 +2206,9 @@ public enum Triumphant implements LogicCardInfo {
               unregisterAfter 1
             }
           }
+          playRequirement{
+            assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You don't have more prize cards remaining than your opponent"
+          }
         };
       case INDIGO_PLATEAU_86:
         return stadium (this) {


### PR DESCRIPTION
* Fix Marshtomp (Supreme Victors 67)
  - "Plunge" will now properly switch Marshtomp into the Active Spot a single time, instead of once for each energy moved. The Poké-Power will also no longer be useable if the Active has no energies attached (from Japanese FAQs for this Marshtomp in particular)

* Fix Palmer's Contribution (Supreme Victors 39)
  - Now allows to shuffle any number of pokemon/basic energy cards up to 5 (but at least choosing one).

* Fix Lunatone (Supreme Victors 32)
  - Should no longer throw a Game Engine error.

* Further fix Porygon-Z (DP Promo DP35) and Level Max (Platinum 107)
  - Should now no longer include Lv.X Pokémon as predecessor options, thus avoiding an engine error when trying to find a valid Pokémon to level up afterwards.

* Fix Feraligatr (Mysterious Treasures 8)
  - Should discard the opponent's card after dealing damage.

* Fix Miltank (Stormfront 44)
  - Should have +20 weakness, not x2.

* Fix Electrode (Stormfront 36)
  - Retreat cost should be zero.

* Fix Roserade (Stormfront 23)
  - Bowed Whip should now discard energy after dealing damage.

* Fix Chingling (Majestic Dawn 58)
  - Uproar's attack cost should be zero, not [P]

* Fix Manaphy (Majestic Dawn 8)
  - "Chase Up" now forces to pick a card. "Fountain" attachments should now count as done from the hand.

* Fix Phione (Majestic Dawn 27)
  - "Whirlpool" should discard energies after damage.

* Fix Cresselia Lv.X (Great Encounters 103)
  - "Full Moon Dance" shouldn't be useable if under a special condition.

* Fix Volbeat (Great Encounters 92)
  - "Light Conduct" shouldn't be usable when under a special condition.

* Fix Makuhita (Great Encounters 78)
  - Arm Thrust should discard energies after dealing damage.

* Fix Lunatone (Great Encounters 76)
  - "Knock Over" should discard the stadium after dealing damage.

* Fix Illumise (Great Encounters 71)
  - "Scent Conduct" should no longer work if under a special condition, and should only bench grass Pokémon. "Firefly Scent" now puts the opponent asleep after dealing damage.

* Fix Skarmory (Great Encounters 53)
  - "Air Crash" should now discard energy after dealing damage.

* Fix Delibird (Great Encounters 36)
  - If "Present" flips a heads, the card search shouldn't be optional.

* Further fix Manaphy (Majestic Dawn 8)
  - Selected card shouldn't be public.

* Fix Wigglytuff (Great Encounters 32)
  - "Good Night Melody" should put your active aslep, not just Wigglytuff itself.

* Fix Slowking (Great Encounter 28)
  - You can't fail the deck search generated by "Trump Card"

* Fix Black Belt (Triumphant 85)
  - Should only be usable if you have more prizes remaining than your opponent.

* Fix Diglett (Triumphant 61)
  - "Sand Veil" should cost [C]

* Fix Junk Arm (Triumphant 87)
  - Shouldn't be usable without items not named "Junk Arm" in the discard pile. And cannot be discarded itself to pay for its cost.