### PR TITLE
Fix several cards with incorrect attack checks (it.to -> it.to.owner)

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -227,7 +227,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner == self.owner && ef.attacker.topPokemonCard.cardTypes.is(DELTA)) {
                 bg.dm().each {
-                  if (it.to.active && it.to != self.owner && it.notNoEffect && it.dmg.value) {
+                  if (it.to.active && it.to.owner != self.owner && it.notNoEffect && it.dmg.value) {
                     bc "Battle Aura +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -394,7 +394,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             after PROCESS_ATTACK_EFFECTS, {
               if (ef.attacker.owner == self.owner && bg.stadiumInfoStruct && bg.stadiumInfoStruct.stadiumCard.name.contains("Holon") && ef.attacker.topPokemonCard.cardTypes.is(DELTA)) {
                 bg.dm().each {
-                  if (it.to != self.owner && it.to.active && it.notNoEffect && it.dmg.value) {
+                  if (it.to.owner != self.owner && it.to.active && it.notNoEffect && it.dmg.value) {
                     bc "Delta Reactor +10"
                     it.dmg += hp(10)
                   }

--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -658,7 +658,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 if (ef.attacker == self && self.owner.pbg.all.any { it.name == "Cresselia" }) {
                   bg.dm().each {
-                    if (it.to != self.owner && it.to.active && it.dmg.value) {
+                    if (it.to.owner != self.owner && it.to.active && it.dmg.value) {
                       bc "Darkness Aura +20"
                       it.dmg += hp(20)
                     }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -2825,7 +2825,7 @@ public enum GreatEncounters implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 if (ef.attacker.owner == self.owner && ef.attacker.types.contains(D) && ef.attacker.cards.filterByBasicEnergyType(D) && bg.em().retrieveObject("Dark_Shadow") != bg.turnCount) {
                   bg.dm().each {
-                    if (it.to.active && it.to != self.owner && it.notNoEffect && it.dmg.value) {
+                    if (it.to.active && it.to.owner != self.owner && it.notNoEffect && it.dmg.value) {
 
                       def bonusDamage = it.from.cards.filterByBasicEnergyType(D).size() * 10
                       bc "Dark Shadow +$bonusDamage"

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1825,7 +1825,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 if (ef.attacker.owner == self.owner && self.benched) {
                   bg.dm().each {
-                    if (it.from.types.contains(F) && it.to.active && it.to != self.owner && it.notZero) {
+                    if (it.from.types.contains(F) && it.to.active && it.to.owner != self.owner && it.notZero) {
                       bc "Princess’s Cheers +20"
                       it.dmg += hp(20)
                     }

--- a/src/tcgwars/logic/impl/gen8/ChillingReign.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChillingReign.groovy
@@ -900,7 +900,7 @@ public enum ChillingReign implements LogicCardInfo {
               after PROCESS_ATTACK_EFFECTS, {
                 if (ef.attacker == self && opp.prizeCardSet.takenCount) {
                   bg.dm().each {
-                    if (it.to != self.owner && it.to.active && it.notNoEffect && it.dmg.value) {
+                    if (it.to.owner != self.owner && it.to.active && it.notNoEffect && it.dmg.value) {
                       def bonus = opp.prizeCardSet.takenCount * 30
                       bc "$thisAbility +$bonus"
                       it.dmg += hp(bonus)


### PR DESCRIPTION
Was trying to compare a player with a Pokémon. Kinda sus. This affected Feraligatr Delta (Dragon Frontiers 2), Gyarados Delta (Holon Phantoms 8), Darkrai (DP Promo DP52), Darkrai Lv.X (Great Encounters 104), Diancie Prism Star (Forbidden Light 74) and Cinderace (Chilling Reign 28).