### PR TITLE
Mass purge of semicolons from groovy files

### DIFF
--- a/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/BaseSetNG.groovy
@@ -1,33 +1,33 @@
 package tcgwars.logic.impl.gen1
 
-import tcgwars.logic.exception.EffectRequirementException;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen4.Unleashed;
+import tcgwars.logic.exception.EffectRequirementException
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen4.Unleashed
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.card.pokemon.*
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -138,150 +138,150 @@ public enum BaseSetNG implements LogicCardInfo {
   WATER_ENERGY ("Water Energy", "102", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
   static SimpleDeck blackout() {
-    SimpleDeck blackout = new SimpleDeck("Blackout Theme Deck");
-    blackout.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(MACHOP, 4);
-    map.put(MACHOKE, 2);
-    map.put(SANDSHREW, 3);
-    map.put(ONIX, 3);
-    map.put(HITMONCHAN, 1);
-    map.put(STARYU, 3);
-    map.put(SQUIRTLE, 4);
-    map.put(WARTORTLE, 2);
-    map.put(FARFETCHD, 2);
-    map.put(ENERGY_REMOVAL, 4);
-    map.put(SUPER_ENERGY_REMOVAL, 1);
-    map.put(GUST_OF_WIND, 1);
-    map.put(PLUSPOWER, 1);
-    map.put(PROFESSOR_OAK, 1);
-    map.put(FIGHTING_ENERGY, 16);
-    map.put(WATER_ENERGY, 12);
-    blackout.setMap(map);
-    return blackout;
+    SimpleDeck blackout = new SimpleDeck("Blackout Theme Deck")
+    blackout.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(MACHOP, 4)
+    map.put(MACHOKE, 2)
+    map.put(SANDSHREW, 3)
+    map.put(ONIX, 3)
+    map.put(HITMONCHAN, 1)
+    map.put(STARYU, 3)
+    map.put(SQUIRTLE, 4)
+    map.put(WARTORTLE, 2)
+    map.put(FARFETCHD, 2)
+    map.put(ENERGY_REMOVAL, 4)
+    map.put(SUPER_ENERGY_REMOVAL, 1)
+    map.put(GUST_OF_WIND, 1)
+    map.put(PLUSPOWER, 1)
+    map.put(PROFESSOR_OAK, 1)
+    map.put(FIGHTING_ENERGY, 16)
+    map.put(WATER_ENERGY, 12)
+    blackout.setMap(map)
+    return blackout
   }
   static SimpleDeck brushfire(){
-    SimpleDeck brushfire = new SimpleDeck("Brushfire Theme Deck");
-    brushfire.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(CHARMANDER, 4);
-    map.put(CHARMELEON, 2);
-    map.put(VULPIX, 2);
-    map.put(NINETALES, 1);
-    map.put(GROWLITHE, 2);
-    map.put(ARCANINE, 1);
-    map.put(WEEDLE, 4);
-    map.put(NIDORAN_MALE, 4);
-    map.put(TANGELA, 2);
-    map.put(ENERGY_REMOVAL, 1);
-    map.put(ENERGY_RETRIEVAL, 2);
-    map.put(GUST_OF_WIND, 1);
-    map.put(LASS, 1);
-    map.put(PLUSPOWER, 1);
-    map.put(POTION, 3);
-    map.put(SWITCH, 1);
-    map.put(FIRE_ENERGY, 18);
-    map.put(GRASS_ENERGY, 10);
-    brushfire.setMap(map);
-    return brushfire;
+    SimpleDeck brushfire = new SimpleDeck("Brushfire Theme Deck")
+    brushfire.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(CHARMANDER, 4)
+    map.put(CHARMELEON, 2)
+    map.put(VULPIX, 2)
+    map.put(NINETALES, 1)
+    map.put(GROWLITHE, 2)
+    map.put(ARCANINE, 1)
+    map.put(WEEDLE, 4)
+    map.put(NIDORAN_MALE, 4)
+    map.put(TANGELA, 2)
+    map.put(ENERGY_REMOVAL, 1)
+    map.put(ENERGY_RETRIEVAL, 2)
+    map.put(GUST_OF_WIND, 1)
+    map.put(LASS, 1)
+    map.put(PLUSPOWER, 1)
+    map.put(POTION, 3)
+    map.put(SWITCH, 1)
+    map.put(FIRE_ENERGY, 18)
+    map.put(GRASS_ENERGY, 10)
+    brushfire.setMap(map)
+    return brushfire
   }
   static SimpleDeck zap(){
-    SimpleDeck zap = new SimpleDeck("Zap! Theme Deck");
-    zap.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(PIKACHU, 4);
-    map.put(MAGNEMITE, 3);
-    map.put(ABRA, 3);
-    map.put(KADABRA, 1);
-    map.put(GASTLY, 3);
-    map.put(HAUNTER, 2);
-    map.put(DROWZEE, 2);
-    map.put(JYNX, 2);
-    map.put(MEWTWO, 1);
-    map.put(BILL, 2);
-    map.put(COMPUTER_SEARCH, 1);
-    map.put(DEFENDER, 1);
-    map.put(GUST_OF_WIND, 2);
-    map.put(POTION, 1);
-    map.put(PROFESSOR_OAK, 1);
-    map.put(SUPER_POTION, 1);
-    map.put(SWITCH, 2);
-    map.put(LIGHTNING_ENERGY, 12);
-    map.put(PSYCHIC_ENERGY, 16);
-    zap.setMap(map);
-    return zap;
+    SimpleDeck zap = new SimpleDeck("Zap! Theme Deck")
+    zap.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(PIKACHU, 4)
+    map.put(MAGNEMITE, 3)
+    map.put(ABRA, 3)
+    map.put(KADABRA, 1)
+    map.put(GASTLY, 3)
+    map.put(HAUNTER, 2)
+    map.put(DROWZEE, 2)
+    map.put(JYNX, 2)
+    map.put(MEWTWO, 1)
+    map.put(BILL, 2)
+    map.put(COMPUTER_SEARCH, 1)
+    map.put(DEFENDER, 1)
+    map.put(GUST_OF_WIND, 2)
+    map.put(POTION, 1)
+    map.put(PROFESSOR_OAK, 1)
+    map.put(SUPER_POTION, 1)
+    map.put(SWITCH, 2)
+    map.put(LIGHTNING_ENERGY, 12)
+    map.put(PSYCHIC_ENERGY, 16)
+    zap.setMap(map)
+    return zap
   }
   static SimpleDeck overgrowth(){
-    SimpleDeck overgrowth = new SimpleDeck("Overgrowth Theme Deck");
-    overgrowth.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BULBASAUR, 4);
-    map.put(IVYSAUR, 2);
-    map.put(WEEDLE, 4);
-    map.put(KAKUNA, 2);
-    map.put(BEEDRILL, 1);
-    map.put(STARYU, 4);
-    map.put(STARMIE, 3);
-    map.put(MAGIKARP, 2);
-    map.put(GYARADOS, 1);
-    map.put(BILL, 2);
-    map.put(GUST_OF_WIND, 2);
-    map.put(POTION, 1);
-    map.put(SUPER_POTION, 2);
-    map.put(SWITCH, 2);
-    map.put(GRASS_ENERGY, 16);
-    map.put(WATER_ENERGY, 12);
-    overgrowth.setMap(map);
-    return overgrowth;
+    SimpleDeck overgrowth = new SimpleDeck("Overgrowth Theme Deck")
+    overgrowth.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BULBASAUR, 4)
+    map.put(IVYSAUR, 2)
+    map.put(WEEDLE, 4)
+    map.put(KAKUNA, 2)
+    map.put(BEEDRILL, 1)
+    map.put(STARYU, 4)
+    map.put(STARMIE, 3)
+    map.put(MAGIKARP, 2)
+    map.put(GYARADOS, 1)
+    map.put(BILL, 2)
+    map.put(GUST_OF_WIND, 2)
+    map.put(POTION, 1)
+    map.put(SUPER_POTION, 2)
+    map.put(SWITCH, 2)
+    map.put(GRASS_ENERGY, 16)
+    map.put(WATER_ENERGY, 12)
+    overgrowth.setMap(map)
+    return overgrowth
   }
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   BaseSetNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.BASE_SET;
+    return tcgwars.logic.card.Collection.BASE_SET
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -318,7 +318,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(CONFUSED)}
             }
           }
-        };
+        }
       case BLASTOISE:
         return evolution (this, from:"Wartortle", hp:HP100, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -343,7 +343,7 @@ public enum BaseSetNG implements LogicCardInfo {
               extraEnergyDamage(2,hp(10),W,thisMove)
             }
           }
-        };
+        }
       case CHANSEY:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -365,7 +365,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 80, self
             }
           }
-        };
+        }
       case CHARIZARD:
         return evolution (this, from:"Charmeleon", hp:HP120, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -412,7 +412,7 @@ public enum BaseSetNG implements LogicCardInfo {
               discardSelfEnergyInOrderTo(C) // one energy card
             }
           }
-        };
+        }
       case CLEFAIRY:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -431,7 +431,7 @@ public enum BaseSetNG implements LogicCardInfo {
               metronome defending, delegate
             }
           }
-        };
+        }
       case GYARADOS:
         return evolution (this, from:"Magikarp", hp:HP100, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -451,7 +451,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case HITMONCHAN:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -469,7 +469,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case MACHAMP:
         return evolution (this, from:"Machoke", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -491,7 +491,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case MAGNETON:
         return evolution (this, from:"Magnemite", hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -515,7 +515,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 80, self
             }
           }
-        };
+        }
       case MEWTWO:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -534,7 +534,7 @@ public enum BaseSetNG implements LogicCardInfo {
               preventAllEffectsNextTurn()
             }
           }
-        };
+        }
       case NIDOKING:
         return evolution (this, from:"Nidorino", hp:HP090, type:GRASS, retreatCost:3) {
           weakness PSYCHIC
@@ -557,7 +557,7 @@ public enum BaseSetNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NINETALES:
         return evolution (this, from:"Vulpix", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -582,7 +582,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case POLIWRATH:
         return evolution (this, from:"Poliwhirl", hp:HP090, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -602,7 +602,7 @@ public enum BaseSetNG implements LogicCardInfo {
               afterDamage{discardDefendingEnergy()}
             }
           }
-        };
+        }
       case RAICHU:
         return evolution (this, from:"Pikachu", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -622,7 +622,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 1, {}, {damage 30, self}
             }
           }
-        };
+        }
       case VENUSAUR:
         return evolution (this, from:"Ivysaur", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -650,7 +650,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case ZAPDOS:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:3) {
           resistance FIGHTING, MINUS30
@@ -670,7 +670,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case BEEDRILL:
         return evolution (this, from:"Kakuna", hp:HP080, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -691,7 +691,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(POISONED)}
             }
           }
-        };
+        }
       case DRAGONAIR:
         return evolution (this, from:"Dratini", hp:HP080, type:COLORLESS, retreatCost:2) {
           resistance PSYCHIC, MINUS30
@@ -710,7 +710,7 @@ public enum BaseSetNG implements LogicCardInfo {
               discardDefendingEnergy()
             }
           }
-        };
+        }
       case DUGTRIO:
         return evolution (this, from:"Diglett", hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -730,7 +730,7 @@ public enum BaseSetNG implements LogicCardInfo {
               my.bench.each({ damage 10, it})
             }
           }
-        };
+        }
       case ELECTABUZZ:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -750,7 +750,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 1, {damage 10}, {damage 10, self}
             }
           }
-        };
+        }
       case ELECTRODE://TODO: PLEASE IMPORT THIS NIGHTMARE FROM EVOLUTIONS
         return evolution (this, from:"Voltorb", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -770,7 +770,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 1, {}, {damage 10, self}
             }
           }
-        };
+        }
       case PIDGEOTTO:
         return evolution (this, from:"Pidgey", hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -806,7 +806,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage lastDamage.value
             }
           }
-        };
+        }
       case ARCANINE:
         return evolution (this, from:"Growlithe", hp:HP100, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -828,7 +828,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case CHARMELEON:
         return evolution (this, from:"Charmander", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -849,7 +849,7 @@ public enum BaseSetNG implements LogicCardInfo {
               discardSelfEnergyInOrderTo(R)
             }
           }
-        };
+        }
       case DEWGONG:
         return evolution (this, from:"Seel", hp:HP080, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -870,7 +870,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case DRATINI:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           resistance PSYCHIC, MINUS30
@@ -882,7 +882,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case FARFETCHD:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -913,7 +913,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GROWLITHE:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -925,7 +925,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HAUNTER:
         return evolution (this, from:"Gastly", hp:HP060, type:PSYCHIC, retreatCost:1) {
           resistance FIGHTING, MINUS30
@@ -947,7 +947,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case IVYSAUR:
         return evolution (this, from:"Bulbasaur", hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -968,7 +968,7 @@ public enum BaseSetNG implements LogicCardInfo {
               applyAfterDamage(POISONED)
             }
           }
-        };
+        }
       case JYNX:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -988,7 +988,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20+10*opp.active.numberOfDamageCounters
             }
           }
-        };
+        }
       case KADABRA:
         return evolution (this, from:"Abra", hp:HP060, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1011,7 +1011,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case KAKUNA:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1032,7 +1032,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(POISONED)}
             }
           }
-        };
+        }
       case MACHOKE:
         return evolution (this, from:"Machoke", hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -1053,7 +1053,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case MAGIKARP:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1073,7 +1073,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 10*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case MAGMAR:
         return basic (this, hp:HP050, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1094,7 +1094,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case NIDORINO:
         return evolution (this, from:"Nidoran♂", hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1114,7 +1114,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case POLIWHIRL:
         return evolution (this, from:"Poliwag", hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1134,7 +1134,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 2, {damage 30}
             }
           }
-        };
+        }
       case PORYGON:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1192,7 +1192,7 @@ public enum BaseSetNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RATICATE:
         return evolution (this, from:"Rattata", hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1213,7 +1213,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage ceil((defending.hp/10)/2)*10
             }
           }
-        };
+        }
       case SEEL:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1225,7 +1225,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case WARTORTLE:
         return evolution (this, from:"Squirtle", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1245,7 +1245,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case ABRA:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           weakness PSYCHIC
@@ -1258,7 +1258,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case BULBASAUR:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1278,7 +1278,7 @@ public enum BaseSetNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CATERPIE:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1291,7 +1291,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case CHARMANDER:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1312,7 +1312,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case DIGLETT:
         return basic (this, hp:HP030, type:FIGHTING, retreatCost:0) {
           weakness GRASS
@@ -1333,7 +1333,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case DODUO:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -1346,7 +1346,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 2, {damage 10}
             }
           }
-        };
+        }
       case DROWZEE:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1367,7 +1367,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(CONFUSED)}
             }
           }
-        };
+        }
       case GASTLY:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           resistance FIGHTING, MINUS30
@@ -1398,7 +1398,7 @@ public enum BaseSetNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KOFFING:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1411,7 +1411,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip 1, {applyAfterDamage(POISONED)}, {applyAfterDamage(CONFUSED)}
             }
           }
-        };
+        }
       case MACHOP:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1423,7 +1423,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MAGNEMITE:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1447,7 +1447,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 40, self
             }
           }
-        };
+        }
       case METAPOD:
         return evolution (this, from:"Caterpie", hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1468,7 +1468,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case NIDORAN_MALE:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1480,7 +1480,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{damage 30}
             }
           }
-        };
+        }
       case ONIX:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1498,7 +1498,7 @@ public enum BaseSetNG implements LogicCardInfo {
               bg.em().run(new Harden("Harden", hp(30)))
             }
           }
-        };
+        }
       case PIDGEY:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1511,7 +1511,7 @@ public enum BaseSetNG implements LogicCardInfo {
               whirlwind()
             }
           }
-        };
+        }
       case PIKACHU:
         // Card used as base for PopSeries2.PIKACHU_16
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
@@ -1531,7 +1531,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flipTails {damage 10, self}
             }
           }
-        };
+        }
       case POLIWAG:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1543,7 +1543,7 @@ public enum BaseSetNG implements LogicCardInfo {
               extraEnergyDamage(2,hp(10),W,thisMove)
             }
           }
-        };
+        }
       case PONYTA:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1561,7 +1561,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case RATTATA:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -1573,7 +1573,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SANDSHREW:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1586,7 +1586,7 @@ public enum BaseSetNG implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case SQUIRTLE:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1605,7 +1605,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{preventAllDamageNextTurn()}
             }
           }
-        };
+        }
       case STARMIE:
         return evolution (this, from:"Staryu", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1626,7 +1626,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(PARALYZED)}
             }
           }
-        };
+        }
       case STARYU:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1637,7 +1637,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TANGELA:
         return basic (this, hp:HP050, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1657,7 +1657,7 @@ public enum BaseSetNG implements LogicCardInfo {
               applyAfterDamage(POISONED)
             }
           }
-        };
+        }
       case VOLTORB:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1668,7 +1668,7 @@ public enum BaseSetNG implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case VULPIX:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1680,7 +1680,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip(applyAfterDamage(CONFUSED))
             }
           }
-        };
+        }
       case WEEDLE:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1692,7 +1692,7 @@ public enum BaseSetNG implements LogicCardInfo {
               flip{applyAfterDamage(POISONED)}
             }
           }
-        };
+        }
       case CLEFAIRY_DOLL:
         return basicTrainer (this) {
           text "Play Clefairy Doll as if it were a Basic Pokémon. While in play, Clefairy Doll counts a a Pokémon (instead of a Trainer card). Clefairy Doll has no attacks, can’t retreat, and can’t be Asleep, Confused, Paralyzed, or Poisoned. If Clefairy Doll is Knocked Out, it doesn’t count as a Knocked Out Pokémon. At any time during your turn before your attack, you may discard Clefairy Doll."
@@ -1744,7 +1744,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case COMPUTER_SEARCH:
         return basicTrainer (this) {
           text "Discard 2 of the other cards from you hand in order to search your deck for any card and put it into your hand. Shuffle your deck afterward."
@@ -1757,7 +1757,7 @@ public enum BaseSetNG implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2
             assert my.deck
           }
-        };
+        }
       case DEVOLUTION_SPRAY:
         return basicTrainer (this) {
           text "Choose 1 of your own Pokémon in play and a Stage of Evolution. Discard all Evolution cards of that Stage or higher attached to that Pokémon. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it)."
@@ -1772,7 +1772,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.evolution} : "You have no evolved pokemon in play"
           }
-        };
+        }
       case IMPOSTER_PROFESSOR_OAK:
         return basicTrainer (this) {
           text "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards."
@@ -1784,7 +1784,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert opp.deck
           }
-        };
+        }
       case ITEM_FINDER:
         return basicTrainer (this) {
           text "Discard 2 of the other cards from your hand in order to put a Trainer card from your discard pile into your hand."
@@ -1797,7 +1797,7 @@ public enum BaseSetNG implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2
             assert my.discard.hasType(TRAINER)
           }
-        };
+        }
       case LASS:
         return basicTrainer (this) {
           text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
@@ -1819,7 +1819,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert (opp.hand || my.hand) : "Neither player has any cards in hand"
           }
-        };
+        }
       case POKEMON_BREEDER: //TODO: Use the implementation of Rare Candy (admin: they are not the same!)
         return basicTrainer (this) {
           text "Put a Stage 2 Evolution card from your hand on the matching Basic Pokémon. You can only play this card when you would be allowed to evolve that Pokémon anyway."
@@ -1841,7 +1841,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert stage2_to_basic : "No matching Stage 2 card in hand"
           }
-        };
+        }
       case POKEMON_TRADER:
         return basicTrainer (this) {
           text "Trade 1 of the Basic Pokémon or Evolution cards in your hand for 1 of the Basic Pokémon or Evolution cards from your deck. Show both cards to your opponent. Shuffle your deck afterward."
@@ -1853,7 +1853,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.hand.find(cardTypeFilter(POKEMON)) && my.deck.notEmpty
           }
-        };
+        }
       case SCOOP_UP:
         return basicTrainer (this) {
           text "Choose 1 of your own Pokémon in play and return its Basic Pokémon card to your hand. (Discard all cards attached to that card.)"
@@ -1865,7 +1865,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement {
             confirmScoopLastPokemon()
           }
-        };
+        }
       case SUPER_ENERGY_REMOVAL:
         return basicTrainer (this) {
           text "Discard 1 Energy card attached to 1 of your Pokémon in order to choose 1 of your opponent’s Pokémon and up to 2 Energy cards attached to it. Discard those Energy cards."
@@ -1886,7 +1886,7 @@ public enum BaseSetNG implements LogicCardInfo {
             assert opp.all.findAll {it.cards.filterByType(ENERGY)} : "Opponent have no Pokemon with energy"
             assert my.all.findAll {it.cards.filterByType(ENERGY)} : "You have no Pokemon with energy"
           }
-        };
+        }
       case DEFENDER: //TODO
         return basicTrainer (this) {
           text "Attach Defender to 1 of your Pokémon. At the end of your opponent’s next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -1894,7 +1894,7 @@ public enum BaseSetNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case ENERGY_RETRIEVAL:
         return basicTrainer (this) {
           text "Trade 1 of the other cards in your hand for up to 2 basic Energy cards from your discard pile."
@@ -1907,7 +1907,7 @@ public enum BaseSetNG implements LogicCardInfo {
             assert my.discard.hasType(BASIC_ENERGY) : "No Basic Energy in Discard"
             assert my.hand.getExcludedList(thisCard).size() >= 1
           }
-        };
+        }
       case FULL_HEAL:
         return basicTrainer (this) {
           text "Your Active Pokémon is no longer Asleep, Confused, Paralyzed, or Poisoned."
@@ -1961,7 +1961,7 @@ public enum BaseSetNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case POKEMON_CENTER:
         return basicTrainer (this) {
           text "Remove all damage counters from all of your own Pokémon with damage counters on them, then discard all Energy cards attached to those Pokémon."
@@ -1977,7 +1977,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.numberOfDamageCounters}
           }
-        };
+        }
       case POKEMON_FLUTE:
         return basicTrainer (this) {
           text "Choose 1 Basic Pokémon card from your opponent’s discard pile and put it onto his or her Bench. (You can’t play Pokémon Flute if your opponent’s Bench is full.)"
@@ -1990,7 +1990,7 @@ public enum BaseSetNG implements LogicCardInfo {
             assert opp.discard.find(cardTypeFilter(BASIC)) : "No basic in opponent's discard"
             assert opp.bench.notFull : "Opponent bench is full"
           }
-        };
+        }
       case POKEDEX:
         return copy(BlackWhite.POKEDEX_98, this)
       case PROFESSOR_OAK:
@@ -2003,7 +2003,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case REVIVE:
         return basicTrainer (this) {
           text "Put 1 Basic Pokémon card from your discard pile onto your Bench. Put damage counters on that Pokémon equal to half its HP (rounded down to the nearest 10). (You can’t play Revive if your Bench is full.)"
@@ -2018,7 +2018,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.discard.find(cardTypeFilter(BASIC)) && my.bench.notFull
           }
-        };
+        }
       case SUPER_POTION:
         return basicTrainer (this) {
           text "Discard 1 Energy card attached to your own Pokémon in order to remove up to 4 damage counters from that Pokémon."
@@ -2035,7 +2035,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll {it.cards.energyCount(C) && it.numberOfDamageCounters} : "No suitable Pokémon to play this."
           }
-        };
+        }
       case BILL:
         return basicTrainer (this) {
           text "Draw 2 cards."
@@ -2045,7 +2045,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards left in your deck."
           }
-        };
+        }
       case ENERGY_REMOVAL:
         return basicTrainer (this) {
           text "Choose 1 Energy card attached to 1 of your opponent’s Pokémon and discard it."
@@ -2059,7 +2059,7 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement {
             assert opp.all.findAll {it.cards.filterByType(ENERGY)} : "Opponent does not have any Energy card in play "
           }
-        };
+        }
       case GUST_OF_WIND:
         return basicTrainer (this) {
           text "Choose 1 of your opponent’s Benched Pokémon and switch it with his or her Active Pokémon."
@@ -2072,30 +2072,30 @@ public enum BaseSetNG implements LogicCardInfo {
           playRequirement{
             assert opp.bench
           }
-        };
+        }
       case POTION:
-        return copy(FireRedLeafGreen.POTION_101, this);
+        return copy(FireRedLeafGreen.POTION_101, this)
       case SWITCH:
-        return copy(FireRedLeafGreen.SWITCH_102, this);
+        return copy(FireRedLeafGreen.SWITCH_102, this)
       case DOUBLE_COLORLESS_ENERGY:
         return specialEnergy (this, [[C],[C]]) {
           text "Double Colorless Energy provides [C][C] Energy."
           onPlay {}
-        };
+        }
       case FIGHTING_ENERGY:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       case FIRE_ENERGY:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case GRASS_ENERGY:
-        return basicEnergy (this, GRASS);
+        return basicEnergy (this, GRASS)
       case LIGHTNING_ENERGY:
-        return basicEnergy (this, LIGHTNING);
+        return basicEnergy (this, LIGHTNING)
       case PSYCHIC_ENERGY:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case WATER_ENERGY:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen1/BestOfGame.groovy
+++ b/src/tcgwars/logic/impl/gen1/BestOfGame.groovy
@@ -1,42 +1,42 @@
-package tcgwars.logic.impl.gen1;
+package tcgwars.logic.impl.gen1
 
-import tcgwars.logic.impl.gen1.BaseSetNG;
-import tcgwars.logic.impl.gen1.GymHeroes;
-import tcgwars.logic.impl.gen1.GymChallenge;
-import tcgwars.logic.impl.gen2.NeoGenesis;
+import tcgwars.logic.impl.gen1.BaseSetNG
+import tcgwars.logic.impl.gen1.GymHeroes
+import tcgwars.logic.impl.gen1.GymChallenge
+import tcgwars.logic.impl.gen2.NeoGenesis
 
 import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.effect.gm.PlayCard;
+import tcgwars.logic.effect.gm.PlayCard
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author piplup
@@ -53,64 +53,64 @@ public enum BestOfGame implements LogicCardInfo {
   ROCKETS_MEWTWO_8 ("Rocket's Mewtwo", "8", Rarity.PROMO, [POKEMON, BASIC, _PSYCHIC_]),
   ROCKETS_HITMONCHAN_9 ("Rocket's Hitmonchan", "9", Rarity.PROMO, [POKEMON, BASIC, _FIGHTING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   BestOfGame(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.BEST_OF_GAME;
+    return tcgwars.logic.card.Collection.BEST_OF_GAME
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case ELECTABUZZ_1:
-        return copy (BaseSetNG.ELECTABUZZ, this);
+        return copy (BaseSetNG.ELECTABUZZ, this)
       case HITMONCHAN_2:
-        return copy (BaseSetNG.HITMONCHAN, this);
+        return copy (BaseSetNG.HITMONCHAN, this)
       case PROFESSOR_ELM_3:
-        return copy (NeoGenesis.PROFESSOR_ELM_96, this);
+        return copy (NeoGenesis.PROFESSOR_ELM_96, this)
       case ROCKETS_SCIZOR_4:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -132,7 +132,7 @@ public enum BestOfGame implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ROCKETS_SNEASEL_5:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -151,7 +151,7 @@ public enum BestOfGame implements LogicCardInfo {
               flip 4, {damage 10}
             }
           }
-        };
+        }
       case DARK_IVYSAUR_6:
         return evolution (this, hp:HP050, from: "Bulbasaur", type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -174,7 +174,7 @@ public enum BestOfGame implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARK_VENUSAUR_7:
         return evolution (this, from: "Dark Ivysaur", hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -197,13 +197,13 @@ public enum BestOfGame implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ROCKETS_MEWTWO_8:
-        return copy (GymChallenge.ROCKET_S_MEWTWO_14, this);
+        return copy (GymChallenge.ROCKET_S_MEWTWO_14, this)
       case ROCKETS_HITMONCHAN_9:
-        return copy (GymHeroes.ROCKET_S_HITMONCHAN_11, this);
+        return copy (GymHeroes.ROCKET_S_HITMONCHAN_11, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen1/FossilNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/FossilNG.groovy
@@ -1,23 +1,23 @@
-package tcgwars.logic.impl.gen1;
+package tcgwars.logic.impl.gen1
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -90,101 +90,101 @@ public enum FossilNG implements LogicCardInfo {
   MYSTERIOUS_FOSSIL ("Mysterious Fossil", "62", Rarity.COMMON, [TRAINER]);
 
   static SimpleDeck lockdown() {
-    SimpleDeck deck = new SimpleDeck("LockDown Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BaseSet.VULPIX, 3);
-    map.put(BaseSet.PONYTA, 3);
-    map.put(MAGMAR, 2);
-    map.put(KRABBY, 4);
-    map.put(KINGLER, 2);
-    map.put(HORSEA, 4);
-    map.put(SEADRA, 2);
-    map.put(LAPRAS, 1);
-    map.put(BaseSet.BILL, 2);
-    map.put(ENERGY_SEARCH, 1);
-    map.put(BaseSet.FULL_HEAL, 1);
-    map.put(GAMBLER, 1);
-    map.put(BaseSet.POTION, 2);
-    map.put(BaseSet.SUPER_POTION, 2);
-    map.put(BaseSet.SWITCH, 2);
-    map.put(BaseSet.FIRE_ENERGY, 14);
-    map.put(BaseSet.WATER_ENERGY, 14);
-    deck.setMap(map);
-    return deck;
+    SimpleDeck deck = new SimpleDeck("LockDown Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BaseSet.VULPIX, 3)
+    map.put(BaseSet.PONYTA, 3)
+    map.put(MAGMAR, 2)
+    map.put(KRABBY, 4)
+    map.put(KINGLER, 2)
+    map.put(HORSEA, 4)
+    map.put(SEADRA, 2)
+    map.put(LAPRAS, 1)
+    map.put(BaseSet.BILL, 2)
+    map.put(ENERGY_SEARCH, 1)
+    map.put(BaseSet.FULL_HEAL, 1)
+    map.put(GAMBLER, 1)
+    map.put(BaseSet.POTION, 2)
+    map.put(BaseSet.SUPER_POTION, 2)
+    map.put(BaseSet.SWITCH, 2)
+    map.put(BaseSet.FIRE_ENERGY, 14)
+    map.put(BaseSet.WATER_ENERGY, 14)
+    deck.setMap(map)
+    return deck
   }
 
   static SimpleDeck bodyguard() {
-    SimpleDeck deck = new SimpleDeck("BodyGuard Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BaseSet.BULBASAUR, 2);
-    map.put(ZUBAT, 4);
-    map.put(GOLBAT, 2);
-    map.put(GRIMER, 4);
-    map.put(MUK, 1);
-    map.put(BaseSet.KOFFING, 4);
-    map.put(GEODUDE, 3);
-    map.put(GRAVELER, 2);
-    map.put(BaseSet.ONIX, 1);
-    map.put(BaseSet.POKEMON_CENTER, 1);
-    map.put(BaseSet.POTION, 4);
-    map.put(BaseSet.PROFESSOR_OAK, 2);
-    map.put(BaseSet.SUPER_POTION, 2);
-    map.put(BaseSet.GRASS_ENERGY, 16);
-    map.put(BaseSet.FIGHTING_ENERGY, 12);
+    SimpleDeck deck = new SimpleDeck("BodyGuard Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BaseSet.BULBASAUR, 2)
+    map.put(ZUBAT, 4)
+    map.put(GOLBAT, 2)
+    map.put(GRIMER, 4)
+    map.put(MUK, 1)
+    map.put(BaseSet.KOFFING, 4)
+    map.put(GEODUDE, 3)
+    map.put(GRAVELER, 2)
+    map.put(BaseSet.ONIX, 1)
+    map.put(BaseSet.POKEMON_CENTER, 1)
+    map.put(BaseSet.POTION, 4)
+    map.put(BaseSet.PROFESSOR_OAK, 2)
+    map.put(BaseSet.SUPER_POTION, 2)
+    map.put(BaseSet.GRASS_ENERGY, 16)
+    map.put(BaseSet.FIGHTING_ENERGY, 12)
     // map.put(,);
-    deck.setMap(map);
-    return deck;
+    deck.setMap(map)
+    return deck
   }
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   FossilNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.FOSSIL;
+    return tcgwars.logic.card.Collection.FOSSIL
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -214,7 +214,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARTICUNO_2:
         return basic (this, hp:HP070, type:WATER, retreatCost:2) {
           resistance FIGHTING, MINUS30
@@ -241,7 +241,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DITTO_3:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -252,7 +252,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGONITE_4:
         return evolution (this, from:"Dragonair", hp:HP100, type:COLORLESS, retreatCost:1) {
           resistance FIGHTING, MINUS30
@@ -276,7 +276,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_5:
         return evolution (this, from:"Haunter", hp:HP080, type:PSYCHIC, retreatCost:1) {
           resistance FIGHTING, MINUS30
@@ -303,7 +303,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_6:
         return evolution (this, from:"Gastly", hp:HP050, type:PSYCHIC, retreatCost:0) {
           resistance FIGHTING, MINUS30
@@ -350,7 +350,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONLEE_7:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -373,7 +373,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYPNO_8:
         return evolution (this, from:"Drowzee", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -400,7 +400,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTOPS_9:
         return evolution (this, from:"Kabuto", hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -422,7 +422,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAPRAS_10:
         return basic (this, hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -446,7 +446,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_11:
         return evolution (this, from:"Magnemite", hp:HP080, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -470,7 +470,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOLTRES_12:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           resistance FIGHTING, MINUS30
@@ -496,7 +496,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUK_13:
         return evolution (this, from:"Grimer", hp:HP070, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -531,7 +531,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_14:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -551,7 +551,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZAPDOS_15:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:2) {
           resistance FIGHTING, MINUS30
@@ -576,37 +576,37 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AERODACTYL:
-        return copy (AERODACTYL_1, this);
+        return copy (AERODACTYL_1, this)
       case ARTICUNO:
-        return copy (ARTICUNO_2, this);
+        return copy (ARTICUNO_2, this)
       case DITTO:
-        return copy (DITTO_3, this);
+        return copy (DITTO_3, this)
       case DRAGONITE:
-        return copy (DRAGONITE_4, this);
+        return copy (DRAGONITE_4, this)
       case GENGAR:
-        return copy (GENGAR_5, this);
+        return copy (GENGAR_5, this)
       case HAUNTER:
-        return copy (HAUNTER_6, this);
+        return copy (HAUNTER_6, this)
       case HITMONLEE:
-        return copy (HITMONLEE_7, this);
+        return copy (HITMONLEE_7, this)
       case HYPNO:
-        return copy (HYPNO_8, this);
+        return copy (HYPNO_8, this)
       case KABUTOPS:
-        return copy (KABUTOPS_9, this);
+        return copy (KABUTOPS_9, this)
       case LAPRAS:
-        return copy (LAPRAS_10, this);
+        return copy (LAPRAS_10, this)
       case MAGNETON:
-        return copy (MAGNETON_11, this);
+        return copy (MAGNETON_11, this)
       case MOLTRES:
-        return copy (MOLTRES_12, this);
+        return copy (MOLTRES_12, this)
       case MUK:
-        return copy (MUK_13, this);
+        return copy (MUK_13, this)
       case RAICHU:
-        return copy (RAICHU_14, this);
+        return copy (RAICHU_14, this)
       case ZAPDOS:
-        return copy (ZAPDOS_15, this);
+        return copy (ZAPDOS_15, this)
       case ARBOK:
         return evolution (this, from:"Ekans", hp:HP060, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -630,7 +630,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLOYSTER:
         return evolution (this, from:"Shellder", hp:HP050, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -654,7 +654,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:0) {
           resistance FIGHTING, MINUS30
@@ -678,7 +678,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT:
         return evolution (this, from:"Zubat", hp:HP060, type:GRASS, retreatCost:0) {
           weakness PSYCHIC
@@ -701,7 +701,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDUCK:
         return evolution (this, from:"Psyduck", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -724,7 +724,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM:
         return evolution (this, from:"Graveler", hp:HP080, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -748,7 +748,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRAVELER:
         return evolution (this, from:"Geodude", hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -782,7 +782,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGLER:
         return evolution (this, from:"Krabby", hp:HP060, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -803,7 +803,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -826,7 +826,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMASTAR:
         return evolution (this, from:"Omanyte", hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -848,7 +848,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSLASH:
         return evolution (this, from:"Sandshrew", hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -870,7 +870,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEADRA:
         return evolution (this, from:"Horsea", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -893,7 +893,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO:
         return evolution (this, from:"Slowbro", hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -920,7 +920,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACRUEL:
         return evolution (this, from:"Tentacool", hp:HP060, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -942,7 +942,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING:
         return evolution (this, from:"Koffing", hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -967,7 +967,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EKANS:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -989,7 +989,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GEODUDE:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1002,7 +1002,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1024,7 +1024,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HORSEA:
         return basic (this, hp:HP040, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -1038,7 +1038,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTO:
         return evolution (this, from:"Mysterious Fossil", hp:HP030, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1073,7 +1073,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRABBY:
         return basic (this, hp:HP050, type:WATER, retreatCost:2) {
           move "Call for Family", {
@@ -1099,7 +1099,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMANYTE:
         return evolution (this, from:"Mysterious Fossil", hp:HP040, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1120,7 +1120,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1149,7 +1149,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLDER:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1170,7 +1170,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1196,7 +1196,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACOOL:
         return basic (this, hp:HP030, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -1220,7 +1220,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT:
         return basic (this, hp:HP040, type:GRASS, retreatCost:0) {
           weakness PSYCHIC
@@ -1243,7 +1243,7 @@ public enum FossilNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR_FUJI:
         return basicTrainer (this) {
           text "Choose a Pokémon on your Bench. Shuffle it any any cards attached to it into your deck."
@@ -1255,7 +1255,7 @@ public enum FossilNG implements LogicCardInfo {
           playRequirement{
             assert my.bench : "There is no Benched Pokémon"
           }
-        };
+        }
       case ENERGY_SEARCH:
         return basicTrainer (this) {
           text "Search your deck for a basic Energy card and put it into your hand. Shuffle your deck afterward."
@@ -1266,7 +1266,7 @@ public enum FossilNG implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case GAMBLER:
         return basicTrainer (this) {
           text "Shuffle your hand into your deck. Flip a coin. If heads, draw 8 cards. If tails, draw 1 card."
@@ -1277,7 +1277,7 @@ public enum FossilNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case RECYCLE:
         return basicTrainer (this) {
           text "Flip a coin. If heads, put a card in your discard pile on top of your deck."
@@ -1291,7 +1291,7 @@ public enum FossilNG implements LogicCardInfo {
           playRequirement{
             assert my.discard
           }
-        };
+        }
       case MYSTERIOUS_FOSSIL:
         return basicTrainer (this) {
           text "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can’t retreat, and can’t be Asleep, Confused, Paralyzed, or Poisoned. If Mysterious Fossil is Knocked Out, it doesn’t count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn, before your attack, you may discard Mysterious Fossil from play."
@@ -1344,10 +1344,10 @@ public enum FossilNG implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
 
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen1/JungleNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/JungleNG.groovy
@@ -1,20 +1,20 @@
-package tcgwars.logic.impl.gen1;
+package tcgwars.logic.impl.gen1
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -87,103 +87,103 @@ public enum JungleNG implements LogicCardInfo {
   VENONAT ("Venonat", "63", Rarity.COMMON, [BASIC, POKEMON, _GRASS_]),
   POKE_BALL ("Poké Ball", "64", Rarity.COMMON, [TRAINER]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING
 
   static SimpleDeck waterBlast() {
-    SimpleDeck deck = new SimpleDeck("Water Blast Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BaseSet.POLIWAG, 4);
-    map.put(BaseSet.POLIWHIRL, 2);
-    map.put(BaseSet.SEEL, 1);
-    map.put(VAPOREON, 1);
-    map.put(BaseSet.MACHOP, 2);
-    map.put(RHYHORN, 3);
-    map.put(RHYDON, 1);
-    map.put(MEOWTH, 4);
-    map.put(PERSIAN, 2);
-    map.put(EEVEE, 4);
-    map.put(BaseSet.GUST_OF_WIND, 2);
-    map.put(BaseSet.POTION, 2);
-    map.put(BaseSet.PROFESSOR_OAK, 1);
-    map.put(BaseSet.SUPER_POTION, 2);
-    map.put(BaseSet.SWITCH, 1);
-    map.put(BaseSet.WATER_ENERGY, 14);
-    map.put(BaseSet.FIGHTING_ENERGY, 14);
-    deck.setMap(map);
-    return deck;
+    SimpleDeck deck = new SimpleDeck("Water Blast Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BaseSet.POLIWAG, 4)
+    map.put(BaseSet.POLIWHIRL, 2)
+    map.put(BaseSet.SEEL, 1)
+    map.put(VAPOREON, 1)
+    map.put(BaseSet.MACHOP, 2)
+    map.put(RHYHORN, 3)
+    map.put(RHYDON, 1)
+    map.put(MEOWTH, 4)
+    map.put(PERSIAN, 2)
+    map.put(EEVEE, 4)
+    map.put(BaseSet.GUST_OF_WIND, 2)
+    map.put(BaseSet.POTION, 2)
+    map.put(BaseSet.PROFESSOR_OAK, 1)
+    map.put(BaseSet.SUPER_POTION, 2)
+    map.put(BaseSet.SWITCH, 1)
+    map.put(BaseSet.WATER_ENERGY, 14)
+    map.put(BaseSet.FIGHTING_ENERGY, 14)
+    deck.setMap(map)
+    return deck
   }
 
   static SimpleDeck powerReserve() {
-    SimpleDeck deck = new SimpleDeck("Power Reserve Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_SERIES);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(NIDORAN_FEMALE, 4);
-    map.put(NIDORINA, 2);
-    map.put(ODDISH, 2);
-    map.put(GLOOM, 1);
-    map.put(BELLSPROUT, 4);
-    map.put(WEEPINBELL, 2);
-    map.put(BaseSet.ABRA, 4);
-    map.put(BaseSet.KADABRA, 2);
-    map.put(BaseSet.JYNX, 1);
-    map.put(KANGASKHAN, 1);
-    map.put(BaseSet.BILL, 2);
-    map.put(BaseSet.GUST_OF_WIND, 2);
-    map.put(BaseSet.POKEDEX, 1);
-    map.put(BaseSet.POTION, 3);
-    map.put(BaseSet.SWITCH, 1);
-    map.put(BaseSet.GRASS_ENERGY, 17);
-    map.put(BaseSet.PSYCHIC_ENERGY, 11);
-    deck.setMap(map);
-    return deck;
+    SimpleDeck deck = new SimpleDeck("Power Reserve Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_SERIES)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(NIDORAN_FEMALE, 4)
+    map.put(NIDORINA, 2)
+    map.put(ODDISH, 2)
+    map.put(GLOOM, 1)
+    map.put(BELLSPROUT, 4)
+    map.put(WEEPINBELL, 2)
+    map.put(BaseSet.ABRA, 4)
+    map.put(BaseSet.KADABRA, 2)
+    map.put(BaseSet.JYNX, 1)
+    map.put(KANGASKHAN, 1)
+    map.put(BaseSet.BILL, 2)
+    map.put(BaseSet.GUST_OF_WIND, 2)
+    map.put(BaseSet.POKEDEX, 1)
+    map.put(BaseSet.POTION, 3)
+    map.put(BaseSet.SWITCH, 1)
+    map.put(BaseSet.GRASS_ENERGY, 17)
+    map.put(BaseSet.PSYCHIC_ENERGY, 11)
+    deck.setMap(map)
+    return deck
   }
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   JungleNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.JUNGLE;
+    return tcgwars.logic.card.Collection.JUNGLE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -201,7 +201,7 @@ public enum JungleNG implements LogicCardInfo {
               def moveList = []
               def labelList = []
 
-              moveList.addAll(defending.topPokemonCard.moves);
+              moveList.addAll(defending.topPokemonCard.moves)
               labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
               def move=choose(moveList, labelList, "Which move do you want to use")
@@ -219,7 +219,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_2:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -246,7 +246,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_3:
         return evolution (this, from:"Eevee", hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -269,7 +269,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JOLTEON_4:
         return evolution (this, from:"Eevee", hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -291,7 +291,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KANGASKHAN_5:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -313,7 +313,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR_MIME_6:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -341,7 +341,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_7:
         return evolution (this, from:"Nidorina", hp:HP090, type:GRASS, retreatCost:3) {
           weakness PSYCHIC
@@ -365,7 +365,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOT_8:
         return evolution (this, from:"Pidgeotto", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -393,7 +393,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PINSIR_9:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -415,7 +415,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_10:
         return basic (this, hp:HP070, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -437,7 +437,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_11:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -463,7 +463,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_12:
         return evolution (this, from:"Eevee", hp:HP080, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -486,7 +486,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_13:
         return evolution (this, from:"Venonat", hp:HP070, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -535,7 +535,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTREEBEL_14:
         return evolution (this, from:"Weepinbell", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -558,7 +558,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_15:
         return evolution (this, from:"Gloom", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -585,7 +585,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIGGLYTUFF_16:
         return evolution (this, from:"Jigglypuff", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -607,7 +607,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE:
         return copy (CLEFABLE_1, this)
       case ELECTRODE:
@@ -665,7 +665,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO:
         return evolution (this, from:"Doduo", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -687,7 +687,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGUTOR:
         return evolution (this, from:"Exeggcute", hp:HP080, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -713,7 +713,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEAROW:
         return evolution (this, from:"Spearow", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -736,7 +736,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLOOM:
         return evolution (this, from:"Oddish", hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -759,7 +759,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -782,7 +782,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAROWAK:
         return evolution (this, from:"Cubone", hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -810,7 +810,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA:
         return evolution (this, from:"Nidoran♀", hp:HP070, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -831,7 +831,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARASECT:
         return evolution (this, from:"Paras", hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -852,7 +852,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN:
         return evolution (this, from:"Meowth", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -889,7 +889,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRIMEAPE:
         return evolution (this, from:"Mankey", hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -911,7 +911,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH:
         return evolution (this, from:"Ponyta", hp:HP070, type:FIRE, retreatCost:0) {
           weakness WATER
@@ -934,7 +934,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON:
         return evolution (this, from:"Rhyhorn", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -962,7 +962,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEAKING:
         return evolution (this, from:"Goldeen", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -983,7 +983,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAUROS:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1009,7 +1009,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEPINBELL:
         return evolution (this, from:"Bellsprout", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1031,7 +1031,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELLSPROUT:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1057,7 +1057,7 @@ public enum JungleNG implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case CUBONE:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1095,7 +1095,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1135,7 +1135,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGCUTE:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1164,7 +1164,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDEEN:
         return basic (this, hp:HP040, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -1177,7 +1177,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1199,7 +1199,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY:
         return basic (this, hp:HP030, type:FIGHTING, retreatCost:0) {
           weakness PSYCHIC
@@ -1211,11 +1211,11 @@ public enum JungleNG implements LogicCardInfo {
               powerUsed()
               def choice = choose([0,1,2,3,4],["Top of your deck", "Top of your opponent's deck", "Your opponent’s hand ", "Your Prizes", "Opponent's Prizes"])
               switch (choice){
-                case 0: my.deck.subList(0,1).showToMe("Top of your deck"); break;
-                case 1: opp.deck.subList(0,1).showToMe("Top of your opponent's deck"); break;
-                case 2: opp.hand.shuffledCopy().select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break;
-                case 3: my.prizeCardSet.select(hidden: true, "Select a random card from your prizes").showToMe("Selected card"); break;
-                case 4: opp.prizeCardSet.select(hidden: true, "Select a random card from your opponent's prizes").showToMe("Selected card"); break;
+                case 0: my.deck.subList(0,1).showToMe("Top of your deck"); break
+                case 1: opp.deck.subList(0,1).showToMe("Top of your opponent's deck"); break
+                case 2: opp.hand.shuffledCopy().select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break
+                case 3: my.prizeCardSet.select(hidden: true, "Select a random card from your prizes").showToMe("Selected card"); break
+                case 4: opp.prizeCardSet.select(hidden: true, "Select a random card from your opponent's prizes").showToMe("Selected card"); break
               }
             }
           }
@@ -1228,7 +1228,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1243,7 +1243,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1270,7 +1270,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1298,7 +1298,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARAS:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1319,7 +1319,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1333,7 +1333,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1372,7 +1372,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEAROW:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -1409,7 +1409,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENONAT:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1432,7 +1432,7 @@ public enum JungleNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POKE_BALL:
         return basicTrainer (this) {
           text "Flip a coin. If heads, you may search your deck for any Basic Pokémon or Evolution card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
@@ -1444,9 +1444,9 @@ public enum JungleNG implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/TeamRocketNG.groovy
@@ -1,22 +1,22 @@
-package tcgwars.logic.impl.gen1;
+package tcgwars.logic.impl.gen1
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -109,108 +109,108 @@ public enum TeamRocketNG implements LogicCardInfo {
   DARK_RAICHU ("Dark Raichu", "83", Rarity.HOLORARE, [STAGE1, EVOLUTION, POKEMON, _LIGHTNING_]);
 
   public static SimpleDeck devastation() {
-    SimpleDeck deck = new SimpleDeck("Devastation Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_EXTENDED);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BaseSet.WEEDLE, 3);
-    map.put(ODDISH, 3);
-    map.put(DARK_GLOOM, 1);
-    map.put(KOFFING, 4);
-    map.put(DARK_WEEZING, 1);
-    map.put(BaseSet.TANGELA, 3);
-    map.put(BaseSet.SQUIRTLE, 3);
-    map.put(BaseSet.WARTORTLE, 1);
-    map.put(DARK_WARTORTLE, 1);
-    map.put(BaseSet.MAGIKARP, 1);
-    map.put(DARK_VAPOREON, 1);
-    map.put(EEVEE, 3);
-    map.put(BaseSet.FULL_HEAL, 1);
-    map.put(BaseSet.GUST_OF_WIND, 1);
-    map.put(IMPOSTER_OAKS_REVENGE, 1);
-    map.put(BaseSet.POTION, 2);
-    map.put(BaseSet.SUPER_POTION, 1);
-    map.put(BaseSet.GRASS_ENERGY, 18);
-    map.put(BaseSet.WATER_ENERGY, 10);
-    deck.setMap(map);
-    return deck;
+    SimpleDeck deck = new SimpleDeck("Devastation Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_EXTENDED)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BaseSet.WEEDLE, 3)
+    map.put(ODDISH, 3)
+    map.put(DARK_GLOOM, 1)
+    map.put(KOFFING, 4)
+    map.put(DARK_WEEZING, 1)
+    map.put(BaseSet.TANGELA, 3)
+    map.put(BaseSet.SQUIRTLE, 3)
+    map.put(BaseSet.WARTORTLE, 1)
+    map.put(DARK_WARTORTLE, 1)
+    map.put(BaseSet.MAGIKARP, 1)
+    map.put(DARK_VAPOREON, 1)
+    map.put(EEVEE, 3)
+    map.put(BaseSet.FULL_HEAL, 1)
+    map.put(BaseSet.GUST_OF_WIND, 1)
+    map.put(IMPOSTER_OAKS_REVENGE, 1)
+    map.put(BaseSet.POTION, 2)
+    map.put(BaseSet.SUPER_POTION, 1)
+    map.put(BaseSet.GRASS_ENERGY, 18)
+    map.put(BaseSet.WATER_ENERGY, 10)
+    deck.setMap(map)
+    return deck
   }
 
   public static SimpleDeck trouble() {
-    SimpleDeck deck = new SimpleDeck("Trouble Theme Deck");
-    deck.setFormat(GameFormat.CLASSIC_EXTENDED);
-    Map<CardInfo, Integer> map = new HashMap<>();
-    map.put(BaseSet.ABRA, 2);
-    map.put(ABRA, 2);
-    map.put(BaseSet.KADABRA, 2);
-    map.put(DARK_KADABRA, 2);
-    map.put(DROWZEE, 3);
-    map.put(BaseSet.GASTLY, 2);
-    map.put(BaseSet.HAUNTER, 1);
-    map.put(BaseSet.JYNX, 1);
-    map.put(EKANS, 4);
-    map.put(DARK_ARBOK, 1);
-    map.put(BaseSet.WEEDLE, 2);
-    map.put(BaseSet.FARFETCHD, 2);
-    map.put(MEOWTH, 2);
-    map.put(BaseSet.BILL, 1);
-    map.put(BaseSet.GUST_OF_WIND, 1);
-    map.put(BaseSet.POTION, 2);
-    map.put(THE_BOSSS_WAY, 1);
-    map.put(BaseSet.SWITCH, 1);
-    map.put(BaseSet.PSYCHIC_ENERGY, 18);
-    map.put(BaseSet.GRASS_ENERGY, 10);
-    map.put(FULL_HEAL_ENERGY, 1);
-    deck.setMap(map);
-    return deck;
+    SimpleDeck deck = new SimpleDeck("Trouble Theme Deck")
+    deck.setFormat(GameFormat.CLASSIC_EXTENDED)
+    Map<CardInfo, Integer> map = new HashMap<>()
+    map.put(BaseSet.ABRA, 2)
+    map.put(ABRA, 2)
+    map.put(BaseSet.KADABRA, 2)
+    map.put(DARK_KADABRA, 2)
+    map.put(DROWZEE, 3)
+    map.put(BaseSet.GASTLY, 2)
+    map.put(BaseSet.HAUNTER, 1)
+    map.put(BaseSet.JYNX, 1)
+    map.put(EKANS, 4)
+    map.put(DARK_ARBOK, 1)
+    map.put(BaseSet.WEEDLE, 2)
+    map.put(BaseSet.FARFETCHD, 2)
+    map.put(MEOWTH, 2)
+    map.put(BaseSet.BILL, 1)
+    map.put(BaseSet.GUST_OF_WIND, 1)
+    map.put(BaseSet.POTION, 2)
+    map.put(THE_BOSSS_WAY, 1)
+    map.put(BaseSet.SWITCH, 1)
+    map.put(BaseSet.PSYCHIC_ENERGY, 18)
+    map.put(BaseSet.GRASS_ENERGY, 10)
+    map.put(FULL_HEAL_ENERGY, 1)
+    deck.setMap(map)
+    return deck
   }
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   TeamRocketNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.TEAM_ROCKET;
+    return tcgwars.logic.card.Collection.TEAM_ROCKET
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -239,7 +239,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ARBOK_2:
         return evolution (this, from:"Ekans", hp:HP060, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -278,7 +278,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_BLASTOISE_3:
         return evolution (this, from:"Dark Wartortle", hp:HP070, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -304,7 +304,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_CHARIZARD_4:
         return evolution (this, from:"Dark Charmeleon", hp:HP080, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -330,7 +330,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONITE_5:
         return evolution (this, from:"Dark Dragonair", hp:HP070, type:COLORLESS, retreatCost:2) {
           resistance FIGHTING, MINUS30
@@ -358,7 +358,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DUGTRIO_6:
         return evolution (this, from:"Diglett", hp:HP050, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -384,7 +384,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GOLBAT_7:
         return evolution (this, from:"Zubat", hp:HP050, type:GRASS, retreatCost:0) {
           weakness PSYCHIC
@@ -415,7 +415,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GYARADOS_8:
         return evolution (this, from:"Magikarp", hp:HP070, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -446,7 +446,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_HYPNO_9:
         return evolution (this, from:"Drowzee", hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -467,7 +467,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MACHAMP_10:
         return evolution (this, from:"Dark Machoke", hp:HP070, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -492,7 +492,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MAGNETON_11:
         return evolution (this, from:"Magnemite", hp:HP060, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -517,7 +517,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_SLOWBRO_12:
         return evolution (this, from:"Slowpoke", hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -538,7 +538,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_VILEPLUME_13:
         return evolution (this, from:"Dark Gloom", hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -569,7 +569,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_WEEZING_14:
         return evolution (this, from:"Koffing", hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -602,7 +602,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERE_COMES_TEAM_ROCKET_15:
         return basicTrainer (this) {
           text "Each player plays with his or her Prize cards face up for the rest of the game."
@@ -614,7 +614,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           playRequirement{
             assert !(my.prizeCardSet.allVisible && opp.prizeCardSet.allVisible) : "All prizes are already visible"
           }
-        };
+        }
       case ROCKETS_SNEAK_ATTACK_16:
         return basicTrainer (this) {
           text "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
@@ -633,7 +633,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           playRequirement{
             assert opp.hand
           }
-        };
+        }
       case RAINBOW_ENERGY_17:
         return specialEnergy (this, [[]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy counts as every type of basic Energy but only provides 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play.) When you attach this card from your hand to 1 of your Pokémon, it does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance.)"
@@ -648,7 +648,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           onRemoveFromPlay {
           }
-        };
+        }
       case DARK_ALAKAZAM:
         return copy (DARK_ALAKAZAM_1, this)
       case DARK_ARBOK:
@@ -702,7 +702,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONAIR:
         return evolution (this, from:"Dratini", hp:HP060, type:COLORLESS, retreatCost:2) {
           resistance PSYCHIC, MINUS30
@@ -725,7 +725,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ELECTRODE:
         return evolution(this, from: "Voltorb", hp: HP060, type: LIGHTNING, retreatCost: 1) {
           weakness FIGHTING
@@ -755,7 +755,7 @@ public enum TeamRocketNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARK_FLAREON:
         return evolution (this, from:"Eevee", hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -783,7 +783,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GLOOM:
         return evolution (this, from:"Oddish", hp:HP050, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -806,7 +806,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GOLDUCK:
         return evolution (this, from:"Psyduck", hp:HP060, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -830,7 +830,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_JOLTEON:
         return evolution (this, from:"Eevee", hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -853,7 +853,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_KADABRA:
         return evolution (this, from:"Abra", hp:HP050, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -879,7 +879,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MACHOKE:
         return evolution (this, from:"Machop", hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -908,7 +908,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MUK:
         return evolution (this, from:"Grimer", hp:HP060, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -930,7 +930,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PERSIAN:
         return evolution (this, from:"Meowth", hp:HP060, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -958,7 +958,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PRIMEAPE:
         return evolution (this, from:"Mankey", hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -987,7 +987,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_RAPIDASH:
         return evolution (this, from:"Ponyta", hp:HP060, type:FIRE, retreatCost:0) {
           weakness WATER
@@ -1013,7 +1013,7 @@ public enum TeamRocketNG implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARK_VAPOREON:
         return evolution (this, from:"Eevee", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1035,7 +1035,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_WARTORTLE:
         return evolution (this, from:"Squirtle", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1079,7 +1079,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1105,7 +1105,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -1151,7 +1151,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABRA:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1179,7 +1179,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1203,7 +1203,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_RATICATE:
         return evolution (this, from:"Rattata", hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1225,7 +1225,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGLETT:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:0) {
           weakness GRASS
@@ -1247,7 +1247,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRATINI:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           resistance PSYCHIC, MINUS30
@@ -1261,7 +1261,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DROWZEE:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1284,7 +1284,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1307,7 +1307,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EKANS:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1329,7 +1329,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1354,7 +1354,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1376,7 +1376,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1397,7 +1397,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1418,7 +1418,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:0) {
           weakness PSYCHIC
@@ -1440,7 +1440,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1455,7 +1455,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1476,7 +1476,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1490,7 +1490,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1514,7 +1514,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -1542,7 +1542,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1565,7 +1565,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SQUIRTLE:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1578,7 +1578,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1591,7 +1591,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT:
         return basic (this, hp:HP040, type:GRASS, retreatCost:0) {
           weakness PSYCHIC
@@ -1613,7 +1613,7 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERE_COMES_TEAM_ROCKET:
         return copy (HERE_COMES_TEAM_ROCKET_15, this)
       case ROCKETS_SNEAK_ATTACK:
@@ -1630,7 +1630,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case CHALLENGE:
         return basicTrainer (this) {
           text "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If you opponent accepts, each of you searches your decks for any number of Basic Pokémon cards and puts them face down onto your Benches. (A player can’t do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
@@ -1660,7 +1660,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case DIGGER:
         return basicTrainer (this) {
           text "Flip a coin. If tails, do 10 damage to your Active Pokémon. If heads, your opponent flips a coin. If tails, your opponent does 10 damage to his or her Active Pokémon. If heads, you flip a coin. Keep doing this until a player gets tails."
@@ -1681,7 +1681,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case IMPOSTER_OAKS_REVENGE:
         return basicTrainer (this) {
           text "Discard a card from your hand in order to play this card. Your opponent shuffles his or her hand into his or her deck, then draws 4 cards."
@@ -1694,7 +1694,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           playRequirement{
             assert my.hand.findAll({it != thisCard})
           }
-        };
+        }
       case NIGHTLY_GARBAGE_RUN:
         return basicTrainer (this) {
           text "Choose up to 3 Basic Pokémon cards, Evolution cards, and/or basic Energy cards from your discard pile. Show them to your opponent and shuffle them into your deck."
@@ -1707,7 +1707,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           playRequirement{
             assert my.discard
           }
-        };
+        }
       case GOOP_GAS_ATTACK:
         return basicTrainer (this) {
           text "All Pokémon Powers stop working until the end of your opponent’s next turn."
@@ -1736,7 +1736,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case SLEEP:
         return basicTrainer (this) {
           text "Flip a coin. If heads, the Defending Pokémon is now Asleep."
@@ -1745,7 +1745,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case RAINBOW_ENERGY:
         return copy (RAINBOW_ENERGY_17, this)
       case FULL_HEAL_ENERGY:
@@ -1756,7 +1756,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           onRemoveFromPlay {
           }
-        };
+        }
       case POTION_ENERGY:
         return specialEnergy (this, [[C]]) {
           text "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any.\nPotion Energy provides [C] energy. (Doesn’t count as a basic Energy card.)"
@@ -1765,7 +1765,7 @@ public enum TeamRocketNG implements LogicCardInfo {
           }
           onRemoveFromPlay {
           }
-        };
+        }
       case DARK_RAICHU:
         return evolution (this, from:"Pikachu", hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1789,9 +1789,9 @@ public enum TeamRocketNG implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
+++ b/src/tcgwars/logic/impl/gen1/WizardsBlackStarPromosNG.groovy
@@ -1,36 +1,36 @@
-package tcgwars.logic.impl.gen1;
+package tcgwars.logic.impl.gen1
 
-import tcgwars.logic.impl.gen1.BaseSetNG;
+import tcgwars.logic.impl.gen1.BaseSetNG
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -91,53 +91,53 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
   HO_OH_52 ("Ho-oh", "52", Rarity.PROMO, [POKEMON, BASIC, _FIRE_]),
   SUICUNE_53 ("Suicune", "53", Rarity.PROMO, [POKEMON, BASIC, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   WizardsBlackStarPromosNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.WIZARDS_BLACK_STAR_PROMOS_NG;
+    return tcgwars.logic.card.Collection.WIZARDS_BLACK_STAR_PROMOS_NG
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -164,7 +164,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case ELECTABUZZ_2:
       return basic (this, hp:HP060, type:L, retreatCost:2) {
         weakness F
@@ -185,7 +185,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case MEWTWO_3:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -209,7 +209,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PIKACHU_4:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -231,7 +231,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             discardAllSelfEnergy(null)
           }
         }
-      };
+      }
       case DRAGONITE_5:
       return evolution (this, from:"Dragonair", hp:HP090, type:C, retreatCost:2) {
         resistance F, MINUS30
@@ -249,7 +249,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { damage 60 }
           }
         }
-      };
+      }
       case ARCANINE_6:
       return evolution (this, from:"Growlithe", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -271,7 +271,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             discardSelfEnergy C,C
           }
         }
-      };
+      }
       case JIGGLYPUFF_7:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -293,7 +293,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case MEW_8:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -313,9 +313,9 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case MEW_9:
-      return copy (MEW_8, this);
+      return copy (MEW_8, this)
       case MEOWTH_10:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -333,7 +333,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case EEVEE_11:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         weakness F
@@ -352,7 +352,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEWTWO_12:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -375,7 +375,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             noWrDamage 30, opp.all.select()
           }
         }
-      };
+      }
       case VENUSAUR_13:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:1) {
         weakness R
@@ -393,9 +393,9 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEWTWO_14:
-      return copy (MEWTWO_3, this);
+      return copy (MEWTWO_3, this)
       case COOL_PORYGON_15:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -416,7 +416,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip 3, { damage 20 }
           }
         }
-      };
+      }
       case COMPUTER_ERROR_16:
       return basicTrainer (this) {
         text "You may draw up to 5 cards, then your opponent may draw up to 5 cards. Your turn is over now (you don't get to attack)."
@@ -425,7 +425,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DARK_PERSIAN_17:
       return evolution (this, from:"Meowth", hp:HP060, type:C, retreatCost:0) {
         weakness F
@@ -450,7 +450,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply POISONED }
           }
         }
-      };
+      }
       case TEAM_ROCKET_S_MEOWTH_18:
       return basic (this, hp:HP040, type:C, retreatCost:2) {
         weakness F
@@ -467,7 +467,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SABRINA_S_ABRA_19:
       return basic (this, hp:HP040, type:P, retreatCost:0) {
         weakness P
@@ -489,7 +489,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PSYDUCK_20:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -517,7 +517,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip 3, { damage 10 }
           }
         }
-      };
+      }
       case MOLTRES_21:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         resistance F, MINUS30
@@ -535,7 +535,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARTICUNO_22:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         resistance F, MINUS30
@@ -554,7 +554,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZAPDOS_23:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         resistance F, MINUS30
@@ -575,7 +575,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BIRTHDAY_PIKACHU_24:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -592,7 +592,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLYING_PIKACHU_25:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         resistance F, MINUS30
@@ -614,7 +614,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case PIKACHU_26:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -635,7 +635,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             discardAllSelfEnergy(null)
           }
         }
-      };
+      }
       case PIKACHU_27:
       return basic (this, hp:HP030, type:L, retreatCost:0) {
         weakness F
@@ -657,7 +657,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case SURFING_PIKACHU_28:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -669,7 +669,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MARILL_29:
       return basic (this, hp:HP050, type:W, retreatCost:2) {
         weakness L
@@ -682,7 +682,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case TOGEPI_30:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -700,7 +700,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { metronome defending, delegate }
           }
         }
-      };
+      }
       case CLEFFA_31:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         move "Eek", {
@@ -711,7 +711,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             draw 2
           }
         }
-      };
+      }
       case SMEARGLE_32:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         weakness F
@@ -724,7 +724,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case SCIZOR_33:
       return evolution (this, from:"Scyther", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -763,7 +763,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flipUntilTails { damage 10 }
           }
         }
-      };
+      }
       case ENTEI_34:
       return basic (this, hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -782,7 +782,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case PICHU_35:
       return basic (this, hp:HP030, type:L, retreatCost:0) {
         move "Let's Play!", {
@@ -793,7 +793,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case IGGLYBUFF_36:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         move "Good Night Song", {
@@ -804,7 +804,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case HITMONTOP_37:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -831,7 +831,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_J__38:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -849,7 +849,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MISDREAVUS_39:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         resistance F, MINUS30
@@ -870,7 +870,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply CONFUSED }
           }
         }
-      };
+      }
       case POKEMON_CENTER_40:
       return copy(BaseSetNG.POKEMON_CENTER, this)
       case LUCKY_STADIUM_41:
@@ -893,7 +893,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             bg().gm().unregisterAction(it)
           }
         }
-      };
+      }
       case POKEMON_TOWER_42:
       return stadium (this) {
         text "If the effect of a Pokémon Power, attack, Energy card, or Trainer card would put a card in a discard pile into its owner's hand, that card stays in that discard pile instead."
@@ -913,7 +913,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case MACHAMP_43:
       return evolution (this, from:"Machoke", hp:HP090, type:F, retreatCost:3) {
         weakness P
@@ -939,7 +939,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAGMAR_44:
       return basic (this, hp:HP060, type:R, retreatCost:2) {
         weakness W
@@ -961,7 +961,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SCYTHER_45:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -975,7 +975,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             cantUseAttack(thisMove,self)
           }
         }
-      };
+      }
       case ELECTABUZZ_46:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -996,7 +996,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             // TODO
           }
         }
-      };
+      }
       case MEW_47:
       // Card used as base for WizardsBlackStarPromos.MEW_47
       return basic (this, hp:HP040, type:P, retreatCost:1) {
@@ -1031,7 +1031,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply CONFUSED }
           }
         }
-      };
+      }
       case ARTICUNO_48:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         resistance F, MINUS30
@@ -1050,7 +1050,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { PARALYZED }
           }
         }
-      };
+      }
       case SNORLAX_49:
       return basic (this, hp:HP090, type:C, retreatCost:4) {
         weakness F
@@ -1071,7 +1071,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply ASLEEP }
           }
         }
-      };
+      }
       case CELEBI_50:
       // Card used as base for NintendoBlackStarPromos.CELEBI_29
       return basic (this, hp:HP050, type:G, retreatCost:1) {
@@ -1084,7 +1084,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case RAPIDASH_51:
       return evolution (this, from:"Ponyta", hp:HP060, type:R, retreatCost:0) {
         weakness W
@@ -1107,7 +1107,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip { apply BURNED }
           }
         }
-      };
+      }
       case HO_OH_52:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1120,7 +1120,7 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip 1, { damage 60 }, { damage 20 }
           }
         }
-      };
+      }
       case SUICUNE_53:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1139,9 +1139,9 @@ public enum WizardsBlackStarPromosNG implements LogicCardInfo {
             flip 1, { damage 20 }, { apply ASLEEP }
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen2/AquapolisNG.groovy
+++ b/src/tcgwars/logic/impl/gen2/AquapolisNG.groovy
@@ -3,35 +3,35 @@ package tcgwars.logic.impl.gen2
 import tcgwars.logic.impl.gen3.CrystalGuardians
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -221,53 +221,53 @@ public enum AquapolisNG implements LogicCardInfo {
   VILEPLUME_H31 ("Vileplume", "H31", Rarity.RARE, [POKEMON, EVOLUTION, STAGE2, _GRASS_]),
   ZAPDOS_H32 ("Zapdos", "H32", Rarity.RARE, [POKEMON, BASIC, _LIGHTNING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   AquapolisNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.AQUAPOLIS;
+    return tcgwars.logic.card.Collection.AQUAPOLIS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -292,7 +292,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ARCANINE_2:
       return evolution (this, from:"Growlithe", hp:HP090, type:R, retreatCost:3) {
         weakness W
@@ -309,7 +309,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARIADOS_3:
       return evolution (this, from:"Spinarak", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -326,7 +326,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case AZUMARILL_4:
       return evolution (this, from:"Marill", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -343,7 +343,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BELLOSSOM_5:
       return evolution (this, from:"Gloom", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -361,7 +361,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BLISSEY_6:
       return evolution (this, from:"Chansey", hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -378,7 +378,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DONPHAN_7:
       return evolution (this, from:"Phanpy", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -399,7 +399,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ELECTRODE_8:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -416,7 +416,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ELEKID_9:
       return basic (this, hp:HP030, type:L, retreatCost:1) {
         move "Energy Kick", {
@@ -427,7 +427,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ENTEI_10:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -444,7 +444,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ESPEON_11:
       return evolution (this, from:"Eevee", hp:HP080, type:P, retreatCost:null) {
         weakness P
@@ -461,7 +461,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case EXEGGUTOR_12:
       return evolution (this, from:"Exeggcute", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -481,7 +481,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGUTOR_13:
       return evolution (this, from:"Exeggcute", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -501,7 +501,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HOUNDOOM_14:
       return evolution (this, from:"Houndour", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -521,7 +521,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HOUNDOOM_15:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -542,7 +542,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HYPNO_16:
       return evolution (this, from:"Drowzee", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -559,7 +559,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JUMPLUFF_17:
       return evolution (this, from:"Skiploom", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -577,7 +577,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JYNX_18:
       return basic (this, hp:HP060, type:P, retreatCost:2) {
         weakness P
@@ -597,7 +597,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KINGDRA_19:
       return evolution (this, from:"Seadra", hp:HP120, type:W, retreatCost:3) {
         weakness L
@@ -614,7 +614,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LANTURN_20:
       return evolution (this, from:"Chinchou", hp:HP080, type:W, retreatCost:1) {
         weakness G
@@ -634,7 +634,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LANTURN_21:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -651,7 +651,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNETON_22:
       return evolution (this, from:"Magnemite", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -669,7 +669,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MUK_23:
       return evolution (this, from:"Grimer", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -686,7 +686,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NIDOKING_24:
       return evolution (this, from:"Nidorino", hp:HP110, type:F, retreatCost:3) {
         weakness G
@@ -704,7 +704,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NINETALES_25:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -724,7 +724,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case OCTILLERY_26:
       return evolution (this, from:"Remoraid", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -741,7 +741,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PARASECT_27:
       return evolution (this, from:"Paras", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -761,7 +761,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PORYGON2_28:
       return evolution (this, from:"Porygon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -778,7 +778,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PRIMEAPE_29:
       return evolution (this, from:"Mankey", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -798,7 +798,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case QUAGSIRE_30:
       return evolution (this, from:"Wooper", hp:HP080, type:W, retreatCost:2) {
         weakness G
@@ -818,7 +818,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAPIDASH_31:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:null) {
         weakness W
@@ -838,7 +838,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCIZOR_32:
       return evolution (this, from:"Scyther", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -863,7 +863,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLOWBRO_33:
       return evolution (this, from:"Slowpoke", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -880,7 +880,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLOWKING_34:
       return evolution (this, from:"Slowpoke", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -900,7 +900,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STEELIX_35:
       return evolution (this, from:"Onix", hp:HP100, type:M, retreatCost:4) {
         weakness R
@@ -921,7 +921,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SUDOWOODO_36:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness W
@@ -942,7 +942,7 @@ public enum AquapolisNG implements LogicCardInfo {
             attachEnergyFrom(basic:true, my.deck, self)
           }
         }
-      };
+      }
       case SUICUNE_37:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -959,7 +959,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TENTACRUEL_38:
       return evolution (this, from:"Tentacool", hp:HP070, type:W, retreatCost:null) {
         weakness L
@@ -976,7 +976,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TOGETIC_39:
       return evolution (this, from:"Togepi", hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -994,7 +994,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TYRANITAR_40:
       return evolution (this, from:"Pupitar", hp:HP120, type:D, retreatCost:3) {
         weakness F
@@ -1023,7 +1023,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case UMBREON_41:
       return evolution (this, from:"Eevee", hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -1041,7 +1041,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VICTREEBEL_42:
       return evolution (this, from:"Weepinbell", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -1058,7 +1058,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VILEPLUME_43:
       return evolution (this, from:"Gloom", hp:HP100, type:G, retreatCost:2) {
         weakness FIRE
@@ -1083,7 +1083,7 @@ public enum AquapolisNG implements LogicCardInfo {
             flip {opponentCantPlaySupporterNextTurn(delegate)}
           }
         }
-      };
+      }
       case ZAPDOS_44:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         weakness L
@@ -1109,7 +1109,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BELLSPROUT_45:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1121,7 +1121,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DODRIO_46:
       return evolution (this, from:"Doduo", hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -1142,7 +1142,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FLAAFFY_47:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1162,7 +1162,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FURRET_48:
       return evolution (this, from:"Sentret", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1179,7 +1179,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GLOOM_49:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1196,7 +1196,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDUCK_50:
       return evolution (this, from:"Psyduck", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1216,7 +1216,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROWLITHE_51:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1228,7 +1228,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGNEMITE_52:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1249,7 +1249,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MARILL_53:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1269,7 +1269,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAROWAK_54:
       return evolution (this, from:"Cubone", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1290,7 +1290,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDORINO_55:
       return evolution (this, from:"Nidoran♂", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1310,7 +1310,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PUPITAR_56:
       return evolution (this, from:"Larvitar", hp:HP080, type:F, retreatCost:1) {
         weakness W
@@ -1322,7 +1322,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCYTHER_57:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1342,7 +1342,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEADRA_58:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1362,7 +1362,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEAKING_59:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1382,7 +1382,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKIPLOOM_60:
       return evolution (this, from:"Hoppip", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1400,7 +1400,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SMOOCHUM_61:
       return basic (this, hp:HP030, type:P, retreatCost:1) {
         move "Energy Kiss", {
@@ -1411,7 +1411,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPINARAK_62:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1431,7 +1431,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TYROGUE_63:
       return basic (this, hp:HP030, type:F, retreatCost:1) {
         move "Energy Punch", {
@@ -1442,7 +1442,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case VOLTORB_64:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1462,7 +1462,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WEEPINBELL_65:
       return evolution (this, from:"Bellsprout", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1482,7 +1482,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WOOPER_66:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1502,7 +1502,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case AIPOM_67:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1522,7 +1522,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELLSPROUT_68:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -1542,7 +1542,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHANSEY_69:
       return basic (this, hp:HP100, type:C, retreatCost:2) {
         weakness F
@@ -1562,7 +1562,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHINCHOU_70:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1582,7 +1582,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHINCHOU_71:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1602,7 +1602,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CUBONE_72:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1623,7 +1623,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DODUO_73:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1644,7 +1644,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DROWZEE_74:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1664,7 +1664,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EEVEE_75:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1684,7 +1684,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case EXEGGCUTE_76:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1704,7 +1704,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGCUTE_77:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1724,7 +1724,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GOLDEEN_78:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1736,7 +1736,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRIMER_79:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1748,7 +1748,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GROWLITHE_80:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1768,7 +1768,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HITMONCHAN_81:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -1788,7 +1788,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HITMONTOP_82:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -1808,7 +1808,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOPPIP_83:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1826,7 +1826,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HORSEA_84:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1838,7 +1838,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HORSEA_85:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1850,7 +1850,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_86:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1870,7 +1870,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_87:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1882,7 +1882,7 @@ public enum AquapolisNG implements LogicCardInfo {
             swiftDamage 20, opp.all.select("Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon.")
           }
         }
-      };
+      }
       case KANGASKHAN_88:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -1902,7 +1902,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LARVITAR_89:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -1922,7 +1922,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LICKITUNG_90:
       return basic (this, hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -1942,7 +1942,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_91:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1959,7 +1959,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MANKEY_92:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
@@ -1979,7 +1979,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAREEP_93:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1999,7 +1999,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MILTANK_94:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2019,7 +2019,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MR_MIME_95:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2031,7 +2031,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NIDORAN_MALE_96:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2051,7 +2051,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ODDISH_97:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2071,7 +2071,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ONIX_98:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness W
@@ -2083,7 +2083,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PARAS_99:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2103,7 +2103,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PHANPY_100:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -2124,7 +2124,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINSIR_101:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -2144,7 +2144,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PONYTA_102:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2164,7 +2164,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PORYGON_103:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2184,7 +2184,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PSYDUCK_104:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2204,7 +2204,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case REMORAID_105:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2216,7 +2216,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SCYTHER_106:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness L
@@ -2237,7 +2237,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SENTRET_107:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2257,7 +2257,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLOWPOKE_108:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2277,7 +2277,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SMEARGLE_109:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2297,7 +2297,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNEASEL_110:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -2318,7 +2318,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SPINARAK_111:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -2330,7 +2330,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TANGELA_112:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -2351,7 +2351,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TENTACOOL_113:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2371,7 +2371,7 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TOGEPI_114:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2391,7 +2391,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VOLTORB_115:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -2403,7 +2403,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VULPIX_116:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -2415,7 +2415,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WOOPER_117:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2435,7 +2435,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case APRICORN_FOREST_118:
       return stadium (this) {
         text "Once during each player's turn (before attacking), if that player's Bench isn't full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffles his or her deck afterward."
@@ -2443,7 +2443,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DARKNESS_CUBE_01_119:
       return basicTrainer (this) {
         text "Before doing damage, discard all Trainer cards attached to the Defending Pokémon."
@@ -2451,7 +2451,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SWITCH_120:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case FIGHTING_CUBE_01_121:
@@ -2461,7 +2461,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FIRE_CUBE_01_122:
       return basicTrainer (this) {
         text "The Defending Pokémon is now Burned."
@@ -2469,7 +2469,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FOREST_GUARDIAN_123:
       return supporter (this) {
         text "Shuffle your deck. Then, look at the top 7 cards of your deck. Choose 1 of those cards and put it into your hand. Shuffle the rest into your deck afterward."
@@ -2477,7 +2477,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GRASS_CUBE_01_124:
       return basicTrainer (this) {
         text "The Defending Pokémon is now Asleep and Poisoned."
@@ -2485,7 +2485,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HEALING_BERRY_125:
       return pokemonTool (this) {
         text "At the end of any turn, if the Pokémon this card is attached to has 20 HP or less, remove 3 damage counters from that Pokémon and discard this card."
@@ -2495,7 +2495,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case JUGGLER_126:
       return supporter (this) {
         text "Discard up to 2 basic Energy cards from your hand. If you discarded 1 basic Energy card, draw 3 cards. If you discarded 2 basic Energy cards, draw 5 cards."
@@ -2503,7 +2503,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LIGHTNING_CUBE_01_127:
       return basicTrainer (this) {
         text "Discard all [L] Energy cards attached to this Pokémon. Then, flip a number of coins equal to the number of Energy cards discarded that way. This attack does 40 damage times the number of heads."
@@ -2511,10 +2511,10 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MEMORY_BERRY_128:
         // "The Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
-        return copy(CrystalGuardians.MEMORY_BERRY_80, this);
+        return copy(CrystalGuardians.MEMORY_BERRY_80, this)
       case METAL_CUBE_01_129:
       return basicTrainer (this) {
         text "Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with the Defending Pokémon."
@@ -2522,7 +2522,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_FAN_CLUB_130:
       return supporter (this) {
         text "Search your deck for up to 2 Baby Pokémon and/or Basic Pokémon cards and put them onto your Bench. Shuffle your deck afterward."
@@ -2530,7 +2530,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_PARK_131:
       return stadium (this) {
         text "Once during each of his or her turns, when a player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter, if any, from that Pokémon."
@@ -2538,7 +2538,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case PSYCHIC_CUBE_01_132:
       return basicTrainer (this) {
         text "The Defending Pokémon is now Confused."
@@ -2546,7 +2546,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SEER_133:
       return supporter (this) {
         text "Look at the top 6 cards of your deck. Take all basic Energy cards you find there, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
@@ -2554,7 +2554,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SUPER_ENERGY_REMOVAL_2_134:
       return basicTrainer (this) {
         text "Flip 2 coins. If both are heads, discard all Energy cards attached to the Defending Pokémon. If both are tails, discard all Energy cards attached to your Active Pokémon. If 1 is heads and 1 is tails, this card does nothing."
@@ -2562,7 +2562,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TIME_SHARD_135:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to is Knocked Out by damage from the Defending Pokémon's attack during your opponent's next turn, you may return up to 2 basic Energy cards attached to that Pokémon to your hand."
@@ -2572,7 +2572,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case TOWN_VOLUNTEERS_136:
       return supporter (this) {
         text "Take 5 Baby Pokémon, Basic Pokémon, Evolution, and/or basic Energy cards from your discard pile and then show them to your opponent. Shuffle them into your deck."
@@ -2580,7 +2580,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TRAVELING_SALESMAN_137:
       return supporter (this) {
         text "Search your deck for up to 2 Technical Machine and/or Pokémon Tool cards, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
@@ -2588,7 +2588,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case UNDERSEA_RUINS_138:
       return stadium (this) {
         text "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player chooses 1 of his or her Evolved Pokémon in play and discards the top Evolution card from that Pokémon, devolving it."
@@ -2596,7 +2596,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case POWER_PLANT_139:
       return stadium (this) {
         text "Once during each of his or her turns, a player may discard a basic Energy card from his or her hand. If that player does, he or she chooses a basic Energy card from his or her discard pile, shows it to his or her opponent, and then puts it into his or her hand."
@@ -2604,7 +2604,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case WATER_CUBE_01_140:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance."
@@ -2612,7 +2612,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case WEAKNESS_GUARD_141:
       return basicTrainer (this) {
         text "As long as this card is attached, this Pokémon has no Weakness."
@@ -2620,7 +2620,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DARKNESS_ENERGY_142:
       return specialEnergy (this, [[C]]) {
         text "If the Pokémon [D] Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon [D] Energy is attached to, unless it's Darkness or has Dark in its name. [D] Energy provides [D] Energy. (Doesn't count as a basic Energy card.)"
@@ -2632,7 +2632,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case METAL_ENERGY_143:
       return specialEnergy (this, [[C]]) {
         text "Damage done to the Pokémon [M] Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon [M] Energy is attached to isn't Metal, whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). [M] Energy provides [M] Energy. (Doesn't count as a basic Energy card.)"
@@ -2644,7 +2644,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RAINBOW_ENERGY_144:
       return specialEnergy (this, [[C]]) {
         text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon."
@@ -2656,7 +2656,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BOOST_ENERGY_145:
       return specialEnergy (this, [[C]]) {
         text "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides [C] [C] [C] Energy. The Pokémon Boost Energy is attached to can't retreat. If the Pokémon Boost Energy is attached to isn't an Evolved Pokémon, discard Boost Energy."
@@ -2668,7 +2668,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CRYSTAL_ENERGY_146:
       return specialEnergy (this, [[C]]) {
         text "Crystal Energy provides 1 Energy of all types (colors) of all basic Energy cards attached to the Pokémon Crystal Energy is attached to. If there are no basic Energy cards attached to the Pokémon Crystal Energy is attached to, Crystal Energy provides [C] Energy."
@@ -2680,7 +2680,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case WARP_ENERGY_147:
       return specialEnergy (this, [[C]]) {
         text "Warp Energy provides 1 [C] Energy. When you attach Warp Energy from your hand to your Active Pokémon, switch your Active Pokémon with 1 of your Benched Pokémon."
@@ -2692,7 +2692,7 @@ public enum AquapolisNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case KINGDRA_148:
       return evolution (this, from:"Seadra", hp:HP110, type:C, retreatCost:3) {
         weakness L
@@ -2717,7 +2717,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case LUGIA_149:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness P
@@ -2742,7 +2742,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDOKING_150:
       return evolution (this, from:"Nidorino", hp:HP100, type:C, retreatCost:3) {
         weakness G
@@ -2762,9 +2762,9 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case AMPHAROS_H1:
-      return copy (AMPHAROS_1, this);
+      return copy (AMPHAROS_1, this)
       case ARCANINE_H2:
       return evolution (this, from:"Growlithe", hp:HP090, type:R, retreatCost:3) {
         weakness W
@@ -2781,19 +2781,19 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARIADOS_H3:
-        return copy (ARIADOS_3, this);
+        return copy (ARIADOS_3, this)
       case AZUMARILL_H4:
-        return copy (AZUMARILL_4, this);
+        return copy (AZUMARILL_4, this)
       case BELLOSSOM_H5:
-        return copy (BELLOSSOM_5, this);
+        return copy (BELLOSSOM_5, this)
       case BLISSEY_H6:
-        return copy (BLISSEY_6, this);
+        return copy (BLISSEY_6, this)
       case ELECTRODE_H7:
-        return copy (ELECTRODE_8, this);
+        return copy (ELECTRODE_8, this)
       case ENTEI_H8:
-        return copy (ENTEI_10, this);
+        return copy (ENTEI_10, this)
       case ESPEON_H9:
       return evolution (this, from:"Eevee", hp:HP080, type:P, retreatCost:null) {
         weakness P
@@ -2810,7 +2810,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case EXEGGUTOR_H10:
       return evolution (this, from:"Exeggcute", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -2830,7 +2830,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOUNDOOM_H11:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -2851,7 +2851,7 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HYPNO_H12:
       return evolution (this, from:"Drowzee", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -2868,35 +2868,35 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JUMPLUFF_H13:
-      return copy (JUMPLUFF_17, this);
+      return copy (JUMPLUFF_17, this)
       case KINGDRA_H14:
-      return copy (KINGDRA_19, this);
+      return copy (KINGDRA_19, this)
       case LANTURN_H15:
-      return copy (LANTURN_21, this);
+      return copy (LANTURN_21, this)
       case MAGNETON_H16:
-      return copy (MAGNETON_22, this);
+      return copy (MAGNETON_22, this)
       case MUK_H17:
-      return copy (MUK_23, this);
+      return copy (MUK_23, this)
       case NIDOKING_H18:
-      return copy (NIDOKING_24, this);
+      return copy (NIDOKING_24, this)
       case NINETALES_H19:
-      return copy (NINETALES_25, this);
+      return copy (NINETALES_25, this)
       case OCTILLERY_H20:
-      return copy (OCTILLERY_26, this);
+      return copy (OCTILLERY_26, this)
       case SCIZOR_H21:
-      return copy (SCIZOR_32, this);
+      return copy (SCIZOR_32, this)
       case SLOWKING_H22:
-      return copy (SLOWKING_34, this);
+      return copy (SLOWKING_34, this)
       case STEELIX_H23:
-      return copy (STEELIX_35, this);
+      return copy (STEELIX_35, this)
       case SUDOWOODO_H24:
-      return copy (SUDOWOODO_36, this);
+      return copy (SUDOWOODO_36, this)
       case SUICUNE_H25:
-      return copy (SUICUNE_37, this);
+      return copy (SUICUNE_37, this)
       case TENTACRUEL_H26:
-      return copy (TENTACRUEL_38, this);
+      return copy (TENTACRUEL_38, this)
       case TOGETIC_H27:
       return evolution (this, from:"Togepi", hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -2914,15 +2914,15 @@ public enum AquapolisNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TYRANITAR_H28:
-      return copy (TYRANITAR_40, this);
+      return copy (TYRANITAR_40, this)
       case UMBREON_H29:
-      return copy (UMBREON_41, this);
+      return copy (UMBREON_41, this)
       case VICTREEBEL_H30:
-      return copy (VICTREEBEL_42, this);
+      return copy (VICTREEBEL_42, this)
       case VILEPLUME_H31:
-      return copy (VILEPLUME_43, this);
+      return copy (VILEPLUME_43, this)
       case ZAPDOS_H32:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         weakness L
@@ -2948,9 +2948,9 @@ public enum AquapolisNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen2/ExpeditionNG.groovy
+++ b/src/tcgwars/logic/impl/gen2/ExpeditionNG.groovy
@@ -1,35 +1,35 @@
 package tcgwars.logic.impl.gen2
 
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
 import tcgwars.logic.util.*
 
 /**
@@ -203,53 +203,53 @@ public enum ExpeditionNG implements LogicCardInfo {
   PSYCHIC_ENERGY_164 ("Psychic Energy", "164", Rarity.COMMON, [ENERGY, BASIC, BASIC_ENERGY]),
   WATER_ENERGY_165 ("Water Energy", "165", Rarity.COMMON, [ENERGY, BASIC, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ExpeditionNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.EXPEDITION;
+    return tcgwars.logic.card.Collection.EXPEDITION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -272,7 +272,7 @@ public enum ExpeditionNG implements LogicCardInfo {
               damage 80
           }
         }
-      };
+      }
       case AMPHAROS_2:
       return evolution (this, from:"Flaaffy", hp:HP100, type:L, retreatCost:2) {
         weakness F
@@ -289,7 +289,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ARBOK_3:
       return evolution (this, from:"Ekans", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -309,7 +309,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BLASTOISE_4:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -326,7 +326,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BUTTERFREE_5:
       return evolution (this, from:"Metapod", hp:HP080, type:G, retreatCost:null) {
         weakness R
@@ -343,7 +343,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHARIZARD_6:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:3) {
         weakness W
@@ -360,7 +360,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case CLEFABLE_7:
       return evolution (this, from:"Clefairy", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -377,7 +377,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLOYSTER_8:
       return evolution (this, from:"Shellder", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -397,7 +397,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DRAGONITE_9:
       return evolution (this, from:"Dragonair", hp:HP100, type:C, retreatCost:2) {
         pokePower "Tailwind", {
@@ -413,7 +413,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DUGTRIO_10:
       return evolution (this, from:"Diglett", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -434,7 +434,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FEAROW_11:
       return evolution (this, from:"Spearow", hp:HP070, type:C, retreatCost:null) {
         weakness L
@@ -455,7 +455,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FERALIGATR_12:
       return evolution (this, from:"Croconaw", hp:HP120, type:W, retreatCost:3) {
         weakness L
@@ -472,7 +472,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GENGAR_13:
       return evolution (this, from:"Haunter", hp:HP090, type:P, retreatCost:1) {
         weakness null
@@ -490,7 +490,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GOLEM_14:
       return evolution (this, from:"Graveler", hp:HP100, type:F, retreatCost:4) {
         weakness W
@@ -507,7 +507,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case KINGLER_15:
       return evolution (this, from:"Krabby", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -527,7 +527,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MACHAMP_16:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -544,7 +544,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MAGBY_17:
       return basic (this, hp:HP030, type:R, retreatCost:1) {
         move "Energy Catch", {
@@ -555,7 +555,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEGANIUM_18:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -573,7 +573,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEW_19:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -585,7 +585,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEWTWO_20:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -605,7 +605,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NINETALES_21:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -625,7 +625,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PICHU_22:
       return basic (this, hp:HP030, type:L, retreatCost:1) {
         move "Energy Patch", {
@@ -636,7 +636,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PIDGEOT_23:
       return evolution (this, from:"Pidgeotto", hp:HP080, type:C, retreatCost:null) {
         weakness L
@@ -654,7 +654,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWRATH_24:
       return evolution (this, from:"Poliwhirl", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -671,7 +671,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAICHU_25:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -691,7 +691,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case RAPIDASH_26:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:null) {
         weakness W
@@ -711,7 +711,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SKARMORY_27:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -732,7 +732,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TYPHLOSION_28:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -749,7 +749,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TYRANITAR_29:
       return evolution (this, from:"Pupitar", hp:HP120, type:D, retreatCost:4) {
         weakness F
@@ -769,7 +769,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             flip { opp.all.each { damage 10, it } }
           }
         }
-      };
+      }
       case VENUSAUR_30:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -786,7 +786,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VILEPLUME_31:
       return evolution (this, from:"Gloom", hp:HP090, type:G, retreatCost:2) {
         weakness P
@@ -803,7 +803,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WEEZING_32:
       return evolution (this, from:"Koffing", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -823,11 +823,11 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ALAKAZAM_33:
-      return copy (ALAKAZAM_1, this);
+      return copy (ALAKAZAM_1, this)
       case AMPHAROS_34:
-      return copy (AMPHAROS_2, this);
+      return copy (AMPHAROS_2, this)
       case ARBOK_35:
       return evolution (this, from:"null", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -847,7 +847,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BLASTOISE_36:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -867,7 +867,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BLASTOISE_37:
       return evolution (this, from:"null", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -884,9 +884,9 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BUTTERFREE_38:
-      return copy (BUTTERFREE_5, this);
+      return copy (BUTTERFREE_5, this)
       case CHARIZARD_39:
       return evolution (this, from:"Charmeleon", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -906,19 +906,19 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CHARIZARD_40:
-      return copy (CHARIZARD_6, this);
+      return copy (CHARIZARD_6, this)
       case CLEFABLE_41:
-      return copy (CLEFABLE_7, this);
+      return copy (CLEFABLE_7, this)
       case CLOYSTER_42:
-      return copy (CLOYSTER_8, this);
+      return copy (CLOYSTER_8, this)
       case DRAGONITE_43:
-      return copy (DRAGONITE_9, this);
+      return copy (DRAGONITE_9, this)
       case DUGTRIO_44:
-      return copy (DUGTRIO_10, this);
+      return copy (DUGTRIO_10, this)
       case FEAROW_45:
-      return copy (FEAROW_11, this);
+      return copy (FEAROW_11, this)
       case FERALIGATR_46:
       return evolution (this, from:"Croconaw", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -938,19 +938,19 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FERALIGATR_47:
-      return copy (FERALIGATR_12, this);
+      return copy (FERALIGATR_12, this)
       case GENGAR_48:
-      return copy (GENGAR_13, this);
+      return copy (GENGAR_13, this)
       case GOLEM_49:
-      return copy (GOLEM_14, this);
+      return copy (GOLEM_14, this)
       case KINGLER_50:
-      return copy (KINGLER_15, this);
+      return copy (KINGLER_15, this)
       case MACHAMP_51:
-      return copy (MACHAMP_16, this);
+      return copy (MACHAMP_16, this)
       case MAGBY_52:
-      return copy (MAGBY_17, this);
+      return copy (MAGBY_17, this)
       case MEGANIUM_53:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -971,27 +971,27 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MEGANIUM_54:
-      return copy (MEGANIUM_18, this);
+      return copy (MEGANIUM_18, this)
       case MEW_55:
-      return copy (MEW_19, this);
+      return copy (MEW_19, this)
       case MEWTWO_56:
-      return copy (MEWTWO_20, this);
+      return copy (MEWTWO_20, this)
       case NINETALES_57:
-      return copy (NINETALES_21, this);
+      return copy (NINETALES_21, this)
       case PICHU_58:
-      return copy (PICHU_22, this);
+      return copy (PICHU_22, this)
       case PIDGEOT_59:
-      return copy (PIDGEOT_23, this);
+      return copy (PIDGEOT_23, this)
       case POLIWRATH_60:
-      return copy (POLIWRATH_24, this);
+      return copy (POLIWRATH_24, this)
       case RAICHU_61:
-      return copy (RAICHU_25, this);
+      return copy (RAICHU_25, this)
       case RAPIDASH_62:
-      return copy (RAPIDASH_26, this);
+      return copy (RAPIDASH_26, this)
       case SKARMORY_63:
-      return copy (SKARMORY_27, this);
+      return copy (SKARMORY_27, this)
       case TYPHLOSION_64:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -1011,11 +1011,11 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TYPHLOSION_65:
-      return copy (TYPHLOSION_28, this);
+      return copy (TYPHLOSION_28, this)
       case TYRANITAR_66:
-      return copy (TYRANITAR_29, this);
+      return copy (TYRANITAR_29, this)
       case VENUSAUR_67:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -1035,13 +1035,13 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VENUSAUR_68:
-      return copy (VENUSAUR_30, this);
+      return copy (VENUSAUR_30, this)
       case VILEPLUME_69:
-      return copy (VILEPLUME_31, this);
+      return copy (VILEPLUME_31, this)
       case WEEZING_70:
-      return copy (WEEZING_32, this);
+      return copy (WEEZING_32, this)
       case BAYLEEF_71:
       return evolution (this, from:"Chikorita", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1062,7 +1062,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHANSEY_72:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness F
@@ -1082,7 +1082,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CHARMELEON_73:
       return evolution (this, from:"Charmander", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -1102,7 +1102,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CROCONAW_74:
       return evolution (this, from:"Totodile", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1122,7 +1122,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGONAIR_75:
       return evolution (this, from:"Dratini", hp:HP070, type:C, retreatCost:2) {
         move "Spiral Wave", {
@@ -1133,7 +1133,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELECTABUZZ_76:
       return basic (this, hp:HP060, type:L, retreatCost:2) {
         weakness F
@@ -1153,7 +1153,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FLAAFFY_77:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1173,7 +1173,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GLOOM_78:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1193,7 +1193,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRAVELER_79:
       return evolution (this, from:"Geodude", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -1213,7 +1213,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HAUNTER_80:
       return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
         weakness null
@@ -1234,7 +1234,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HITMONLEE_81:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -1254,7 +1254,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case IVYSAUR_82:
       return evolution (this, from:"Bulbasaur", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -1274,7 +1274,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case JYNX_83:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness M
@@ -1294,7 +1294,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KADABRA_84:
       return evolution (this, from:"Abra", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1314,7 +1314,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOKE_85:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1334,7 +1334,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MAGMAR_86:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1354,7 +1354,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case METAPOD_87:
       return evolution (this, from:"Caterpie", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1371,7 +1371,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIDGEOTTO_88:
       return evolution (this, from:"Pidgey", hp:HP090, type:C, retreatCost:null) {
         weakness L
@@ -1384,7 +1384,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWHIRL_89:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1404,7 +1404,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PUPITAR_90:
       return evolution (this, from:"Larvitar", hp:HP070, type:F, retreatCost:1) {
         weakness W
@@ -1416,7 +1416,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QUILAVA_91:
       return evolution (this, from:"Cyndaquil", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1436,7 +1436,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WARTORTLE_92:
       return evolution (this, from:"Squirtle", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1456,7 +1456,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ABRA_93:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1476,7 +1476,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BULBASAUR_94:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1496,7 +1496,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BULBASAUR_95:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1516,7 +1516,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CATERPIE_96:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1536,7 +1536,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHARMANDER_97:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1556,7 +1556,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARMANDER_98:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1576,7 +1576,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHIKORITA_99:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1597,7 +1597,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHIKORITA_100:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1618,7 +1618,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CLEFAIRY_101:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1638,7 +1638,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CORSOLA_102:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness G
@@ -1658,7 +1658,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CUBONE_103:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1679,7 +1679,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CYNDAQUIL_104:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1699,7 +1699,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CYNDAQUIL_105:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1719,7 +1719,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DIGLETT_106:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1732,7 +1732,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DRATINI_107:
       return basic (this, hp:HP040, type:C, retreatCost:null) {
         move "Dragon Smash", {
@@ -1743,7 +1743,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case EKANS_108:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1755,7 +1755,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GASTLY_109:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness null
@@ -1768,7 +1768,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GEODUDE_110:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1780,7 +1780,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GOLDEEN_111:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1792,7 +1792,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOPPIP_112:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1805,7 +1805,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOUNDOUR_113:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1818,7 +1818,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KOFFING_114:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1838,7 +1838,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case KRABBY_115:
       return basic (this, hp:HP050, type:W, retreatCost:2) {
         weakness L
@@ -1850,7 +1850,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LARVITAR_116:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1870,7 +1870,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOP_117:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1890,7 +1890,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_118:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1902,7 +1902,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAREEP_119:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1914,7 +1914,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MARILL_120:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1934,7 +1934,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEOWTH_121:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1954,7 +1954,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ODDISH_122:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1974,7 +1974,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIDGEY_123:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1995,7 +1995,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIKACHU_124:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2015,7 +2015,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWAG_125:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2035,7 +2035,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PONYTA_126:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2055,7 +2055,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QWILFISH_127:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -2067,7 +2067,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RATTATA_128:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         weakness F
@@ -2079,7 +2079,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHELLDER_129:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2099,7 +2099,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPEAROW_130:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -2112,7 +2112,7 @@ public enum ExpeditionNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SQUIRTLE_131:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2132,7 +2132,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SQUIRTLE_132:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2152,7 +2152,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TAUROS_133:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -2172,7 +2172,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TOTODILE_134:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2192,7 +2192,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOTODILE_135:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2212,7 +2212,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VULPIX_136:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -2232,7 +2232,7 @@ public enum ExpeditionNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BILL_S_MAINTENANCE_137:
       return supporter (this) {
         text "If you have any cards in your hand, shuffle 1 of them into your deck, then draw 3 cards."
@@ -2240,7 +2240,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case COPYCAT_138:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards."
@@ -2248,7 +2248,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DUAL_BALL_139:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card other than a Baby Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2256,7 +2256,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_REMOVAL_2_140:
       return basicTrainer (this) {
         text "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
@@ -2264,7 +2264,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_RESTORE_141:
       return basicTrainer (this) {
         text "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
@@ -2272,7 +2272,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MARY_S_IMPULSE_142:
       return supporter (this) {
         text "Flip a coin until you get tails. For each heads, draw 2 cards."
@@ -2280,7 +2280,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MASTER_BALL_143:
       return basicTrainer (this) {
         text "Look at 7 cards from the top of your deck. You may choose a Basic Pokémon or Evolution card from those cards, show it to your opponent, and put it into your hand. Shuffle the rest into your deck."
@@ -2288,7 +2288,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MULTI_TECHNICAL_MACHINE_01_144:
       return basicTrainer (this) {
         text "The Defending Pokémon is now Paralyzed."
@@ -2296,7 +2296,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_NURSE_145:
       return supporter (this) {
         text "Remove all damage counters from one of your Pokémon. Then discard all Energy cards attached to it, if any."
@@ -2304,7 +2304,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_REVERSAL_146:
       return basicTrainer (this) {
         text "Choose one of your opponent's Benched Pokémon. Flip a coin. If heads, switch that Pokémon with the Defending Pokémon."
@@ -2312,7 +2312,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POWER_CHARGE_147:
       return basicTrainer (this) {
         text "Flip a coin. If heads, shuffle 2 Energy cards from your discard pile into your deck (1 if you have only 1)."
@@ -2320,7 +2320,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_ELM_S_TRAINING_METHOD_148:
       return supporter (this) {
         text "Search your deck for an Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2328,7 +2328,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_OAK_S_RESEARCH_149:
       return supporter (this) {
         text "Shuffle your hand into your deck, then draw 5 cards."
@@ -2336,7 +2336,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case STRENGTH_CHARM_150:
       return pokemonTool (this) {
         text "Whenever an attack from the Pokémon that Strength Charm is attached to does damage (after applying Weakness and Resistance), the attack does 10 more damage. At the end of the turn in which this happens, discard Strength Charm."
@@ -2346,7 +2346,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case SUPER_SCOOP_UP_151:
       return basicTrainer (this) {
         text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
@@ -2354,7 +2354,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case WARP_POINT_152:
       return basicTrainer (this) {
         text "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any; then you switch your Active Pokémon with 1 of your Benched Pokémon, if any."
@@ -2362,7 +2362,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SEARCH_153:
       return basicTrainer (this) {
         text "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2370,7 +2370,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FULL_HEAL_154:
       return basicTrainer (this) {
         text "Remove all Special Conditions from your Active Pokémon."
@@ -2378,7 +2378,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MOO_MOO_MILK_155:
       return basicTrainer (this) {
         text "Choose 1 of your Pokémon. Flip 2 coins. Remove 2 damage counters times the number of heads from that Pokémon. If the Pokémon has fewer damage counters than that, remove all of them."
@@ -2386,7 +2386,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POTION_156:
       return basicTrainer (this) {
         text "Remove 2 damage counters from 1 of your Pokémon (1 if it has only 1)."
@@ -2394,9 +2394,9 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SWITCH_157:
-      return copy(FireRedLeafGreen.SWITCH_102, this);
+      return copy(FireRedLeafGreen.SWITCH_102, this)
       case DARKNESS_ENERGY_158:
       return specialEnergy (this, [[C]]) {
         text "If the Pokémon [D] Energy is attached to does damage with an attack (after applying Weakness and Resistance), the attack does 10 more damage. At the end of every turn, put 1 damage counter on the Pokémon [D] Energy is attached to, unless it's Darkness or has Dark in its name. [D] Energy provides [D] Energy. (Doesn't count as a basic Energy card.)"
@@ -2408,7 +2408,7 @@ public enum ExpeditionNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case METAL_ENERGY_159:
       return specialEnergy (this, [[C]]) {
         text "Damage done by attacks to the Pokémon [M] Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon [M] Energy is attached to isn't Metal, whenever it damages a Pokémon by an attack, reduce that damage by 10 (after applying Weakness and Resistance). [M] Energy provides [M] Energy. (Doesn't count as a basic Energy card.)"

--- a/src/tcgwars/logic/impl/gen2/SkyridgeNG.groovy
+++ b/src/tcgwars/logic/impl/gen2/SkyridgeNG.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen2;
+package tcgwars.logic.impl.gen2
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -218,53 +218,53 @@ public enum SkyridgeNG implements LogicCardInfo {
   VAPOREON_H31 ("Vaporeon", "H31", Rarity.RARE, [POKEMON, EVOLUTION, STAGE1, _WATER_]),
   XATU_H32 ("Xatu", "H32", Rarity.RARE, [POKEMON, EVOLUTION, STAGE1, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SkyridgeNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SKYRIDGE;
+    return tcgwars.logic.card.Collection.SKYRIDGE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -286,7 +286,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ALAKAZAM_2:
       return evolution (this, from:"Kadabra", hp:HP100, type:P, retreatCost:2) {
         weakness P
@@ -303,7 +303,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARCANINE_3:
       return evolution (this, from:"Growlithe", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -328,7 +328,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ARTICUNO_4:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -354,7 +354,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case BEEDRILL_5:
       return evolution (this, from:"Kakuna", hp:HP080, type:G, retreatCost:null) {
         weakness R
@@ -371,7 +371,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CROBAT_6:
       return evolution (this, from:"Golbat", hp:HP090, type:G, retreatCost:null) {
         weakness P
@@ -388,7 +388,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DEWGONG_7:
       return evolution (this, from:"Seel", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -408,7 +408,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FLAREON_8:
       return evolution (this, from:"Eevee", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -433,7 +433,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FORRETRESS_9:
       return evolution (this, from:"Pineco", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -454,7 +454,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GENGAR_10:
       return evolution (this, from:"Haunter", hp:HP100, type:P, retreatCost:2) {
         weakness null
@@ -472,7 +472,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GYARADOS_11:
       return evolution (this, from:"Magikarp", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -489,7 +489,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HOUNDOOM_12:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -510,7 +510,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JOLTEON_13:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:null) {
         weakness F
@@ -535,7 +535,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KABUTOPS_14:
       return evolution (this, from:"Kabuto", hp:HP090, type:F, retreatCost:2) {
         weakness G
@@ -552,7 +552,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LEDIAN_15:
       return evolution (this, from:"Ledyba", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -572,7 +572,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MACHAMP_16:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -597,7 +597,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGCARGO_17:
       return evolution (this, from:"Slugma", hp:HP080, type:R, retreatCost:3) {
         weakness W
@@ -617,7 +617,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MAGCARGO_18:
       return evolution (this, from:"Slugma", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -634,7 +634,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MAGNETON_19:
       return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -651,7 +651,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MAGNETON_20:
       return evolution (this, from:"Magnemite", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -672,7 +672,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MOLTRES_21:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -698,7 +698,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case NIDOQUEEN_22:
       return evolution (this, from:"Nidorina", hp:HP110, type:G, retreatCost:3) {
         weakness P
@@ -715,7 +715,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case OMASTAR_23:
       return evolution (this, from:"Omanyte", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -732,7 +732,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PILOSWINE_24:
       return evolution (this, from:"Swinub", hp:HP090, type:W, retreatCost:3) {
         weakness M
@@ -752,7 +752,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case POLITOED_25:
       return evolution (this, from:"Poliwhirl", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -780,7 +780,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case POLIWRATH_26:
       return evolution (this, from:"Poliwhirl", hp:HP110, type:F, retreatCost:2) {
         weakness P
@@ -797,7 +797,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAICHU_27:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -817,7 +817,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAIKOU_28:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness R
@@ -834,7 +834,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RHYDON_29:
       return evolution (this, from:"Rhyhorn", hp:HP090, type:F, retreatCost:2) {
         weakness G
@@ -855,7 +855,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case STARMIE_30:
       return evolution (this, from:"Staryu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -875,7 +875,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STEELIX_31:
       return evolution (this, from:"Onix", hp:HP100, type:M, retreatCost:4) {
         weakness R
@@ -901,7 +901,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case UMBREON_32:
       return evolution (this, from:"Eevee", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -919,7 +919,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VAPOREON_33:
       return evolution (this, from:"Eevee", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -944,7 +944,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WIGGLYTUFF_34:
       return evolution (this, from:"Jigglypuff", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -961,7 +961,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case XATU_35:
       return evolution (this, from:"Natu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -978,7 +978,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ELECTRODE_36:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -998,7 +998,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case KABUTO_37:
       return evolution (this, from:"null", hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1015,7 +1015,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MACHOKE_38:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1035,7 +1035,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MISDREAVUS_39:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness null
@@ -1056,7 +1056,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NOCTOWL_40:
       return evolution (this, from:"Hoothoot", hp:HP070, type:C, retreatCost:null) {
         weakness L
@@ -1074,7 +1074,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case OMANYTE_41:
       return evolution (this, from:"null", hp:HP060, type:W, retreatCost:null) {
         weakness L
@@ -1095,7 +1095,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PERSIAN_42:
       return evolution (this, from:"Meowth", hp:HP070, type:C, retreatCost:null) {
         weakness F
@@ -1115,7 +1115,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PILOSWINE_43:
       return evolution (this, from:"Swinub", hp:HP080, type:F, retreatCost:3) {
         weakness G
@@ -1136,7 +1136,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case STARMIE_44:
       return evolution (this, from:"Staryu", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1156,7 +1156,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WOBBUFFET_45:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -1173,7 +1173,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ABRA_46:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1190,7 +1190,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BURIED_FOSSIL_47:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         pokePower "Reconstruction", {
@@ -1199,7 +1199,7 @@ public enum SkyridgeNG implements LogicCardInfo {
           }
         }
 
-      };
+      }
       case CLEFFA_48:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         move "Energy Recycle", {
@@ -1210,7 +1210,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DELIBIRD_49:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1230,7 +1230,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DIGLETT_50:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1243,7 +1243,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DITTO_51:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1264,7 +1264,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             metronome keepEnergyRequirement: true, defending, delegate
           }
         }
-      };
+      }
       case DUGTRIO_52:
       return evolution (this, from:"Diglett", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1285,7 +1285,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DUNSPARCE_53:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1302,7 +1302,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EEVEE_54:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1322,7 +1322,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FARFETCH_D_55:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1343,7 +1343,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FORRETRESS_56:
       return evolution (this, from:"Pineco", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1368,7 +1368,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GASTLY_57:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness null
@@ -1381,7 +1381,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GIRAFARIG_58:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -1401,7 +1401,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GLIGAR_59:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -1421,7 +1421,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GOLBAT_60:
       return evolution (this, from:"Zubat", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1441,7 +1441,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRANBULL_61:
       return evolution (this, from:"Snubbull", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1461,7 +1461,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GROWLITHE_62:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1481,7 +1481,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HAUNTER_63:
       return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
         weakness null
@@ -1502,7 +1502,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HERACROSS_64:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1522,7 +1522,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HOOTHOOT_65:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1543,7 +1543,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HOUNDOUR_66:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1563,7 +1563,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case IGGLYBUFF_67:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         move "Energy Heal", {
@@ -1574,7 +1574,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case JIGGLYPUFF_68:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1594,7 +1594,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KADABRA_69:
       return evolution (this, from:"Abra", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1614,7 +1614,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KAKUNA_70:
       return evolution (this, from:"Weedle", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1631,7 +1631,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LAPRAS_71:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness M
@@ -1651,7 +1651,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LEDYBA_72:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness L
@@ -1672,7 +1672,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LEDYBA_73:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1692,7 +1692,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOP_74:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1712,7 +1712,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_75:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1732,7 +1732,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAGNEMITE_76:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1752,7 +1752,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MANTINE_77:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness L
@@ -1773,7 +1773,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MEOWTH_78:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1785,7 +1785,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MURKROW_79:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1806,7 +1806,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NATU_80:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1826,7 +1826,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_81:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1846,7 +1846,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_82:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1858,7 +1858,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NIDORINA_83:
       return evolution (this, from:"Nidoran♀", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -1878,7 +1878,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PIKACHU_84:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1890,7 +1890,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINECO_85:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1902,7 +1902,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PINECO_86:
       return basic (this, hp:HP050, type:G, retreatCost:null) {
         weakness R
@@ -1914,7 +1914,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case POLIWAG_87:
       return basic (this, hp:HP040, type:W, retreatCost:null) {
         weakness L
@@ -1934,7 +1934,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWHIRL_88:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1954,7 +1954,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RATICATE_89:
       return evolution (this, from:"Rattata", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1974,7 +1974,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RATTATA_90:
       return basic (this, hp:HP030, type:C, retreatCost:1) {
         weakness F
@@ -1994,7 +1994,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RHYHORN_91:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -2015,7 +2015,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSHREW_92:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -2036,7 +2036,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSLASH_93:
       return evolution (this, from:"Sandshrew", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2057,7 +2057,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEEL_94:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2069,7 +2069,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEEL_95:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2089,7 +2089,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHUCKLE_96:
       return basic (this, hp:HP030, type:G, retreatCost:2) {
         weakness R
@@ -2106,7 +2106,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SKARMORY_97:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -2127,7 +2127,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLUGMA_98:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -2147,7 +2147,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SLUGMA_99:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -2159,7 +2159,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNORLAX_100:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness F
@@ -2176,7 +2176,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SNUBBULL_101:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2196,7 +2196,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STANTLER_102:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2216,7 +2216,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case STARYU_103:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2236,7 +2236,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STARYU_104:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2256,7 +2256,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SUNFLORA_105:
       return evolution (this, from:"Sunkern", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -2277,7 +2277,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SUNKERN_106:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2298,7 +2298,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SWINUB_107:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -2318,7 +2318,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SWINUB_108:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2339,7 +2339,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEDDIURSA_109:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2359,7 +2359,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case URSARING_110:
       return evolution (this, from:"Teddiursa", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -2379,7 +2379,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VENOMOTH_111:
       return evolution (this, from:"Venonat", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -2399,7 +2399,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case VENONAT_112:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2419,7 +2419,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VOLTORB_113:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2439,7 +2439,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WEEDLE_114:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2451,7 +2451,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WEEDLE_115:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2471,7 +2471,7 @@ public enum SkyridgeNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case YANMA_116:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness L
@@ -2492,7 +2492,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ZUBAT_117:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness L
@@ -2513,7 +2513,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZUBAT_118:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2533,7 +2533,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ANCIENT_RUINS_119:
       return stadium (this) {
         text "Once during each player's turn (before he or she attacks), if he or she has not played a Supporter card, that player may reveal his or her hand to his or her opponent. If that player reveals his or her hand and there is no Supporter card there, that player draws a card."
@@ -2541,7 +2541,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case RELIC_HUNTER_120:
       return supporter (this) {
         text "Search your deck for up to 2 Supporter and/or Stadium cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2549,7 +2549,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case APRICORN_MAKER_121:
       return supporter (this) {
         text "Search your deck for up to 2 Trainer cards with Ball in their names, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2557,7 +2557,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CRYSTAL_SHARD_122:
       return pokemonTool (this) {
         text "As long as this card is attached to a Pokémon, that Pokémon's type (color) is [C]. If that Pokémon attacks, discard this card at the end of the turn."
@@ -2567,7 +2567,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DESERT_SHAMAN_123:
       return supporter (this) {
         text "Shuffle your hand into your deck and draw up to 4 cards. You opponent does the same."
@@ -2575,7 +2575,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FAST_BALL_124:
       return basicTrainer (this) {
         text "Reveal cards from your deck until you reveal an Evolution card. Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don't reveal an Evolution card, shuffle all the revealed cards back into your deck.)"
@@ -2583,7 +2583,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FISHERMAN_125:
       return supporter (this) {
         text "Choose 4 basic Energy cards from your discard pile (if there are fewer basic Energy cards than 4, take all of them), show them to your opponent, and put them into your hand."
@@ -2591,7 +2591,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FRIEND_BALL_126:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Pokémon. Search your deck for a Baby Pokémon, Basic Pokémon, of Evolution card of the same type (color), show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2599,7 +2599,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HYPER_POTION_127:
       return basicTrainer (this) {
         text "Choose 1 of your Pokémon. Discard 1 or 2 basic Energy cards attached to that Pokémon. If you discarded 1 Energy card, remove up to 3 damage counters from that Pokémon. If you discarded 2 Energy cards, remove up to 5 damage counters from that Pokémon."
@@ -2607,7 +2607,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LURE_BALL_128:
       return basicTrainer (this) {
         text "Flip 3 coins. For each heads, choose an Evolution card from your discard pile, show it to your opponent, and put it into your hand."
@@ -2615,7 +2615,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_ALPHA_129:
       return basicTrainer (this) {
         text "If the Pokémon using this attack has and Energy cards attached to it, the Defending Pokémon is now Confused. If the Pokémon using this attack has and basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and removes 3 damage counters from the Pokémon that Miracle Sphere alpha is attached to."
@@ -2623,7 +2623,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_BETA_130:
       return basicTrainer (this) {
         text "If the Pokémon using this attack has and basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and the Defending Pokémon is now Burned. If the Pokémon using this attack has and basic Energy cards attached to it, choose an Energy card attached to the Defending Pokémon, if any, and your opponent shuffles that card into his or her deck."
@@ -2631,7 +2631,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_GAMMA_131:
       return basicTrainer (this) {
         text "If the Pokémon using this attack has and basic Energy cards attached to it, the Defending Pokémon is now Asleep and Poisoned. If the Pokémon using this attack has and basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and lets you put 1 damage counter on each of your opponent's Benched Pokémon."
@@ -2639,7 +2639,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRAGE_STADIUM_132:
       return stadium (this) {
         text "Whenever a player tries to Retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discards Energy normally). If tails, that Pokémon can't Retreat this turn (the player doesn't discard any Energy)."
@@ -2647,7 +2647,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case MYSTERY_PLATE_ALPHA_133:
       return basicTrainer (this) {
         text "If your opponent has 5 or more Prizes, search your deck for a Trainer card, show it to your opponent, and put it into your hand. If your opponent has only 1 Prize, the Defending Pokémon is now Burned, Paralyzed, and Poisoned."
@@ -2655,7 +2655,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_BETA_134:
       return basicTrainer (this) {
         text "If your opponent has 5 or more Prizes, draw 3 cards. If your opponent has only 1 Prize, choose 2 Energy cards attached to the Defending Pokémon (1 if it has only 1). Your opponent shuffles those cards into his or her deck."
@@ -2663,7 +2663,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_GAMMA_135:
       return basicTrainer (this) {
         text "If your opponent has 5 or more Prizes, shuffle your hand into your deck and then draw 6 cards. If your opponent has exactly 2 Prizes, choose 1 of your opponent's Evolved Pokémon. Your opponent puts the top card on that Evolved Pokémon on the bottom of his or her deck. (This counts as devolving that Pokémon.)"
@@ -2671,7 +2671,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_DELTA_136:
       return basicTrainer (this) {
         text "If your opponent has 5 or more Prizes, search your deck for up to 3 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward. If your opponent has exactly 2 Prizes, remove all damage counters from 1 of your Pokémon."
@@ -2679,7 +2679,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_ZONE_137:
       return stadium (this) {
         text "Once during each player's turn (before he or she attacks), if that player has an Evolution card in his or her hand, he or she may search his or her deck for a basic Energy card, show it to his or her opponent, and put it into his or her hand. Then that player chooses an Evolution card from his or her hand, shows it to his or her opponent, and puts it into his or her deck. That player shuffles his or her deck afterward."
@@ -2687,7 +2687,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case ORACLE_138:
       return supporter (this) {
         text "Choose 2 cards from your deck and shuffle the rest of your deck. Put the chosen cards in top of your deck in any order."
@@ -2695,7 +2695,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case STAR_PIECE_139:
       return pokemonTool (this) {
         text "At any time between turns, if the Pokémon this card is attached to is Benched and has 2 or more damage counters in it, search your deck for an Evolution card that Pokémon evolves into and put it on top of that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. Then, discard Star Piece."
@@ -2705,7 +2705,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case UNDERGROUND_EXPEDITION_140:
       return supporter (this) {
         text "Look at the bottom 4 cards if your deck. Put 2 of those cards into your hand, and then return the remaining cards to the bottom of your deck in any order."
@@ -2713,7 +2713,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case UNDERGROUND_LAKE_141:
       return stadium (this) {
         text "Once during each player's turn, that player may put an Omanyte or Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench in this way are considered Basic Pokémon.)"
@@ -2721,7 +2721,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case BOUNCE_ENERGY_142:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] [C] Energy. You can attach this card to your Pokémon that has basic Energy cards attached to it. When you play this card from your hand and attach it to 1 of your Pokémon, return a basic Energy card attached to that Pokémon to your hand."
@@ -2733,7 +2733,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CYCLONE_ENERGY_143:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] Energy. When you play this card from your hand and attach it to your Active Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon."
@@ -2745,7 +2745,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RETRO_ENERGY_144:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] Energy. When you play this card from your hand and attach it to 1 of your Evolved Pokémon, you may remove up to 2 damage counters from that Pokémon and discard the top card from it. (This counts as devolving it.)"
@@ -2757,7 +2757,7 @@ public enum SkyridgeNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CELEBI_145:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness R
@@ -2782,7 +2782,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARIZARD_146:
       return evolution (this, from:"Charmeleon", hp:HP110, type:C, retreatCost:4) {
         weakness W
@@ -2807,7 +2807,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CROBAT_147:
       return evolution (this, from:"Golbat", hp:HP080, type:C, retreatCost:null) {
         weakness P
@@ -2832,7 +2832,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLEM_148:
       return evolution (this, from:"Graveler", hp:HP100, type:C, retreatCost:4) {
         weakness W
@@ -2857,7 +2857,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HO_OH_149:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness W
@@ -2882,7 +2882,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KABUTOPS_150:
       return evolution (this, from:"Kabuto", hp:HP090, type:C, retreatCost:3) {
         weakness G
@@ -2907,43 +2907,43 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ALAKAZAM_H1:
-      return copy (ALAKAZAM_2, this);
+      return copy (ALAKAZAM_2, this)
       case ARCANINE_H2:
-      return copy (ARCANINE_3, this);
+      return copy (ARCANINE_3, this)
       case ARTICUNO_H3:
-      return copy (ARTICUNO_4, this);
+      return copy (ARTICUNO_4, this)
       case BEEDRILL_H4:
-      return copy (BEEDRILL_5, this);
+      return copy (BEEDRILL_5, this)
       case CROBAT_H5:
-      return copy (CROBAT_6, this);
+      return copy (CROBAT_6, this)
       case DEWGONG_H6:
-      return copy (DEWGONG_7, this);
+      return copy (DEWGONG_7, this)
       case FLAREON_H7:
-      return copy (FLAREON_8, this);
+      return copy (FLAREON_8, this)
       case FORRETRESS_H8:
-      return copy (FORRETRESS_9, this);
+      return copy (FORRETRESS_9, this)
       case GENGAR_H9:
-      return copy (GENGAR_10, this);
+      return copy (GENGAR_10, this)
       case GYARADOS_H10:
-      return copy (GYARADOS_11, this);
+      return copy (GYARADOS_11, this)
       case HOUNDOOM_H11:
-      return copy (HOUNDOOM_12, this);
+      return copy (HOUNDOOM_12, this)
       case JOLTEON_H12:
-      return copy (JOLTEON_13, this);
+      return copy (JOLTEON_13, this)
       case KABUTOPS_H13:
-      return copy (KABUTOPS_14, this);
+      return copy (KABUTOPS_14, this)
       case LEDIAN_H14:
-      return copy (LEDIAN_15, this);
+      return copy (LEDIAN_15, this)
       case MACHAMP_H15:
-      return copy (MACHAMP_16, this);
+      return copy (MACHAMP_16, this)
       case MAGCARGO_H16:
-      return copy (MAGCARGO_17, this);
+      return copy (MAGCARGO_17, this)
       case MAGCARGO_H17:
-      return copy (MAGCARGO_18, this);
+      return copy (MAGCARGO_18, this)
       case MAGNETON_H18:
-      return copy (MAGNETON_19, this);
+      return copy (MAGNETON_19, this)
       case MAGNETON_H19:
       return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -2964,13 +2964,13 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MOLTRES_H20:
-      return copy (MOLTRES_21, this);
+      return copy (MOLTRES_21, this)
       case NIDOQUEEN_H21:
-      return copy (NIDOQUEEN_22, this);
+      return copy (NIDOQUEEN_22, this)
       case PILOSWINE_H22:
-      return copy (PILOSWINE_24, this);
+      return copy (PILOSWINE_24, this)
       case POLITOED_H23:
       return evolution (this, from:"Poliwhirl", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -2998,9 +2998,9 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case POLIWRATH_H24:
-      return copy (POLIWRATH_26, this);
+      return copy (POLIWRATH_26, this)
       case RAICHU_H25:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -3020,7 +3020,7 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAIKOU_H26:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness R
@@ -3037,21 +3037,21 @@ public enum SkyridgeNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RHYDON_H27:
-      return copy (RHYDON_29, this);
+      return copy (RHYDON_29, this)
       case STARMIE_H28:
-      return copy (STARMIE_30, this);
+      return copy (STARMIE_30, this)
       case STEELIX_H29:
-      return copy (STEELIX_31, this);
+      return copy (STEELIX_31, this)
       case UMBREON_H30:
-      return copy (UMBREON_32, this);
+      return copy (UMBREON_32, this)
       case VAPOREON_H31:
-      return copy (VAPOREON_33, this);
+      return copy (VAPOREON_33, this)
       case XATU_H32:
-      return copy (XATU_35, this);
+      return copy (XATU_35, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -1,46 +1,46 @@
 package tcgwars.logic.impl.gen3
 
 import tcgwars.logic.effect.ability.custom.Safeguard
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.Emerald;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.DeltaSpecies;
-import tcgwars.logic.impl.gen5.PlasmaStorm;
-import tcgwars.logic.impl.gen5.BlackWhite;
-import tcgwars.logic.impl.gen7.GuardiansRising;
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.Emerald
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.DeltaSpecies
+import tcgwars.logic.impl.gen5.PlasmaStorm
+import tcgwars.logic.impl.gen5.BlackWhite
+import tcgwars.logic.impl.gen7.GuardiansRising
 
 import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.effect.gm.PlayCard;
+import tcgwars.logic.effect.gm.PlayCard
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -148,53 +148,53 @@ public enum CrystalGuardians implements LogicCardInfo {
   ALAKAZAM_STAR_99 ("Alakazam Star", "99", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _PSYCHIC_]),
   CELEBI_STAR_100 ("Celebi Star", "100", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   CrystalGuardians(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CRYSTAL_GUARDIANS;
+    return tcgwars.logic.card.Collection.CRYSTAL_GUARDIANS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -217,7 +217,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BLASTOISE_DELTA_2:
       return evolution (this, from:"Wartortle", hp:HP110, type:[F, M], retreatCost:3) {
         weakness L
@@ -247,7 +247,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CAMERUPT_3:
       return evolution (this, from:"Numel", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -278,7 +278,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CHARIZARD_DELTA_4:
       return evolution (this, from:"Charmeleon", hp:HP120, type:[L, M], retreatCost:2) {
         weakness W
@@ -309,7 +309,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DUGTRIO_5:
       return evolution (this, from:"Diglett", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -339,7 +339,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case LUDICOLO_DELTA_6:
       return evolution (this, from:"Lombre", hp:HP100, type:R, retreatCost:2) {
         weakness L
@@ -375,7 +375,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case LUVDISC_7:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -412,7 +412,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MANECTRIC_8:
       return evolution (this, from:"Electrike", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -441,7 +441,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAWILE_9:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -470,7 +470,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SABLEYE_10:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         resistance C, MINUS30
@@ -495,7 +495,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             amnesia delegate
           }
         }
-      };
+      }
       case SWALOT_11:
       return evolution (this, from:"Gulpin", hp:HP080, type:G, retreatCost:1) {
         weakness P
@@ -525,7 +525,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50+20*defending.specialConditions.size()
           }
         }
-      };
+      }
       case TAUROS_12:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -550,7 +550,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WIGGLYTUFF_13:
       return evolution (this, from:"Jigglypuff", hp:HP090, type:C, retreatCost:2) {
         weakness F
@@ -577,7 +577,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             if(defending.specialConditions) damage 20
           }
         }
-      };
+      }
       case BLASTOISE_14:
       return evolution (this, from:"Wartortle", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -604,7 +604,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             extraEnergyDamage(2, hp(20), W, thisMove)
           }
         }
-      };
+      }
       case CACTURNE_DELTA_15:
       return evolution (this, from:"Cacnea", hp:HP080, type:F, retreatCost:1) {
         weakness R
@@ -635,7 +635,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case COMBUSKEN_16:
       return evolution (this, from:"Torchic", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -653,7 +653,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DUSCLOPS_17:
       return evolution (this, from:"Duskull", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -684,7 +684,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             preventAllEffectsFromCustomPokemonNextTurn(thisMove, self, {it.EX})
           }
         }
-      };
+      }
       case FEAROW_DELTA_18:
       return evolution (this, from:"Spearow", hp:HP060, type:L, retreatCost:1) {
         weakness L
@@ -709,7 +709,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROVYLE_DELTA_19:
       return evolution (this, from:"Treecko", hp:HP070, type:P, retreatCost:1) {
         weakness R
@@ -729,7 +729,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case GRUMPIG_20:
       return evolution (this, from:"Spoink", hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -755,7 +755,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10*(all.size() - 1)
           }
         }
-      };
+      }
       case IGGLYBUFF_21:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -776,7 +776,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             babyEvolution("Jigglypuff", self)
           }
         }
-      };
+      }
       case KINGLER_DELTA_22:
       return evolution (this, from:"Krabby", hp:HP080, type:[R, M], retreatCost:3) {
         weakness L
@@ -796,7 +796,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             if (self.cards.hasType(POKEMON_TOOL)) damage 40
           }
         }
-      };
+      }
       case LOUDRED_23:
       return evolution (this, from:"Whismur", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -815,7 +815,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40, opp.all.select()
           }
         }
-      };
+      }
       case MARSHTOMP_24:
       return evolution (this, from:"Mudkip", hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -836,7 +836,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEDICHAM_25:
       return evolution (this, from:"Meditite", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -862,7 +862,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case PELIPPER_DELTA_26:
       return evolution (this, from:"Wingull", hp:HP070, type:L, retreatCost:1) {
         weakness L
@@ -892,7 +892,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SWAMPERT_27:
       return evolution (this, from:"Marshtomp", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -914,7 +914,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case VENUSAUR_28:
       return evolution (this, from:"Ivysaur", hp:HP110, type:G, retreatCost:3) {
         weakness R
@@ -947,7 +947,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             extraPoison 1
           }
         }
-      };
+      }
       case CHARMELEON_29:
       return evolution (this, from:"Charmander", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -968,7 +968,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHARMELEON_DELTA_30:
       return evolution (this, from:"Charmander", hp:HP070, type:L, retreatCost:1) {
         weakness W
@@ -987,7 +987,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip 1, {}, { damage 10, self }
           }
         }
-      };
+      }
       case COMBUSKEN_31:
       return evolution (this, from:"Torchic", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1007,7 +1007,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case GROVYLE_32:
       return evolution (this, from:"Treecko", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1026,7 +1026,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GULPIN_33:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1044,7 +1044,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case IVYSAUR_34:
       return evolution (this, from:"Bulbasaur", hp:HP080, type:G, retreatCost:1) {
         weakness P
@@ -1063,7 +1063,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case IVYSAUR_35:
       return evolution (this, from:"Bulbasaur", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1087,7 +1087,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case LAIRON_36:
       return evolution (this, from:"Aron", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -1107,7 +1107,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             directDamage 10, self
           }
         }
-      };
+      }
       case LOMBRE_37:
       return evolution (this, from:"Lotad", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1128,7 +1128,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MARSHTOMP_38:
       return evolution (this, from:"Mudkip", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1147,7 +1147,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NUZLEAF_39:
       return evolution (this, from:"Seedot", hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -1169,7 +1169,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHUPPET_40:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1186,7 +1186,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SKITTY_41:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1204,7 +1204,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             swiftDamage(20, opp.all.select())
           }
         }
-      };
+      }
       case WARTORTLE_42:
       return evolution (this, from:"Squirtle", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1223,7 +1223,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case WARTORTLE_43:
       return evolution (this, from:"Squirtle", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1241,7 +1241,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ARON_44:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness R
@@ -1256,7 +1256,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case BULBASAUR_45:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1274,7 +1274,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case BULBASAUR_46:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1295,7 +1295,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CACNEA_47:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1312,7 +1312,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case CHARMANDER_48:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1333,7 +1333,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARMANDER_DELTA_49:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness W
@@ -1351,7 +1351,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DIGLETT_50:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1370,7 +1370,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case DUSKULL_51:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1390,7 +1390,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTRIKE_52:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1411,7 +1411,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case JIGGLYPUFF_53:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1423,7 +1423,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             applyAfterDamage ASLEEP
           }
         }
-      };
+      }
       case KRABBY_54:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1435,7 +1435,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case LOTAD_55:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1454,7 +1454,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEDITITE_56:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1472,7 +1472,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             putDamageCountersOnOpponentsPokemon(2)
           }
         }
-      };
+      }
       case MUDKIP_57:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1496,7 +1496,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MUDKIP_58:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1514,7 +1514,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NUMEL_59:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1526,7 +1526,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case SEEDOT_60:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1537,7 +1537,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPEAROW_61:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1550,7 +1550,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             draw 1
           }
         }
-      };
+      }
       case SPOINK_62:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1568,7 +1568,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SQUIRTLE_63:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1586,7 +1586,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SQUIRTLE_64:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1611,7 +1611,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case TORCHIC_65:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1622,7 +1622,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case TORCHIC_66:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1634,7 +1634,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case TREECKO_67:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1653,7 +1653,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TREECKO_DELTA_68:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness R
@@ -1673,7 +1673,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             flip { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case WHISMUR_69:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1691,7 +1691,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WINGULL_70:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1703,7 +1703,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BILL_S_MAINTENANCE_71:
       return copy(FireRedLeafGreen.BILL_S_MAINTENANCE_87, this)
       case CASTAWAY_72:
@@ -1719,7 +1719,7 @@ public enum CrystalGuardians implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case CELIO_S_NETWORK_73:
       return copy(FireRedLeafGreen.CELIO_S_NETWORK_88, this)
       case CESSATION_CRYSTAL_74:
@@ -1750,7 +1750,7 @@ public enum CrystalGuardians implements LogicCardInfo {
         allowAttach { to->
           !to.EX
         }
-      };
+      }
       case CRYSTAL_BEACH_75:
       return stadium (this) {
         text "Each Special Energy card that provides 2 or more Energy (both yours and your opponent's) now provides only 1 [C] Energy. This isn't affected by any Poké-Powers or Poké-Bodies."
@@ -1765,7 +1765,7 @@ public enum CrystalGuardians implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case CRYSTAL_SHARD_76:
       return copy(Deoxys.CRYSTAL_SHARD_85, this)
       case DOUBLE_FULL_HEAL_77:
@@ -1795,7 +1795,7 @@ public enum CrystalGuardians implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case MEMORY_BERRY_80:
       return pokemonTool (this) {
         text "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.) If that Pokémon attacks, discard this card at the end of the turn."
@@ -1822,7 +1822,7 @@ public enum CrystalGuardians implements LogicCardInfo {
           eff.unregister()
           eff2.unregister()
         }
-      };
+      }
       case MYSTERIOUS_SHARD_81:
       return pokemonTool (this) {
         text "Prevent all effects of attacks, including damage, done to the Pokémon that Mysterious Shard is attached to by your opponent's Pokémon-ex. Discard this card at the end of your opponent's next turn."
@@ -1866,21 +1866,21 @@ public enum CrystalGuardians implements LogicCardInfo {
         allowAttach { to->
           !to.EX
         }
-      };
+      }
       case POKE_BALL_82:
       return copy(FireRedLeafGreen.POKE_BALL_95, this)
       case POKENAV_83:
-      return copy(RubySapphire.POKENAV_88, this);
+      return copy(RubySapphire.POKENAV_88, this)
       case WARP_POINT_84:
       return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case WINDSTORM_85:
       return copy(GuardiansRising.FIELD_BLOWER_125, this)
       case ENERGY_SEARCH_86:
-      return copy(BlackWhite.ENERGY_SEARCH_93, this);
+      return copy(BlackWhite.ENERGY_SEARCH_93, this)
       case POTION_87:
       return copy (FireRedLeafGreen.POTION_101, this)
       case DOUBLE_RAINBOW_ENERGY_88:
-      return copy (Emerald.DOUBLE_RAINBOW_ENERGY_87, this);
+      return copy (Emerald.DOUBLE_RAINBOW_ENERGY_87, this)
       case AGGRON_EX_89:
       return evolution (this, from:"Lairon", hp:HP150, type:M, retreatCost:4) {
         weakness R
@@ -1935,7 +1935,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case BLAZIKEN_EX_90:
       return evolution (this, from:"Combusken", hp:HP150, type:F, retreatCost:2) {
         weakness P
@@ -1960,7 +1960,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             swiftDamage(100, defending)
           }
         }
-      };
+      }
       case DELCATTY_EX_91:
       return evolution (this, from:"Skitty", hp:HP090, type:C, retreatCost:0) {
         weakness F
@@ -2001,7 +2001,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case EXPLOUD_EX_92:
       return evolution (this, from:"Loudred", hp:HP150, type:C, retreatCost:3) {
         weakness F
@@ -2040,13 +2040,13 @@ public enum CrystalGuardians implements LogicCardInfo {
             def hasPokeBody = false
             def hasPokePower = false
             for (Ability ability : defending.getAbilities().keySet()) {
-              if (ability instanceof PokeBody) hasPokeBody = true;
-              if (ability instanceof PokePower) hasPokePower = true;
+              if (ability instanceof PokeBody) hasPokeBody = true
+              if (ability instanceof PokePower) hasPokePower = true
             }
             if (hasPokeBody || hasPokePower) damage 20
           }
         }
-      };
+      }
       case GROUDON_EX_93:
       return basic (this, hp:HP100, type:F, retreatCost:2) {
         weakness G
@@ -2076,7 +2076,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JIRACHI_EX_94:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         pokeBody "Star Light", {
@@ -2123,7 +2123,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case KYOGRE_EX_95:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -2147,7 +2147,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SCEPTILE_EX_DELTA_96:
       return evolution (this, from:"Grovyle", hp:HP140, type:P, retreatCost:1) {
         weakness G
@@ -2205,7 +2205,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 60+10*opp.prizeCardSet.takenCount
           }
         }
-      };
+      }
       case SHIFTRY_EX_97:
       return evolution (this, from:"Nuzleaf", hp:HP140, type:D, retreatCost:0) {
         weakness G
@@ -2241,7 +2241,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SWAMPERT_EX_98:
       return evolution (this, from:"Marshtomp", hp:HP150, type:W, retreatCost:3) {
         weakness G
@@ -2270,7 +2270,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ALAKAZAM_STAR_99:
       return basic (this, hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -2299,7 +2299,7 @@ public enum CrystalGuardians implements LogicCardInfo {
             bef.unregisterItself(bg().em())
           }
         }
-      };
+      }
       case CELEBI_STAR_100:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -2328,9 +2328,9 @@ public enum CrystalGuardians implements LogicCardInfo {
             directDamage count*10, opp.all.select()
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -1,38 +1,38 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.RubySapphire;
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.RubySapphire
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -154,53 +154,53 @@ public enum DeltaSpecies implements LogicCardInfo {
   METAGROSS_STAR_113 ("Metagross Star", "113", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _METAL_]),
   AZUMARILL_114 ("Azumarill", "114", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DeltaSpecies(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DELTA_SPECIES;
+    return tcgwars.logic.card.Collection.DELTA_SPECIES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -234,7 +234,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CROBAT_DELTA_2:
       return evolution (this, from:"Golbat", hp:HP090, type:[G, M], retreatCost:0) {
         weakness P
@@ -267,7 +267,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DRAGONITE_DELTA_3:
       return evolution (this, from:"Dragonair", hp:HP100, type:[L, M], retreatCost:2) {
         weakness C
@@ -300,7 +300,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ESPEON_DELTA_4:
       return evolution (this, from:"Eevee", hp:HP070, type:[P, M], retreatCost:1) {
         weakness P
@@ -327,7 +327,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case FLAREON_DELTA_5:
       return evolution (this, from:"Eevee", hp:HP070, type:[R, M], retreatCost:1) {
         weakness W
@@ -362,7 +362,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GARDEVOIR_DELTA_6:
       return evolution (this, from:"Kirlia", hp:HP100, type:[P, M], retreatCost:2) {
         weakness P
@@ -397,7 +397,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10+20*opp.bench.size()
           }
         }
-      };
+      }
       case JOLTEON_DELTA_7:
       return evolution (this, from:"Eevee", hp:HP070, type:[L, M], retreatCost:1) {
         weakness F
@@ -434,7 +434,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LATIAS_DELTA_8:
       return basic (this, hp:HP070, type:[L, M], retreatCost:1) {
         weakness C
@@ -474,7 +474,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LATIOS_DELTA_9:
       return basic (this, hp:HP080, type:[L, M], retreatCost:2) {
         weakness C
@@ -513,7 +513,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAROWAK_DELTA_10:
       return evolution (this, from:"Cubone", hp:HP080, type:[F, M], retreatCost:1) {
         weakness G
@@ -538,7 +538,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case METAGROSS_DELTA_11:
       return evolution (this, from:"Metang", hp:HP100, type:[L, M], retreatCost:3) {
         weakness R
@@ -569,11 +569,11 @@ public enum DeltaSpecies implements LogicCardInfo {
               def pl = my.all.findAll{
                 it.cards.filterByType(ENERGY).any{enCard -> !toBeDiscarded.contains(enCard)}
               }
-              if(!pl) break;
+              if(!pl) break
 
               def info = "Energy cards already marked for discard: ${toBeDiscarded.size()}\nCurrent base damage: 30 + ${20 * toBeDiscarded.size()}\nDiscard an Energy card from which Pokémon? (cancel to stop)"
               def src = pl.select(info, false)
-              if(!src) break;
+              if(!src) break
 
               def selection = src.cards.filterByType(ENERGY).findAll{!toBeDiscarded.contains(it)}.select("Card to discard")
               toBeDiscarded.addAll(selection)
@@ -582,7 +582,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             afterDamage { toBeDiscarded.discard() }
           }
         }
-      };
+      }
       case MEWTWO_DELTA_12:
       return basic (this, hp:HP070, type:[R, M], retreatCost:1) {
         weakness P
@@ -592,9 +592,9 @@ public enum DeltaSpecies implements LogicCardInfo {
             if (it == PLAY_FROM_HAND && my.all.any{it.cards.filterByType(BASIC_ENERGY)} && confirm("Use Delta Switch?")) {
               while (1) {
                 def pl = (my.all.findAll {it.cards.filterByType(BASIC_ENERGY)})
-                if(!pl) break;
+                if(!pl) break
                 def src = pl.select("Source for energy (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.select("Card to move",cardTypeFilter(BASIC_ENERGY)).first()
                 def target = my.all.findAll{ it != src && it != self }.select("Move Energy to?")
                 energySwitch(src, target, card)
@@ -609,7 +609,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10 * (self.cards.energyCount(C) + defending.cards.energyCount(C))
           }
         }
-      };
+      }
       case RAYQUAZA_DELTA_13:
       return basic (this, hp:HP090, type:[L, M], retreatCost:3) {
         weakness C
@@ -642,7 +642,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SALAMENCE_DELTA_14:
       return evolution (this, from:"Shelgon", hp:HP110, type:[R, M], retreatCost:1) {
         weakness C
@@ -668,7 +668,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STARMIE_DELTA_15:
       return evolution (this, from:"Staryu", hp:HP060, type:[W, M], retreatCost:0) {
         weakness L
@@ -702,7 +702,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYRANITAR_DELTA_16:
       return evolution (this, from:"Pupitar", hp:HP120, type:[R, M], retreatCost:2) {
         weakness G
@@ -738,7 +738,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UMBREON_DELTA_17:
       return evolution (this, from:"Eevee", hp:HP070, type:[D, M], retreatCost:1) {
         weakness F
@@ -762,7 +762,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             swiftDamage(30, opp.all.select())
           }
         }
-      };
+      }
       case VAPOREON_DELTA_18:
       return evolution (this, from:"Eevee", hp:HP070, type:[W, M], retreatCost:1) {
         weakness L
@@ -796,7 +796,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case AZUMARILL_DELTA_19:
       return evolution (this, from:"Marill", hp:HP080, type:[W, M], retreatCost:2) {
         weakness L
@@ -815,7 +815,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case AZURILL_20:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -849,7 +849,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case HOLON_S_ELECTRODE_21:
       return evolution (this, from:"Holon's Voltorb", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -862,7 +862,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case HOLON_S_MAGNETON_22:
       return evolution (this, from:"Holon's Magnemite", hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -878,7 +878,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HYPNO_23:
       return evolution (this, from:"Drowzee", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -918,7 +918,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MIGHTYENA_DELTA_24:
       return evolution (this, from:"Poochyena", hp:HP070, type:[D, M], retreatCost:1) {
         weakness F
@@ -940,7 +940,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10*my.all.findAll { it.types.contains(D) || it.types.contains(M) }.size()
           }
         }
-      };
+      }
       case PORYGON2_25:
       return evolution (this, from:"Porygon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -966,7 +966,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAIN_CASTFORM_26:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -983,7 +983,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 30+10*self.cards.findAll {it.name.contains("Holon Energy")}.size()
           }
         }
-      };
+      }
       case SANDSLASH_DELTA_27:
       return evolution (this, from:"Sandshrew", hp:HP080, type:[F, M], retreatCost:1) {
         weakness G
@@ -1020,7 +1020,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SLOWKING_28:
       return evolution (this, from:"Slowpoke", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1053,7 +1053,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             if (self.cards.filterByEnergyType(P)) { discardDefendingSpecialEnergy(delegate) }
           }
         }
-      };
+      }
       case SNOW_CLOUD_CASTFORM_29:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness M
@@ -1076,7 +1076,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STARMIE_DELTA_30:
       return evolution (this, from:"Staryu", hp:HP070, type:[W, M], retreatCost:1) {
         weakness L
@@ -1094,7 +1094,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             swiftDamage(50, defending)
           }
         }
-      };
+      }
       case SUNNY_CASTFORM_31:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -1119,7 +1119,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SWELLOW_32:
       return evolution (this, from:"Taillow", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -1142,7 +1142,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WEEZING_33:
       return evolution (this, from:"Koffing", hp:HP070, type:G, retreatCost:2) {
         weakness P
@@ -1156,7 +1156,7 @@ public enum DeltaSpecies implements LogicCardInfo {
 
                 self.owner.opposite.pbg.all.each {
                   for (Ability ability : it.getAbilities().keySet()) {
-                    if (ability instanceof PokeBody) hasPokeBody = true;
+                    if (ability instanceof PokeBody) hasPokeBody = true
                   }
                   if (once) {
                     bc "Body Odor Activates"
@@ -1187,7 +1187,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CASTFORM_34:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1208,7 +1208,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DITTO_35:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1229,7 +1229,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DITTO_36:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1247,7 +1247,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             extraPoison 1
           }
         }
-      };
+      }
       case DITTO_37:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1264,7 +1264,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10+10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case DITTO_38:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -1289,7 +1289,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             bef.unregisterItself(bg().em())
           }
         }
-      };
+      }
       case DITTO_39:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1307,7 +1307,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             discardAllSelfEnergy(null)
           }
         }
-      };
+      }
       case DITTO_40:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1325,7 +1325,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             switchYourActive(may: true)
           }
         }
-      };
+      }
       case DRAGONAIR_DELTA_41:
       return evolution (this, from:"Dratini", hp:HP070, type:L, retreatCost:1) {
         weakness C
@@ -1345,7 +1345,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGONAIR_DELTA_42:
       return evolution (this, from:"Dratini", hp:HP070, type:L, retreatCost:2) {
         weakness C
@@ -1365,7 +1365,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GOLBAT_43:
       return evolution (this, from:"Zubat", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1387,7 +1387,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HARIYAMA_44:
       return evolution (this, from:"Makuhita", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1430,7 +1430,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             noResistanceOrAnyEffectDamage(50, defending)
           }
         }
-      };
+      }
       case ILLUMISE_45:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1468,7 +1468,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             if (defending.evolution) { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case KAKUNA_46:
       return evolution (this, from:"Weedle", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1490,7 +1490,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KIRLIA_47:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1508,7 +1508,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20+10*opp.active.cards.energyCount()
           }
         }
-      };
+      }
       case MAGNETON_48:
       return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1528,7 +1528,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case METANG_DELTA_49:
       return evolution (this, from:"Beldum", hp:HP080, type:L, retreatCost:2) {
         weakness R
@@ -1548,7 +1548,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PERSIAN_50:
       return evolution (this, from:"Meowth", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1569,7 +1569,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 30, opp.all.select()
           }
         }
-      };
+      }
       case PUPITAR_DELTA_51:
       return evolution (this, from:"Larvitar", hp:HP070, type:R, retreatCost:0) {
         weakness G
@@ -1588,7 +1588,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case RAPIDASH_52:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:0) {
         weakness W
@@ -1607,7 +1607,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case SHELGON_DELTA_53:
       return evolution (this, from:"Bagon", hp:HP080, type:R, retreatCost:2) {
         weakness C
@@ -1628,7 +1628,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHELGON_DELTA_54:
       return evolution (this, from:"Bagon", hp:HP070, type:R, retreatCost:2) {
         weakness C
@@ -1654,7 +1654,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKARMORY_55:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -1689,7 +1689,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             reduceDamageNextTurn(hp(20), thisMove)
           }
         }
-      };
+      }
       case VOLBEAT_56:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1721,7 +1721,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             swiftDamage(30, defending)
           }
         }
-      };
+      }
       case BAGON_DELTA_57:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness C
@@ -1734,7 +1734,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BAGON_DELTA_58:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness C
@@ -1748,7 +1748,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             discardSelfEnergy R
           }
         }
-      };
+      }
       case BELDUM_DELTA_59:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness R
@@ -1769,7 +1769,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case CUBONE_60:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1787,7 +1787,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10+10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case DITTO_61:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1805,7 +1805,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip 1, {}, { discardSelfEnergy R }
           }
         }
-      };
+      }
       case DITTO_62:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -1822,7 +1822,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20, opp.all.select()
           }
         }
-      };
+      }
       case DITTO_63:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1840,7 +1840,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case DITTO_64:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1858,7 +1858,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case DRATINI_DELTA_65:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness C
@@ -1879,7 +1879,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip 1, {}, { damage 10, self }
           }
         }
-      };
+      }
       case DRATINI_DELTA_66:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness C
@@ -1893,7 +1893,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case DROWZEE_67:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1911,7 +1911,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EEVEE_DELTA_68:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness F
@@ -1925,7 +1925,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case EEVEE_69:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1941,7 +1941,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOLON_S_MAGNEMITE_70:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1954,7 +1954,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10, opp.all.select()
           }
         }
-      };
+      }
       case HOLON_S_VOLTORB_71:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1967,7 +1967,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case KOFFING_72:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1985,7 +1985,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LARVITAR_DELTA_73:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness G
@@ -2004,7 +2004,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case MAGNEMITE_74:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2023,7 +2023,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAKUHITA_75:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -2035,7 +2035,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case MARILL_76:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2054,7 +2054,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case MEOWTH_77:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2075,7 +2075,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PONYTA_78:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -2086,7 +2086,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case POOCHYENA_79:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -2106,7 +2106,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case PORYGON_80:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2117,7 +2117,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RALTS_81:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2136,7 +2136,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case SANDSHREW_82:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2154,7 +2154,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLOWPOKE_83:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2172,7 +2172,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STARYU_84:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2190,7 +2190,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STARYU_85:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2209,7 +2209,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             heal 40, self
           }
         }
-      };
+      }
       case TAILLOW_86:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -2221,7 +2221,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10, opp.all.select()
           }
         }
-      };
+      }
       case WEEDLE_87:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2233,7 +2233,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case ZUBAT_88:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2245,7 +2245,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply POISONED }
           }
         }
-      };
+      }
       case DUAL_BALL_89:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon, show it to your opponent, and put it into your hand. If you do, shuffle your deck afterward."
@@ -2263,9 +2263,9 @@ public enum DeltaSpecies implements LogicCardInfo {
         playRequirement{
           assert my.deck.notEmpty
         }
-      };
+      }
       case GREAT_BALL_90:
-      return copy(FireRedLeafGreen.GREAT_BALL_92, this);
+      return copy(FireRedLeafGreen.GREAT_BALL_92, this)
       case HOLON_FARMER_91:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2288,7 +2288,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert my.discard.filterByType(BASIC_ENERGY) || my.discard.filterByType(POKEMON) : "No Basic Energy cards or Pokémon in discard pile."
         }
-      };
+      }
       case HOLON_LASS_92:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2310,7 +2310,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case HOLON_MENTOR_93:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2329,7 +2329,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case HOLON_RESEARCH_TOWER_94:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2347,7 +2347,7 @@ public enum DeltaSpecies implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case HOLON_RESEARCHER_95:
       return supporter (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2369,7 +2369,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert my.deck : "Deck is empty."
         }
-      };
+      }
       case HOLON_RUINS_96:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2391,7 +2391,7 @@ public enum DeltaSpecies implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case HOLON_SCIENTIST_97:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2406,7 +2406,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert (my.hand.size()-2 < opp.hand.size()) : "You must be able to draw at least one card after you have paid the discard cost"
         }
-      };
+      }
       case HOLON_TRANSCEIVER_98:
       return itemCard (this) {
         text "Search your deck for a Supporter card that has Holon in its name, show it to your opponent, and put it into your hand. Shuffle your deck afterward. Or, search your discard pile for a Supporter card that has Holon in its name, show it to your opponent, and put it into your hand."
@@ -2442,17 +2442,17 @@ public enum DeltaSpecies implements LogicCardInfo {
             it.cardTypes.is(SUPPORTER) && it.name.contains("Holon")
           } || my.deck.notEmpty : "Deck is empty and your discard pile does not have any Holon Supporters"
         }
-      };
+      }
       case MASTER_BALL_99:
-        return copy(Deoxys.MASTER_BALL_88, this);
+        return copy(Deoxys.MASTER_BALL_88, this)
       case SUPER_SCOOP_UP_100:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case POTION_101:
-        return copy(FireRedLeafGreen.POTION_101, this);
+        return copy(FireRedLeafGreen.POTION_101, this)
       case SWITCH_102:
-        return copy(FireRedLeafGreen.SWITCH_102, this);
+        return copy(FireRedLeafGreen.SWITCH_102, this)
       case DARKNESS_ENERGY_103:
-        return copy (Emerald.DARKNESS_ENERGY_86, this);
+        return copy (Emerald.DARKNESS_ENERGY_86, this)
       case HOLON_ENERGY_FF_104:
       return specialEnergy (this, [[C]]) {
         text "Holon Energy FF provides [C] Energy. If the Pokémon that Holon Energy FF is attached to also has a basic [R] Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Holon Energy FF is attached to also has a basic [F] Energy card attached to it, damage done by that Pokémon's attack isn't affected by Resistance. Ignore these effects if Holon Energy FF is attached to Pokémon-ex."
@@ -2480,7 +2480,7 @@ public enum DeltaSpecies implements LogicCardInfo {
           eff.unregister()
           eff2.unregister()
         }
-      };
+      }
       case HOLON_ENERGY_GL_105:
       return specialEnergy (this, [[C]]) {
         text "Holon Energy GL provides [C] Energy. If the Pokémon that Holon Energy GL is attached to also has a basic [G] Energy card attached to it, that Pokémon can't be affected by any Special Conditions. If the Pokémon that Holon Energy GL is attached to also has a basic [L] Energy card attached to it, damage done by your opponent's Pokémon-ex is reduced by 10. Ignore these effects if Holon Energy GL is attached to Pokémon-ex."
@@ -2534,7 +2534,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             clearSpecialCondition(self)
           }
         }
-      };
+      }
       case HOLON_ENERGY_WP_106:
       return specialEnergy (this, [[C]]) {
         text "Holon Energy WP provides [C] Energy. If the Pokémon that Holon Energy WP is attached to also has a basic [W] Energy card attached to it, prevent all effects, excluding damage, done to that Pokémon by your opponent's Pokémon. If the Pokémon that Holon Energy WP is attached to also has a basic [P] Energy card attached to it, that Pokémon's Retreat Cost is 0. Ignore these effects if Holon Energy WP is attached to Pokémon-ex."
@@ -2561,9 +2561,9 @@ public enum DeltaSpecies implements LogicCardInfo {
           eff.unregister()
           eff2.unregister()
         }
-      };
+      }
       case METAL_ENERGY_107:
-      return copy (RubySapphire.METAL_ENERGY_94, this);
+      return copy (RubySapphire.METAL_ENERGY_94, this)
       case FLAREON_EX_108:
       return evolution (this, from:"Eevee", hp:HP110, type:R, retreatCost:1) {
         weakness W
@@ -2593,7 +2593,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case JOLTEON_EX_109:
       return evolution (this, from:"Eevee", hp:HP100, type:L, retreatCost:0) {
         weakness F
@@ -2624,7 +2624,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             discardSelfEnergy L
           }
         }
-      };
+      }
       case VAPOREON_EX_110:
       return evolution (this, from:"Eevee", hp:HP120, type:W, retreatCost:1) {
         weakness L
@@ -2653,7 +2653,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case GROUDON_STAR_111:
       return basic (this, hp:HP090, type:F, retreatCost:3) {
         weakness W
@@ -2680,7 +2680,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             discardSelfEnergy F
           }
         }
-      };
+      }
       case KYOGRE_STAR_112:
       return basic (this, hp:HP090, type:W, retreatCost:3) {
         weakness L
@@ -2707,7 +2707,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { cantAttackNextTurn defending }
           }
         }
-      };
+      }
       case METAGROSS_STAR_113:
       return basic (this, hp:HP090, type:M, retreatCost:3) {
         weakness R
@@ -2735,7 +2735,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { discardDefendingEnergy() }
           }
         }
-      };
+      }
       case AZUMARILL_114:
       return evolution (this, from:"Marill", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -2762,9 +2762,9 @@ public enum DeltaSpecies implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -1,27 +1,27 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.effect.ability.custom.Safeguard;
+import tcgwars.logic.effect.ability.custom.Safeguard
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -137,53 +137,53 @@ public enum Deoxys implements LogicCardInfo {
   RAYQUAZA_STAR_107 ("Rayquaza Star", "107", Rarity.SECRET, [POKEMON_STAR, BASIC, POKEMON, _COLORLESS_]),
   ROCKET_S_RAIKOU_EX_108 ("Rocket's Raikou ex", "108", Rarity.ULTRARARE, [BASIC, POKEMON, _DARKNESS_, EX]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Deoxys(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DEOXYS;
+    return tcgwars.logic.card.Collection.DEOXYS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -211,7 +211,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEAUTIFLY_2:
         return evolution (this, from:"Silcoon", hp:HP100, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -248,7 +248,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRELOOM_3:
         return evolution (this, from:"Shroomish", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -269,7 +269,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CAMERUPT_4:
         return evolution (this, from:"Numel", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -293,7 +293,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLAYDOL_5:
         return evolution (this, from:"Baltoy", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -319,7 +319,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRAWDAUNT_6:
         return evolution (this, from:"Corphish", hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness GRASS
@@ -355,7 +355,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_7:
         return evolution (this, from:"Duskull", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -382,7 +382,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_8:
         return evolution (this, from:"Magikarp", hp:HP090, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -415,7 +415,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIRACHI_9:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -440,13 +440,13 @@ public enum Deoxys implements LogicCardInfo {
               damage 20
               def hasPokeBody = false
               for (Ability ability : defending.getAbilities().keySet()) {
-                if (ability instanceof PokeBody) hasPokeBody = true;
+                if (ability instanceof PokeBody) hasPokeBody = true
               }
               if(hasPokeBody) damage 30
             }
           }
 
-        };
+        }
       case LUDICOLO_10:
         return evolution (this, from:"Lombre", hp:HP100, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -480,7 +480,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAGROSS_11:
         return evolution (this, from:"Metang", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -507,7 +507,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MIGHTYENA_12:
         return evolution (this, from:"Poochyena", hp:HP070, type:DARKNESS, retreatCost:0) {
           weakness FIGHTING
@@ -536,7 +536,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINJASK_13:
         return evolution (this, from:"Nincada", hp:HP070, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -580,7 +580,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHEDINJA_14:
         return evolution (this, from:"Nincada", hp:HP050, type:PSYCHIC, retreatCost:0) {
 
@@ -604,7 +604,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLAKING_15:
         return evolution (this, from:"Vigoroth", hp:HP120, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -640,7 +640,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_16:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -663,7 +663,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_17:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -685,7 +685,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_18:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -704,7 +704,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUDICOLO_19:
         return evolution (this, from:"Lombre", hp:HP100, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -730,7 +730,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGCARGO_20:
         return evolution (this, from:"Slugma", hp:HP080, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -764,7 +764,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PELIPPER_21:
         return evolution (this, from:"Wingull", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -788,7 +788,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_22:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness COLORLESS
@@ -812,7 +812,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SABLEYE_23:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           resistance COLORLESS, MINUS30
@@ -842,7 +842,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEAKING_24:
         return evolution (this, from:"Goldeen", hp:HP070, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -862,7 +862,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIFTRY_25:
         return evolution (this, from:"Nuzleaf", hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -885,7 +885,7 @@ public enum Deoxys implements LogicCardInfo {
               if(bg.stadiumInfoStruct) damage 20
             }
           }
-        };
+        }
       case SKARMORY_26:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness LIGHTNING
@@ -914,7 +914,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TROPIUS_27:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -944,7 +944,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHISCASH_28:
         return evolution (this, from:"Barboach", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -963,7 +963,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case XATU_29:
         return evolution (this, from:"Natu", hp:HP070, type:PSYCHIC, retreatCost:0) {
           weakness LIGHTNING
@@ -1013,7 +1013,7 @@ public enum Deoxys implements LogicCardInfo {
               damage 30 * addDmg
             }
           }
-        };
+        }
       case DONPHAN_30:
         return evolution (this, from:"Phanpy", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1035,7 +1035,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT_31:
         return evolution (this, from:"Zubat", hp:HP070, type:GRASS, retreatCost:0) {
           weakness PSYCHIC
@@ -1059,7 +1059,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUMPIG_32:
         return evolution (this, from:"Spoink", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1091,7 +1091,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOMBRE_33:
         return evolution (this, from:"Lotad", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1112,7 +1112,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOMBRE_34:
         return evolution (this, from:"Lotad", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1135,7 +1135,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOTAD_35:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1148,7 +1148,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUNATONE_36:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -1177,7 +1177,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGCARGO_37:
         return evolution (this, from:"Slugma", hp:HP080, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1197,7 +1197,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_38:
         return evolution (this, from:"Electrike", hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1224,7 +1224,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MASQUERAIN_39:
         return evolution (this, from:"Surskit", hp:HP060, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -1251,7 +1251,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METANG_40:
         return evolution (this, from:"Beldum", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1271,7 +1271,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_41:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1293,13 +1293,13 @@ public enum Deoxys implements LogicCardInfo {
               opp.all.each{
                 hasPokeBody = false
                 for (Ability ability : it.getAbilities().keySet()) {
-                  if (ability instanceof PokeBody) hasPokeBody = true;
+                  if (ability instanceof PokeBody) hasPokeBody = true
                 }
                 if(hasPokeBody) noWrDamage 20,it
               }
             }
           }
-        };
+        }
       case NOSEPASS_42:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -1324,7 +1324,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUZLEAF_43:
         return evolution (this, from:"Seedot", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1344,7 +1344,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PLUSLE_44:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1361,14 +1361,14 @@ public enum Deoxys implements LogicCardInfo {
               opp.all.each{
                 hasPokePower = false
                 for (Ability ability : it.getAbilities().keySet()) {
-                  if (ability instanceof PokePower) hasPokePower = true;
+                  if (ability instanceof PokePower) hasPokePower = true
                 }
                 if(hasPokePower) noWrDamage 20,it
               }
             }
           }
 
-        };
+        }
       case SHELGON_45:
         return evolution (this, from:"Bagon", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness COLORLESS
@@ -1396,7 +1396,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SILCOON_46:
         return evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1424,7 +1424,7 @@ public enum Deoxys implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SOLROCK_47:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness GRASS
@@ -1457,7 +1457,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARMIE_48:
         return evolution (this, from:"Staryu", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1498,7 +1498,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWELLOW_49:
         return evolution (this, from:"Taillow", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -1525,7 +1525,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIGOROTH_50:
         return evolution (this, from:"Slakoth", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1550,7 +1550,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING_51:
         return evolution (this, from:"Koffing", hp:HP070, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1572,7 +1572,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAGON_52:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness COLORLESS
@@ -1593,7 +1593,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BALTOY_53:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -1619,7 +1619,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BARBOACH_54:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1638,7 +1638,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELDUM_55:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1651,7 +1651,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARVANHA_56:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness GRASS
@@ -1671,7 +1671,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CORPHISH_57:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1696,7 +1696,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_58:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1716,7 +1716,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_59:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1746,7 +1746,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_60:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1766,7 +1766,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDEEN_61:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1785,7 +1785,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_62:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1797,7 +1797,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOTAD_63:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1817,7 +1817,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_64:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1839,7 +1839,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAKUHITA_65:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1863,7 +1863,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NATU_66:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1887,7 +1887,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINCADA_67:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1906,7 +1906,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUMEL_68:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1931,7 +1931,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHANPY_69:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1950,7 +1950,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POOCHYENA_70:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1970,7 +1970,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEDOT_71:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1990,7 +1990,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHROOMISH_72:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2011,7 +2011,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLAKOTH_73:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2030,7 +2030,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLUGMA_74:
         return basic (this, hp:HP050, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2049,7 +2049,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLUGMA_75:
         return basic (this, hp:HP050, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2069,7 +2069,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPOINK_76:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2088,7 +2088,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARYU_77:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2102,7 +2102,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SURSKIT_78:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2115,7 +2115,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWABLU_79:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2170,7 +2170,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAILLOW_80:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2187,7 +2187,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WINGULL_81:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2201,7 +2201,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WURMPLE_82:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2220,7 +2220,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_83:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -2242,9 +2242,9 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BALLOON_BERRY_84:
-        return copy(Dragon.BALLOON_BERRY_82, BALLOON_BERRY_84);
+        return copy(Dragon.BALLOON_BERRY_82, BALLOON_BERRY_84)
       case CRYSTAL_SHARD_85:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAs long as this card is attached to a Pokémon, that Pokémon’s type is [C]. If that Pokémon attacks, discard this card at the end of the turn."
@@ -2269,7 +2269,7 @@ public enum Deoxys implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case ENERGY_CHARGE_86:
         return basicTrainer (this) {
           text "Flip a coin. If heads, search your discard pile for 2 Energy cards (1 if there is only 1), show them to your opponent, and shuffle them into your deck."
@@ -2284,9 +2284,9 @@ public enum Deoxys implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(ENERGY) : "There are no Energy cards in your discard"
           }
-        };
+        }
       case LADY_OUTING_87:
-        return copy (RubySapphire.LADY_OUTING_83, this);
+        return copy (RubySapphire.LADY_OUTING_83, this)
       case MASTER_BALL_88:
         return basicTrainer (this) {
           text "Look at the top 7 cards from your deck. Choose a Basic Pokémon or Evolution card from those cards, show it to your opponent, and put it into your hand. Put the other 6 cards back on top of your deck. Shuffle your deck afterward."
@@ -2297,7 +2297,7 @@ public enum Deoxys implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no cards left in your deck."
           }
-        };
+        }
       case METEOR_FALLS_89:
         return stadium (this) {
           text "Each player’s Active Evolved Pokémon (excluding Pokémon-ex) can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack’s Energy cost.)\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -2317,7 +2317,7 @@ public enum Deoxys implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case PROFESSOR_COZMO_S_DISCOVERY_90:
         return supporter (this) {
           text "Flip a coin. If heads, draw the bottom 3 cards of your deck. If tails, draw the top 2 cards of your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2332,7 +2332,7 @@ public enum Deoxys implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case SPACE_CENTER_91:
         return stadium (this) {
           text "Ignore Poké-Bodies for all Basic Pokémon in play (both yours and your opponent’s) (excluding Pokémon-ex and Pokémon that has an owner in its name).\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -2356,7 +2356,7 @@ public enum Deoxys implements LogicCardInfo {
             eff2.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case STRENGTH_CHARM_92:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nWhenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon, the attack does 10 more damage (before applying Weakness and Resistance). Discard Strength Charm at the end of the turn in which this Pokémon attacks."
@@ -2385,7 +2385,7 @@ public enum Deoxys implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case BOOST_ENERGY_93:
         return specialEnergy (this, [[C],[C],[C]]) {
           text "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached. Boost Energy provides [C][C][C] Energy. The Pokémon Boost Energy is attached to can’t retreat. If the Pokémon Boost Energy is attached to isn’t an Evolved Pokémon, discard Boost Energy."
@@ -2422,7 +2422,7 @@ public enum Deoxys implements LogicCardInfo {
           allowAttach {to->
             to.evolution
           }
-        };
+        }
       case HEAL_ENERGY_94:
         return specialEnergy (this, [[C]]) {
           text "Heal Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter and all Special Conditions from that Pokémon. If heal Energy is attached to Pokémon-ex, Heal Energy has no effect other than providing Energy."
@@ -2434,7 +2434,7 @@ public enum Deoxys implements LogicCardInfo {
           }
           onRemoveFromPlay {
           }
-        };
+        }
       case SCRAMBLE_ENERGY_95:
         return specialEnergy (this, [[C]]) {
           text "Scramble Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). Scramble Energy provides [C] Energy. While in play, if you have more prizes left than your opponent, Scramble Energy provides every type of Energy but provides only 3 in any combination at a time. If the Pokémon Scramble Energy is attached to isn’t an Evolved Pokémon (or evolves into Pokémon-ex), discard Scramble Energy."
@@ -2469,7 +2469,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROBAT_EX_96:
         return evolution (this, from:"Golbat", hp:HP130, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -2505,7 +2505,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_EX_97:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2523,7 +2523,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_EX_98:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -2547,7 +2547,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_EX_99:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -2591,7 +2591,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HARIYAMA_EX_100:
         return evolution (this, from:"Makuhita", hp:HP110, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -2637,7 +2637,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_EX_101:
         return evolution (this, from:"Electrike", hp:HP100, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2667,7 +2667,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_EX_102:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness COLORLESS
@@ -2680,9 +2680,9 @@ public enum Deoxys implements LogicCardInfo {
                 powerUsed()
                 while(1){
                   def pl = (my.all.findAll{ it.cards.filterByType(BASIC_ENERGY) && it != self })
-                  if (pl.empty) break;
+                  if (pl.empty) break
                   def src = pl.select("source for energy (cancel to stop)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
                   energySwitch(src, self, card)
                 }
@@ -2697,7 +2697,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAMENCE_EX_103:
         return evolution (this, from:"Shelgon", hp:HP160, type:COLORLESS, retreatCost:2) {
           weakness COLORLESS
@@ -2729,7 +2729,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHARPEDO_EX_104:
         return evolution (this, from:"Carvanha", hp:HP100, type:DARKNESS, retreatCost:0) {
           weakness GRASS
@@ -2759,7 +2759,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LATIAS_STAR_105:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness COLORLESS
@@ -2789,7 +2789,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LATIOS_STAR_106:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness COLORLESS
@@ -2818,7 +2818,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_STAR_107:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness COLORLESS
@@ -2842,7 +2842,7 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_RAIKOU_EX_108:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -2868,9 +2868,9 @@ public enum Deoxys implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1,45 +1,45 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.effect.gm.ActivateSimpleTrainer;
-import tcgwars.logic.effect.gm.PlayTrainer;
+import tcgwars.logic.effect.gm.ActivateSimpleTrainer
+import tcgwars.logic.effect.gm.PlayTrainer
 
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.DeltaSpecies;
-import tcgwars.logic.impl.gen3.HolonPhantoms;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
-import tcgwars.logic.impl.gen4.HeartgoldSoulsilver;
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.DeltaSpecies
+import tcgwars.logic.impl.gen3.HolonPhantoms
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.TeamRocketReturns
+import tcgwars.logic.impl.gen4.HeartgoldSoulsilver
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -148,53 +148,53 @@ public enum DragonFrontiers implements LogicCardInfo {
   CHARIZARD_STAR_DELTA_100 ("Charizard Star", "100", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, DELTA, _DARKNESS_]),
   MEW_STAR_DELTA_101 ("Mew Star", "101", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, DELTA, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DragonFrontiers(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DRAGON_FRONTIERS;
+    return tcgwars.logic.card.Collection.DRAGON_FRONTIERS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -217,7 +217,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20 + 10*my.all.findAll { it.topPokemonCard.cardTypes.is(DELTA) }.size()
           }
         }
-      };
+      }
       case FERALIGATR_DELTA_2:
       return evolution (this, from:"Croconaw", hp:HP120, type:L, retreatCost:2) {
         weakness L
@@ -256,7 +256,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HERACROSS_DELTA_3:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness R
@@ -291,7 +291,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEGANIUM_DELTA_4:
       return evolution (this, from:"Bayleef", hp:HP110, type:F, retreatCost:2) {
         weakness R
@@ -324,7 +324,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MILOTIC_DELTA_5:
       return evolution (this, from:"Feebas", hp:HP090, type:R, retreatCost:2) {
         weakness L
@@ -356,7 +356,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case NIDOKING_DELTA_6:
       return evolution (this, from:"Nidorino", hp:HP120, type:D, retreatCost:3) {
         weakness P
@@ -379,7 +379,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NIDOQUEEN_DELTA_7:
       return evolution (this, from:"Nidorina", hp:HP100, type:M, retreatCost:2) {
         weakness P
@@ -405,7 +405,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 30 + bonusDamage
           }
         }
-      };
+      }
       case NINETALES_DELTA_8:
       return evolution (this, from:"Vulpix", hp:HP070, type:P, retreatCost:0) {
         weakness W
@@ -434,7 +434,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             attachEnergyFrom(my.discard, my.all.select())
           }
         }
-      };
+      }
       case PINSIR_DELTA_9:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness R
@@ -471,7 +471,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SNORLAX_DELTA_10:
       return basic (this, hp:HP080, type:G, retreatCost:3) {
         weakness F
@@ -497,7 +497,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TOGETIC_DELTA_11:
       return evolution (this, from:"Togepi", hp:HP060, type:W, retreatCost:0) {
         weakness L
@@ -530,7 +530,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TYPHLOSION_DELTA_12:
       return evolution (this, from:"Quilava", hp:HP100, type:P, retreatCost:1) {
         weakness W
@@ -567,7 +567,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARBOK_DELTA_13:
       return evolution (this, from:"Ekans", hp:HP080, type:R, retreatCost:1) {
         weakness P
@@ -589,7 +589,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CLOYSTER_DELTA_14:
       return evolution (this, from:"Shellder", hp:HP070, type:F, retreatCost:1) {
         weakness L
@@ -621,7 +621,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10+10*self.cards.energyCount(C)
           }
         }
-      };
+      }
       case DEWGONG_DELTA_15:
       return evolution (this, from:"Seel", hp:HP080, type:C, retreatCost:2) {
         weakness L
@@ -658,7 +658,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GLIGAR_DELTA_16:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness W
@@ -686,7 +686,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JYNX_DELTA_17:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness P
@@ -705,7 +705,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LEDIAN_DELTA_18:
       return evolution (this, from:"Ledyba", hp:HP070, type:M, retreatCost:0) {
         weakness R
@@ -729,7 +729,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LICKITUNG_DELTA_19:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness F
@@ -752,7 +752,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MANTINE_DELTA_20:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness L
@@ -775,7 +775,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             heal 10, self
           }
         }
-      };
+      }
       case QUAGSIRE_DELTA_21:
       return evolution (this, from:"Wooper", hp:HP080, type:G, retreatCost:1) {
         weakness G
@@ -797,7 +797,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             if (self.cards.hasType(POKEMON_TOOL)) damage 20
           }
         }
-      };
+      }
       case SEADRA_DELTA_22:
       return evolution (this, from:"Horsea", hp:HP070, type:F, retreatCost:1) {
         weakness L
@@ -816,7 +816,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TROPIUS_DELTA_23:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -860,7 +860,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10*self.cards.energyCount(C)
           }
         }
-      };
+      }
       case VIBRAVA_DELTA_24:
       return evolution (this, from:"Trapinch", hp:HP070, type:P, retreatCost:1) {
         weakness C
@@ -882,7 +882,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case XATU_DELTA_25:
       return evolution (this, from:"Natu", hp:HP070, type:D, retreatCost:1) {
         weakness P
@@ -909,7 +909,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case BAYLEEF_DELTA_26:
       return evolution (this, from:"Chikorita", hp:HP070, type:F, retreatCost:1) {
         weakness R
@@ -922,7 +922,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case CROCONAW_DELTA_27:
       return evolution (this, from:"Totodile", hp:HP070, type:L, retreatCost:1) {
         weakness L
@@ -943,7 +943,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DRAGONAIR_DELTA_28:
       return evolution (this, from:"Dratini", hp:HP070, type:G, retreatCost:2) {
         move "Wrap", {
@@ -960,7 +960,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ELECTABUZZ_DELTA_29:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness F
@@ -983,7 +983,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             swiftDamage(30, defending)
           }
         }
-      };
+      }
       case FLAAFFY_DELTA_30:
       return evolution (this, from:"Mareep", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -995,7 +995,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case HORSEA_DELTA_31:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness L
@@ -1014,7 +1014,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case KIRLIA_32:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1037,7 +1037,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case KIRLIA_DELTA_33:
       return evolution (this, from:"Ralts", hp:HP070, type:R, retreatCost:1) {
         weakness P
@@ -1056,7 +1056,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case NIDORINA_DELTA_34:
       return evolution (this, from:"Nidoran♀", hp:HP070, type:M, retreatCost:1) {
         weakness P
@@ -1075,7 +1075,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case NIDORINO_DELTA_35:
       return evolution (this, from:"Nidoran♂", hp:HP070, type:D, retreatCost:1) {
         weakness P
@@ -1093,7 +1093,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case QUILAVA_DELTA_36:
       return evolution (this, from:"Cyndaquil", hp:HP070, type:P, retreatCost:1) {
         weakness W
@@ -1112,7 +1112,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case SEADRA_DELTA_37:
       return evolution (this, from:"Horsea", hp:HP070, type:F, retreatCost:1) {
         weakness L
@@ -1133,7 +1133,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SHELGON_DELTA_38:
       return evolution (this, from:"Bagon", hp:HP070, type:W, retreatCost:2) {
         move "Headbutt", {
@@ -1151,7 +1151,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case SMEARGLE_DELTA_39:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness F
@@ -1173,7 +1173,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SWELLOW_DELTA_40:
       return evolution (this, from:"Taillow", hp:HP070, type:R, retreatCost:0) {
         weakness L
@@ -1195,7 +1195,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case TOGEPI_DELTA_41:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness F
@@ -1206,7 +1206,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             reduceDamageFromDefendingNextTurn(hp(20),thisMove,defending)
           }
         }
-      };
+      }
       case VIBRAVA_DELTA_42:
       return evolution (this, from:"Trapinch", hp:HP070, type:P, retreatCost:1) {
         move "Bite", {
@@ -1226,7 +1226,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BAGON_DELTA_43:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         move "Granite Head", {
@@ -1237,7 +1237,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             reduceDamageNextTurn(hp(10), thisMove)
           }
         }
-      };
+      }
       case CHIKORITA_DELTA_44:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness R
@@ -1256,7 +1256,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CYNDAQUIL_DELTA_45:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness W
@@ -1267,7 +1267,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             swiftDamage(30, defending)
           }
         }
-      };
+      }
       case DRATINI_DELTA_46:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         move "Ram", {
@@ -1277,7 +1277,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EKANS_DELTA_47:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness P
@@ -1295,7 +1295,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELEKID_DELTA_48:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness F
@@ -1315,7 +1315,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10, opp.all.select()
           }
         }
-      };
+      }
       case FEEBAS_DELTA_49:
       return basic (this, hp:HP030, type:R, retreatCost:1) {
         weakness L
@@ -1329,7 +1329,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case HORSEA_DELTA_50:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness L
@@ -1341,7 +1341,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             applyAfterDamage ASLEEP
           }
         }
-      };
+      }
       case LARVITAR_51:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1359,7 +1359,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LARVITAR_DELTA_52:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness G
@@ -1377,7 +1377,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LEDYBA_DELTA_53:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1395,7 +1395,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { apply CONFUSED }
           }
         }
-      };
+      }
       case MAREEP_DELTA_54:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1406,7 +1406,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NATU_DELTA_55:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness P
@@ -1417,7 +1417,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_DELTA_56:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness P
@@ -1435,7 +1435,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORAN_MALE_DELTA_57:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness P
@@ -1453,7 +1453,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { apply POISONED }
           }
         }
-      };
+      }
       case PUPITAR_58:
       return evolution (this, from:"Larvitar", hp:HP070, type:F, retreatCost:1) {
         weakness W
@@ -1464,7 +1464,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PUPITAR_DELTA_59:
       return evolution (this, from:"Larvitar", hp:HP070, type:L, retreatCost:1) {
         weakness G
@@ -1478,7 +1478,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RALTS_60:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1499,7 +1499,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10*defending.cards.energyCount()
           }
         }
-      };
+      }
       case RALTS_DELTA_61:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness P
@@ -1517,7 +1517,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEEL_DELTA_62:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1535,7 +1535,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHELLDER_DELTA_63:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness L
@@ -1547,7 +1547,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case SMOOCHUM_DELTA_64:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness P
@@ -1572,7 +1572,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case SWABLU_DELTA_65:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1587,7 +1587,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TAILLOW_DELTA_66:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness L
@@ -1600,7 +1600,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case TOTODILE_DELTA_67:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness L
@@ -1618,7 +1618,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 10 + 10 * self.numberOfDamageCounters
           }
         }
-      };
+      }
       case TRAPINCH_DELTA_68:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness G
@@ -1636,7 +1636,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TRAPINCH_DELTA_69:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness G
@@ -1647,7 +1647,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             swiftDamage (10, opp.all.select())
           }
         }
-      };
+      }
       case VULPIX_DELTA_70:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness W
@@ -1665,7 +1665,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WOOPER_DELTA_71:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness G
@@ -1683,7 +1683,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BUFFER_PIECE_72:
       return pokemonTool (this) {
         text "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card." +
@@ -1707,9 +1707,9 @@ public enum DragonFrontiers implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case COPYCAT_73:
-      return copy(TeamRocketReturns.COPYCAT_83, this);
+      return copy(TeamRocketReturns.COPYCAT_83, this)
       case HOLON_LEGACY_74:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -1736,9 +1736,9 @@ public enum DragonFrontiers implements LogicCardInfo {
           eff2.unregister()
           new CheckAbilities().run(bg)
         }
-      };
+      }
       case HOLON_MENTOR_75:
-      return copy(DeltaSpecies.HOLON_MENTOR_93, this);
+      return copy(DeltaSpecies.HOLON_MENTOR_93, this)
       case ISLAND_HERMIT_76:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -1758,7 +1758,7 @@ public enum DragonFrontiers implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MR_STONE_S_PROJECT_77:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -1781,7 +1781,7 @@ public enum DragonFrontiers implements LogicCardInfo {
         playRequirement{
           assert ( my.deck.notEmpty || my.discard.hasType(BASIC_ENERGY)) : "You have no cards in deck, and there are no Basic Energy cards in your discard pile"
         }
-      };
+      }
       case OLD_ROD_78:
       return itemCard (this) {
         text "Flip 2 coins. If both are heads, search your discard pile for a Basic Pokémon or Evolution card, show it to your opponent, and put it into your hand. If both are tails, search your discard pile for a Trainer card, show it to your opponent, and put it into your hand."
@@ -1811,7 +1811,7 @@ public enum DragonFrontiers implements LogicCardInfo {
         playRequirement{
           assert my.discard.hasType(POKEMON) || my.discard.hasType(TRAINER) : "You don't have any Pokémon or Trainer cards in your discard pile"
         }
-      };
+      }
       case PROFESSOR_ELM_S_TRAINING_METHOD_79:
       return copy(HeartgoldSoulsilver.PROFESSOR_ELM_S_TRAINING_METHOD_100, this)
       case PROFESSOR_OAK_S_RESEARCH_80:
@@ -1826,25 +1826,25 @@ public enum DragonFrontiers implements LogicCardInfo {
         playRequirement{
           assert my.deck.notEmpty || (my.hand.getExcludedList(thisCard).size() != 0)
         }
-      };
+      }
       case STRENGTH_CHARM_81:
-      return copy(Deoxys.STRENGTH_CHARM_92, this);
+      return copy(Deoxys.STRENGTH_CHARM_92, this)
       case TV_REPORTER_82:
-      return copy(CelestialStorm.TV_REPORTER_149, this);
+      return copy(CelestialStorm.TV_REPORTER_149, this)
       case SWITCH_83:
-      return copy(FireRedLeafGreen.SWITCH_102, this);
+      return copy(FireRedLeafGreen.SWITCH_102, this)
       case HOLON_ENERGY_FF_84:
-      return copy(DeltaSpecies.HOLON_ENERGY_FF_104, this);
+      return copy(DeltaSpecies.HOLON_ENERGY_FF_104, this)
       case HOLON_ENERGY_GL_85:
-      return copy(DeltaSpecies.HOLON_ENERGY_GL_105, this);
+      return copy(DeltaSpecies.HOLON_ENERGY_GL_105, this)
       case HOLON_ENERGY_WP_86:
-      return copy(DeltaSpecies.HOLON_ENERGY_WP_106, this);
+      return copy(DeltaSpecies.HOLON_ENERGY_WP_106, this)
       case BOOST_ENERGY_87:
-      return copy(Deoxys.BOOST_ENERGY_93, this);
+      return copy(Deoxys.BOOST_ENERGY_93, this)
       case DELTA_RAINBOW_ENERGY_88:
-      return copy(HolonPhantoms.DELTA_RAINBOW_ENERGY_98, this);
+      return copy(HolonPhantoms.DELTA_RAINBOW_ENERGY_98, this)
       case SCRAMBLE_ENERGY_89:
-      return copy(Deoxys.SCRAMBLE_ENERGY_95, this);
+      return copy(Deoxys.SCRAMBLE_ENERGY_95, this)
       case ALTARIA_EX_DELTA_90:
       return evolution (this, from:"Swablu", hp:HP100, type:W, retreatCost:1) {
         weakness C
@@ -1872,7 +1872,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DRAGONITE_EX_DELTA_91:
       return evolution (this, from:"Dragonair", hp:HP150, type:G, retreatCost:2) {
         move "Deafen", {
@@ -1906,7 +1906,7 @@ public enum DragonFrontiers implements LogicCardInfo {
                   if (excessDamageCounters && opp.bench) {
                     for (i in 1..excessDamageCounters){
                       def tar = opp.bench.select("Move a damage counter from $defending to some of your opponent's benched Pokémon? There are still ${excessDamageCounters - i + 1} available counters to move (Cancel to stop)", false)
-                      if(!tar) break;
+                      if(!tar) break
                       directDamage 10, tar
                     }
                   }
@@ -1918,7 +1918,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLYGON_EX_DELTA_92:
       return evolution (this, from:"Vibrava", hp:HP150, type:P, retreatCost:2) {
         pokeBody "Sand Damage", {
@@ -1950,7 +1950,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GARDEVOIR_EX_DELTA_93:
       return evolution (this, from:"Kirlia", hp:HP150, type:R, retreatCost:2) {
         weakness P
@@ -2033,7 +2033,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case KINGDRA_EX_DELTA_94:
       return evolution (this, from:"Seadra", hp:HP140, type:F, retreatCost:1) {
         weakness L
@@ -2084,7 +2084,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LATIAS_EX_DELTA_95:
       return basic (this, hp:HP100, type:R, retreatCost:2) {
         weakness P
@@ -2117,7 +2117,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LATIOS_EX_DELTA_96:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness P
@@ -2145,7 +2145,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case RAYQUAZA_EX_DELTA_97:
       return basic (this, hp:HP110, type:L, retreatCost:2) {
         pokeBody "Rage Aura", {
@@ -2188,7 +2188,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SALAMENCE_EX_DELTA_98:
       return evolution (this, from:"Shelgon", hp:HP160, type:W, retreatCost:2) {
         weakness C
@@ -2234,7 +2234,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYRANITAR_EX_DELTA_99:
       return evolution (this, from:"Pupitar", hp:HP150, type:L, retreatCost:3) {
         weakness G
@@ -2321,7 +2321,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHARIZARD_STAR_DELTA_100:
       return basic (this, hp:HP090, type:D, retreatCost:3) {
         weakness W
@@ -2353,7 +2353,7 @@ public enum DragonFrontiers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEW_STAR_DELTA_101:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness P
@@ -2394,9 +2394,9 @@ public enum DragonFrontiers implements LogicCardInfo {
             if (!flag) bc "$thisMove failed! None of the opponent's Pokémon were ${type} type."
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/DragonNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonNG.groovy
@@ -1,36 +1,36 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -138,53 +138,53 @@ public enum DragonNG implements LogicCardInfo {
   CHARMELEON_99 ("Charmeleon", "99", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, _FIRE_]),
   CHARIZARD_100 ("Charizard", "100", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE2, _FIRE_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DragonNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DRAGON;
+    return tcgwars.logic.card.Collection.DRAGON
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -210,7 +210,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ALTARIA_2:
       return evolution (this, from:"Swablu", hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -232,7 +232,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CRAWDAUNT_3:
       return evolution (this, from:"Corphish", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -249,7 +249,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case FLYGON_4:
       return evolution (this, from:"Vibrava", hp:HP120, type:C, retreatCost:2) {
         weakness C
@@ -271,7 +271,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GOLEM_5:
       return evolution (this, from:"Graveler", hp:HP120, type:F, retreatCost:4) {
         weakness W
@@ -291,7 +291,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case GRUMPIG_6:
       return evolution (this, from:"Spoink", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -311,7 +311,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MINUN_7:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -337,7 +337,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PLUSLE_8:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -363,7 +363,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ROSELIA_9:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -388,7 +388,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SALAMENCE_10:
       return evolution (this, from:"Shelgon", hp:HP120, type:C, retreatCost:2) {
         weakness C
@@ -415,7 +415,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SHEDINJA_11:
       return evolution (this, from:"Nincada", hp:HP030, type:G, retreatCost:1) {
         pokeBody "Wonder Guard", {
@@ -431,7 +431,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TORKOAL_12:
       return basic (this, hp:HP080, type:R, retreatCost:3) {
         weakness W
@@ -451,7 +451,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CRAWDAUNT_13:
       return evolution (this, from:"Corphish", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -471,7 +471,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DRAGONAIR_14:
       return evolution (this, from:"Dratini", hp:HP070, type:C, retreatCost:2) {
         weakness C
@@ -493,7 +493,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FLYGON_15:
       return evolution (this, from:"Vibrava", hp:HP100, type:C, retreatCost:2) {
         pokeBody "Sand Guard", {
@@ -509,7 +509,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case GIRAFARIG_16:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -547,7 +547,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NINJASK_18:
       return evolution (this, from:"Nincada", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -564,7 +564,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SALAMENCE_19:
       return evolution (this, from:"Shelgon", hp:HP100, type:C, retreatCost:2) {
         pokeBody "Intimidating Fang", {
@@ -580,7 +580,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHELGON_20:
       return evolution (this, from:"Bagon", hp:HP080, type:C, retreatCost:2) {
         weakness C
@@ -602,7 +602,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SKARMORY_21:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -623,7 +623,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VIBRAVA_22:
       return evolution (this, from:"Trapinch", hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -645,7 +645,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BAGON_23:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness C
@@ -667,7 +667,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CAMERUPT_24:
       return evolution (this, from:"Numel", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -687,7 +687,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case COMBUSKEN_25:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -707,7 +707,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRATINI_26:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness C
@@ -729,7 +729,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FLAAFFY_27:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -750,7 +750,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FORRETRESS_28:
       return evolution (this, from:"Pineco", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -771,7 +771,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GRAVELER_29:
       return evolution (this, from:"Geodude", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -791,7 +791,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GRAVELER_30:
       return evolution (this, from:"Geodude", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -811,7 +811,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GROVYLE_31:
       return evolution (this, from:"Treecko", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -824,7 +824,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GYARADOS_32:
       return evolution (this, from:"Magikarp", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -844,7 +844,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case HORSEA_33:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -864,7 +864,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOUNDOOM_34:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -885,7 +885,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MAGNETON_35:
       return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -905,7 +905,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MARSHTOMP_36:
       return evolution (this, from:"Mudkip", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -917,7 +917,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEDITITE_37:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -937,7 +937,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NINJASK_38:
       return evolution (this, from:"Nincada", hp:HP070, type:G, retreatCost:null) {
         weakness R
@@ -957,7 +957,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEADRA_39:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -977,7 +977,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SEADRA_40:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -997,7 +997,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHELGON_41:
       return evolution (this, from:"Bagon", hp:HP070, type:C, retreatCost:2) {
         pokeBody "Energy Guard", {
@@ -1013,7 +1013,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHELGON_42:
       return evolution (this, from:"Bagon", hp:HP070, type:C, retreatCost:2) {
         move "Granite Head", {
@@ -1032,7 +1032,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHUPPET_43:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1053,7 +1053,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SNORUNT_44:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1065,7 +1065,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SWELLOW_45:
       return evolution (this, from:"Taillow", hp:HP070, type:C, retreatCost:null) {
         weakness L
@@ -1086,7 +1086,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case VIBRAVA_46:
       return evolution (this, from:"Trapinch", hp:HP070, type:C, retreatCost:1) {
         pokeBody "Levitate", {
@@ -1102,7 +1102,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VIBRAVA_47:
       return evolution (this, from:"Trapinch", hp:HP070, type:C, retreatCost:1) {
         move "Dive", {
@@ -1121,7 +1121,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WHISCASH_48:
       return evolution (this, from:"Barboach", hp:HP090, type:W, retreatCost:2) {
         weakness G
@@ -1146,7 +1146,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BAGON_49:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         move "Headbutt", {
@@ -1165,7 +1165,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BAGON_50:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         move "Risky Kick", {
@@ -1184,7 +1184,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BARBOACH_51:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1204,7 +1204,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CORPHISH_52:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1224,7 +1224,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CORPHISH_53:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1244,7 +1244,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CORPHISH_54:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1264,7 +1264,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GEODUDE_55:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1284,7 +1284,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GEODUDE_56:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -1296,7 +1296,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRIMER_57:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1316,7 +1316,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HORSEA_58:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1336,7 +1336,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_59:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1357,7 +1357,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_60:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1377,7 +1377,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_61:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1398,7 +1398,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_62:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1411,7 +1411,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MAGNEMITE_63:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1423,7 +1423,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAREEP_64:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1436,7 +1436,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MUDKIP_65:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1448,7 +1448,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NINCADA_66:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1460,7 +1460,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NINCADA_67:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1480,7 +1480,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NINCADA_68:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1492,7 +1492,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NUMEL_69:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1512,7 +1512,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NUMEL_70:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -1532,7 +1532,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PINECO_71:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1549,7 +1549,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLUGMA_72:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1569,7 +1569,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SPOINK_73:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1581,7 +1581,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPOINK_74:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1601,7 +1601,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SWABLU_75:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1622,7 +1622,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TAILLOW_76:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1635,7 +1635,7 @@ public enum DragonNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TORCHIC_77:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1647,7 +1647,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TRAPINCH_78:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1659,7 +1659,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TRAPINCH_79:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1679,7 +1679,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TREECKO_80:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1692,7 +1692,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WURMPLE_81:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1712,7 +1712,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BALLOON_BERRY_82:
       return pokemonTool (this) {
         text "When the Pokémon Balloon Berry is attached to retreats, discard Balloon Berry instead of discarding Energy cards." +
@@ -1735,7 +1735,7 @@ public enum DragonNG implements LogicCardInfo {
           eff1.unregister()
           eff2.unregister()
         }
-      };
+      }
       case BUFFER_PIECE_83:
         return copy (DragonFrontiers.BUFFER_PIECE_72, this)
       case ENERGY_RECYCLE_SYSTEM_84:
@@ -1765,7 +1765,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGONITE_EX_90:
       return evolution (this, from:"Dragonair", hp:HP150, type:C, retreatCost:2) {
         weakness C
@@ -1792,7 +1792,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case GOLEM_EX_91:
       return evolution (this, from:"Graveler", hp:HP160, type:F, retreatCost:5) {
         weakness G
@@ -1813,7 +1813,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case KINGDRA_EX_92:
       return evolution (this, from:"Seadra", hp:HP150, type:W, retreatCost:3) {
         weakness G
@@ -1834,7 +1834,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LATIAS_EX_93:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness C
@@ -1856,7 +1856,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case LATIOS_EX_94:
       return basic (this, hp:HP100, type:C, retreatCost:2) {
         weakness C
@@ -1878,7 +1878,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case MAGCARGO_EX_95:
       return evolution (this, from:"Slugma", hp:HP100, type:R, retreatCost:3) {
         weakness W
@@ -1898,7 +1898,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MUK_EX_96:
       return evolution (this, from:"Grimer", hp:HP100, type:G, retreatCost:2) {
         weakness P
@@ -1923,7 +1923,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAYQUAZA_EX_97:
       return basic (this, hp:HP100, type:C, retreatCost:2) {
         weakness C
@@ -1945,7 +1945,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHARMANDER_98:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1965,7 +1965,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHARMELEON_99:
       return evolution (this, from:"Charmander", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1985,7 +1985,7 @@ public enum DragonNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHARIZARD_100:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -2005,9 +2005,9 @@ public enum DragonNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/Emerald.groovy
+++ b/src/tcgwars/logic/impl/gen3/Emerald.groovy
@@ -1,11 +1,11 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.EffectType.*
@@ -13,13 +13,13 @@ import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -134,53 +134,53 @@ public enum Emerald implements LogicCardInfo {
   FIGHTING_ENERGY_106 ("Fighting Energy", "106", Rarity.RARE, [BASIC_ENERGY, ENERGY]),
   FARFETCH_D_107 ("Farfetch'd", "107", Rarity.RARE, [BASIC, POKEMON, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Emerald(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.EMERALD;
+    return tcgwars.logic.card.Collection.EMERALD
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -219,7 +219,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_2:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -237,7 +237,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXPLOUD_3:
         return evolution (this, from:"Loudred", hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -274,7 +274,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARDEVOIR_4:
         return evolution (this, from:"Kirlia", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -305,7 +305,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROUDON_5:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -325,7 +325,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KYOGRE_6:
         return basic (this, hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -345,7 +345,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_7:
         return evolution (this, from:"Electrike", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -366,7 +366,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MILOTIC_8:
         return evolution (this, from:"Feebas", hp:HP090, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -386,7 +386,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_9:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness COLORLESS
@@ -417,7 +417,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCEPTILE_10:
         return evolution (this, from:"Grovyle", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -455,7 +455,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWAMPERT_11:
         return evolution (this, from:"Marshtomp", hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -488,7 +488,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMECHO_12:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -508,7 +508,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLALIE_13:
         return evolution (this, from:"Snorunt", hp:HP080, type:WATER, retreatCost:1) {
           weakness METAL
@@ -528,7 +528,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROUDON_14:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness WATER
@@ -555,7 +555,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KYOGRE_15:
         return basic (this, hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -578,7 +578,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_16:
         return evolution (this, from:"Electrike", hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -599,7 +599,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOSEPASS_17:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -618,7 +618,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RELICANTH_18:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -638,7 +638,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON_19:
         return evolution (this, from:"Rhyhorn", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness WATER
@@ -658,7 +658,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEVIPER_20:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -678,7 +678,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZANGOOSE_21:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -699,7 +699,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRELOOM_22:
         return evolution (this, from:"Shroomish", hp:HP080, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -719,7 +719,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CAMERUPT_23:
         return evolution (this, from:"Numel", hp:HP080, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -742,7 +742,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLAYDOL_24:
         return evolution (this, from:"Baltoy", hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -763,7 +763,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMBUSKEN_25:
         return evolution (this, from:"Torchic", hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -786,7 +786,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO_26:
         return evolution (this, from:"Doduo", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -807,7 +807,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_27:
         return evolution (this, from:"Voltorb", hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -827,7 +827,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROVYLE_28:
         return evolution (this, from:"Treecko", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -848,7 +848,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUMPIG_29:
         return evolution (this, from:"Spoink", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -869,7 +869,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUMPIG_30:
         return evolution (this, from:"Spoink", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -888,7 +888,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HARIYAMA_31:
         return evolution (this, from:"Makuhita", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -909,7 +909,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ILLUMISE_32:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -928,7 +928,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KIRLIA_33:
         return evolution (this, from:"Ralts", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -947,7 +947,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LINOONE_34:
         return evolution (this, from:"Zigzagoon", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -967,7 +967,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOUDRED_35:
         return evolution (this, from:"Whismur", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -988,7 +988,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARSHTOMP_36:
         return evolution (this, from:"Mudkip", hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1008,7 +1008,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_37:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1031,7 +1031,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINETALES_38:
         return evolution (this, from:"Vulpix", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1052,7 +1052,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PLUSLE_39:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1073,7 +1073,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWALOT_40:
         return evolution (this, from:"Gulpin", hp:HP080, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -1094,7 +1094,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWELLOW_41:
         return evolution (this, from:"Taillow", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -1114,7 +1114,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLBEAT_42:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1134,7 +1134,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BALTOY_43:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1153,7 +1153,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CACNEA_44:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1165,7 +1165,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODUO_45:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1178,7 +1178,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_46:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1191,7 +1191,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_47:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1204,7 +1204,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_48:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1224,7 +1224,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEEBAS_49:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1249,7 +1249,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEEBAS_50:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1261,7 +1261,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GULPIN_51:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1280,7 +1280,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_52:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1292,7 +1292,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUVDISC_53:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1310,7 +1310,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAKUHITA_54:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1323,7 +1323,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEDITITE_55:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1343,7 +1343,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDKIP_56:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1356,7 +1356,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUMEL_57:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1375,7 +1375,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUMEL_58:
         return basic (this, hp:HP050, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1394,7 +1394,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PICHU_59:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1415,7 +1415,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_60:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1435,7 +1435,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RALTS_61:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1448,7 +1448,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_62:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness WATER
@@ -1467,7 +1467,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHROOMISH_63:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1487,7 +1487,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORUNT_64:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness METAL
@@ -1499,7 +1499,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPOINK_65:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1512,7 +1512,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPOINK_66:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1524,7 +1524,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWABLU_67:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1550,7 +1550,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAILLOW_68:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1563,7 +1563,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORCHIC_69:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1575,7 +1575,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREECKO_70:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1588,7 +1588,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_71:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1607,7 +1607,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VULPIX_72:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1627,7 +1627,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHISMUR_73:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1646,7 +1646,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZIGZAGOON_74:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1666,7 +1666,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BATTLE_FRONTIER_75:
         return stadium (this) {
           text "Each player’s [C] Evolved Pokémon, [D] Evolved Pokémon and [M] Evolved Pokémon can’t use any Poké-Powers or Poké-Bodies.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -1683,11 +1683,11 @@ public enum Emerald implements LogicCardInfo {
             eff.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case DOUBLE_FULL_HEAL_76:
-        return copy (Sandstorm.DOUBLE_FULL_HEAL_86, this);
+        return copy (Sandstorm.DOUBLE_FULL_HEAL_86, this)
       case LANETTE_S_NET_SEARCH_77:
-        return copy (Sandstorm.LANETTE_S_NET_SEARCH_87, this);
+        return copy (Sandstorm.LANETTE_S_NET_SEARCH_87, this)
       case LUM_BERRY_78:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAt any time between turns, if the Pokémon this card is attached to is affected by any Special Conditions, remove all of them. Then, discard Lum Berry."
@@ -1711,7 +1711,7 @@ public enum Emerald implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case MR__STONE_S_PROJECT_79:
         return supporter (this) {
           text "Search your deck for up to 2 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward. Or, search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -1733,7 +1733,7 @@ public enum Emerald implements LogicCardInfo {
           playRequirement{
             assert my.deck || my.discard.filterByType(BASIC_ENERGY) : "You have no cards left in deck, and no basic Energy cards in your discard pile"
           }
-        };
+        }
       case ORAN_BERRY_80:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAt any time between turns, if the Pokémon this card is attached to has at least 2 damage counters on it, remove 2 damage counters from it. Then, discard Oran Berry."
@@ -1752,9 +1752,9 @@ public enum Emerald implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case POKENAV_81:
-        return copy (RubySapphire.POKENAV_88, this);
+        return copy (RubySapphire.POKENAV_88, this)
       case PROFESSOR_BIRCH_82:
         return supporter (this) {
           text "Draw cards from your deck until you have 6 cards in your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -1766,9 +1766,9 @@ public enum Emerald implements LogicCardInfo {
           onPlay {
             draw ( 6 - my.hand.getExcludedList(thisCard).size() )
           }
-        };
+        }
       case RARE_CANDY_83:
-        return copy (Sandstorm.RARE_CANDY_88, this);
+        return copy (Sandstorm.RARE_CANDY_88, this)
       case SCOTT_84:
         return supporter (this) {
           text "Search you deck for up to 3 cards in any combination of Supporter cards and Stadium cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -1779,7 +1779,7 @@ public enum Emerald implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case WALLY_S_TRAINING_85:
         return supporter (this) {
           text "Search your deck for a card that evolves from your Active Pokémon (choose 1 if there are 2) and put it on your Active Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward."
@@ -1798,7 +1798,7 @@ public enum Emerald implements LogicCardInfo {
             assert my.deck : "Your deck is empty."
             //TODO: Check for the existance of any card the Active can evolve into.
           }
-        };
+        }
       case DARKNESS_ENERGY_86:
         return specialEnergy (this, [[D]]) {
           text: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)"
@@ -1866,11 +1866,11 @@ public enum Emerald implements LogicCardInfo {
             else return [[] as Set]
           }
 
-        };
+        }
       case METAL_ENERGY_88:
-        return copy (RubySapphire.METAL_ENERGY_94, this);
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case MULTI_ENERGY_89:
-        return copy (FireRedLeafGreen.MULTI_ENERGY_103, this);
+        return copy (FireRedLeafGreen.MULTI_ENERGY_103, this)
       case ALTARIA_EX_90:
         return evolution (this, from:"Swablu", hp:HP100, type:COLORLESS, retreatCost:1) {
           pokeBody "Mist", {
@@ -1901,7 +1901,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CACTURNE_EX_91:
         return evolution (this, from:"Cacnea", hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1933,7 +1933,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CAMERUPT_EX_92:
         return evolution (this, from:"Numel", hp:HP120, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1972,7 +1972,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEOXYS_EX_93:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1990,7 +1990,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_EX_94:
         return evolution (this, from:"Duskull", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -2014,7 +2014,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEDICHAM_EX_95:
         return evolution (this, from:"Meditite", hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -2049,7 +2049,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MILOTIC_EX_96:
         return evolution (this, from:"Feebas", hp:HP130, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -2087,7 +2087,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_EX_97:
         return evolution (this, from:"Pikachu", hp:HP100, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -2114,7 +2114,7 @@ public enum Emerald implements LogicCardInfo {
               def tar = opp.all.select("Select the targeted Pokémon")
               def hasPokePower = false
               for (Ability ability : tar.getAbilities().keySet()) {
-                if (ability instanceof PokePower) hasPokePower = true;
+                if (ability instanceof PokePower) hasPokePower = true
               }
               if(hasPokePower) damage 20,tar
 
@@ -2129,7 +2129,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGICE_EX_98:
         return basic (this, hp:HP100, type:WATER, retreatCost:3) {
           weakness METAL
@@ -2154,7 +2154,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGIROCK_EX_99:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:3) {
           weakness WATER
@@ -2180,7 +2180,7 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGISTEEL_EX_100:
         return basic (this, hp:HP090, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2202,19 +2202,19 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRASS_ENERGY_101:
-        return basicEnergy (this, GRASS);
+        return basicEnergy (this, GRASS)
       case FIRE_ENERGY_102:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case WATER_ENERGY_103:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       case LIGHTNING_ENERGY_104:
-        return basicEnergy (this, LIGHTNING);
+        return basicEnergy (this, LIGHTNING)
       case PSYCHIC_ENERGY_105:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case FIGHTING_ENERGY_106:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       case FARFETCH_D_107:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2235,9 +2235,9 @@ public enum Emerald implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1,15 +1,15 @@
 package tcgwars.logic.impl.gen3
 
 import tcgwars.logic.effect.ability.custom.Safeguard
-import tcgwars.logic.exception.EffectRequirementException;
-import tcgwars.logic.impl.gen2.Expedition;
+import tcgwars.logic.exception.EffectRequirementException
+import tcgwars.logic.impl.gen2.Expedition
 
 import tcgwars.logic.effect.gm.Attack
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.EffectType.*
@@ -18,13 +18,13 @@ import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -150,53 +150,53 @@ public enum FireRedLeafGreen implements LogicCardInfo {
   MOLTRES_EX_115 ("Moltres ex", "115", Rarity.HOLORARE, [BASIC, POKEMON, _FIRE_, EX]),
   ZAPDOS_EX_116 ("Zapdos ex", "116", Rarity.HOLORARE, [BASIC, POKEMON, _LIGHTNING_, EX]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   FireRedLeafGreen(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.FIRERED_LEAFGREEN;
+    return tcgwars.logic.card.Collection.FIRERED_LEAFGREEN
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -224,7 +224,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUTTERFREE_2:
         return evolution (this, from:"Metapod", hp:HP100, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -259,7 +259,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWGONG_3:
         return evolution (this, from:"Seel", hp:HP080, type:WATER, retreatCost:2) {
           weakness METAL
@@ -282,7 +282,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DITTO_4:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -311,7 +311,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGUTOR_5:
         return evolution (this, from:"Exeggcute", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -336,7 +336,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KANGASKHAN_6:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -363,7 +363,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAROWAK_7:
         return evolution (this, from:"Cubone", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -384,7 +384,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOKING_8:
         return evolution (this, from:"Nidorino", hp:HP120, type:FIGHTING, retreatCost:3) {
           weakness WATER
@@ -418,7 +418,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_9:
         return evolution (this, from:"Nidorina", hp:HP120, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -451,7 +451,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOT_10:
         return evolution (this, from:"Pidgeotto", hp:HP100, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -477,7 +477,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWRATH_11:
         return evolution (this, from:"Poliwhirl", hp:HP120, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -511,7 +511,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_12:
         return evolution (this, from:"Pikachu", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -538,7 +538,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_13:
         return evolution (this, from:"Ponyta", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -567,7 +567,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_14:
         return evolution (this, from:"Slowpoke", hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -593,7 +593,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_15:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -632,7 +632,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAUROS_16:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -655,7 +655,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTREEBEL_17:
         return evolution (this, from:"Weepinbell", hp:HP110, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -680,7 +680,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCANINE_18:
         return evolution (this, from:"Growlithe", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -700,7 +700,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANSEY_19:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -724,7 +724,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLOYSTER_20:
         return evolution (this, from:"Shellder", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -759,7 +759,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO_21:
         return evolution (this, from:"Doduo", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -780,7 +780,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUGTRIO_22:
         return evolution (this, from:"Diglett", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -800,7 +800,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FARFETCH_D_23:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -831,7 +831,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEAROW_24:
         return evolution (this, from:"Spearow", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -860,7 +860,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYPNO_25:
         return evolution (this, from:"Drowzee", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -886,7 +886,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGLER_26:
         return evolution (this, from:"Krabby", hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -908,7 +908,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_27:
         return evolution (this, from:"Magnemite", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -929,7 +929,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRIMEAPE_28:
         return evolution (this, from:"Mankey", hp:HP070, type:FIGHTING, retreatCost:0) {
           weakness PSYCHIC
@@ -950,7 +950,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_29:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -971,7 +971,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_30:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -996,7 +996,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMELEON_31:
         return evolution (this, from:"Charmander", hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1016,7 +1016,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DROWZEE_32:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1036,7 +1036,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGCUTE_33:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1056,7 +1056,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_34:
         return evolution (this, from:"Gastly", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1079,7 +1079,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case IVYSAUR_35:
         return evolution (this, from:"Bulbasaur", hp:HP080, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1098,7 +1098,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KAKUNA_36:
         return evolution (this, from:"Weedle", hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1117,7 +1117,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_37:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1137,7 +1137,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY_38:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1156,7 +1156,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAPOD_39:
         return evolution (this, from:"Caterpie", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1182,7 +1182,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA_40:
         return evolution (this, from:"Nidoran♀", hp:HP080, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1205,7 +1205,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINO_41:
         return evolution (this, from:"Nidoran♂", hp:HP070, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1225,7 +1225,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_42:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness WATER
@@ -1254,7 +1254,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARASECT_43:
         return evolution (this, from:"Paras", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1280,7 +1280,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_44:
         return evolution (this, from:"Meowth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1309,7 +1309,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOTTO_45:
         return evolution (this, from:"Pidgey", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -1330,7 +1330,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWHIRL_46:
         return evolution (this, from:"Poliwag", hp:HP080, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1354,7 +1354,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_47:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1376,7 +1376,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATICATE_48:
         return evolution (this, from:"Rattata", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -1394,7 +1394,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             energyCost C
             onAttack {
               if(my.discard){
-                def selectedCard = new CardList();
+                def selectedCard = new CardList()
                 if(my.discard.filterByType(POKEMON)) selectedCard.add(my.discard.filterByType(POKEMON).select(count : 1, "Search your discard pile for a Basic Pokémon (or Evolution card)").first())
                 if(my.discard.filterByType(TRAINER)) selectedCard.add(my.discard.filterByType(TRAINER).select(count : 1, "Search your discard pile for a Trainer card").first())
                 if(my.discard.filterByType(ENERGY)) selectedCard.add(my.discard.filterByType(ENERGY).select(count : 1, "Search your discard pile for an Energy card)").first())
@@ -1411,7 +1411,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_49:
         return evolution (this, from:"Venonat", hp:HP070, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -1442,7 +1442,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WARTORTLE_50:
         return evolution (this, from:"Squirtle", hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -1463,7 +1463,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEPINBELL_51:
         return evolution (this, from:"Bellsprout", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1483,7 +1483,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIGGLYTUFF_52:
         return evolution (this, from:"Jigglypuff", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1509,7 +1509,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELLSPROUT_53:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1521,7 +1521,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BULBASAUR_54:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1543,7 +1543,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BULBASAUR_55:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1563,7 +1563,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CATERPIE_56:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1586,7 +1586,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARMANDER_57:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1598,7 +1598,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER_58:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1617,7 +1617,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_59:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1639,7 +1639,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_60:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1658,7 +1658,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGLETT_61:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1670,7 +1670,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODUO_62:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1693,7 +1693,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_63:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1720,7 +1720,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROWLITHE_64:
         return basic (this, hp:HP060, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1739,7 +1739,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_65:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1763,7 +1763,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRABBY_66:
         return basic (this, hp:HP050, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -1785,7 +1785,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_67:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1802,7 +1802,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             ascension delegate
           }
 
-        };
+        }
       case MAGNEMITE_68:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1822,7 +1822,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH_69:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1844,7 +1844,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE_70:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1855,7 +1855,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               assert my.deck
             }
             onAttack {
-              def revealCard = new CardList();
+              def revealCard = new CardList()
               def foundBasic = false
               def ind = 0
               def curCard
@@ -1887,7 +1887,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_MALE_71:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1913,7 +1913,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARAS_72:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1931,7 +1931,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEY_73:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1951,7 +1951,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_74:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1966,7 +1966,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWAG_75:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1985,7 +1985,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_76:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1998,7 +1998,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA_77:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2020,7 +2020,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEL_78:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2032,7 +2032,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLDER_79:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2051,7 +2051,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_80:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2064,7 +2064,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEAROW_81:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2084,7 +2084,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SQUIRTLE_82:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2097,7 +2097,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SQUIRTLE_83:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2117,7 +2117,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENONAT_84:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2137,7 +2137,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_85:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2158,7 +2158,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEDLE_86:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2186,7 +2186,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BILL_S_MAINTENANCE_87:
         return supporter (this) {
           text "If you have any cards in your hand, shuffle 1 of them into your deck, then draw 3 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2198,7 +2198,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard)
           }
-        };
+        }
       case CELIO_S_NETWORK_88:
         return supporter (this) {
           text "Search your deck for a Basic Pokémon or Evolution card (excluding Pokémon-ex), show it to your opponent, and put it into your hand. Shuffle your deck afterward.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2211,9 +2211,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case ENERGY_REMOVAL_2_89:
-        return copy(Expedition.ENERGY_REMOVAL_2_140, this);
+        return copy(Expedition.ENERGY_REMOVAL_2_140, this)
       case ENERGY_SWITCH_90:
         return basicTrainer (this) {
           text "Move a basic Energy card attached to 1 of your Pokémon to another of your Pokémon."
@@ -2228,7 +2228,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             assertMyBench()
             assertMyAll(info:"with basic Energy cards attached to them", {it.cards.filterByType(BASIC_ENERGY)})
           }
-        };
+        }
       case EXP_ALL_91:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nAttach EXP.ALL to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nDuring your opponent’s turn, if 1 of your Active Pokémon would be Knocked Out by your opponent’s attack, you may take 1 basic Energy card attached to that Knocked Out Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
@@ -2258,7 +2258,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           allowAttach {to->
             to.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON) && !to.EX
           }
-        };
+        }
       case GREAT_BALL_92:
         return basicTrainer (this) {
           text "Search your deck for a Basic Pokémon (excluding Pokémon-ex) and put it onto your Bench. Shuffle your deck afterward."
@@ -2271,7 +2271,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.bench.notFull
           }
-        };
+        }
       case LIFE_HERB_93:
         return basicTrainer (this) {
           text "Flip a coin. If heads, choose 1 of your Pokémon (excluding Pokémon-ex), and remove all Special Conditions and 6 damage counters from that Pokémon (all if there are less than 6)."
@@ -2288,7 +2288,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{(it.numberOfDamageCounters || !(it.noSPC())) && it.topPokemonCard.cardTypes.isNot(EX)}
           }
-        };
+        }
       case MT__MOON_94:
         return stadium (this) {
           text "Any Pokémon (both yours and your opponent’s) with maximum HP of 70 or less can’t use any Poké-Powers.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -2313,7 +2313,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             effect2.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case POKE_BALL_95:
         return basicTrainer (this) {
           text "Flip a coin. If heads, search your deck for a Basic Pokémon or Evolution card, show it to your opponent and put it into your hand. Shuffle your deck afterward."
@@ -2326,7 +2326,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case POKEDEX_HANDY909_96:
         return basicTrainer (this) {
           text "Shuffle your deck. Look at 6 cards from the top of your deck, then put them back on top of your deck in any order."
@@ -2338,7 +2338,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             assert my.deck
 
           }
-        };
+        }
       case POKEMON_REVERSAL_97:
         return basicTrainer (this) {
           text "Flip a coin. If heads, choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
@@ -2352,7 +2352,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert opp.bench : "Opponent has no benched Pokémon"
           }
-        };
+        }
       case PROF__OAK_S_RESEARCH_98:
         return supporter (this) {
           text "Shuffle your hand into your deck, then draw 5 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2364,7 +2364,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || (my.hand.getExcludedList(thisCard).size() >0)
           }
-        };
+        }
       case SUPER_SCOOP_UP_99:
         return basicTrainer (this) {
           text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
@@ -2377,7 +2377,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             confirmScoopLastPokemon()
           }
-        };
+        }
       case VS_SEEKER_100:
         return basicTrainer (this) {
           text "Search your discard pile for a Supporter card, show it to your opponent, and put it into your hand."
@@ -2387,7 +2387,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(SUPPORTER) : "You have no Supporters in your discard"
           }
-        };
+        }
       case POTION_101:
         return basicTrainer (this) {
           text "Remove 2 damage counters from 1 of your Pokémon (remove 1 damage counter if that Pokémon has only 1)."
@@ -2401,7 +2401,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assertMyAll(info:"with damage on them", {it.numberOfDamageCounters})
           }
-        };
+        }
       case SWITCH_102:
         return basicTrainer (this) {
           text "Switch 1 of your Active Pokémon with 1 of your Benched Pokémon."
@@ -2413,7 +2413,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
           playRequirement{
             assert my.bench : "No benched Pokémon"
           }
-        };
+        }
       case MULTI_ENERGY_103:
         return specialEnergy (this, [[C]]) {
           text "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) Multi Energy provides [C] Energy when attached to a Pokémon that already has Special Energy cards attached to it."
@@ -2427,7 +2427,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               return [valuesBasicEnergy() as Set]
             }
           }
-        };
+        }
       case BLASTOISE_EX_104:
         return evolution (this, from:"Wartortle", hp:HP150, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -2461,7 +2461,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_EX_105:
         return evolution (this, from:"Charmeleon", hp:HP160, type:FIRE, retreatCost:2) {
           weakness LIGHTNING
@@ -2491,7 +2491,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE_EX_106:
         return evolution (this, from:"Clefairy", hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2502,7 +2502,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               def moveList = []
               def labelList = []
 
-              moveList.addAll(defending.topPokemonCard.moves);
+              moveList.addAll(defending.topPokemonCard.moves)
               labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
               def move=choose(moveList, labelList)
@@ -2519,7 +2519,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_EX_107:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2542,7 +2542,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_EX_108:
         return evolution (this, from:"Haunter", hp:HP150, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -2567,7 +2567,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_EX_109:
         return evolution (this, from:"Magikarp", hp:HP130, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -2593,7 +2593,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR__MIME_EX_110:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           pokeBody "Magic Odds", {
@@ -2617,7 +2617,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR__MIME_EX_111:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           pokeBody "Magic Evens", {
@@ -2641,7 +2641,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENUSAUR_EX_112:
         return evolution (this, from:"Ivysaur", hp:HP150, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -2681,7 +2681,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER_113:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -2700,7 +2700,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARTICUNO_EX_114:
         return basic (this, hp:HP110, type:WATER, retreatCost:2) {
           weakness METAL
@@ -2712,9 +2712,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                 sw my.active, self
                 while(1){
                   def pl=(my.all.findAll {it.cards.filterByBasicEnergyType(W) && it!=self})
-                  if(!pl) break;
+                  if(!pl) break
                   def src=pl.select("Source for basic [W] Energy (cancel to stop moving)", false)
-                  if(!src) break;
+                  if(!src) break
                   def card=src.cards.filterByBasicEnergyType(W).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -2735,7 +2735,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOLTRES_EX_115:
         return basic (this, hp:HP110, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2747,9 +2747,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                 sw my.active, self
                 while (1) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(R) && it != self })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for basic [R] Energy (cancel to stop moving)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(R).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -2768,7 +2768,7 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZAPDOS_EX_116:
         return basic (this, hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness LIGHTNING
@@ -2780,9 +2780,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
                 sw my.active, self
                 while (1) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(L) && it != self })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for basic [L] Energy (cancel to stop moving)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(L).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -2800,9 +2800,9 @@ public enum FireRedLeafGreen implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/HiddenLegendsNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/HiddenLegendsNG.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -138,53 +138,53 @@ public enum HiddenLegendsNG implements LogicCardInfo {
   WIGGLYTUFF_EX_101 ("Wigglytuff ex", "101", Rarity.ULTRARARE, [POKEMON, EVOLUTION, EX, STAGE1, _COLORLESS_]),
   GROUDON_102 ("Groudon", "102", Rarity.HOLORARE, [POKEMON, BASIC, _FIGHTING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   HiddenLegendsNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.HIDDEN_LEGENDS;
+    return tcgwars.logic.card.Collection.HIDDEN_LEGENDS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -210,7 +210,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CLAYDOL_2:
       return evolution (this, from:"Baltoy", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -227,7 +227,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CROBAT_3:
       return evolution (this, from:"Golbat", hp:HP090, type:G, retreatCost:null) {
         weakness P
@@ -247,7 +247,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DARK_CELEBI_4:
       return basic (this, hp:HP070, type:[G, D], retreatCost:1) {
         weakness R
@@ -267,7 +267,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELECTRODE_5:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -287,7 +287,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case EXPLOUD_6:
       return evolution (this, from:"Loudred", hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -323,7 +323,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HERACROSS_7:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -343,7 +343,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case JIRACHI_8:
       return basic (this, hp:HP070, type:[P, M], retreatCost:1) {
         weakness R
@@ -363,7 +363,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MACHAMP_9:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -388,7 +388,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MEDICHAM_10:
       return evolution (this, from:"Meditite", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -408,7 +408,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case METAGROSS_11:
       return evolution (this, from:"Metang", hp:HP100, type:[P, M], retreatCost:2) {
         weakness R
@@ -426,7 +426,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MILOTIC_12:
       return evolution (this, from:"Feebas", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -451,7 +451,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case PINSIR_13:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -468,7 +468,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SHIFTRY_14:
       return evolution (this, from:"Nuzleaf", hp:HP110, type:D, retreatCost:2) {
         weakness F
@@ -489,7 +489,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WALREIN_15:
       return evolution (this, from:"Sealeo", hp:HP120, type:W, retreatCost:3) {
         weakness M
@@ -506,7 +506,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case BELLOSSOM_16:
       return evolution (this, from:"Gloom", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -532,7 +532,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CHIMECHO_17:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -552,7 +552,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GOREBYSS_18:
       return evolution (this, from:"Clamperl", hp:HP070, type:W, retreatCost:null) {
         weakness L
@@ -572,7 +572,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HUNTAIL_19:
       return evolution (this, from:"Clamperl", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -592,7 +592,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MASQUERAIN_20:
       return evolution (this, from:"Surskit", hp:HP070, type:G, retreatCost:null) {
         weakness L
@@ -613,7 +613,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case METANG_21:
       return evolution (this, from:"Beldum", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -634,7 +634,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NINETALES_22:
       return evolution (this, from:"Vulpix", hp:HP070, type:F, retreatCost:1) {
         weakness W
@@ -659,7 +659,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAIN_CASTFORM_23:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -685,7 +685,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RELICANTH_24:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -702,7 +702,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNOW_CLOUD_CASTFORM_25:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness M
@@ -728,7 +728,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SUNNY_CASTFORM_26:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -754,7 +754,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TROPIUS_27:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -774,7 +774,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELDUM_28:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness F
@@ -792,7 +792,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BELDUM_29:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness F
@@ -810,7 +810,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CASTFORM_30:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -836,7 +836,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAYDOL_31:
       return evolution (this, from:"Baltoy", hp:HP080, type:F, retreatCost:1) {
         weakness W
@@ -856,7 +856,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CORSOLA_32:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -876,7 +876,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DODRIO_33:
       return evolution (this, from:"Doduo", hp:HP080, type:C, retreatCost:null) {
         weakness L
@@ -902,7 +902,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GLALIE_34:
       return evolution (this, from:"Snorunt", hp:HP080, type:W, retreatCost:1) {
         weakness M
@@ -919,7 +919,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GLOOM_35:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:1) {
         weakness F
@@ -939,7 +939,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GOLBAT_36:
       return evolution (this, from:"Zubat", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -959,7 +959,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case IGGLYBUFF_37:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -976,7 +976,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case LANTURN_38:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -993,7 +993,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LOUDRED_39:
       return evolution (this, from:"Whismur", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -1013,7 +1013,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LUVDISC_40:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1033,7 +1033,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MACHOKE_41:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1050,7 +1050,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MEDICHAM_42:
       return evolution (this, from:"Meditite", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1070,7 +1070,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case METANG_43:
       return evolution (this, from:"Beldum", hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -1090,7 +1090,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case METANG_44:
       return evolution (this, from:"Beldum", hp:HP070, type:M, retreatCost:2) {
         weakness F
@@ -1108,7 +1108,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NUZLEAF_45:
       return evolution (this, from:"Seedot", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -1129,7 +1129,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case RHYDON_46:
       return evolution (this, from:"Rhyhorn", hp:HP090, type:F, retreatCost:2) {
         weakness W
@@ -1154,7 +1154,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SEALEO_47:
       return evolution (this, from:"Spheal", hp:HP070, type:W, retreatCost:1) {
         weakness M
@@ -1174,7 +1174,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SPINDA_48:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1194,7 +1194,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STARMIE_49:
       return evolution (this, from:"Staryu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -1214,7 +1214,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SWALOT_50:
       return evolution (this, from:"Gulpin", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -1234,7 +1234,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TENTACRUEL_51:
       return evolution (this, from:"Tentacool", hp:HP070, type:W, retreatCost:null) {
         weakness L
@@ -1254,7 +1254,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BALTOY_52:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1266,7 +1266,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BALTOY_53:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1286,7 +1286,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELDUM_54:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1306,7 +1306,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CHIKORITA_55:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness F
@@ -1319,7 +1319,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHINCHOU_56:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1339,7 +1339,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHINCHOU_57:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1359,7 +1359,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAMPERL_58:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1376,7 +1376,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CYNDAQUIL_59:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1396,7 +1396,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DODUO_60:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1409,7 +1409,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FEEBAS_61:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1426,7 +1426,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
           energyCost W
           ascension delegate
         }
-      };
+      }
       case GULPIN_62:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1446,7 +1446,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case JIGGLYPUFF_63:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1466,7 +1466,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MACHOP_64:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1486,7 +1486,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MEDITITE_65:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1506,7 +1506,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEDITITE_66:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1526,7 +1526,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MINUN_67:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1547,7 +1547,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ODDISH_68:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1567,7 +1567,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PLUSLE_69:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1588,7 +1588,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RHYHORN_70:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -1608,7 +1608,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SEEDOT_71:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1628,7 +1628,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHUPPET_72:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1641,7 +1641,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNORUNT_73:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1661,7 +1661,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SPHEAL_74:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness M
@@ -1673,7 +1673,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case STARYU_75:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1690,7 +1690,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SURSKIT_76:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1702,7 +1702,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TENTACOOL_77:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1719,7 +1719,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TOGEPI_78:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1731,7 +1731,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TOTODILE_79:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1751,7 +1751,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VOLTORB_80:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1771,7 +1771,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VULPIX_81:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1790,7 +1790,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
           // TODO: Handle the coin flip mentioned in the errata
           ascension delegate
         }
-      };
+      }
       case WHISMUR_82:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1802,7 +1802,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZUBAT_83:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1822,7 +1822,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ANCIENT_TECHNICAL_MACHINE_ICE__84:
       return pokemonTool (this) {
         text "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Ice)."
@@ -1832,7 +1832,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ANCIENT_TECHNICAL_MACHINE_ROCK__85:
       return pokemonTool (this) {
         text "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Rock)."
@@ -1842,7 +1842,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ANCIENT_TECHNICAL_MACHINE_STEEL__86:
       return pokemonTool (this) {
         text "Attach this card to 1 of your Evolved Pokémon (excluding Pokémon-ex and Pokémon that has an owner in its name) in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Ancient Technical Machine (Steel)."
@@ -1852,7 +1852,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ANCIENT_TOMB_87:
       return stadium (this) {
         text "Don't apply Weakness for all Pokémon in play (excluding Pokémon-ex and Pokémon that has an owner in its name)." +
@@ -1868,7 +1868,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case DESERT_RUINS_88:
       return stadium (this) {
         text "At any time between turns, each player puts 1 damage counter on his or her Pokémon-ex with maximum HP of at least 100." +
@@ -1893,7 +1893,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case ISLAND_CAVE_89:
       return stadium (this) {
         text "Whenever any player attaches an Energy card from his or her hand to [W] Pokémon, [F] Pokémon, or [M] Pokémon, remove any Special Conditions from that Pokémon." +
@@ -1913,7 +1913,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case LIFE_HERB_90:
         return copy(FireRedLeafGreen.LIFE_HERB_93, this)
       case MAGNETIC_STORM_91:
@@ -1933,7 +1933,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case STEVEN_S_ADVICE_92:
         return copy(PowerKeepers.STEVEN_S_ADVICE_83, this)
       case GROUDON_EX_93:
@@ -1960,7 +1960,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case KYOGRE_EX_94:
       return basic (this, hp:HP100, type:W, retreatCost:3) {
         weakness G
@@ -1985,7 +1985,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case METAGROSS_EX_95:
       return evolution (this, from:"Metang", hp:HP150, type:M, retreatCost:4) {
         weakness F
@@ -2007,7 +2007,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NINETALES_EX_96:
       return evolution (this, from:"Vulpix", hp:HP090, type:R, retreatCost:1) {
         weakness W
@@ -2027,7 +2027,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case REGICE_EX_97:
       return basic (this, hp:HP090, type:W, retreatCost:2) {
         weakness M
@@ -2044,7 +2044,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case REGIROCK_EX_98:
       return basic (this, hp:HP100, type:F, retreatCost:3) {
         weakness W
@@ -2061,7 +2061,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case REGISTEEL_EX_99:
       return basic (this, hp:HP090, type:M, retreatCost:2) {
         weakness R
@@ -2079,7 +2079,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case VILEPLUME_EX_100:
       return evolution (this, from:"Gloom", hp:HP140, type:G, retreatCost:2) {
         weakness P
@@ -2096,7 +2096,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case WIGGLYTUFF_EX_101:
       return evolution (this, from:"Jigglypuff", hp:HP100, type:C, retreatCost:1) {
         weakness F
@@ -2116,7 +2116,7 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROUDON_102:
       return basic (this, hp:HP080, type:F, retreatCost:3) {
         weakness G
@@ -2136,9 +2136,9 @@ public enum HiddenLegendsNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
+++ b/src/tcgwars/logic/impl/gen3/HolonPhantoms.groovy
@@ -2,42 +2,42 @@ package tcgwars.logic.impl.gen3
 
 import tcgwars.logic.effect.gm.AttachEnergy
 import tcgwars.logic.effect.gm.PlayEnergy
-import tcgwars.logic.effect.gm.PlayTrainer;
-import tcgwars.logic.impl.gen1.FossilNG;
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
-import tcgwars.logic.impl.gen3.LegendMaker;
-import tcgwars.logic.impl.gen3.DragonFrontiers;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.effect.gm.PlayTrainer
+import tcgwars.logic.impl.gen1.FossilNG
+import tcgwars.logic.impl.gen3.TeamRocketReturns
+import tcgwars.logic.impl.gen3.LegendMaker
+import tcgwars.logic.impl.gen3.DragonFrontiers
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -156,53 +156,53 @@ public enum HolonPhantoms implements LogicCardInfo {
   FIGHTING_ENERGY_110 ("Fighting Energy", "110", Rarity.HOLORARE, [ENERGY, BASIC_ENERGY]),
   MEW_111 ("Mew", "111", Rarity.HOLORARE, [POKEMON, BASIC, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   HolonPhantoms(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.HOLON_PHANTOMS;
+    return tcgwars.logic.card.Collection.HOLON_PHANTOMS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -235,7 +235,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CRADILY_DELTA_2:
       return evolution (this, from:"Lileep", hp:HP100, type:[D, M], retreatCost:2) {
         weakness R
@@ -269,7 +269,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case DEOXYS_DELTA_3:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness P
@@ -287,7 +287,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.hand, C, C
           }
         }
-      };
+      }
       case DEOXYS_DELTA_4:
       return basic (this, hp:HP080, type:M, retreatCost:2) {
         weakness P
@@ -319,7 +319,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DEOXYS_DELTA_5:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness P
@@ -337,7 +337,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             doMoreDamageNextTurn(thisMove, 40, self)
           }
         }
-      };
+      }
       case DEOXYS_DELTA_6:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness P
@@ -357,7 +357,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLYGON_DELTA_7:
       return evolution (this, from:"Vibrava", hp:HP110, type:[G, M], retreatCost:2) {
         weakness C
@@ -384,7 +384,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             swiftDamage(60, defending)
           }
         }
-      };
+      }
       case GYARADOS_DELTA_8:
       return evolution (this, from:"Magikarp", hp:HP090, type:[L, M], retreatCost:2) {
         weakness L
@@ -418,7 +418,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case KABUTOPS_DELTA_9:
       return evolution (this, from:"Kabuto", hp:HP100, type:L, retreatCost:1) {
         weakness G
@@ -444,7 +444,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40+10*self.cards.energyCount(L)
           }
         }
-      };
+      }
       case KINGDRA_DELTA_10:
       return evolution (this, from:"Seadra", hp:HP110, type:[R, M], retreatCost:2) {
         weakness L
@@ -476,7 +476,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case LATIAS_DELTA_11:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness C
@@ -517,7 +517,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LATIOS_DELTA_12:
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness C
@@ -561,7 +561,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case OMASTAR_DELTA_13:
       return evolution (this, from:"Omanyte", hp:HP110, type:P, retreatCost:2) {
         weakness L
@@ -585,7 +585,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage amount
           }
         }
-      };
+      }
       case PIDGEOT_DELTA_14:
       return evolution (this, from:"Pidgeotto", hp:HP100, type:[L, M], retreatCost:1) {
         weakness L
@@ -625,7 +625,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAICHU_DELTA_15:
       return evolution (this, from:"Pikachu", hp:HP070, type:M, retreatCost:0) {
         weakness F
@@ -637,8 +637,8 @@ public enum HolonPhantoms implements LogicCardInfo {
               def hasPokeBody = false
               def hasPokePower = false
               for (Ability ability : it.getAbilities().keySet()) {
-                if (ability instanceof PokeBody) hasPokeBody = true;
-                if (ability instanceof PokePower) hasPokePower = true;
+                if (ability instanceof PokeBody) hasPokeBody = true
+                if (ability instanceof PokePower) hasPokePower = true
               }
               if (hasPokeBody || hasPokePower) noWrDamage 20, it
             }
@@ -658,7 +658,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAYQUAZA_DELTA_16:
       return basic (this, hp:HP080, type:[W, M], retreatCost:2) {
         weakness C
@@ -695,7 +695,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case VILEPLUME_DELTA_17:
       return evolution (this, from:"Gloom", hp:HP090, type:[P, M], retreatCost:1) {
         weakness P
@@ -728,7 +728,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 30+10*trainerSize
           }
         }
-      };
+      }
       case ABSOL_18:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -748,7 +748,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BELLOSSOM_DELTA_19:
       return evolution (this, from:"Gloom", hp:HP100, type:W, retreatCost:1) {
         weakness R
@@ -782,7 +782,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BLAZIKEN_20:
       return evolution (this, from:"Combusken", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -805,7 +805,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LATIAS_DELTA_21:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness C
@@ -826,7 +826,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { applyAfterDamage BURNED }
           }
         }
-      };
+      }
       case LATIOS_DELTA_22:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness C
@@ -850,7 +850,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAWILE_23:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -870,7 +870,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             afterDamage { astonish() }
           }
         }
-      };
+      }
       case MEWTWO_DELTA_24:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness P
@@ -888,7 +888,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             swiftDamage(40, defending)
           }
         }
-      };
+      }
       case NOSEPASS_25:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -912,7 +912,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAYQUAZA_DELTA_26:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness C
@@ -935,7 +935,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGICE_27:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -962,7 +962,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { applyAfterDamage ASLEEP }
           }
         }
-      };
+      }
       case REGIROCK_28:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness W
@@ -993,7 +993,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGISTEEL_29:
       return basic (this, hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -1023,7 +1023,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RELICANTH_30:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1043,7 +1043,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case SABLEYE_31:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         resistance C, MINUS30
@@ -1062,7 +1062,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             discardRandomCardFromOpponentsHand()
           }
         }
-      };
+      }
       case SEVIPER_32:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1080,7 +1080,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TORKOAL_33:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1098,7 +1098,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ZANGOOSE_34:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1117,7 +1117,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip 3,{},{}, [ 1:{damage 10}, 2:{damage 20}, 3:{damage 40} ]
           }
         }
-      };
+      }
       case AERODACTYL_DELTA_35:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:R, retreatCost:0) {
         weakness L
@@ -1141,7 +1141,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             reduceDamageNextTurn(hp(10),thisMove)
           }
         }
-      };
+      }
       case CAMERUPT_36:
       return evolution (this, from:"Numel", hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -1165,7 +1165,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case CHIMECHO_DELTA_37:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness P
@@ -1187,7 +1187,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAYDOL_38:
       return evolution (this, from:"Baltoy", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -1210,7 +1210,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case COMBUSKEN_39:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1229,7 +1229,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { applyAfterDamage BURNED }
           }
         }
-      };
+      }
       case DONPHAN_40:
       return evolution (this, from:"Phanpy", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -1248,7 +1248,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case EXEGGUTOR_DELTA_41:
       return evolution (this, from:"Exeggcute", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1268,7 +1268,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GLOOM_DELTA_42:
       return evolution (this, from:"Oddish", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1287,7 +1287,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case GOLDUCK_DELTA_43:
       return evolution (this, from:"Psyduck", hp:HP070, type:L, retreatCost:1) {
         weakness L
@@ -1324,7 +1324,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             chosenCard.showToMe("The card you selected. ${result}").showToOpponent("Mind Play: Your opponent chose a random card from your hand. ${result}")
           }
         }
-      };
+      }
       case HOLON_S_CASTFORM_44:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1340,7 +1340,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             draw choose(1..maxCards, "Draw how many cards?")
           }
         }
-      };
+      }
       case LAIRON_45:
       return evolution (this, from:"Aron", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -1359,7 +1359,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flipUntilTails { damage 30 }
           }
         }
-      };
+      }
       case MANECTRIC_46:
       return evolution (this, from:"Electrike", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1382,7 +1382,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case MASQUERAIN_47:
       return evolution (this, from:"Surskit", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -1401,7 +1401,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case PERSIAN_DELTA_48:
       return evolution (this, from:"Meowth", hp:HP070, type:[D, M], retreatCost:0) {
         weakness F
@@ -1424,7 +1424,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             directDamage 40, opp.all.oppSelect("Put 4 damage counters on which Pokémon?")
           }
         }
-      };
+      }
       case PIDGEOTTO_DELTA_49:
       return evolution (this, from:"Pidgey", hp:HP070, type:L, retreatCost:1) {
         weakness L
@@ -1441,7 +1441,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PRIMEAPE_DELTA_50:
       return evolution (this, from:"Mankey", hp:HP070, type:R, retreatCost:0) {
         weakness P
@@ -1469,7 +1469,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAICHU_51:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1488,7 +1488,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SEADRA_DELTA_52:
       return evolution (this, from:"Horsea", hp:HP070, type:R, retreatCost:1) {
         weakness L
@@ -1507,7 +1507,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHARPEDO_DELTA_53:
       return evolution (this, from:"Carvanha", hp:HP070, type:F, retreatCost:0) {
         weakness L
@@ -1530,7 +1530,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             if(defending.resistances.find{it.type==F}) damage 30
           }
         }
-      };
+      }
       case VIBRAVA_DELTA_54:
       return evolution (this, from:"Trapinch", hp:HP080, type:G, retreatCost:1) {
         weakness C
@@ -1551,7 +1551,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WHISCASH_55:
       return evolution (this, from:"Barboach", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -1573,7 +1573,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WOBBUFFET_56:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -1592,7 +1592,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case ANORITH_DELTA_57:
       return evolution (this, from:"Claw Fossil", hp:HP070, type:M, retreatCost:1) {
         weakness G
@@ -1611,7 +1611,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case ARON_58:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1630,7 +1630,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BALTOY_59:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1648,7 +1648,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip 2, {damage 20}
           }
         }
-      };
+      }
       case BARBOACH_60:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1669,7 +1669,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case CARVANHA_DELTA_61:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness L
@@ -1690,7 +1690,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CORPHISH_62:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1708,7 +1708,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CORPHISH_63:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1729,7 +1729,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTRIKE_64:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1742,7 +1742,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case EXEGGCUTE_DELTA_65:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1765,7 +1765,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HORSEA_DELTA_66:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness L
@@ -1783,7 +1783,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KABUTO_DELTA_67:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:L, retreatCost:2) {
         weakness G
@@ -1801,7 +1801,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LILEEP_DELTA_68:
       return evolution (this, from:"Root Fossil", hp:HP080, type:D, retreatCost:2) {
         weakness R
@@ -1819,7 +1819,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_DELTA_69:
       return basic (this, hp:HP030, type:M, retreatCost:1) {
         weakness L
@@ -1830,7 +1830,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MANKEY_DELTA_70:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness P
@@ -1848,7 +1848,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEOWTH_DELTA_71:
       return basic (this, hp:HP050, type:[D, M], retreatCost:1) {
         weakness F
@@ -1867,7 +1867,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             draw 1
           }
         }
-      };
+      }
       case NUMEL_72:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1885,7 +1885,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ODDISH_DELTA_73:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness R
@@ -1904,7 +1904,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             heal 20, self
           }
         }
-      };
+      }
       case OMANYTE_DELTA_74:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:P, retreatCost:1) {
         weakness L
@@ -1922,7 +1922,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20, opp.all.select()
           }
         }
-      };
+      }
       case PHANPY_75:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1940,7 +1940,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PICHU_DELTA_76:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness F
@@ -1964,7 +1964,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             attachEnergyFrom(my.discard, my.all.findAll{ it.topPokemonCard.cardTypes.is(DELTA) }.select("Attach an Energy to?"))
           }
         }
-      };
+      }
       case PIDGEY_DELTA_77:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness L
@@ -1976,7 +1976,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIKACHU_78:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1995,7 +1995,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case PIKACHU_DELTA_79:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness F
@@ -2014,7 +2014,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case POOCHYENA_80:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness F
@@ -2033,7 +2033,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PSYDUCK_DELTA_81:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness L
@@ -2051,7 +2051,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             amnesia delegate
           }
         }
-      };
+      }
       case SURSKIT_82:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2063,7 +2063,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             applyAfterDamage ASLEEP
           }
         }
-      };
+      }
       case TORCHIC_83:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2081,7 +2081,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TRAPINCH_DELTA_84:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness G
@@ -2100,7 +2100,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOLON_ADVENTURER_85:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2115,7 +2115,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "One other card in hand is required to play this card."
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case HOLON_FOSSIL_86:
       return itemCard (this) {
         text "Flip a coin. If heads, search your deck for an Omanyte, Kabuto, Aerodactyl, Aerodactyl ex, Lileep, or Anorith and put it onto your Bench. Shuffle your deck afterward. If tails, put an Omanyte, Kabuto, Aerodactyl, Aerodactyl ex, Lileep, or Anorith from your hand onto your Bench. Treat the new Benched Pokémon as a Basic Pokémon."
@@ -2140,7 +2140,7 @@ public enum HolonPhantoms implements LogicCardInfo {
           assert my.bench.notFull : "Your bench is full."
           assert my.deck || my.hand.getExcludedList(thisCard) : "You cannot play this card if its your only card in hand, and you have no more cards in deck"
         }
-      };
+      }
       case HOLON_LAKE_87:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2169,27 +2169,27 @@ public enum HolonPhantoms implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case MR_STONE_S_PROJECT_88:
-      return copy(DragonFrontiers.MR_STONE_S_PROJECT_77, this);
+      return copy(DragonFrontiers.MR_STONE_S_PROJECT_77, this)
       case PROFESSOR_COZMO_S_DISCOVERY_89:
-      return copy(Deoxys.PROFESSOR_COZMO_S_DISCOVERY_90, this);
+      return copy(Deoxys.PROFESSOR_COZMO_S_DISCOVERY_90, this)
       case RARE_CANDY_90:
-      return copy (Sandstorm.RARE_CANDY_88, this);
+      return copy (Sandstorm.RARE_CANDY_88, this)
       case CLAW_FOSSIL_91:
-      return copy(LegendMaker.CLAW_FOSSIL_78, this);
+      return copy(LegendMaker.CLAW_FOSSIL_78, this)
       case MYSTERIOUS_FOSSIL_92:
-      return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this);
+      return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this)
       case ROOT_FOSSIL_93:
-      return copy(LegendMaker.ROOT_FOSSIL_80, this);
+      return copy(LegendMaker.ROOT_FOSSIL_80, this)
       case DARKNESS_ENERGY_94:
-      return copy (Emerald.DARKNESS_ENERGY_86, this);
+      return copy (Emerald.DARKNESS_ENERGY_86, this)
       case METAL_ENERGY_95:
-      return copy (RubySapphire.METAL_ENERGY_94, this);
+      return copy (RubySapphire.METAL_ENERGY_94, this)
       case MULTI_ENERGY_96:
-      return copy(FireRedLeafGreen.MULTI_ENERGY_103, this);
+      return copy(FireRedLeafGreen.MULTI_ENERGY_103, this)
       case DARK_METAL_ENERGY_97:
-      return copy(TeamRocketReturns.DARK_METAL_ENERGY_94, this);
+      return copy(TeamRocketReturns.DARK_METAL_ENERGY_94, this)
       case DELTA_RAINBOW_ENERGY_98:
       return specialEnergy (this, [[C]]) {
         text "δ Rainbow Energy provides [C] Energy. While attached to a Pokémon that has δ on its card, δ Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.)"
@@ -2206,7 +2206,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             return [[C] as Set]
           }
         }
-      };
+      }
       case CRAWDAUNT_EX_99:
       return evolution (this, from:"Corphish", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -2228,7 +2228,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             damage 20*self.cards.energyCount(C)
           }
         }
-      };
+      }
       case MEW_EX_100:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness P
@@ -2264,7 +2264,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MIGHTYENA_EX_101:
       return evolution (this, from:"Poochyena", hp:HP100, type:D, retreatCost:0) {
         weakness F
@@ -2296,7 +2296,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GYARADOS_STAR_DELTA_102:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness L
@@ -2329,7 +2329,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEWTWO_STAR_103:
       return basic (this, hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -2351,7 +2351,7 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PIKACHU_STAR_104:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -2373,19 +2373,19 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GRASS_ENERGY_105:
-        return basicEnergy (this, G);
+        return basicEnergy (this, G)
       case FIRE_ENERGY_106:
-        return basicEnergy (this, R);
+        return basicEnergy (this, R)
       case WATER_ENERGY_107:
-        return basicEnergy (this, W);
+        return basicEnergy (this, W)
       case LIGHTNING_ENERGY_108:
-        return basicEnergy (this, L);
+        return basicEnergy (this, L)
       case PSYCHIC_ENERGY_109:
-        return basicEnergy (this, P);
+        return basicEnergy (this, P)
       case FIGHTING_ENERGY_110:
-        return basicEnergy (this, F);
+        return basicEnergy (this, F)
       case MEW_111:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2403,9 +2403,9 @@ public enum HolonPhantoms implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -1,40 +1,40 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.effect.ability.custom.Safeguard;
-import tcgwars.logic.impl.gen1.FossilNG;
-import tcgwars.logic.impl.gen6.Xy;
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.effect.ability.custom.Safeguard
+import tcgwars.logic.impl.gen1.FossilNG
+import tcgwars.logic.impl.gen6.Xy
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
-import static tcgwars.logic.effect.Source.POKEPOWER;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.Source.POKEPOWER
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -135,53 +135,53 @@ public enum LegendMaker implements LogicCardInfo {
   REGISTEEL_STAR_92 ("Registeel Star", "92", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _METAL_]),
   PIKACHU_DELTA_93 ("Pikachu", "93", Rarity.HOLORARE, [POKEMON, BASIC, DELTA, _METAL_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   LegendMaker(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.LEGEND_MAKER;
+    return tcgwars.logic.card.Collection.LEGEND_MAKER
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -234,7 +234,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case AGGRON_2:
       return evolution (this, from:"Lairon", hp:HP110, type:M, retreatCost:4) {
         weakness R
@@ -258,7 +258,7 @@ public enum LegendMaker implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case CRADILY_3:
       return evolution (this, from:"Lileep", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -277,7 +277,7 @@ public enum LegendMaker implements LogicCardInfo {
             while (evolvedPoke && remainingTargets > 0) {
               def info = "Select one of your opponent's devolved Pokémon to mark it for devolution, or press Cancel to stop. You have ${remainingTargets} out of ${maxTargets} potential devolutions remaining."
               def sel = evolvedPoke.select(info, (remainingTargets == maxTargets), self.owner) // Mandatory to devolve at least one, if attacking.
-              if (!sel) break; //TODO: Allow to unmark a Pokémon. Ideal way would be a search-like pop-up.
+              if (!sel) break //TODO: Allow to unmark a Pokémon. Ideal way would be a search-like pop-up.
               toBeDevolved.add(sel)
               evolvedPoke.remove(sel)
               remainingTargets--
@@ -302,7 +302,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DELCATTY_4:
       return evolution (this, from:"Skitty", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -336,7 +336,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GENGAR_5:
       return evolution (this, from:"Haunter", hp:HP100, type:P, retreatCost:1) {
         weakness D
@@ -370,7 +370,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case GOLEM_6:
       return evolution (this, from:"Graveler", hp:HP120, type:F, retreatCost:3) {
         weakness W
@@ -403,7 +403,7 @@ public enum LegendMaker implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case KABUTOPS_7:
       return evolution (this, from:"Kabuto", hp:HP110, type:F, retreatCost:2) {
         weakness G
@@ -444,7 +444,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LAPRAS_8:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -465,7 +465,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MACHAMP_9:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -486,7 +486,7 @@ public enum LegendMaker implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEW_10:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -528,7 +528,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MUK_11:
       return evolution (this, from:"Grimer", hp:HP070, type:G, retreatCost:2) {
         weakness P
@@ -562,7 +562,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SHIFTRY_12:
       return evolution (this, from:"Nuzleaf", hp:HP110, type:D, retreatCost:1) {
         weakness F
@@ -599,7 +599,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VICTREEBEL_13:
       return evolution (this, from:"Weepinbell", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -633,7 +633,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case WAILORD_14:
       return evolution (this, from:"Wailmer", hp:HP120, type:W, retreatCost:4) {
         weakness L
@@ -664,7 +664,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 40+10*friends
           }
         }
-      };
+      }
       case ABSOL_15:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -698,7 +698,7 @@ public enum LegendMaker implements LogicCardInfo {
             swiftDamage(20, opp.all.select())
           }
         }
-      };
+      }
       case GIRAFARIG_16:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -734,7 +734,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GOREBYSS_17:
       return evolution (this, from:"Clamperl", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -755,7 +755,7 @@ public enum LegendMaker implements LogicCardInfo {
             extraEnergyDamage(2, hp(20), W, thisMove)
           }
         }
-      };
+      }
       case HUNTAIL_18:
       return evolution (this, from:"Clamperl", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -785,7 +785,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LANTURN_19:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -810,7 +810,7 @@ public enum LegendMaker implements LogicCardInfo {
             extraEnergyDamage(2, hp(20), W, thisMove)
           }
         }
-      };
+      }
       case LUNATONE_20:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -851,7 +851,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case MAGMAR_21:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -881,7 +881,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAGNETON_22:
       return evolution (this, from:"Magnemite", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -923,7 +923,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case OMASTAR_23:
       return evolution (this, from:"Omanyte", hp:HP100, type:W, retreatCost:1) {
         weakness L
@@ -965,7 +965,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PINSIR_24:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1001,7 +1001,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20, my.bench.select()
           }
         }
-      };
+      }
       case SOLROCK_25:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1042,7 +1042,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { discardDefendingEnergy() }
           }
         }
-      };
+      }
       case SPINDA_26:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1084,7 +1084,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip 1, {}, { damage 10, self }
           }
         }
-      };
+      }
       case TORKOAL_27:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1109,7 +1109,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip 1, {}, { discardSelfEnergy R }
           }
         }
-      };
+      }
       case WOBBUFFET_28:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -1149,7 +1149,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ANORITH_29:
       return evolution (this, from:"Claw Fossil", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1180,7 +1180,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CASCOON_30:
       return evolution (this, from:"Wurmple", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1208,7 +1208,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DUNSPARCE_31:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1247,7 +1247,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ELECTRODE_32:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -1267,7 +1267,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case FURRET_33:
       return evolution (this, from:"Sentret", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1286,7 +1286,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 10+10*my.bench.size()
           }
         }
-      };
+      }
       case GRAVELER_34:
       return evolution (this, from:"Geodude", hp:HP070, type:F, retreatCost:2) {
         weakness W
@@ -1315,7 +1315,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HAUNTER_35:
       return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1342,7 +1342,7 @@ public enum LegendMaker implements LogicCardInfo {
             directDamage 20, defending
           }
         }
-      };
+      }
       case KABUTO_36:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -1363,7 +1363,7 @@ public enum LegendMaker implements LogicCardInfo {
             reduceDamageNextTurn(hp(10), thisMove)
           }
         }
-      };
+      }
       case KECLEON_37:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1398,7 +1398,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case LAIRON_38:
       return evolution (this, from:"Aron", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -1420,7 +1420,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case MACHOKE_39:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1453,7 +1453,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MISDREAVUS_40:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1465,7 +1465,7 @@ public enum LegendMaker implements LogicCardInfo {
               //TODO: Check this not stacking with other cards (Slumbering Forest, Dark Gengar NeoDestiny). 99% sure it doesn't but just to make sure.
               if(self.active){
                 flip "Asleep (Deep Sleep)", 2, {}, {}, [2:{
-                  ef.unregisterItself(bg.em());
+                  ef.unregisterItself(bg.em())
                 },1:{
                   bc "$ef.target is still asleep."
                 },0:{
@@ -1496,7 +1496,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NUZLEAF_41:
       return evolution (this, from:"Seedot", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -1518,7 +1518,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ROSELIA_42:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1553,7 +1553,7 @@ public enum LegendMaker implements LogicCardInfo {
             if ( sw2(target) ) { apply POISONED, target }
           }
         }
-      };
+      }
       case SEALEO_43:
       return evolution (this, from:"Spheal", hp:HP070, type:W, retreatCost:1) {
         weakness M
@@ -1577,7 +1577,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TANGELA_44:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1611,7 +1611,7 @@ public enum LegendMaker implements LogicCardInfo {
             cantRetreat(defending)
           }
         }
-      };
+      }
       case TENTACRUEL_45:
       return evolution (this, from:"Tentacool", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -1650,7 +1650,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip 3, { damage 20 }
           }
         }
-      };
+      }
       case VIBRAVA_46:
       return evolution (this, from:"Trapinch", hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -1673,7 +1673,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WEEPINBELL_47:
       return evolution (this, from:"Bellsprout", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1692,7 +1692,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ARON_48:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness R
@@ -1711,7 +1711,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELLSPROUT_49:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1722,7 +1722,7 @@ public enum LegendMaker implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case CHINCHOU_50:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1740,7 +1740,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAMPERL_51:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1758,7 +1758,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GASTLY_52:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1777,7 +1777,7 @@ public enum LegendMaker implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case GEODUDE_53:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1795,7 +1795,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 50, self
           }
         }
-      };
+      }
       case GRIMER_54:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -1811,7 +1811,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GROWLITHE_55:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1831,7 +1831,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case LILEEP_56:
       return evolution (this, from:"Root Fossil", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -1853,7 +1853,7 @@ public enum LegendMaker implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case MACHOP_57:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1867,7 +1867,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAGBY_58:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1890,7 +1890,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAGNEMITE_59:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1905,7 +1905,7 @@ public enum LegendMaker implements LogicCardInfo {
             }, {}
           }
         }
-      };
+      }
       case OMANYTE_60:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1932,7 +1932,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case SEEDOT_61:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1954,7 +1954,7 @@ public enum LegendMaker implements LogicCardInfo {
             flipUntilTails { damage 10 }
           }
         }
-      };
+      }
       case SENTRET_62:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1973,7 +1973,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case SHUPPET_63:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1992,7 +1992,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SKITTY_64:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2015,7 +2015,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case SPHEAL_65:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -2026,7 +2026,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TENTACOOL_66:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2037,7 +2037,7 @@ public enum LegendMaker implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case TRAPINCH_67:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2056,7 +2056,7 @@ public enum LegendMaker implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case VOLTORB_68:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2075,7 +2075,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case WAILMER_69:
       return basic (this, hp:HP080, type:W, retreatCost:3) {
         weakness L
@@ -2096,7 +2096,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WURMPLE_70:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2117,7 +2117,7 @@ public enum LegendMaker implements LogicCardInfo {
             switchYourOpponentsBenchedWithActive()
           }
         }
-      };
+      }
       case WYNAUT_71:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2138,7 +2138,7 @@ public enum LegendMaker implements LogicCardInfo {
             apply CONFUSED, self
           }
         }
-      };
+      }
       case CURSED_STONE_72:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2151,7 +2151,7 @@ public enum LegendMaker implements LogicCardInfo {
               all.each {
                 def hasPokePower = false
                 for (Ability ability : it.getAbilities().keySet()) {
-                  if (ability instanceof PokePower) hasPokePower = true;
+                  if (ability instanceof PokePower) hasPokePower = true
                 }
 
                 if (hasPokePower) {
@@ -2168,7 +2168,7 @@ public enum LegendMaker implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case FIELDWORKER_73:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2182,7 +2182,7 @@ public enum LegendMaker implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case FULL_FLAME_74:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2207,7 +2207,7 @@ public enum LegendMaker implements LogicCardInfo {
           eff1.unregister()
           eff2.unregister()
         }
-      };
+      }
       case GIANT_STUMP_75:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2227,7 +2227,7 @@ public enum LegendMaker implements LogicCardInfo {
           thisCard.player.pbg.triggerBenchSizeCheck()
           new CheckAbilities().run(bg)
         }
-      };
+      }
       case POWER_TREE_76:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2248,7 +2248,7 @@ public enum LegendMaker implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case STRANGE_CAVE_77:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -2271,7 +2271,7 @@ public enum LegendMaker implements LogicCardInfo {
         onRemoveFromPlay {
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case CLAW_FOSSIL_78:
       return itemCard (this) {
         text "Play Claw Fossil as if it were a Basic Pokémon. While in play, Claw Fossil counts as a [C] Pokémon (as well as a Trainer card). Claw Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Claw Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Claw Fossil from play." +
@@ -2337,7 +2337,7 @@ public enum LegendMaker implements LogicCardInfo {
         playRequirement{
           assert bench.notFull
         }
-      };
+      }
       case MYSTERIOUS_FOSSIL_79:
       return itemCard (this) {
         text "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a [C] Pokémon (as well as a Trainer card). Mysterious Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Mysterious Fossil is Knocked out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
@@ -2388,7 +2388,7 @@ public enum LegendMaker implements LogicCardInfo {
         playRequirement{
           assert bench.notFull : "Bench is full"
         }
-      };
+      }
       case ROOT_FOSSIL_80:
       return itemCard (this) {
         text "Play Root Fossil as if it were a Basic Pokémon. While in play, Root Fossil counts as a [C] Pokémon (as well as a Trainer card). Root Fossil has no attacks of its own, can't retreat, and can't be affected by any Special Conditions. If Root Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Root Fossil from play." +
@@ -2459,15 +2459,15 @@ public enum LegendMaker implements LogicCardInfo {
         playRequirement{
           assert bench.notFull
         }
-      };
+      }
       case RAINBOW_ENERGY_81:
-      return copy(CelestialStorm.RAINBOW_ENERGY_151,this);
+      return copy(CelestialStorm.RAINBOW_ENERGY_151,this)
       case REACT_ENERGY_82:
       return specialEnergy (this, [[C]]) {
         text "React Energy provides [C] Energy."
         onPlay {reason->
         }
-      };
+      }
       case ARCANINE_EX_83:
       return evolution (this, from:"Growlithe", hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -2510,7 +2510,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARMALDO_EX_84:
       return evolution (this, from:"Anorith", hp:HP160, type:F, retreatCost:3) {
         weakness G
@@ -2543,7 +2543,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BANETTE_EX_85:
       return evolution (this, from:"Shuppet", hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -2577,7 +2577,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 30 + Math.min(my.discard.filterByType(SUPPORTER).size()*10, 60)
           }
         }
-      };
+      }
       case DUSTOX_EX_86:
       return evolution (this, from:"Cascoon", hp:HP140, type:G, retreatCost:1) {
         weakness R
@@ -2602,7 +2602,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case FLYGON_EX_87:
       return evolution (this, from:"Vibrava", hp:HP150, type:C, retreatCost:2) {
         weakness C
@@ -2639,7 +2639,7 @@ public enum LegendMaker implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case MEW_EX_88:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness P
@@ -2656,7 +2656,7 @@ public enum LegendMaker implements LogicCardInfo {
             switchYourActive(may: true)
           }
         }
-      };
+      }
       case WALREIN_EX_89:
       return evolution (this, from:"Sealeo", hp:HP150, type:W, retreatCost:3) {
         weakness F
@@ -2694,7 +2694,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGICE_STAR_90:
       return basic (this, hp:HP090, type:W, retreatCost:3) {
         weakness M
@@ -2719,7 +2719,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGIROCK_STAR_91:
       return basic (this, hp:HP090, type:F, retreatCost:3) {
         weakness W
@@ -2742,7 +2742,7 @@ public enum LegendMaker implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGISTEEL_STAR_92:
       return basic (this, hp:HP090, type:M, retreatCost:3) {
         weakness R
@@ -2766,7 +2766,7 @@ public enum LegendMaker implements LogicCardInfo {
             putDamageCountersOnOpponentsPokemon(counters)
           }
         }
-      };
+      }
       case PIKACHU_DELTA_93:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness F
@@ -2784,9 +2784,9 @@ public enum LegendMaker implements LogicCardInfo {
             flipUntilTails { damage 20 }
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/NintendoBlackStarPromos.groovy
+++ b/src/tcgwars/logic/impl/gen3/NintendoBlackStarPromos.groovy
@@ -1,39 +1,39 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
 import tcgwars.logic.impl.gen1.WizardsBlackStarPromosNG
-import tcgwars.logic.impl.gen2.Aquapolis;
-import tcgwars.logic.impl.gen3.UnseenForces;
-import tcgwars.logic.impl.gen3.LegendMaker;
+import tcgwars.logic.impl.gen2.Aquapolis
+import tcgwars.logic.impl.gen3.UnseenForces
+import tcgwars.logic.impl.gen3.LegendMaker
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -81,53 +81,53 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
   RAYQUAZA_EX_39 ("Rayquaza ex", "039", Rarity.PROMO, [POKEMON, BASIC, EX, _COLORLESS_]),
   MEW_40 ("Mew", "040", Rarity.PROMO, [POKEMON, BASIC, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   NintendoBlackStarPromos(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.NINTENDO_BLACK_STAR_PROMOS;
+    return tcgwars.logic.card.Collection.NINTENDO_BLACK_STAR_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -151,7 +151,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GROUDON_EX_2:
       return basic (this, hp:HP120, type:F, retreatCost:3) {
         weakness G
@@ -168,25 +168,25 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TREECKO_3:
-        return copy(RubySapphire.TREECKO_76, this);
+        return copy(RubySapphire.TREECKO_76, this)
       case GROVYLE_4:
-        return copy(RubySapphire.GROVYLE_31, this);
+        return copy(RubySapphire.GROVYLE_31, this)
       case MUDKIP_5:
-        return copy(RubySapphire.MUDKIP_60, this);
+        return copy(RubySapphire.MUDKIP_60, this)
       case TORCHIC_6:
-        return copy(RubySapphire.TORCHIC_73, this);
+        return copy(RubySapphire.TORCHIC_73, this)
       case TREECKO_7:
-      return copy (TREECKO_3, this);
+      return copy (TREECKO_3, this)
       case TORCHIC_8:
-      return copy (TORCHIC_6, this);
+      return copy (TORCHIC_6, this)
       case COMBUSKEN_9:
-        return copy(RubySapphire.COMBUSKEN_27, this);
+        return copy(RubySapphire.COMBUSKEN_27, this)
       case MUDKIP_10:
-      return copy (MUDKIP_5, this);
+      return copy (MUDKIP_5, this)
       case MARSHTOMP_11:
-        return copy(RubySapphire.MARSHTOMP_40, this);
+        return copy(RubySapphire.MARSHTOMP_40, this)
       case PIKACHU_12:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -205,7 +205,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case MEOWTH_13:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -226,7 +226,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LATIAS_14:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness P
@@ -245,7 +245,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             flip { applyAfterDamage(BURNED) }
           }
         }
-      };
+      }
       case LATIOS_15:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness P
@@ -264,7 +264,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case TREECKO_16:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -286,7 +286,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TORCHIC_17:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -300,7 +300,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MUDKIP_18:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -321,7 +321,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WHISMUR_19:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -339,7 +339,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LUDICOLO_20:
       return evolution (this, from:"Lombre", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -361,7 +361,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             flip 3, { damage 30 }
           }
         }
-      };
+      }
       case JIRACHI_21:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -380,11 +380,11 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             damage 10 * defending.cards.energyCount(C)
           }
         }
-      };
+      }
       case BELDUM_22:
-        return copy(HiddenLegends.BELDUM_29, this);
+        return copy(HiddenLegends.BELDUM_29, this)
       case METANG_23:
-        return copy(HiddenLegends.METANG_21, this);
+        return copy(HiddenLegends.METANG_21, this)
       case CHIMECHO_24:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -403,7 +403,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case FLYGON_25:
       return evolution (this, from:"Vibrava", hp:HP120, type:C, retreatCost:2) {
         weakness C
@@ -427,7 +427,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TROPICAL_WIND_26:
       return itemCard (this) {
         text "Flip a coin. If heads, remove 2 damage counters from each Active Pokémon (remove 1 damage counter if a Pokémon has only 1). If tails, each Active Pokémon is now Asleep."
@@ -441,7 +441,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
         playRequirement{
           assert [my.active, opp.active].any{it.numberOfDamageCounters || !it.isSPC(ASLEEP)} : "Neither Active Pokémon has any damage counters on it, and both are already asleep"
         }
-      };
+      }
       case TROPICAL_TIDAL_WAVE_27:
       return itemCard (this) {
         text "Flip a coin. If heads, discard all Trainer cards your opponent has in play. If tails, discard all Trainer cards (excluding Supporter cards) you have in play."
@@ -450,7 +450,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CHAMPIONSHIP_ARENA_28:
       return stadium (this) {
         text "At the end of each player's turn, if that player has 8 or more cards in his or her hand, that player discards a number of cards until the player has 7 cards left in his or her hand."
@@ -468,11 +468,11 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case CELEBI_29:
-        return copy(WizardsBlackStarPromosNG.CELEBI_50, this);
+        return copy(WizardsBlackStarPromosNG.CELEBI_50, this)
       case SUICUNE_30:
-        return copy(Aquapolis.SUICUNE_H25, this);
+        return copy(Aquapolis.SUICUNE_H25, this)
         //TODO: Implement in Groovy.
 //      return basic (this, hp:HP070, type:W, retreatCost:1) {
 //        weakness L
@@ -523,7 +523,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARTICUNO_EX_32:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness M
@@ -555,7 +555,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             flip { applyAfterDamage ASLEEP }
           }
         }
-      };
+      }
       case ZAPDOS_EX_33:
       return basic (this, hp:HP100, type:L, retreatCost:2) {
         weakness L
@@ -589,13 +589,13 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYPHLOSION_34:
-      return copy(UnseenForces.TYPHLOSION_17, this);
+      return copy(UnseenForces.TYPHLOSION_17, this)
       case PIKACHU_DELTA_35:
-      return copy(LegendMaker.PIKACHU_DELTA_93, this);
+      return copy(LegendMaker.PIKACHU_DELTA_93, this)
       case TROPICAL_TIDAL_WAVE_36:
-      return copy (TROPICAL_TIDAL_WAVE_27, this);
+      return copy (TROPICAL_TIDAL_WAVE_27, this)
       case KYOGRE_EX_37:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -634,7 +634,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GROUDON_EX_38:
       return basic (this, hp:HP100, type:F, retreatCost:2) {
         weakness W
@@ -674,7 +674,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAYQUAZA_EX_39:
       return basic (this, hp:HP100, type:C, retreatCost:1) {
         weakness C
@@ -717,7 +717,7 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEW_40:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -742,9 +742,9 @@ public enum NintendoBlackStarPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries1.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries1.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -53,53 +53,53 @@ public enum PopSeries1 implements LogicCardInfo {
   ARMALDO_EX_16 ("Armaldo ex", "16", Rarity.RARE, [POKEMON, EVOLUTION, STAGE2, EX, _FIGHTING_]),
   TYRANITAR_EX_17 ("Tyranitar ex", "17", Rarity.RARE, [POKEMON, EVOLUTION, STAGE2, EX, _DARKNESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries1(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_1;
+    return tcgwars.logic.card.Collection.POP_SERIES_1
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -122,7 +122,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case METAGROSS_2:
       return evolution (this, from:"Metang", hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -142,7 +142,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { discardDefendingEnergy() }
           }
         }
-      };
+      }
       case RAYQUAZA_3:
       return basic (this, hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -163,7 +163,7 @@ public enum PopSeries1 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCEPTILE_4:
       return evolution (this, from:"Grovyle", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -184,7 +184,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case SWAMPERT_5:
       return evolution (this, from:"Marshtomp", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -209,7 +209,7 @@ public enum PopSeries1 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BEAUTIFLY_6:
       return evolution (this, from:"Silcoon", hp:HP100, type:G, retreatCost:0) {
         weakness R
@@ -231,7 +231,7 @@ public enum PopSeries1 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MASQUERAIN_7:
       return evolution (this, from:"Surskit", hp:HP070, type:G, retreatCost:0) {
         weakness L
@@ -251,7 +251,7 @@ public enum PopSeries1 implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MURKROW_8:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -277,7 +277,7 @@ public enum PopSeries1 implements LogicCardInfo {
             swiftDamage(20, opp.all.select("Which Pokémon to deal 20 damage to?"))
           }
         }
-      };
+      }
       case PUPITAR_9:
       return evolution (this, from:"Larvitar", hp:HP070, type:F, retreatCost:1) {
         weakness W
@@ -289,7 +289,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case TORKOAL_10:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness W
@@ -308,7 +308,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case LARVITAR_11:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -320,7 +320,7 @@ public enum PopSeries1 implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case MINUN_12:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -347,7 +347,7 @@ public enum PopSeries1 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PLUSLE_13:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -368,7 +368,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case SURSKIT_14:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -380,7 +380,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case SWELLOW_15:
       return evolution (this, from:"Tailow", hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -400,7 +400,7 @@ public enum PopSeries1 implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case ARMALDO_EX_16:
       return evolution (this, from:"Anorith", hp:HP160, type:F, retreatCost:3) {
         weakness G
@@ -420,7 +420,7 @@ public enum PopSeries1 implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case TYRANITAR_EX_17:
       return evolution (this, from:"Pupitar", hp:HP150, type:D, retreatCost:4) {
         weakness G
@@ -444,9 +444,9 @@ public enum PopSeries1 implements LogicCardInfo {
             self.cards.filterByType(BASIC_ENERGY).select(count:2, "Select 2 Basic Energies to discard.").discard()
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries2.groovy
@@ -1,39 +1,39 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen1.BaseSetNG;
-import tcgwars.logic.impl.gen2.Expedition;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.impl.gen1.BaseSetNG
+import tcgwars.logic.impl.gen2.Expedition
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -58,53 +58,53 @@ public enum PopSeries2 implements LogicCardInfo {
   PIKACHU_16 ("Pikachu", "16", Rarity.COMMON, [POKEMON, BASIC, _LIGHTNING_]),
   CELEBI_EX_17 ("Celebi ex", "17", Rarity.RARE, [POKEMON, BASIC, EX, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries2(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_2;
+    return tcgwars.logic.card.Collection.POP_SERIES_2
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -132,7 +132,7 @@ public enum PopSeries2 implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PIDGEOT_2:
       return evolution (this, from:"Pidgeotto", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -162,7 +162,7 @@ public enum PopSeries2 implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case RAIKOU_3:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -181,7 +181,7 @@ public enum PopSeries2 implements LogicCardInfo {
             flip 1, {}, { damage 20, self }
           }
         }
-      };
+      }
       case SUICUNE_4:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -204,7 +204,7 @@ public enum PopSeries2 implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case TAUROS_5:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -223,7 +223,7 @@ public enum PopSeries2 implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case VENUSAUR_6:
       return evolution (this, from:"Ivysaur", hp:HP120, type:G, retreatCost:3) {
         weakness R
@@ -249,9 +249,9 @@ public enum PopSeries2 implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case IVYSAUR_7:
-        return copy(FireRedLeafGreen.IVYSAUR_35, this);
+        return copy(FireRedLeafGreen.IVYSAUR_35, this)
       case MR__BRINEY_S_COMPASSION_8:
       return supporter (this) {
         text "Choose 1 of your Pokémon in play (excluding Pokémon ex). Return that Pokémon and all cards attached to it to your hand."
@@ -267,10 +267,10 @@ public enum PopSeries2 implements LogicCardInfo {
         playRequirement {
           assert my.all.findAll { !it.EX } : "No eligible Pokémon to return back to your hand"
         }
-      };
+      }
       case MULTI_TECHNICAL_MACHINE_01_9:
       // Commented for now, TechnicalMachineGroovyImpl needs to be made first.
-        return copy(Expedition.MULTI_TECHNICAL_MACHINE_01_144, this);
+        return copy(Expedition.MULTI_TECHNICAL_MACHINE_01_144, this)
       /*return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon in play. This Pokémon may use this card's attack instead of its own. At the end of your turn, discard Multi Technical Machine 01"
         def eff1, eff2
@@ -331,9 +331,9 @@ public enum PopSeries2 implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case TV_REPORTER_11:
-      return copy(CelestialStorm.TV_REPORTER_149, this);
+      return copy(CelestialStorm.TV_REPORTER_149, this)
       case BULBASAUR_12:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -351,7 +351,7 @@ public enum PopSeries2 implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CACNEA_13:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -363,7 +363,7 @@ public enum PopSeries2 implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case LUVDISC_14:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -383,7 +383,7 @@ public enum PopSeries2 implements LogicCardInfo {
             // Only one defending Pokémon in single battles, so the effect is ignored.
           }
         }
-      };
+      }
       case PHANPY_15:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -402,9 +402,9 @@ public enum PopSeries2 implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case PIKACHU_16:
-        return copy(BaseSetNG.PIKACHU, this);
+        return copy(BaseSetNG.PIKACHU, this)
       case CELEBI_EX_17:
       return basic (this, hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -425,9 +425,9 @@ public enum PopSeries2 implements LogicCardInfo {
             preventAllEffectsFromCustomPokemonNextTurn(thisMove, self, {it.EX})
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries3.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries3.groovy
@@ -1,36 +1,36 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen3.UnseenForces;
+import tcgwars.logic.impl.gen3.UnseenForces
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -55,53 +55,53 @@ public enum PopSeries3 implements LogicCardInfo {
   PICHU_BROS__16 ("Pichu Bros.", "16", Rarity.COMMON, [POKEMON, BASIC, _LIGHTNING_]),
   HO_OH_EX_17 ("Ho-Oh ex", "17", Rarity.RARE, [POKEMON, BASIC, EX, _FIRE_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries3(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_3;
+    return tcgwars.logic.card.Collection.POP_SERIES_3
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -129,7 +129,7 @@ public enum PopSeries3 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLAREON_2:
       return evolution (this, from:"Eevee", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -152,7 +152,7 @@ public enum PopSeries3 implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case JOLTEON_3:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -172,7 +172,7 @@ public enum PopSeries3 implements LogicCardInfo {
             flip 4, { damage 20 }
           }
         }
-      };
+      }
       case MINUN_4:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -214,7 +214,7 @@ public enum PopSeries3 implements LogicCardInfo {
             damage 30, validTargets.select("Choose 1 of your opponent's Pokémon that has any Poké-Powers to deal 30 damage to it.")
           }
         }
-      };
+      }
       case PLUSLE_5:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -256,7 +256,7 @@ public enum PopSeries3 implements LogicCardInfo {
             damage 30, validTargets.select("Choose 1 of your opponent's Pokémon that has any Poké-Bodies to deal 30 damage to it.")
           }
         }
-      };
+      }
       case VAPOREON_6:
       return evolution (this, from:"Diglett", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -275,7 +275,7 @@ public enum PopSeries3 implements LogicCardInfo {
             extraEnergyDamage(2, hp(20), W, thisMove)
           }
         }
-      };
+      }
       case COMBUSKEN_7:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -294,7 +294,7 @@ public enum PopSeries3 implements LogicCardInfo {
             discardSelfEnergy(R)
           }
         }
-      };
+      }
       case DONPHAN_8:
       return evolution (this, from:"Phanpy", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -313,7 +313,7 @@ public enum PopSeries3 implements LogicCardInfo {
             flip 3, { damage 30 }
           }
         }
-      };
+      }
       case FORRETRESS_9:
       return evolution (this, from:"Pineco", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -335,7 +335,7 @@ public enum PopSeries3 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HIGH_PRESSURE_SYSTEM_10:
       return stadium (this) {
         text "Each player pays [C] less to retreat his or her [R] and [W] Pokémon)"
@@ -350,7 +350,7 @@ public enum PopSeries3 implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case LOW_PRESSURE_SYSTEM_11:
       return stadium (this) {
         text "Each [G] and [L] Pokémon in play (both yours and your opponent's) gets +10 HP."
@@ -365,7 +365,7 @@ public enum PopSeries3 implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case DITTO_12:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -383,7 +383,7 @@ public enum PopSeries3 implements LogicCardInfo {
             flip { applyAfterDamage(CONFUSED) }
           }
         }
-      };
+      }
       case EEVEE_13:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -402,7 +402,7 @@ public enum PopSeries3 implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case IVYSAUR_14:
       return evolution (this, from:"Bulbasaur", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -422,7 +422,7 @@ public enum PopSeries3 implements LogicCardInfo {
             applyAfterDamage(POISONED)
           }
         }
-      };
+      }
       case MARSHTOMP_15:
       return evolution (this, from:"Mudkip", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -441,7 +441,7 @@ public enum PopSeries3 implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case PICHU_BROS__16:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -455,11 +455,11 @@ public enum PopSeries3 implements LogicCardInfo {
             if (headsCount) { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case HO_OH_EX_17:
-      return copy(UnseenForces.HO_OH_EX_104, this);
+      return copy(UnseenForces.HO_OH_EX_104, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries4.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries4.groovy
@@ -1,39 +1,39 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen3.Emerald;
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.CrystalGuardians;
-import tcgwars.logic.impl.gen6.Flashfire;
+import tcgwars.logic.impl.gen3.Emerald
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.CrystalGuardians
+import tcgwars.logic.impl.gen6.Flashfire
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -58,53 +58,53 @@ public enum PopSeries4 implements LogicCardInfo {
   WOBBUFFET_16 ("Wobbuffet", "16", Rarity.COMMON, [POKEMON, BASIC, _PSYCHIC_]),
   DEOXYS_EX_17 ("Deoxys ex", "17", Rarity.RARE, [POKEMON, BASIC, EX, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries4(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_4;
+    return tcgwars.logic.card.Collection.POP_SERIES_4
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -127,9 +127,9 @@ public enum PopSeries4 implements LogicCardInfo {
             noWrDamage(30, defending)
           }
         }
-      };
+      }
       case DEOXYS_DELTA_2:
-      return copy(HolonPhantoms.DEOXYS_DELTA_5, this);
+      return copy(HolonPhantoms.DEOXYS_DELTA_5, this)
       case FLYGON_3:
       return evolution (this, from:"Vibrava", hp:HP120, type:F, retreatCost:2) {
         weakness W
@@ -156,7 +156,7 @@ public enum PopSeries4 implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case MEW_4:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -179,9 +179,9 @@ public enum PopSeries4 implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case SCEPTILE_5:
-      return copy(RubySapphireNG.SCEPTILE_20, this);
+      return copy(RubySapphireNG.SCEPTILE_20, this)
       case COMBUSKEN_6:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -201,7 +201,7 @@ public enum PopSeries4 implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case GROVYLE_7:
       return evolution (this, from:"Treecko", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -222,9 +222,9 @@ public enum PopSeries4 implements LogicCardInfo {
             heal 20, self
           }
         }
-      };
+      }
       case HEAL_ENERGY_8:
-      return copy(Deoxys.HEAL_ENERGY_94, this);
+      return copy(Deoxys.HEAL_ENERGY_94, this)
       case POKEMON_FAN_CLUB_9:
       return supporter (this) {
         text "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward."
@@ -239,9 +239,9 @@ public enum PopSeries4 implements LogicCardInfo {
           assert bench.notFull : "Bench is full"
           assert deck.notEmpty : "Deck is empty"
         }
-      };
+      }
       case SCRAMBLE_ENERGY_10:
-      return copy(Deoxys.SCRAMBLE_ENERGY_95, this);
+      return copy(Deoxys.SCRAMBLE_ENERGY_95, this)
       case MUDKIP_11:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -253,7 +253,7 @@ public enum PopSeries4 implements LogicCardInfo {
             applyAfterDamage(ASLEEP)
           }
         }
-      };
+      }
       case PIDGEY_12:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -266,7 +266,7 @@ public enum PopSeries4 implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case PIKACHU_13:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -280,7 +280,7 @@ public enum PopSeries4 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SQUIRTLE_14:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -304,9 +304,9 @@ public enum PopSeries4 implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TREECKO_DELTA_15:
-        return copy (CrystalGuardians.TREECKO_DELTA_68, this);
+        return copy (CrystalGuardians.TREECKO_DELTA_68, this)
       case WOBBUFFET_16:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -325,11 +325,11 @@ public enum PopSeries4 implements LogicCardInfo {
             reduceDamageNextTurn(hp(20), thisMove)
           }
         }
-      };
+      }
       case DEOXYS_EX_17:
-      return copy(Emerald.DEOXYS_EX_93, this);
+      return copy(Emerald.DEOXYS_EX_93, this)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PopSeries5.groovy
+++ b/src/tcgwars/logic/impl/gen3/PopSeries5.groovy
@@ -1,39 +1,39 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.impl.gen3.CrystalGuardians;
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.HolonPhantoms;
+import tcgwars.logic.impl.gen3.CrystalGuardians
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.HolonPhantoms
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -58,53 +58,53 @@ public enum PopSeries5 implements LogicCardInfo {
   ESPEON_STAR_16 ("Espeon Star", "16", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _PSYCHIC_]),
   UMBREON_STAR_17 ("Umbreon Star", "17", Rarity.HOLORARE, [POKEMON_STAR, POKEMON, BASIC, _DARKNESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries5(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_5;
+    return tcgwars.logic.card.Collection.POP_SERIES_5
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -128,7 +128,7 @@ public enum PopSeries5 implements LogicCardInfo {
             discardSelfEnergy(R)
           }
         }
-      };
+      }
       case LUGIA_2:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -150,7 +150,7 @@ public enum PopSeries5 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEW_DELTA_3:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness P
@@ -183,21 +183,21 @@ public enum PopSeries5 implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case DOUBLE_RAINBOW_ENERGY_4:
-        return copy (Emerald.DOUBLE_RAINBOW_ENERGY_87, this);
+        return copy (Emerald.DOUBLE_RAINBOW_ENERGY_87, this)
       case CHARMELEON_DELTA_5:
-        return copy(CrystalGuardians.CHARMELEON_DELTA_30, this);
+        return copy(CrystalGuardians.CHARMELEON_DELTA_30, this)
       case BILL_S_MAINTENANCE_6:
-        return copy(FireRedLeafGreen.BILL_S_MAINTENANCE_87, this);
+        return copy(FireRedLeafGreen.BILL_S_MAINTENANCE_87, this)
       case RARE_CANDY_7:
-        return copy (Sandstorm.RARE_CANDY_88, this);
+        return copy (Sandstorm.RARE_CANDY_88, this)
       case BOOST_ENERGY_8:
-        return copy(Deoxys.BOOST_ENERGY_93, this);
+        return copy(Deoxys.BOOST_ENERGY_93, this)
       case DELTA_RAINBOW_ENERGY_9:
-        return copy(HolonPhantoms.DELTA_RAINBOW_ENERGY_98, this);
+        return copy(HolonPhantoms.DELTA_RAINBOW_ENERGY_98, this)
       case CHARMANDER_DELTA_10:
-        return copy(CrystalGuardians.CHARMANDER_DELTA_49, this);
+        return copy(CrystalGuardians.CHARMANDER_DELTA_49, this)
       case MEOWTH_DELTA_11:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -208,7 +208,7 @@ public enum PopSeries5 implements LogicCardInfo {
             swiftDamage(10, opp.all.select("Select Feint Attack's target."))
           }
         }
-      };
+      }
       case PIKACHU_12:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -227,7 +227,7 @@ public enum PopSeries5 implements LogicCardInfo {
             discardAllSelfEnergy(null)
           }
         }
-      };
+      }
       case PIKACHU_DELTA_13:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness F
@@ -248,7 +248,7 @@ public enum PopSeries5 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PELIPPER_DELTA_14:
       return evolution (this, from:"Wingull", hp:HP070, type:L, retreatCost:0) {
         weakness L
@@ -277,7 +277,7 @@ public enum PopSeries5 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZANGOOSE_DELTA_15:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness F
@@ -295,7 +295,7 @@ public enum PopSeries5 implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ESPEON_STAR_16:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -317,7 +317,7 @@ public enum PopSeries5 implements LogicCardInfo {
             damage 10*defending.cards.energyCount(C)
           }
         }
-      };
+      }
       case UMBREON_STAR_17:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -338,9 +338,9 @@ public enum PopSeries5 implements LogicCardInfo {
             swiftDamage(30, opp.all.select("Use Feint Attack on which Pokémon?"))
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -1,45 +1,45 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.effect.ability.custom.Safeguard;
-import tcgwars.logic.impl.gen1.FossilNG;
-import tcgwars.logic.impl.gen2.Expedition;
-import tcgwars.logic.impl.gen2.Aquapolis;
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.Dragon;
-import tcgwars.logic.impl.gen3.Emerald;
-import tcgwars.logic.impl.gen3.UnseenForces;
-import tcgwars.logic.impl.gen3.LegendMaker;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.effect.ability.custom.Safeguard
+import tcgwars.logic.impl.gen1.FossilNG
+import tcgwars.logic.impl.gen2.Expedition
+import tcgwars.logic.impl.gen2.Aquapolis
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.Dragon
+import tcgwars.logic.impl.gen3.Emerald
+import tcgwars.logic.impl.gen3.UnseenForces
+import tcgwars.logic.impl.gen3.LegendMaker
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -155,53 +155,53 @@ public enum PowerKeepers implements LogicCardInfo {
   PSYCHIC_ENERGY_107 ("Psychic Energy", "107", Rarity.HOLORARE, [ENERGY, BASIC_ENERGY]),
   FIGHTING_ENERGY_108 ("Fighting Energy", "108", Rarity.HOLORARE, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PowerKeepers(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POWER_KEEPERS;
+    return tcgwars.logic.card.Collection.POWER_KEEPERS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -240,7 +240,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ALTARIA_2:
       return evolution (this, from:"Swablu", hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -271,7 +271,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ARMALDO_3:
       return evolution (this, from:"Anorith", hp:HP120, type:F, retreatCost:3) {
         weakness G
@@ -302,7 +302,7 @@ public enum PowerKeepers implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case BANETTE_4:
       return evolution (this, from:"Shuppet", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -325,9 +325,9 @@ public enum PowerKeepers implements LogicCardInfo {
             flip opp.bench.size(), {}, { noWrDamage 40, defending }
           }
         }
-      };
+      }
       case BLAZIKEN_5:
-      return copy (RubySapphireNG.BLAZIKEN_3, this);
+      return copy (RubySapphireNG.BLAZIKEN_3, this)
       case CHARIZARD_6:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -346,7 +346,7 @@ public enum PowerKeepers implements LogicCardInfo {
             applyAfterDamage BURNED
           }
         }
-      };
+      }
       case CRADILY_7:
       return evolution (this, from:"Lileep", hp:HP110, type:G, retreatCost:2) {
         weakness R
@@ -371,11 +371,11 @@ public enum PowerKeepers implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case DELCATTY_8:
-      return copy(RubySapphireNG.DELCATTY_5, this);
+      return copy(RubySapphireNG.DELCATTY_5, this)
       case GARDEVOIR_9:
-      return copy(RubySapphireNG.GARDEVOIR_7, this);
+      return copy(RubySapphireNG.GARDEVOIR_7, this)
       case KABUTOPS_10:
       return evolution (this, from:"Kabuto", hp:HP110, type:F, retreatCost:2) {
         weakness G
@@ -408,7 +408,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MACHAMP_11:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -443,7 +443,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case RAICHU_12:
       return evolution (this, from:"Pikachu", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -467,9 +467,9 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SLAKING_13:
-      return copy(RubySapphireNG.SLAKING_12, this);
+      return copy(RubySapphireNG.SLAKING_12, this)
       case DUSCLOPS_14:
       return evolution (this, from:"Duskull", hp:HP080, type:P, retreatCost:2) {
         weakness D
@@ -494,7 +494,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LANTURN_15:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -520,7 +520,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MAGNETON_16:
       return evolution (this, from:"Magnemite", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -553,7 +553,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage amount
           }
         }
-      };
+      }
       case MAWILE_17:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -576,7 +576,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MIGHTYENA_18:
       return evolution (this, from:"Poochyena", hp:HP070, type:D, retreatCost:0) {
         weakness F
@@ -601,7 +601,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NINETALES_19:
       return evolution (this, from:"Vulpix", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -623,7 +623,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case OMASTAR_20:
       return evolution (this, from:"Omanyte", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -647,7 +647,7 @@ public enum PowerKeepers implements LogicCardInfo {
             extraEnergyDamage(2, hp(20), W, thisMove)
           }
         }
-      };
+      }
       case PICHU_21:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -673,7 +673,7 @@ public enum PowerKeepers implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case SABLEYE_22:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         resistance C, MINUS30
@@ -714,7 +714,7 @@ public enum PowerKeepers implements LogicCardInfo {
             swiftDamage(20, opp.all.select())
           }
         }
-      };
+      }
       case SEVIPER_23:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -733,7 +733,7 @@ public enum PowerKeepers implements LogicCardInfo {
             extraPoison 1
           }
         }
-      };
+      }
       case WOBBUFFET_24:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -748,7 +748,7 @@ public enum PowerKeepers implements LogicCardInfo {
             noWrDamage 10, self
           }
         }
-      };
+      }
       case ZANGOOSE_25:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -780,7 +780,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case ANORITH_26:
       return evolution (this, from:"Claw Fossil", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -805,7 +805,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 3,{},{}, [ 1:{damage 10}, 2:{damage 30}, 3:{damage 50} ]
           }
         }
-      };
+      }
       case CACTURNE_27:
       return evolution (this, from:"Cacnea", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -827,7 +827,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 4, { damage 20 }
           }
         }
-      };
+      }
       case CHARMELEON_28:
       return evolution (this, from:"Charmander", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -848,7 +848,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case COMBUSKEN_29:
       return evolution (this, from:"Torchic", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -870,7 +870,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 50 }
           }
         }
-      };
+      }
       case GLALIE_30:
       return evolution (this, from:"Snorunt", hp:HP080, type:W, retreatCost:1) {
         weakness M
@@ -905,7 +905,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case KIRLIA_31:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -928,7 +928,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LAIRON_32:
       return evolution (this, from:"Aron", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -949,7 +949,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case MACHOKE_33:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -968,7 +968,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MEDICHAM_34:
       return evolution (this, from:"Meditite", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1002,7 +1002,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case METANG_35:
       return evolution (this, from:"Beldum", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -1030,7 +1030,7 @@ public enum PowerKeepers implements LogicCardInfo {
             increasedBaseDamageNextTurn("Extra Comet Punch", hp(30))
           }
         }
-      };
+      }
       case NUZLEAF_36:
       return evolution (this, from:"Seedot", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -1050,7 +1050,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SEALEO_37:
       return evolution (this, from:"Spheal", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1062,7 +1062,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case SHARPEDO_38:
       return evolution (this, from:"Carvanha", hp:HP070, type:D, retreatCost:0) {
         weakness G
@@ -1083,7 +1083,7 @@ public enum PowerKeepers implements LogicCardInfo {
             directDamage 10, self
           }
         }
-      };
+      }
       case SHELGON_39:
       return evolution (this, from:"Bagon", hp:HP080, type:C, retreatCost:2) {
         weakness C
@@ -1103,7 +1103,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VIBRAVA_40:
       return evolution (this, from:"Trapinch", hp:HP080, type:C, retreatCost:1) {
         weakness C
@@ -1126,7 +1126,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VIGOROTH_41:
       return evolution (this, from:"Slakoth", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1144,7 +1144,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case ARON_42:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness R
@@ -1166,7 +1166,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BAGON_43:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness C
@@ -1182,7 +1182,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 10 * self.numberOfDamageCounters
           }
         }
-      };
+      }
       case BALTOY_44:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1201,7 +1201,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELDUM_45:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness R
@@ -1220,7 +1220,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CACNEA_46:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1231,7 +1231,7 @@ public enum PowerKeepers implements LogicCardInfo {
             swiftDamage(10, opp.all.select())
           }
         }
-      };
+      }
       case CARVANHA_47:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness G
@@ -1250,7 +1250,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARMANDER_48:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1262,7 +1262,7 @@ public enum PowerKeepers implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case CHINCHOU_49:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1282,7 +1282,7 @@ public enum PowerKeepers implements LogicCardInfo {
             reduceDamageFromDefendingNextTurn(hp(10),thisMove,defending)
           }
         }
-      };
+      }
       case DUSKULL_50:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1294,7 +1294,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case KABUTO_51:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -1314,7 +1314,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case LILEEP_52:
       return evolution (this, from:"Root Fossil", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -1334,7 +1334,7 @@ public enum PowerKeepers implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case MACHOP_53:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1353,7 +1353,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case MAGNEMITE_54:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1375,7 +1375,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEDITITE_55:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
@@ -1395,7 +1395,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case OMANYTE_56:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1423,7 +1423,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PIKACHU_57:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1444,7 +1444,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case POOCHYENA_58:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1456,7 +1456,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 2, { damage 10 }
           }
         }
-      };
+      }
       case RALTS_59:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1475,7 +1475,7 @@ public enum PowerKeepers implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case SEEDOT_60:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1493,7 +1493,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case SHUPPET_61:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1506,7 +1506,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 1, { applyAfterDamage ASLEEP }, { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case SKITTY_62:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1524,7 +1524,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLAKOTH_63:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1542,7 +1542,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNORUNT_64:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1565,7 +1565,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case SPHEAL_65:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1583,7 +1583,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SWABLU_66:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1595,7 +1595,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 3, { damage 10 }
           }
         }
-      };
+      }
       case TORCHIC_67:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1607,7 +1607,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { applyAfterDamage BURNED }
           }
         }
-      };
+      }
       case TRAPINCH_68:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1618,7 +1618,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case VULPIX_69:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1639,7 +1639,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WYNAUT_70:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1662,9 +1662,9 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case BATTLE_FRONTIER_71:
-      return copy(Emerald.BATTLE_FRONTIER_75, this);
+      return copy(Emerald.BATTLE_FRONTIER_75, this)
       case DRAKE_S_STADIUM_72:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -1685,11 +1685,11 @@ public enum PowerKeepers implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case ENERGY_RECYCLE_SYSTEM_73:
-      return copy(Dragon.ENERGY_RECYCLE_SYSTEM_84, this);
+      return copy(Dragon.ENERGY_RECYCLE_SYSTEM_84, this)
       case ENERGY_REMOVAL_2_74:
-      return copy(Expedition.ENERGY_REMOVAL_2_140, this);
+      return copy(Expedition.ENERGY_REMOVAL_2_140, this)
       case ENERGY_SWITCH_75:
       return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case GLACIA_S_STADIUM_76:
@@ -1707,11 +1707,11 @@ public enum PowerKeepers implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case GREAT_BALL_77:
-      return copy(FireRedLeafGreen.GREAT_BALL_92, this);
+      return copy(FireRedLeafGreen.GREAT_BALL_92, this)
       case MASTER_BALL_78:
-      return copy(Deoxys.MASTER_BALL_88, this);
+      return copy(Deoxys.MASTER_BALL_88, this)
       case PHOEBE_S_STADIUM_79:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -1728,11 +1728,11 @@ public enum PowerKeepers implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case PROFESSOR_BIRCH_80:
-      return copy(Emerald.PROFESSOR_BIRCH_82, this);
+      return copy(Emerald.PROFESSOR_BIRCH_82, this)
       case SCOTT_81:
-      return copy(Emerald.SCOTT_84, this);
+      return copy(Emerald.SCOTT_84, this)
       case SIDNEY_S_STADIUM_82:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -1760,7 +1760,7 @@ public enum PowerKeepers implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case STEVEN_S_ADVICE_83:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -1772,21 +1772,21 @@ public enum PowerKeepers implements LogicCardInfo {
           assert my.deck : "Your deck is empty!"
           assert my.hand.size() < 7 : "You have 7 or more cards in your hand (including this card)"
         }
-      };
+      }
       case CLAW_FOSSIL_84:
-      return copy(LegendMaker.CLAW_FOSSIL_78, this);
+      return copy(LegendMaker.CLAW_FOSSIL_78, this)
       case MYSTERIOUS_FOSSIL_85:
-      return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this);
+      return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this)
       case ROOT_FOSSIL_86:
-      return copy(LegendMaker.ROOT_FOSSIL_80, this);
+      return copy(LegendMaker.ROOT_FOSSIL_80, this)
       case DARKNESS_ENERGY_87:
-      return copy (Emerald.DARKNESS_ENERGY_86, this);
+      return copy (Emerald.DARKNESS_ENERGY_86, this)
       case METAL_ENERGY_88:
-      return copy(RubySapphire.METAL_ENERGY_94, this);
+      return copy(RubySapphire.METAL_ENERGY_94, this)
       case MULTI_ENERGY_89:
-      return copy(FireRedLeafGreen.MULTI_ENERGY_103, this);
+      return copy(FireRedLeafGreen.MULTI_ENERGY_103, this)
       case CYCLONE_ENERGY_90:
-      return copy(UnseenForces.CYCLONE_ENERGY_99, this);
+      return copy(UnseenForces.CYCLONE_ENERGY_99, this)
       case WARP_ENERGY_91:
       return copy(Aquapolis.WARP_ENERGY_147, this)
       case ABSOL_EX_92:
@@ -1822,7 +1822,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CLAYDOL_EX_93:
       return evolution (this, from:"Baltoy", hp:HP120, type:P, retreatCost:2) {
         weakness P
@@ -1868,7 +1868,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLYGON_EX_94:
       return evolution (this, from:"Vibrava", hp:HP150, type:C, retreatCost:0) {
         weakness C
@@ -1905,7 +1905,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip 1, {}, { cantUseAttack(thisMove, self) }
           }
         }
-      };
+      }
       case METAGROSS_EX_95:
       return evolution (this, from:"Metang", hp:HP150, type:M, retreatCost:4) {
         weakness R
@@ -1940,7 +1940,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SALAMENCE_EX_96:
       return evolution (this, from:"Shelgon", hp:HP160, type:C, retreatCost:2) {
         weakness C
@@ -1971,7 +1971,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SHIFTRY_EX_97:
       return evolution (this, from:"Nuzleaf", hp:HP140, type:D, retreatCost:1) {
         weakness G
@@ -2015,7 +2015,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SKARMORY_EX_98:
       return basic (this, hp:HP100, type:M, retreatCost:1) {
         weakness R
@@ -2049,7 +2049,7 @@ public enum PowerKeepers implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case WALREIN_EX_99:
       return evolution (this, from:"Sealeo", hp:HP150, type:W, retreatCost:3) {
         weakness L
@@ -2084,7 +2084,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLAREON_STAR_100:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -2109,7 +2109,7 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JOLTEON_STAR_101:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -2132,7 +2132,7 @@ public enum PowerKeepers implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case VAPOREON_STAR_102:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -2158,21 +2158,21 @@ public enum PowerKeepers implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GRASS_ENERGY_103:
-        return basicEnergy (this, G);
+        return basicEnergy (this, G)
       case FIRE_ENERGY_104:
-        return basicEnergy (this, R);
+        return basicEnergy (this, R)
       case WATER_ENERGY_105:
-        return basicEnergy (this, W);
+        return basicEnergy (this, W)
       case LIGHTNING_ENERGY_106:
-        return basicEnergy (this, L);
+        return basicEnergy (this, L)
       case PSYCHIC_ENERGY_107:
-        return basicEnergy (this, P);
+        return basicEnergy (this, P)
       case FIGHTING_ENERGY_108:
-        return basicEnergy (this, F);
+        return basicEnergy (this, F)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/RubySapphireNG.groovy
@@ -5,35 +5,35 @@ import tcgwars.logic.impl.gen1.Jungle
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -150,53 +150,53 @@ public enum RubySapphireNG implements LogicCardInfo {
   FIRE_ENERGY_108 ("Fire Energy", "108", Rarity.COMMON, [ENERGY, BASIC, BASIC_ENERGY]),
   LIGHTNING_ENERGY_109 ("Lightning Energy", "109", Rarity.COMMON, [ENERGY, BASIC, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   RubySapphireNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.RUBY_SAPPHIRE_NG;
+    return tcgwars.logic.card.Collection.RUBY_SAPPHIRE_NG
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -229,7 +229,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             flip 2, {damage 70}
           }
         }
-      };
+      }
       case BEAUTIFLY_2:
       return evolution (this, from:"Silcoon", hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -262,7 +262,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             my.all.each {heal 10, it}
           }
         }
-      };
+      }
       case BLAZIKEN_3:
       return evolution (this, from:"Combusken", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -290,7 +290,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             discardSelfEnergyAfterDamage R
           }
         }
-      };
+      }
       case CAMERUPT_4:
       return evolution (this, from:"Numel", hp:HP090, type:R, retreatCost:3) {
         weakness W
@@ -316,7 +316,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DELCATTY_5:
       return evolution (this, from:"Skitty", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -343,7 +343,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10*self.cards.energyCount(C)
           }
         }
-      };
+      }
       case DUSTOX_6:
       return evolution (this, from:"Cascoon", hp:HP090, type:G, retreatCost:0) {
         weakness P
@@ -373,7 +373,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GARDEVOIR_7:
       return evolution (this, from:"Kirlia", hp:HP100, type:P, retreatCost:2) {
         weakness P
@@ -400,7 +400,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10 * (self.cards.energyCount(C) + defending.cards.energyCount(C))
           }
         }
-      };
+      }
       case HARIYAMA_8:
       return evolution (this, from:"Makuhita", hp:HP090, type:F, retreatCost:2) {
         weakness P
@@ -419,7 +419,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             if (defending.EX) damage 40
           }
         }
-      };
+      }
       case MANECTRIC_9:
       return evolution (this, from:"Electrike", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -440,7 +440,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             flip 1, {}, {damage 10, self}
           }
         }
-      };
+      }
       case MIGHTYENA_10:
       return evolution (this, from:"Poochyena", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -470,7 +470,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SCEPTILE_11:
       return evolution (this, from:"Grovyle", hp:HP120, type:G, retreatCost:3) {
         weakness R
@@ -494,7 +494,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SLAKING_12:
       return evolution (this, from:"Vigoroth", hp:HP120, type:C, retreatCost:3) {
         weakness F
@@ -534,7 +534,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SWAMPERT_13:
       return evolution (this, from:"Marshtomp", hp:HP110, type:W, retreatCost:3) {
         weakness L
@@ -558,7 +558,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             applyAfterDamage(ASLEEP)
           }
         }
-      };
+      }
       case WAILORD_14:
       return evolution (this, from:"Wailmer", hp:HP120, type:W, retreatCost:4) {
         weakness L
@@ -577,7 +577,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case BLAZIKEN_15:
       return evolution (this, from:"Combusken", hp:HP110, type:R, retreatCost:2) {
         weakness W
@@ -597,7 +597,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             discardSelfEnergyAfterDamage R
           }
         }
-      };
+      }
       case BRELOOM_16:
       return evolution (this, from:"Shroomish", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -615,7 +615,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40 + 10 * self.cards.energyCount(F)
           }
         }
-      };
+      }
       case DONPHAN_17:
       return evolution (this, from:"Phanpy", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -636,7 +636,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             flip 2, {damage 60}
           }
         }
-      };
+      }
       case NOSEPASS_18:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -662,7 +662,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PELIPPER_19:
       return evolution (this, from:"Wingull", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -690,7 +690,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             removeDamageCounterEqualToDamageDone()
           }
         }
-      };
+      }
       case SCEPTILE_20:
       return evolution (this, from:"Grovyle", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -718,7 +718,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case SEAKING_21:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -738,7 +738,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             // Only one defending Pokémon in single battles, so the effect is ignored.
           }
         }
-      };
+      }
       case SHARPEDO_22:
       return evolution (this, from:"Carvanha", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -761,7 +761,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SWAMPERT_23:
       return evolution (this, from:"Marshtomp", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -786,7 +786,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case WEEZING_24:
       return evolution (this, from:"Koffing", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -806,7 +806,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ARON_25:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness R
@@ -827,7 +827,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CASCOON_26:
       return evolution (this, from:"Wurmple", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -844,7 +844,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case COMBUSKEN_27:
       return evolution (this, from:"Torchic", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -864,7 +864,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case COMBUSKEN_28:
       return evolution (this, from:"Torchic", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -881,7 +881,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DELCATTY_29:
       return evolution (this, from:"Skitty", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -901,7 +901,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ELECTRIKE_30:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -922,7 +922,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROVYLE_31:
       return evolution (this, from:"Treecko", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -943,7 +943,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROVYLE_32:
       return evolution (this, from:"Treecko", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -961,7 +961,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HARIYAMA_33:
       return evolution (this, from:"Makuhita", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -981,7 +981,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KIRLIA_34:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1001,7 +1001,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case KIRLIA_35:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1021,7 +1021,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case LAIRON_36:
       return evolution (this, from:"Aron", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -1042,7 +1042,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LAIRON_37:
       return evolution (this, from:"Aron", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -1063,7 +1063,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LINOONE_38:
       return evolution (this, from:"Zigzagoon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1083,7 +1083,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MANECTRIC_39:
       return evolution (this, from:"Electrike", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1104,7 +1104,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MARSHTOMP_40:
       return evolution (this, from:"Mudkip", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1124,7 +1124,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MARSHTOMP_41:
       return evolution (this, from:"Mudkip", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1141,7 +1141,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MIGHTYENA_42:
       return evolution (this, from:"Poochyena", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -1162,7 +1162,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SILCOON_43:
       return evolution (this, from:"Wurmple", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1179,7 +1179,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SKITTY_44:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1199,7 +1199,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLAKOTH_45:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1219,7 +1219,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SWELLOW_46:
       return evolution (this, from:"Taillow", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -1237,7 +1237,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VIGOROTH_47:
       return evolution (this, from:"Slakoth", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1257,7 +1257,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WAILMER_48:
       return basic (this, hp:HP080, type:W, retreatCost:3) {
         weakness L
@@ -1277,7 +1277,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ARON_49:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1298,7 +1298,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ARON_50:
       return basic (this, hp:HP050, type:M, retreatCost:2) {
         weakness R
@@ -1311,7 +1311,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CARVANHA_51:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1328,7 +1328,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTRIKE_52:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1341,7 +1341,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTRIKE_53:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1362,7 +1362,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KOFFING_54:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1382,7 +1382,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GOLDEEN_55:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1394,7 +1394,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAKUHITA_56:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1414,7 +1414,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAKUHITA_57:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1434,7 +1434,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAKUHITA_58:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1446,7 +1446,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MUDKIP_59:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1458,7 +1458,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MUDKIP_60:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1478,7 +1478,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NUMEL_61:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1498,7 +1498,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PHANPY_62:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1518,7 +1518,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case POOCHYENA_63:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness F
@@ -1531,7 +1531,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case POOCHYENA_64:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1552,7 +1552,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POOCHYENA_65:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1565,7 +1565,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RALTS_66:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1577,7 +1577,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RALTS_67:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1597,7 +1597,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RALTS_68:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1617,7 +1617,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHROOMISH_69:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1630,7 +1630,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SKITTY_70:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1650,7 +1650,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SKITTY_71:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1670,7 +1670,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TAILLOW_72:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1691,7 +1691,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TORCHIC_73:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1711,7 +1711,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TORCHIC_74:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1723,7 +1723,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TREECKO_75:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1736,7 +1736,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TREECKO_76:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1757,7 +1757,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WINGULL_77:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1770,7 +1770,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WURMPLE_78:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1790,7 +1790,7 @@ public enum RubySapphireNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ZIGZAGOON_79:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1802,7 +1802,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       //TODO: Reimplement
       case ENERGY_REMOVAL_2_80:
       return itemCard (this) {
@@ -1811,7 +1811,7 @@ public enum RubySapphireNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       //TODO: Reimplement
       case ENERGY_RESTORE_81:
       return itemCard (this) {
@@ -1820,7 +1820,7 @@ public enum RubySapphireNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SWITCH_82:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case LADY_OUTING_83:
@@ -1849,7 +1849,7 @@ public enum RubySapphireNG implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case LUM_BERRY_84:
         return copy(Emerald.LUM_BERRY_78, this)
       case ORAN_BERRY_85:
@@ -1876,7 +1876,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             bc "${thisCard.player} rearranged the top $rearrangeSize cards of their deck."
           }
         }
-      };
+      }
       case PROFESSOR_BIRCH_89:
       return copy(Emerald.PROFESSOR_BIRCH_82, this)
       case ENERGY_SEARCH_90:
@@ -1930,7 +1930,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case ELECTABUZZ_EX_97:
       return basic (this, hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -1951,7 +1951,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HITMONCHAN_EX_98:
       return basic (this, hp:HP090, type:F, retreatCost:2) {
         weakness P
@@ -1971,7 +1971,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LAPRAS_EX_99:
       return basic (this, hp:HP110, type:W, retreatCost:3) {
         weakness L
@@ -1991,7 +1991,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGMAR_EX_100:
       return basic (this, hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -2011,7 +2011,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEWTWO_EX_101:
       return basic (this, hp:HP100, type:P, retreatCost:3) {
         weakness P
@@ -2031,7 +2031,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SCYTHER_EX_102:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -2052,7 +2052,7 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SNEASEL_EX_103:
       return basic (this, hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -2073,33 +2073,33 @@ public enum RubySapphireNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GRASS_ENERGY_104:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       case FIGHTING_ENERGY_105:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       case WATER_ENERGY_106:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       case PSYCHIC_ENERGY_107:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       case FIRE_ENERGY_108:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       case LIGHTNING_ENERGY_109:
       return basic (this, hp:null, type:null, retreatCost:null) {
 
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/SandstormNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/SandstormNG.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.gen3
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -136,53 +136,53 @@ public enum SandstormNG implements LogicCardInfo {
   TYPHLOSION_EX_99 ("Typhlosion ex", "99", Rarity.ULTRARARE, [POKEMON, EVOLUTION, EX, STAGE2, _FIRE_]),
   WAILORD_EX_100 ("Wailord ex", "100", Rarity.ULTRARARE, [POKEMON, EVOLUTION, EX, STAGE1, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SandstormNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SANDSTORM;
+    return tcgwars.logic.card.Collection.SANDSTORM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -204,7 +204,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CACTURNE_2:
       return evolution (this, from:"Cacnea", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -221,7 +221,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CRADILY_3:
       return evolution (this, from:"Lileep", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -246,7 +246,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DUSCLOPS_4:
       return evolution (this, from:"Duskull", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -267,7 +267,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FLAREON_5:
       return evolution (this, from:"Eevee", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -287,7 +287,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case JOLTEON_6:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -308,7 +308,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LUDICOLO_7:
       return evolution (this, from:"Lombre", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -325,7 +325,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LUNATONE_8:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -350,7 +350,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAWILE_9:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -370,7 +370,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SABLEYE_10:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -390,7 +390,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEVIPER_11:
       return basic (this, hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -410,7 +410,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHIFTRY_12:
       return evolution (this, from:"Nuzleaf", hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -427,7 +427,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case SOLROCK_13:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -452,7 +452,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ZANGOOSE_14:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -477,7 +477,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARCANINE_15:
       return evolution (this, from:"Growlithe", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -494,7 +494,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ESPEON_16:
       return evolution (this, from:"Eevee", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -514,7 +514,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDUCK_17:
       return evolution (this, from:"Psyduck", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -531,7 +531,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KECLEON_18:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -548,7 +548,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case OMASTAR_19:
       return evolution (this, from:"Omanyte", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -568,7 +568,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PICHU_20:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -585,7 +585,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SANDSLASH_21:
       return evolution (this, from:"Sandshrew", hp:HP070, type:F, retreatCost:0) {
         weakness G
@@ -605,7 +605,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SHIFTRY_22:
       return evolution (this, from:"Nuzleaf", hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -625,7 +625,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case STEELIX_23:
       return evolution (this, from:"Onix", hp:HP100, type:M, retreatCost:4) {
         weakness R
@@ -646,7 +646,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case UMBREON_24:
       return evolution (this, from:"Eevee", hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -667,7 +667,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VAPOREON_25:
       return evolution (this, from:"Eevee", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -687,7 +687,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case WOBBUFFET_26:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -704,7 +704,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ANORITH_27:
       return evolution (this, from:"Claw Fossil", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -724,7 +724,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ANORITH_28:
       return evolution (this, from:"Claw Fossil", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -744,7 +744,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ARBOK_29:
       return evolution (this, from:"Ekans", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -761,7 +761,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case AZUMARILL_30:
       return evolution (this, from:"Marill", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -781,7 +781,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case AZURILL_31:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -798,7 +798,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BALTOY_32:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -810,7 +810,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BRELOOM_33:
       return evolution (this, from:"Shroomish", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -830,7 +830,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DELCATTY_34:
       return evolution (this, from:"Skitty", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -850,7 +850,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTABUZZ_35:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -871,7 +871,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ELEKID_36:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -888,7 +888,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FEAROW_37:
       return evolution (this, from:"Spearow", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -909,7 +909,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ILLUMISE_38:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -934,7 +934,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KABUTO_39:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:W, retreatCost:2) {
         weakness G
@@ -959,7 +959,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KIRLIA_40:
       return evolution (this, from:"Ralts", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -979,7 +979,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case LAIRON_41:
       return evolution (this, from:"Aron", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -1000,7 +1000,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LILEEP_42:
       return evolution (this, from:"Root Fossil", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -1020,7 +1020,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case LILEEP_43:
       return evolution (this, from:"Root Fossil", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -1040,7 +1040,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LINOONE_44:
       return evolution (this, from:"Zigzagoon", hp:HP070, type:C, retreatCost:0) {
         weakness F
@@ -1060,7 +1060,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LOMBRE_45:
       return evolution (this, from:"Lotad", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1077,7 +1077,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LOMBRE_46:
       return evolution (this, from:"Lotad", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1097,7 +1097,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MURKROW_47:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -1118,7 +1118,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NUZLEAF_48:
       return evolution (this, from:"Seedot", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -1138,7 +1138,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case NUZLEAF_49:
       return evolution (this, from:"Seedot", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -1158,7 +1158,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case PELIPPER_50:
       return evolution (this, from:"Wingull", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -1171,7 +1171,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case QUILAVA_51:
       return evolution (this, from:"Cyndaquil", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1191,7 +1191,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VIGOROTH_52:
       return evolution (this, from:"Slakoth", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1211,7 +1211,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VOLBEAT_53:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1236,7 +1236,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WYNAUT_54:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1253,7 +1253,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case XATU_55:
       return evolution (this, from:"Natu", hp:HP070, type:P, retreatCost:0) {
         weakness P
@@ -1271,7 +1271,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ARON_56:
       return basic (this, hp:HP050, type:M, retreatCost:1) {
         weakness R
@@ -1284,7 +1284,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CACNEA_57:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1301,7 +1301,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CACNEA_58:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1313,7 +1313,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CYNDAQUIL_59:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1333,7 +1333,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DUNSPARCE_60:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1353,7 +1353,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DUSKULL_61:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1374,7 +1374,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DUSKULL_62:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1395,7 +1395,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EEVEE_63:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1415,7 +1415,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EKANS_64:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1427,7 +1427,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GROWLITHE_65:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1444,7 +1444,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LOTAD_66:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1461,7 +1461,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LOTAD_67:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1481,7 +1481,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MARILL_68:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1493,7 +1493,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NATU_69:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1513,7 +1513,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case OMANYTE_70:
       return evolution (this, from:"Mysterious Fossil", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1533,7 +1533,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ONIX_71:
       return basic (this, hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -1553,7 +1553,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIKACHU_72:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1573,7 +1573,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PSYDUCK_73:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1585,7 +1585,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case RALTS_74:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1605,7 +1605,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSHREW_75:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1617,7 +1617,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEEDOT_76:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1629,7 +1629,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEEDOT_77:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1641,7 +1641,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHROOMISH_78:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1662,7 +1662,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SKITTY_79:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1682,7 +1682,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLAKOTH_80:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1694,7 +1694,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPEAROW_81:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1715,7 +1715,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TRAPINCH_82:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1735,7 +1735,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WAILMER_83:
       return basic (this, hp:HP080, type:W, retreatCost:3) {
         weakness L
@@ -1755,7 +1755,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WINGULL_84:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1768,7 +1768,7 @@ public enum SandstormNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ZIGZAGOON_85:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1788,7 +1788,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DOUBLE_FULL_HEAL_86:
       return itemCard (this) {
         text "Remove all Special Conditions from each of your Active Pokémon."
@@ -1798,7 +1798,7 @@ public enum SandstormNG implements LogicCardInfo {
         playRequirement{
           assert my.active.specialConditions : "Your Active Pokémon needs to have some Special Condition applied to it"
         }
-      };
+      }
       case LANETTE_S_NET_SEARCH_87:
       return supporter (this) {
         text "Search your deck for up to 3 different types of Basic Pokémon cards (excluding Baby Pokémon), show them to your opponent, and put them into your hand. Shuffle your deck afterward." +
@@ -1821,7 +1821,7 @@ public enum SandstormNG implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case RARE_CANDY_88:
       return itemCard (this) {
         text "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)"
@@ -1852,17 +1852,17 @@ public enum SandstormNG implements LogicCardInfo {
           sel = possibleEvolutions.select(min: 0)
           assert sel : "Cancelled"
         }
-      };
+      }
       case WALLY_S_TRAINING_89:
-        return copy(Emerald.WALLY_S_TRAINING_85, this);
+        return copy(Emerald.WALLY_S_TRAINING_85, this)
       case CLAW_FOSSIL_90:
-        return copy(LegendMaker.CLAW_FOSSIL_78, this);
+        return copy(LegendMaker.CLAW_FOSSIL_78, this)
       case MYSTERIOUS_FOSSIL_91:
-        return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this);
+        return copy(LegendMaker.MYSTERIOUS_FOSSIL_79, this)
       case ROOT_FOSSIL_92:
-        return copy(LegendMaker.ROOT_FOSSIL_80, this);
+        return copy(LegendMaker.ROOT_FOSSIL_80, this)
       case MULTI_ENERGY_93:
-        return copy (FireRedLeafGreen.MULTI_ENERGY_103, this);
+        return copy (FireRedLeafGreen.MULTI_ENERGY_103, this)
       case AERODACTYL_EX_94:
       return evolution (this, from:"Mysterious Fossil", hp:HP100, type:C, retreatCost:1) {
         weakness L
@@ -1888,7 +1888,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case AGGRON_EX_95:
       return evolution (this, from:"Lairon", hp:HP150, type:M, retreatCost:4) {
         weakness F
@@ -1910,7 +1910,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GARDEVOIR_EX_96:
       return evolution (this, from:"Kirlia", hp:HP150, type:P, retreatCost:2) {
         weakness G
@@ -1931,7 +1931,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KABUTOPS_EX_97:
       return evolution (this, from:"Kabuto", hp:HP150, type:W, retreatCost:2) {
         weakness G
@@ -1952,7 +1952,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case RAICHU_EX_98:
       return evolution (this, from:"Pikachu", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -1972,7 +1972,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case TYPHLOSION_EX_99:
       return evolution (this, from:"Quilava", hp:HP160, type:R, retreatCost:2) {
         weakness F
@@ -1993,7 +1993,7 @@ public enum SandstormNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case WAILORD_EX_100:
       return evolution (this, from:"Wailmer", hp:HP200, type:W, retreatCost:5) {
         weakness G
@@ -2014,9 +2014,9 @@ public enum SandstormNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/TeamMagmaVsTeamAquaNG.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamMagmaVsTeamAquaNG.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -133,53 +133,53 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
   ABSOL_96 ("Absol", "96", Rarity.HOLORARE, [POKEMON, BASIC, _DARKNESS_]),
   JIRACHI_97 ("Jirachi", "97", Rarity.HOLORARE, [POKEMON, BASIC, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   TeamMagmaVsTeamAquaNG(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.TEAM_MAGMA_VS_TEAM_AQUA;
+    return tcgwars.logic.card.Collection.TEAM_MAGMA_VS_TEAM_AQUA
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -204,7 +204,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CRAWDAUNT_2:
       return evolution (this, from:"null", hp:HP080, type:[W, D], retreatCost:1) {
         weakness L
@@ -224,7 +224,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_AQUA_S_KYOGRE_3:
       return basic (this, hp:HP100, type:[W, D], retreatCost:3) {
         weakness G
@@ -249,7 +249,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_AQUA_S_MANECTRIC_4:
       return evolution (this, from:"null", hp:HP070, type:[L, D], retreatCost:1) {
         weakness F
@@ -267,7 +267,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SHARPEDO_5:
       return evolution (this, from:"null", hp:HP070, type:[W, D], retreatCost:null) {
         weakness L
@@ -287,7 +287,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case TEAM_AQUA_S_WALREIN_6:
       return evolution (this, from:"null", hp:HP120, type:[W, D], retreatCost:2) {
         weakness F
@@ -308,7 +308,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_AGGRON_7:
       return evolution (this, from:"null", hp:HP120, type:[F, D], retreatCost:2) {
         weakness G
@@ -329,7 +329,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_CLAYDOL_8:
       return evolution (this, from:"null", hp:HP080, type:[P, D], retreatCost:2) {
         weakness P
@@ -346,7 +346,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_GROUDON_9:
       return basic (this, hp:HP100, type:[F, D], retreatCost:3) {
         weakness G
@@ -371,7 +371,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_HOUNDOOM_10:
       return evolution (this, from:"null", hp:HP070, type:[R, D], retreatCost:1) {
         weakness W
@@ -391,7 +391,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_RHYDON_11:
       return evolution (this, from:"null", hp:HP090, type:[F, D], retreatCost:2) {
         weakness G
@@ -411,7 +411,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_TORKOAL_12:
       return basic (this, hp:HP080, type:[R, D], retreatCost:2) {
         weakness W
@@ -431,7 +431,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RAICHU_13:
       return evolution (this, from:"null", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -451,7 +451,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CRAWDAUNT_14:
       return evolution (this, from:"null", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -471,7 +471,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TEAM_AQUA_S_MIGHTYENA_15:
       return evolution (this, from:"null", hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -492,7 +492,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SEALEO_16:
       return evolution (this, from:"null", hp:HP070, type:W, retreatCost:1) {
         weakness M
@@ -512,7 +512,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SEVIPER_17:
       return basic (this, hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -532,7 +532,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SHARPEDO_18:
       return evolution (this, from:"null", hp:HP070, type:W, retreatCost:null) {
         weakness L
@@ -552,7 +552,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_CAMERUPT_19:
       return evolution (this, from:"null", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -569,7 +569,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_LAIRON_20:
       return evolution (this, from:"null", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -589,7 +589,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_MIGHTYENA_21:
       return evolution (this, from:"null", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -610,7 +610,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_RHYDON_22:
       return evolution (this, from:"null", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -630,7 +630,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_ZANGOOSE_23:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -650,7 +650,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CACNEA_24:
       return basic (this, hp:HP050, type:[G, D], retreatCost:1) {
         weakness R
@@ -670,7 +670,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CARVANHA_25:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -687,7 +687,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CORPHISH_26:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -707,7 +707,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_ELECTRIKE_27:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -728,7 +728,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_LANTURN_28:
       return evolution (this, from:"null", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -746,7 +746,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_AQUA_S_MANECTRIC_29:
       return evolution (this, from:"null", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -767,7 +767,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_AQUA_S_MIGHTYENA_30:
       return evolution (this, from:"null", hp:HP080, type:D, retreatCost:1) {
         weakness G
@@ -788,7 +788,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SEALEO_31:
       return evolution (this, from:"null", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -808,7 +808,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_BALTOY_32:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -828,7 +828,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_CLAYDOL_33:
       return evolution (this, from:"null", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -848,7 +848,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_HOUNDOOM_34:
       return evolution (this, from:"null", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -868,7 +868,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_HOUNDOUR_35:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -888,7 +888,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_LAIRON_36:
       return evolution (this, from:"null", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -908,7 +908,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_MIGHTYENA_37:
       return evolution (this, from:"null", hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -926,7 +926,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_RHYHORN_38:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -946,7 +946,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BULBASAUR_39:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -966,7 +966,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CUBONE_40:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -978,7 +978,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case JIGGLYPUFF_41:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -998,7 +998,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEOWTH_42:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1018,7 +1018,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PIKACHU_43:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1038,7 +1038,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PSYDUCK_44:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1058,7 +1058,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLOWPOKE_45:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1078,7 +1078,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SQUIRTLE_46:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1095,7 +1095,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CARVANHA_47:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1115,7 +1115,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CARVANHA_48:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1135,7 +1135,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CHINCHOU_49:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1156,7 +1156,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CORPHISH_50:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1168,7 +1168,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TEAM_AQUA_S_CORPHISH_51:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1188,7 +1188,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_ELECTRIKE_52:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1209,7 +1209,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_ELECTRIKE_53:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1230,7 +1230,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_POOCHYENA_54:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness G
@@ -1251,7 +1251,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_AQUA_S_POOCHYENA_55:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness G
@@ -1272,7 +1272,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SPHEAL_56:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness M
@@ -1284,7 +1284,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_S_SPHEAL_57:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1304,7 +1304,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_ARON_58:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1324,7 +1324,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_ARON_59:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1336,7 +1336,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_BALTOY_60:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1356,7 +1356,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_BALTOY_61:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1376,7 +1376,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_HOUNDOUR_62:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1396,7 +1396,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_HOUNDOUR_63:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1416,7 +1416,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_NUMEL_64:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1436,7 +1436,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_POOCHYENA_65:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness F
@@ -1449,7 +1449,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_POOCHYENA_66:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1470,7 +1470,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_RHYHORN_67:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1490,7 +1490,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_MAGMA_S_RHYHORN_68:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -1510,7 +1510,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEAM_AQUA_SCHEMER_69:
       return supporter (this) {
         text "Discard any 1 Pokémon from your hand. Then draw 3 cards. If you discarded a Pokémon with Team Aqua in its name, draw 4 cards instead." +
@@ -1519,7 +1519,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_MAGMA_SCHEMER_70:
       return supporter (this) {
         text "Discard any 1 Pokémon from your hand. Then draw 3 cards. If you discarded a Pokémon with Team Magma in its name, draw 4 cards instead." +
@@ -1528,7 +1528,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ARCHIE_71:
       return supporter (this) {
         text "Search your deck for a Pokémon with Team Aqua in its name and put it onto your Bench. Shuffle your deck afterward. Treat the new Benched Pokémon as a Basic Pokémon. If it is a Stage 2 Pokémon, put 2 damage counters on that Pokémon." +
@@ -1537,7 +1537,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DUAL_BALL_72:
       return itemCard (this) {
         text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -1545,7 +1545,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MAXIE_73:
       return supporter (this) {
         text "Search your hand or discard pile for a Pokémon with Team Magma in its name and put it onto your Bench. Treat the new Benched Pokémon as a Basic Pokémon. If it is a Stage 2 Pokémon, put 2 damage counters on that Pokémon." +
@@ -1554,7 +1554,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case STRENGTH_CHARM_74:
       return pokemonTool (this) {
         text "Whenever an attack from the Pokémon that Strength Charm is attached to does damage to the Active Pokémon (after applying Weakness and Resistance), the attack does 10 more damage. At the end of the turn in which this happens, discard Strength Charm." +
@@ -1565,7 +1565,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case TEAM_AQUA_BALL_75:
       return itemCard (this) {
         text "Flip a coin. If heads, search your deck for a Pokémon that has Team Aqua in its name, show it to your opponent, and put it into your hand. If tails, search your deck for a Basic Pokémon that has Team Aqua in its name, show it to your opponent and put into your hand. Shuffle your deck afterward."
@@ -1573,7 +1573,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_AQUA_BELT_76:
       return pokemonTool (this) {
         text "At any time between turns, if the Pokémon Team Aqua Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward, then discard Team Aqua Belt." +
@@ -1584,7 +1584,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case TEAM_AQUA_CONSPIRATOR_77:
       return supporter (this) {
         text "Search your deck for up to 2 in any combination of Basic Pokémon with Team Aqua in its name and basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward." +
@@ -1593,7 +1593,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_AQUA_HIDEOUT_78:
       return stadium (this) {
         text "Each Pokémon that does not have Team Aqua in its name pays [C] more to retreat." +
@@ -1602,7 +1602,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case TEAM_AQUA_S_TECHNICAL_MACHINE_01_79:
       return itemCard (this) {
         text "Attach this card to 1 of your Pokémon that has Team Aqua in its name. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Team Aqua Technical Machine 01."
@@ -1610,7 +1610,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_MAGMA_BALL_80:
       return itemCard (this) {
         text "Flip a coin. If heads, search your deck for a Pokémon that has Team Magma in its name, show it to your opponent, and put it into your hand. If tails, search your deck for a Basic Pokémon that has Team Magma in its name, show it to your opponent and put into your hand. Shuffle your deck afterward."
@@ -1618,7 +1618,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_MAGMA_BELT_81:
       return pokemonTool (this) {
         text "At any time between turns, if the Pokémon Team Magma Belt is attached to is your Active Pokémon, search your deck for a card that evolves from that Pokémon and put it on that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward, then discard Team Magma Belt." +
@@ -1629,7 +1629,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case TEAM_MAGMA_CONSPIRATOR_82:
       return supporter (this) {
         text "Search your deck for up to 2 in any combination of Basic Pokémon with Team Magma in its name and basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward." +
@@ -1638,7 +1638,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TEAM_MAGMA_HIDEOUT_83:
       return stadium (this) {
         text "Whenever any player plays a Basic Pokémon that doesn't have Team Magma in its name from his or her hand, that player puts 1 damage counter on that Pokémon." +
@@ -1647,7 +1647,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case TEAM_MAGMA_S_TECHNICAL_MACHINE_01_84:
       return itemCard (this) {
         text "Attach this card to 1 of your Pokémon that has Team Magma in its name. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Team Magma Technical Machine 01."
@@ -1655,7 +1655,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case WARP_POINT_85:
       return itemCard (this) {
         text "Your opponent switches 1 of his or her Defending Pokémon with 1 of his or her Benched Pokémon, if any. You switch 1 of your Active Pokémon with 1 of your Benched Pokémon, if any."
@@ -1663,7 +1663,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case AQUA_ENERGY_86:
       return specialEnergy (this, [[C]]) {
         text "Aqua Energy can be attached only to a Pokémon with Team Aqua in its name. Aqua Energy provides Water and [D] Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Aqua Energy."
@@ -1675,7 +1675,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case MAGMA_ENERGY_87:
       return specialEnergy (this, [[C]]) {
         text "Magma Energy can be attached only to a Pokémon with Team Magma in its name. Magma Energy provides Fighting and /or [D] Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy card when not in play and has no effect other than providing Energy.) At the end of your turn, discard Magma Energy."
@@ -1687,7 +1687,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DOUBLE_RAINBOW_ENERGY_88:
       return specialEnergy (this, [[C]]) {
         text "Double Rainbow Energy can be attached only to an Evolved Pokémon (excluding Pokémon-ex). While in play, Double Rainbow Energy provides every type of Energy but provides 2 Energy at a time. (Doesn't count as a basic Energy when not in play and has no effect other than providing Energy.) Damage done to your opponent's Pokémon by the Pokémon Double Rainbow Energy is attached to is reduced by 10 (after applying Weakness and Resistance). When the Pokémon Double Rainbow Energy is attached to is no longer an Evolved Pokémon, discard Double Rainbow Energy."
@@ -1699,7 +1699,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BLAZIKEN_EX_89:
       return basic (this, hp:HP150, type:R, retreatCost:2) {
         weakness W
@@ -1720,7 +1720,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CRADILY_EX_90:
       return basic (this, hp:HP150, type:G, retreatCost:2) {
         weakness W
@@ -1746,7 +1746,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ENTEI_EX_91:
       return basic (this, hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -1766,7 +1766,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case RAIKOU_EX_92:
       return basic (this, hp:HP100, type:L, retreatCost:2) {
         weakness F
@@ -1786,7 +1786,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SCEPTILE_EX_93:
       return basic (this, hp:HP150, type:G, retreatCost:2) {
         weakness G
@@ -1816,7 +1816,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SUICUNE_EX_94:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -1836,7 +1836,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SWAMPERT_EX_95:
       return basic (this, hp:HP150, type:F, retreatCost:3) {
         weakness G
@@ -1856,7 +1856,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ABSOL_96:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -1876,7 +1876,7 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case JIRACHI_97:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1896,9 +1896,9 @@ public enum TeamMagmaVsTeamAquaNG implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -1,26 +1,26 @@
-package tcgwars.logic.impl.gen3;
+package tcgwars.logic.impl.gen3
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
 import tcgwars.logic.effect.*
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 import tcgwars.logic.effect.ability.*
-import tcgwars.logic.effect.special.*;
+import tcgwars.logic.effect.special.*
 
 /**
  * @author axpendix@hotmail.com
@@ -139,53 +139,53 @@ public enum TeamRocketReturns implements LogicCardInfo {
   CHARMELEON_110 ("Charmeleon", "110", Rarity.HOLORARE, [STAGE1, EVOLUTION, POKEMON, _FIRE_]),
   HERE_COMES_TEAM_ROCKET__111 ("Here Comes Team Rocket!", "111", Rarity.HOLORARE, [TRAINER, SUPPORTER]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   TeamRocketReturns(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.TEAM_ROCKET_RETURNS;
+    return tcgwars.logic.card.Collection.TEAM_ROCKET_RETURNS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -213,7 +213,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_AMPHAROS_2:
         return evolution (this, from:"Dark Flaaffy", hp:HP120, type:[DARKNESS, LIGHTNING], retreatCost:2) {
           weakness FIGHTING
@@ -253,7 +253,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               afterDamage { discardAllSelfEnergy(L) } //TODO: Handle in static.
             }
           }
-        };
+        }
       case DARK_CROBAT_3:
         return evolution (this, from:"Dark Golbat", hp:HP090, type:[DARKNESS, GRASS], retreatCost:1) {
           weakness LIGHTNING
@@ -286,7 +286,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ELECTRODE_4:
         return evolution (this, from:"Voltorb", hp:HP070, type:[DARKNESS, LIGHTNING], retreatCost:1) {
           weakness FIGHTING
@@ -318,7 +318,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_HOUNDOOM_5:
         return evolution (this, from:"Houndour", hp:HP070, type:[DARKNESS, FIRE], retreatCost:1) {
           weakness FIGHTING
@@ -353,7 +353,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_HYPNO_6:
         return evolution (this, from:"Drowzee", hp:HP070, type:[DARKNESS, PSYCHIC], retreatCost:1) {
           weakness PSYCHIC
@@ -369,7 +369,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 def labelList = []
                 my.bench.each {pcs->
                   if(pcs.name.contains("Dark ")){
-                    moveList.addAll(pcs.topPokemonCard.moves);
+                    moveList.addAll(pcs.topPokemonCard.moves)
                     labelList.addAll(pcs.topPokemonCard.moves.collect{pcs.name+"-"+it.name})
                   }
                 }
@@ -388,7 +388,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MAROWAK_7:
         return evolution (this, from:"Cubone", hp:HP070, type:[DARKNESS, FIGHTING], retreatCost:1) {
           weakness GRASS
@@ -411,7 +411,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_OCTILLERY_8:
         return evolution (this, from:"Remoraid", hp:HP070, type:[DARKNESS, WATER], retreatCost:1) {
           weakness LIGHTNING
@@ -432,7 +432,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_SLOWKING_9:
         return evolution (this, from:"Slowpoke", hp:HP080, type:[DARKNESS, PSYCHIC], retreatCost:1) {
           weakness GRASS
@@ -457,7 +457,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARK_STEELIX_10:
         return evolution (this, from:"Onix", hp:HP110, type:[DARKNESS, METAL], retreatCost:4) {
           weakness FIRE
@@ -480,7 +480,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JUMPLUFF_11:
         return evolution (this, from:"Skiploom", hp:HP090, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -511,7 +511,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGDRA_12:
         return evolution (this, from:"Seadra", hp:HP120, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -543,7 +543,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PILOSWINE_13:
         return evolution (this, from:"Swinub", hp:HP100, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -567,7 +567,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGETIC_14:
         return evolution (this, from:"Togepi", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -614,7 +614,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               def moveList = []
               def labelList = []
               opp.bench.each {pcs->
-                moveList.addAll(pcs.topPokemonCard.moves);
+                moveList.addAll(pcs.topPokemonCard.moves)
                 labelList.addAll(pcs.topPokemonCard.moves.collect{pcs.name+"-"+it.name})
               }
               def move=choose(moveList, labelList)
@@ -624,7 +624,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONITE_15:
         return evolution (this, from:"Dark Dragonair", hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness COLORLESS
@@ -661,7 +661,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MUK_16:
         return evolution (this, from:"Grimer", hp:HP070, type:[DARKNESS, GRASS], retreatCost:1) {
           weakness PSYCHIC
@@ -692,7 +692,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_RATICATE_17:
         return evolution (this, from:"Rattata", hp:HP070, type:DARKNESS, retreatCost:0) {
           weakness FIGHTING
@@ -728,7 +728,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_SANDSLASH_18:
         return evolution (this, from:"Sandshrew", hp:HP070, type:[DARKNESS, FIGHTING], retreatCost:0) {
           weakness GRASS
@@ -747,7 +747,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_TYRANITAR_19:
         return evolution (this, from:"Dark Pupitar", hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -777,7 +777,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_TYRANITAR_20:
         return evolution (this, from:"Dark Pupitar", hp:HP120, type:[DARKNESS, FIGHTING], retreatCost:3) {
           weakness GRASS
@@ -806,7 +806,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DELIBIRD_21:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness METAL
@@ -832,7 +832,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FURRET_22:
         return evolution (this, from:"Sentret", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -858,7 +858,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDIAN_23:
         return evolution (this, from:"Ledyba", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -891,7 +891,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGBY_24:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -912,7 +912,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_25:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -938,7 +938,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUAGSIRE_26:
         return evolution (this, from:"Wooper", hp:HP080, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -962,7 +962,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QWILFISH_27:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -989,7 +989,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMA_28:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -1018,7 +1018,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ARBOK_29:
         return evolution (this, from:"Ekans", hp:HP090, type:[DARKNESS, GRASS], retreatCost:1) {
           weakness PSYCHIC
@@ -1042,7 +1042,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ARIADOS_30:
         return evolution (this, from:"Spinarak", hp:HP070, type:[DARKNESS, GRASS], retreatCost:1) {
           weakness FIRE
@@ -1062,7 +1062,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONAIR_31:
         return evolution (this, from:"Dratini", hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness COLORLESS
@@ -1087,7 +1087,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONAIR_32:
         return evolution (this, from:"Dratini", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness COLORLESS
@@ -1111,7 +1111,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_FLAAFFY_33:
         return evolution (this, from:"Mareep", hp:HP080, type:[DARKNESS, LIGHTNING], retreatCost:1) {
           weakness FIGHTING
@@ -1132,7 +1132,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GOLBAT_34:
         return evolution (this, from:"Zubat", hp:HP070, type:[DARKNESS, GRASS], retreatCost:0) {
           weakness PSYCHIC
@@ -1145,7 +1145,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GOLDUCK_35:
         return evolution (this, from:"Psyduck", hp:HP070, type:[DARKNESS, WATER], retreatCost:1) {
           weakness LIGHTNING
@@ -1169,7 +1169,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GYARADOS_36:
         return evolution (this, from:"Magikarp", hp:HP080, type:[DARKNESS, WATER], retreatCost:2) {
           weakness LIGHTNING
@@ -1200,7 +1200,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_HOUNDOOM_37:
         return evolution (this, from:"Houndour", hp:HP070, type:[DARKNESS, FIRE], retreatCost:1) {
           weakness WATER
@@ -1223,7 +1223,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MAGCARGO_38:
         return evolution (this, from:"Slugma", hp:HP080, type:[DARKNESS, FIRE], retreatCost:2) {
           weakness WATER
@@ -1242,7 +1242,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MAGNETON_39:
         return evolution (this, from:"Magnemite", hp:HP070, type:[DARKNESS, LIGHTNING], retreatCost:1) {
           weakness FIGHTING
@@ -1263,7 +1263,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PUPITAR_40:
         return evolution (this, from:"Larvitar", hp:HP070, type:[DARKNESS, FIGHTING], retreatCost:1) {
           weakness GRASS
@@ -1293,7 +1293,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PUPITAR_41:
         return evolution (this, from:"Larvitar", hp:HP080, type:[DARKNESS, FIGHTING], retreatCost:2) {
           weakness GRASS
@@ -1314,7 +1314,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_WEEZING_42:
         return evolution (this, from:"Koffing", hp:HP080, type:[DARKNESS, GRASS], retreatCost:2) {
           weakness PSYCHIC
@@ -1345,7 +1345,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_43:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1371,7 +1371,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_44:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1394,7 +1394,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANTINE_45:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1419,7 +1419,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_MEOWTH_46:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1446,7 +1446,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_WOBBUFFET_47:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness PSYCHIC
@@ -1483,7 +1483,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEADRA_48:
         return evolution (this, from:"Horsea", hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1504,7 +1504,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKIPLOOM_49:
         return evolution (this, from:"Hoppip", hp:HP060, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -1535,7 +1535,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEPI_50:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1554,7 +1554,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
                 def moveList = []
                 def labelList = []
 
-                moveList.addAll(defending.topPokemonCard.moves);
+                moveList.addAll(defending.topPokemonCard.moves)
                 labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
                 def move=choose(moveList, labelList, "Which move do you want to use")
@@ -1565,7 +1565,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_51:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1576,7 +1576,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               assert my.deck
             }
             onAttack {
-              def revealCard = new CardList();
+              def revealCard = new CardList()
               def ind = 0
               def curCard
               while(ind < my.deck.size()){
@@ -1602,7 +1602,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRATINI_52:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           move "Pound", {
@@ -1613,7 +1613,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRATINI_53:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness COLORLESS
@@ -1635,7 +1635,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DROWZEE_54:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1661,7 +1661,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EKANS_55:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1673,7 +1673,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER_56:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1696,7 +1696,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOPPIP_57:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1726,7 +1726,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HORSEA_58:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1748,7 +1748,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOUR_59:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1768,7 +1768,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOUR_60:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1789,7 +1789,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_61:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1813,7 +1813,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_62:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1825,7 +1825,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_63:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1845,7 +1845,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDYBA_64:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1871,7 +1871,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_65:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1890,7 +1890,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case MAGNEMITE_66:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1902,7 +1902,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAREEP_67:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1926,7 +1926,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARILL_68:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1942,7 +1942,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_69:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness WATER
@@ -1962,7 +1962,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK_70:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1990,7 +1990,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RATTATA_71:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2010,7 +2010,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA_72:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2027,7 +2027,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REMORAID_73:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2049,7 +2049,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSHREW_74:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2068,7 +2068,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SENTRET_75:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2092,7 +2092,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_76:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2118,7 +2118,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLUGMA_77:
         return basic (this, hp:HP050, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2138,7 +2138,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPINARAK_78:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2158,7 +2158,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWINUB_79:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2181,7 +2181,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_80:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2205,7 +2205,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOOPER_81:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -2228,7 +2228,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_82:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -2248,7 +2248,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COPYCAT_83:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nShuffle your hand into your deck. Then, count the number of cards in your opponent’s hand and draw that many cards."
@@ -2260,7 +2260,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard) || my.deck
           }
-        };
+        }
       case POKEMON_RETRIEVER_84:
         return basicTrainer (this) {
           text "Search your discard pile for Basic Pokémon and Evolution cards. You may either show 1 Basic Pokémon or Evolution card to your opponent and put it into your hand, or show a combination of 3 Basic Pokémon or Evolution cards to your opponent and shuffle them into your deck."
@@ -2277,7 +2277,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC, EVOLUTION)
           }
-        };
+        }
       case POW__HAND_EXTENSION_85:
         return basicTrainer (this) {
           text "You may use this card only if you have more Prize cards left than your opponent.\nMove 1 Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon. Or, switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
@@ -2298,7 +2298,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You need more Prize cards left than your opponent to use this card"
             assert opp.bench : "Your opponent has no Benched Pokémon."
           }
-        };
+        }
       case ROCKET_S_ADMIN__86:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nEach player shuffles his or her hand into his or her deck. Then, each player counts his or her Prize cards left and draws up to that many cards. (You draw your cards first.)"
@@ -2312,7 +2312,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case ROCKET_S_HIDEOUT_87:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play.\nEach Pokémon in play with Dark or Rocket’s in its name (both yours and your opponent’s) gets +20 HP."
@@ -2327,7 +2327,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case ROCKET_S_MISSION_88:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDiscard a card from your hand. Then, draw 3 cards. If you discarded a Pokémon that has Dark or Rocket’s in its name, draw 4 cards instead."
@@ -2345,7 +2345,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard)
           }
-        };
+        }
       case ROCKET_S_POKE_BALL_89:
         return basicTrainer (this) {
           text "Search your deck for a Pokémon that has Dark in its name, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2356,7 +2356,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case ROCKET_S_TRICKY_GYM_90:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play." +
@@ -2382,7 +2382,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-        };
+        }
       case SURPRISE__TIME_MACHINE_91:
         return basicTrainer (this) {
           text "Choose 1 of your Evolved Pokémon, remove the highest Stage Evolution card from it, and shuffle it into your deck (this counts as devolving that Pokémon). If that Pokémon remains in play, search your deck for an Evolution card that evolves from that Pokémon and put it onto that Pokémon (this counts as evolving that Pokémon). Shuffle your deck afterward."
@@ -2404,7 +2404,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.evolution}
           }
-        };
+        }
       case SWOOP__TELEPORTER_92:
         return basicTrainer (this) {
           text "Search your deck for a Basic Pokémon (excluding Pokémon-ex) and switch it with 1 of your Basic Pokémon (excluding Pokémon-ex) in play. (Any cards attached to that Pokémon, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Place the first Basic Pokémon in the discard pile. Shuffle your deck afterward."
@@ -2423,7 +2423,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll {it.notEvolution && it.topPokemonCard.cardTypes.isNot(EX)} : "No basic in play"
           }
-        };
+        }
       case VENTURE_BOMB_93:
         return basicTrainer (this) {
           text "Flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. If tails, put 1 damage counter on 1 of your Pokémon."
@@ -2438,7 +2438,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case DARK_METAL_ENERGY_94:
         return specialEnergy (this, [[]]) {
           text "Attach Dark Metal Energy to 1 of your Pokémon. While in play, Dark Metal Energy provides [D] Energy and [M] Energy, but provides only 1 Energy at a time. (Doesn’t count as a basic Energy card when not in play and has no effect other than providing Energy.)"
@@ -2449,7 +2449,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             if (self) return [[D, M] as Set]
             else return [[] as Set]
           }
-        };
+        }
       case R_ENERGY_95:
         return specialEnergy (this, [[]]) {
           text "R Energy can be attached only to a Pokémon that have Dark or Rocket’s in its name. While in play, R Energy provides 2 [D] Energy. (Doesn’t count as a basic Energy card.) If the Pokémon R Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). When your turn ends, discard R Energy."
@@ -2496,7 +2496,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             if (self) return [[D] as Set, [D] as Set]
             else return [[] as Set]
           }
-        };
+        }
       case ROCKET_S_ARTICUNO_EX_96:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness METAL
@@ -2527,7 +2527,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_ENTEI_EX_97:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness WATER
@@ -2557,7 +2557,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_HITMONCHAN_EX_98:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness PSYCHIC
@@ -2584,7 +2584,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_MEWTWO_EX_99:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:2) {
           weakness PSYCHIC
@@ -2616,7 +2616,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_MOLTRES_EX_100:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:2) {
           weakness WATER
@@ -2644,7 +2644,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_SCIZOR_EX_101:
         return evolution (this, from:"Rocket's Scyther ex", hp:HP120, type:DARKNESS, retreatCost:1) {
           weakness FIRE
@@ -2669,7 +2669,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_SCYTHER_EX_102:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness FIRE
@@ -2697,7 +2697,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_SNEASEL_EX_103:
         return basic (this, hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2723,7 +2723,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_SNORLAX_EX_104:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2754,7 +2754,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_SUICUNE_EX_105:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2786,7 +2786,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKET_S_ZAPDOS_EX_106:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2819,7 +2819,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDKIP_STAR_107:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2842,7 +2842,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORCHIC_STAR_108:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -2866,7 +2866,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREECKO_STAR_109:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2890,7 +2890,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMELEON_110:
         return evolution (this, from:"Charmander", hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -2911,7 +2911,7 @@ public enum TeamRocketReturns implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERE_COMES_TEAM_ROCKET__111:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nEach player plays with his or her Prize cards face up for the rest of the game."
@@ -2923,9 +2923,9 @@ public enum TeamRocketReturns implements LogicCardInfo {
           playRequirement {
             assert !(my.prizeCardSet.allVisible && opp.prizeCardSet.allVisible) : "All prizes are already visible"
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -1,48 +1,48 @@
 package tcgwars.logic.impl.gen3
 
-import tcgwars.logic.effect.gm.ActivateSimpleTrainer;
-import tcgwars.logic.impl.gen2.Expedition;
-import tcgwars.logic.impl.gen2.Aquapolis;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.Deoxys;
-import tcgwars.logic.impl.gen3.Dragon;
-import tcgwars.logic.impl.gen4.HeartgoldSoulsilver;
-import tcgwars.logic.impl.gen5.BlackWhite;
-import tcgwars.logic.impl.gen5.PlasmaStorm;
-import tcgwars.logic.impl.gen6.KalosStarterSet;
+import tcgwars.logic.effect.gm.ActivateSimpleTrainer
+import tcgwars.logic.impl.gen2.Expedition
+import tcgwars.logic.impl.gen2.Aquapolis
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.Deoxys
+import tcgwars.logic.impl.gen3.Dragon
+import tcgwars.logic.impl.gen4.HeartgoldSoulsilver
+import tcgwars.logic.impl.gen5.BlackWhite
+import tcgwars.logic.impl.gen5.PlasmaStorm
+import tcgwars.logic.impl.gen6.KalosStarterSet
 
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.effect.gm.Attack
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author luongthomasdev@gmail.com
@@ -196,53 +196,53 @@ public enum UnseenForces implements LogicCardInfo {
   UNOWN_145 ("Unown", "em", Rarity.HOLORARE, [POKEMON, BASIC, _PSYCHIC_]);
 
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   UnseenForces(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.UNSEEN_FORCES;
+    return tcgwars.logic.card.Collection.UNSEEN_FORCES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -258,9 +258,9 @@ public enum UnseenForces implements LogicCardInfo {
             checkNoSPC()
             while(true){
               def pl = my.bench.findAll{ it.cards.filterByType(BASIC_ENERGY) }
-              if(!pl) break;
+              if(!pl) break
               def src = pl.select("source for energy (cancel to stop)", false)
-              if(!src) break;
+              if(!src) break
               def card = src.cards.select("Card to move", cardTypeFilter(BASIC_ENERGY)).first()
               energySwitch(src, my.active, card)
             }
@@ -280,7 +280,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARIADOS_2:
       return evolution (this, from:"Spinarak", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -306,7 +306,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BELLOSSOM_3:
       return evolution (this, from:"Gloom", hp:HP090, type:G, retreatCost:1) {
         weakness R
@@ -338,7 +338,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FERALIGATR_4:
       return evolution (this, from:"Croconaw", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -379,7 +379,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLAREON_5:
       return evolution (this, from:"Eevee", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -410,7 +410,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FORRETRESS_6:
       return evolution (this, from:"Pineco", hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -452,7 +452,7 @@ public enum UnseenForces implements LogicCardInfo {
             directDamage 70, self
           }
         }
-      };
+      }
       case HOUNDOOM_7:
       return evolution (this, from:"Houndour", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -487,7 +487,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JOLTEON_8:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -523,7 +523,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEGANIUM_9:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -560,7 +560,7 @@ public enum UnseenForces implements LogicCardInfo {
               }
           }
         }
-      };
+      }
       case OCTILLERY_10:
       return evolution (this, from:"Remoraid", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -590,7 +590,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case POLIWRATH_11:
       return evolution (this, from:"Poliwhirl", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -625,7 +625,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PORYGON2_12:
       return evolution (this, from:"Porygon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -663,7 +663,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SLOWBRO_13:
       return evolution (this, from:"Slowpoke", hp:HP080, type:W, retreatCost:2) {
         weakness G
@@ -690,7 +690,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SLOWKING_14:
       return evolution (this, from:"Slowpoke", hp:HP070, type:P, retreatCost:1) {
         weakness G
@@ -713,7 +713,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20 + extraDamage
           }
         }
-      };
+      }
       case SUDOWOODO_15:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -739,7 +739,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 50 - 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case SUNFLORA_16:
       return evolution (this, from:"Sunkern", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -762,7 +762,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYPHLOSION_17:
       return evolution (this, from:"Quilava", hp:HP110, type:R, retreatCost:1) {
         weakness W
@@ -793,7 +793,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 50+10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case URSARING_18:
       return evolution (this, from:"Teddiursa", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -837,7 +837,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case VAPOREON_19:
       return evolution (this, from:"Eevee", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -868,7 +868,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHANSEY_20:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness F
@@ -891,7 +891,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLEFFA_21:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -913,7 +913,7 @@ public enum UnseenForces implements LogicCardInfo {
             draw 6
           }
         }
-      };
+      }
       case ELECTABUZZ_22:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -954,7 +954,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ELEKID_23:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -977,7 +977,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HITMONCHAN_24:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness P
@@ -1007,7 +1007,7 @@ public enum UnseenForces implements LogicCardInfo {
             swiftDamage 50, defending
           }
         }
-      };
+      }
       case HITMONLEE_25:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -1043,7 +1043,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HITMONTOP_26:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness P
@@ -1071,7 +1071,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HO_OH_27:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1092,7 +1092,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JYNX_28:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness M
@@ -1127,7 +1127,7 @@ public enum UnseenForces implements LogicCardInfo {
             putDamageCountersOnOpponentsPokemon(4)
           }
         }
-      };
+      }
       case LUGIA_29:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -1139,7 +1139,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case MURKROW_30:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness L
@@ -1164,7 +1164,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SMOOCHUM_31:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1184,7 +1184,7 @@ public enum UnseenForces implements LogicCardInfo {
             directDamage 10, opp.all.select("Select a Pokémon to put a damage counter on")
           }
         }
-      };
+      }
       case STANTLER_32:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1211,7 +1211,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYROGUE_33:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
@@ -1234,7 +1234,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case AIPOM_34:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1261,7 +1261,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10, opp.all.select()
           }
         }
-      };
+      }
       case BAYLEEF_35:
       return evolution (this, from:"Chikorita", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1281,7 +1281,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CLEFABLE_36:
       return evolution (this, from:"Clefairy", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1301,7 +1301,7 @@ public enum UnseenForces implements LogicCardInfo {
             increasedBaseDamageNextTurn("Extra Comet Punch", hp(30))
           }
         }
-      };
+      }
       case CORSOLA_37:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness G
@@ -1330,7 +1330,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CROCONAW_38:
       return evolution (this, from:"Totodile", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -1349,7 +1349,7 @@ public enum UnseenForces implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case GRANBULL_39:
       return evolution (this, from:"Snubbull", hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -1381,7 +1381,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case LANTURN_40:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1405,7 +1405,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case MAGCARGO_41:
       return evolution (this, from:"Slugma", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -1433,7 +1433,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MILTANK_42:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1475,7 +1475,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case NOCTOWL_43:
       return evolution (this, from:"Hoothoot", hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -1495,7 +1495,7 @@ public enum UnseenForces implements LogicCardInfo {
             afterDamage { astonish() }
           }
         }
-      };
+      }
       case QUAGSIRE_44:
       return evolution (this, from:"Wooper", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -1527,7 +1527,7 @@ public enum UnseenForces implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case QUILAVA_45:
       return evolution (this, from:"Cyndaquil", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1546,7 +1546,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SCYTHER_46:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1573,7 +1573,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case SHUCKLE_47:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1598,7 +1598,7 @@ public enum UnseenForces implements LogicCardInfo {
             extraPoison 1
           }
         }
-      };
+      }
       case SMEARGLE_48:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1631,7 +1631,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { applyAfterDamage CONFUSED }
           }
         }
-      };
+      }
       case XATU_49:
       return evolution (this, from:"Natu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -1650,7 +1650,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case YANMA_50:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1671,7 +1671,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHIKORITA_51:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1690,7 +1690,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHINCHOU_52:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1708,7 +1708,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CLEFAIRY_53:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1727,7 +1727,7 @@ public enum UnseenForces implements LogicCardInfo {
             applyAfterDamage ASLEEP
           }
         }
-      };
+      }
       case CYNDAQUIL_54:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1748,7 +1748,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case EEVEE_55:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1781,7 +1781,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FLAAFFY_56:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1804,7 +1804,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case GLIGAR_57:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness L
@@ -1824,7 +1824,7 @@ public enum UnseenForces implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case GLOOM_58:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1836,7 +1836,7 @@ public enum UnseenForces implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case HOOTHOOT_59:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1855,7 +1855,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_60:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1866,7 +1866,7 @@ public enum UnseenForces implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case LARVITAR_61:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1884,7 +1884,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAREEP_62:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1896,7 +1896,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NATU_63:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1907,7 +1907,7 @@ public enum UnseenForces implements LogicCardInfo {
             noWrDamage 10, opp.all.select("Do 10 damage to which pokémon?")
           }
         }
-      };
+      }
       case ODDISH_64:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1919,7 +1919,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case ONIX_65:
       return basic (this, hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -1940,7 +1940,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINECO_66:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1951,7 +1951,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case POLIWAG_67:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1969,7 +1969,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case POLIWHIRL_68:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1981,7 +1981,7 @@ public enum UnseenForces implements LogicCardInfo {
             extraEnergyDamage(2, hp(10), C, thisMove)
           }
         }
-      };
+      }
       case PORYGON_69:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1992,7 +1992,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip 3, {damage 10}
           }
         }
-      };
+      }
       case PUPITAR_70:
       return evolution (this, from:"Larvitar", hp:HP070, type:F, retreatCost:0) {
         weakness G
@@ -2010,7 +2010,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case REMORAID_71:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2026,7 +2026,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLOWPOKE_72:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2050,7 +2050,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case SLUGMA_73:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2068,7 +2068,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNUBBULL_74:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2080,7 +2080,7 @@ public enum UnseenForces implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case SPINARAK_75:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2101,7 +2101,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SUNKERN_76:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2124,7 +2124,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEDDIURSA_77:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2142,7 +2142,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TOTODILE_78:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2153,7 +2153,7 @@ public enum UnseenForces implements LogicCardInfo {
             noWrDamage 10, opp.all.select("Deal 10 damage to which Pokémon?")
           }
         }
-      };
+      }
       case WOOPER_79:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2171,7 +2171,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CURSE_POWDER_80:
       return pokemonTool (this) {
         text "Attach Curse Powder to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Curse Powder is attached to is a Basic Pokémon or Pokémon-ex, discard Curse Powder." +
@@ -2198,11 +2198,11 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           to.evolution && !to.EX
         }
-      };
+      }
       case ENERGY_RECYCLE_SYSTEM_81:
-      return copy(Dragon.ENERGY_RECYCLE_SYSTEM_84, this);
+      return copy(Dragon.ENERGY_RECYCLE_SYSTEM_84, this)
       case ENERGY_REMOVAL_2_82:
-      return copy(Expedition.ENERGY_REMOVAL_2_140, this);
+      return copy(Expedition.ENERGY_REMOVAL_2_140, this)
       case ENERGY_ROOT_83:
       return pokemonTool (this) {
         text "Attach Energy Root to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Energy Root is attached to is Pokémon-ex or has Dark or an owner in its name, discard Energy Root.\nAs long as Energy Root is attached to a Pokémon, that Pokémon gets +20 HP and can't use any Poké-Powers or Poké-Bodies."
@@ -2242,7 +2242,7 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           !to.topPokemonCard.name.contains("Dark ") && to.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON) && !to.EX
         }
-      };
+      }
       case ENERGY_SWITCH_84:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case FLUFFY_BERRY_85:
@@ -2272,7 +2272,7 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           !to.topPokemonCard.name.contains("Dark ") && to.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON) && !to.EX
         }
-      };
+      }
       case MARY_S_REQUEST_86:
       return supporter (this) {
         text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -2284,7 +2284,7 @@ public enum UnseenForces implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case POKE_BALL_87:
       return itemCard (this) {
         text "Flip a coin. If heads, search your deck for a Basic Pokémon or Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2297,7 +2297,7 @@ public enum UnseenForces implements LogicCardInfo {
         playRequirement{
           assert my.deck: "Deck is empty"
         }
-      };
+      }
       case POKEMON_REVERSAL_88:
       return copy (FireRedLeafGreen.POKEMON_REVERSAL_97, this)
       case PROFESSOR_ELM_S_TRAINING_METHOD_89:
@@ -2326,7 +2326,7 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           to.evolution && !to.EX
         }
-      };
+      }
       case SITRUS_BERRY_91:
       return pokemonTool (this) {
         text "Attach Sitrus Berry to 1 of your Pokémon (excluding Pokémon-ex and Pokémon that has Dark or an owner in its name) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Sitrus Berry is attached to is Pokémon-ex or has Dark or an owner in its name, discard Sitrus Berry." +
@@ -2357,7 +2357,7 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           !to.topPokemonCard.name.contains("Dark ") && to.topPokemonCard.cardTypes.isNot(OWNERS_POKEMON) && !to.EX
         }
-      };
+      }
       case SOLID_RAGE_92:
       return pokemonTool (this) {
         text "Attach Solid Rage to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Solid Rage is attached to is a Basic Pokémon or Pokémon-ex, discard Solid Rage." +
@@ -2384,19 +2384,19 @@ public enum UnseenForces implements LogicCardInfo {
         allowAttach {to->
           to.evolution && !to.EX
         }
-      };
+      }
       case WARP_POINT_93:
       return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case ENERGY_SEARCH_94:
-      return copy(BlackWhite.ENERGY_SEARCH_93, this);
+      return copy(BlackWhite.ENERGY_SEARCH_93, this)
       case POTION_95:
       return copy (FireRedLeafGreen.POTION_101, this)
       case DARKNESS_ENERGY_96:
-      return copy (Emerald.DARKNESS_ENERGY_86, this);
+      return copy (Emerald.DARKNESS_ENERGY_86, this)
       case METAL_ENERGY_97:
-      return copy (RubySapphire.METAL_ENERGY_94, this);
+      return copy (RubySapphire.METAL_ENERGY_94, this)
       case BOOST_ENERGY_98:
-      return copy (Deoxys.BOOST_ENERGY_93, this);
+      return copy (Deoxys.BOOST_ENERGY_93, this)
       case CYCLONE_ENERGY_99:
       return specialEnergy (this, [[C]]) {
         text "Cyclone Energy provides [C] Energy. When you attach this card from your hand to your Active Pokémon, switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. Your opponent chooses the Benched Pokémon to switch."
@@ -2409,7 +2409,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WARP_ENERGY_100:
       return copy (Aquapolis.WARP_ENERGY_147, this)
       case BLISSEY_EX_101:
@@ -2454,7 +2454,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ESPEON_EX_102:
       return evolution (this, from:"Eevee", hp:HP110, type:P, retreatCost:0) {
         weakness P
@@ -2505,7 +2505,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 30 * addDmg
           }
         }
-      };
+      }
       case FERALIGATR_EX_103:
       return evolution (this, from:"Croconaw", hp:HP150, type:W, retreatCost:3) {
         weakness L
@@ -2543,7 +2543,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 70+10*defending.numberOfDamageCounters
           }
         }
-      };
+      }
       case HO_OH_EX_104:
       return basic (this, hp:HP110, type:R, retreatCost:2) {
         weakness W
@@ -2573,7 +2573,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LUGIA_EX_105:
       return basic (this, hp:HP100, type:C, retreatCost:1) {
         weakness P
@@ -2698,7 +2698,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEGANIUM_EX_106:
       return evolution (this, from:"Bayleef", hp:HP150, type:G, retreatCost:2) {
         weakness G
@@ -2733,7 +2733,7 @@ public enum UnseenForces implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case POLITOED_EX_107:
       return evolution (this, from:"Poliwhirl", hp:HP150, type:W, retreatCost:3) {
         weakness G
@@ -2769,7 +2769,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SCIZOR_EX_108:
       return evolution (this, from:["Scyther", "Scyther ex"], hp:HP120, type:M, retreatCost:1) {
         weakness R
@@ -2805,7 +2805,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STEELIX_EX_109:
       return evolution (this, from:"Onix", hp:HP150, type:M, retreatCost:5) {
         weakness R
@@ -2839,7 +2839,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 100, opp.all.select("Deal 100 damage to which Pokémon?")
           }
         }
-      };
+      }
       case TYPHLOSION_EX_110:
       return evolution (this, from:"Quilava", hp:HP150, type:R, retreatCost:1) {
         weakness W
@@ -2869,7 +2869,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYRANITAR_EX_111:
       return evolution (this, from:"Pupitar", hp:HP160, type:D, retreatCost:2) {
         weakness G
@@ -2918,7 +2918,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UMBREON_EX_112:
       return evolution (this, from:"Eevee", hp:HP110, type:D, retreatCost:1) {
         weakness F
@@ -2971,7 +2971,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ENTEI_STAR_113:
       return basic (this, hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -2996,7 +2996,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAIKOU_STAR_114:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -3021,7 +3021,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SUICUNE_STAR_115:
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -3047,7 +3047,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ROCKET_S_PERSIAN_EX_116:
       return evolution (this, from:"Rocket's Meowth", hp:HP100, type:D, retreatCost:1) {
         weakness F
@@ -3075,7 +3075,7 @@ public enum UnseenForces implements LogicCardInfo {
             extraPoison 1
           }
         }
-      };
+      }
       case CELEBI_EX_117:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -3118,7 +3118,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_118:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3152,7 +3152,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_119:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3173,7 +3173,7 @@ public enum UnseenForces implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case UNOWN_120:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3190,7 +3190,7 @@ public enum UnseenForces implements LogicCardInfo {
             directDamage 10*opp.hand.size(), opp.active
           }
         }
-      };
+      }
       case UNOWN_121:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3211,7 +3211,7 @@ public enum UnseenForces implements LogicCardInfo {
             bg.em().run(new ActivateSimpleTrainer(card))
           }
         }
-      };
+      }
       case UNOWN_122:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3234,7 +3234,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_123:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3262,7 +3262,7 @@ public enum UnseenForces implements LogicCardInfo {
               sw2 benched
           }
         }
-      };
+      }
       case UNOWN_124:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3289,7 +3289,7 @@ public enum UnseenForces implements LogicCardInfo {
             ]
           }
         }
-      };
+      }
       case UNOWN_125:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3306,7 +3306,7 @@ public enum UnseenForces implements LogicCardInfo {
             directDamage 10*my.all.findAll { it.numberOfDamageCounters }.size(), defending
           }
         }
-      };
+      }
       case UNOWN_126:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3334,7 +3334,7 @@ public enum UnseenForces implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case UNOWN_127:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3358,7 +3358,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_128:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3381,7 +3381,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_129:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3403,7 +3403,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_130:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3422,7 +3422,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_131:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3444,7 +3444,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_132:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3461,7 +3461,7 @@ public enum UnseenForces implements LogicCardInfo {
             heal(50, self)
           }
         }
-      };
+      }
       case UNOWN_133:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3482,7 +3482,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_134:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3501,7 +3501,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_135:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3529,7 +3529,7 @@ public enum UnseenForces implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case UNOWN_136:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3549,7 +3549,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_137:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3575,7 +3575,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_138:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3592,7 +3592,7 @@ public enum UnseenForces implements LogicCardInfo {
             noWrDamage 20, opp.all.select("Deal 20 damage to which Pokémon?")
           }
         }
-      };
+      }
       case UNOWN_139:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3610,7 +3610,7 @@ public enum UnseenForces implements LogicCardInfo {
             amnesia delegate
           }
         }
-      };
+      }
       case UNOWN_140:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3629,7 +3629,7 @@ public enum UnseenForces implements LogicCardInfo {
             damage 10*addDmg
           }
         }
-      };
+      }
       case UNOWN_141:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3652,7 +3652,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_142:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3669,7 +3669,7 @@ public enum UnseenForces implements LogicCardInfo {
             flipUntilTails { damage 20 }
           }
         }
-      };
+      }
       case UNOWN_143:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3687,7 +3687,7 @@ public enum UnseenForces implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case UNOWN_144:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3707,7 +3707,7 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case UNOWN_145:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -3728,9 +3728,9 @@ public enum UnseenForces implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/Arceus.groovy
+++ b/src/tcgwars/logic/impl/gen4/Arceus.groovy
@@ -1,41 +1,41 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.effect.gm.ActivateSimpleTrainer;
+import tcgwars.logic.effect.gm.ActivateSimpleTrainer
 import tcgwars.logic.impl.gen2.Expedition
-import tcgwars.logic.impl.gen3.DragonFrontiers;
-import tcgwars.logic.impl.gen8.SwordShield;
+import tcgwars.logic.impl.gen3.DragonFrontiers
+import tcgwars.logic.impl.gen8.SwordShield
 
-import tcgwars.logic.effect.gm.PlayTrainer;
+import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -155,53 +155,53 @@ public enum Arceus implements LogicCardInfo {
   ARCEUS_AR8 ("Arceus", "AR8", Rarity.HOLORARE, [BASIC, POKEMON, _FIGHTING_]),
   ARCEUS_AR9 ("Arceus", "AR9", Rarity.HOLORARE, [BASIC, POKEMON, _METAL_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Arceus(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.ARCEUS;
+    return tcgwars.logic.card.Collection.ARCEUS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -239,7 +239,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROSLASS_2:
         return evolution (this, from:"Snorunt", hp:HP080, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -264,7 +264,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEATRAN_3:
         return basic (this, hp:HP100, type:FIRE, retreatCost:3) {
           weakness W
@@ -291,7 +291,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTOPS_4:
         return evolution (this, from:"Kabuto", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS30
@@ -322,7 +322,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXRAY_5:
         return evolution (this, from:"Luxio", hp:HP120, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS30
@@ -349,7 +349,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOTHIM_6:
         return evolution (this, from:["Burmy","Burmy Plant Cloak","Burmy Sandy Cloak","Burmy Trash Cloak"], hp:HP090, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
@@ -376,7 +376,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PROBOPASS_7:
         return evolution (this, from:"Nosepass", hp:HP100, type:METAL, retreatCost:3) {
           weakness R, PLUS20
@@ -415,7 +415,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAMENCE_8:
         return evolution (this, from:"Shelgon", hp:HP140, type:COLORLESS, retreatCost:2) {
           weakness C, PLUS30
@@ -453,7 +453,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWALOT_9:
         return evolution (this, from:"Gulpin", hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -479,7 +479,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGROWTH_10:
         return evolution (this, from:"Tangela", hp:HP110, type:GRASS, retreatCost:3) {
           weakness R, PLUS30
@@ -503,7 +503,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_11:
         return evolution (this, from:"Croagunk", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20
@@ -529,7 +529,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZAPDOS_G_12:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness L
@@ -558,7 +558,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AERODACTYL_13:
         return evolution (this, from:"Old Amber", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness L, PLUS20
@@ -585,7 +585,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_14:
         return evolution (this, from:"Bronzor", hp:HP090, type:METAL, retreatCost:3) {
           weakness R, PLUS20
@@ -622,7 +622,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERRIM_15:
         return evolution (this, from:"Cherubi", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -653,7 +653,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_16:
         return evolution (this, from:"Haunter", hp:HP110, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS30
@@ -686,7 +686,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_17:
         return evolution (this, from:"Haunter", hp:HP120, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS30
@@ -707,7 +707,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLALIE_18:
         return evolution (this, from:"Snorunt", hp:HP090, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -738,7 +738,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM_19:
         return evolution (this, from:"Graveler", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness G, PLUS30
@@ -774,7 +774,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HARIYAMA_20:
         return evolution (this, from:"Makuhita", hp:HP110, type:FIGHTING, retreatCost:4) {
           weakness P, PLUS30
@@ -797,7 +797,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOPUNNY_21:
         return evolution (this, from:"Buneary", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -825,7 +825,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_22:
         return evolution (this, from:"Electrike", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -845,7 +845,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMASTAR_23:
         return evolution (this, from:"Omanyte", hp:HP120, type:WATER, retreatCost:1) {
           weakness G, PLUS30
@@ -869,7 +869,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PELIPPER_24:
         return evolution (this, from:"Wingull", hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -893,7 +893,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PICHU_25:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -923,7 +923,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_Z_G_26:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -948,7 +948,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_27:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -974,7 +974,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_28:
         return evolution (this, from:"Ponyta", hp:HP080, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1021,7 +1021,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATICATE_29:
         return evolution (this, from:"Rattata", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness F, PLUS20
@@ -1050,7 +1050,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCEPTILE_30:
         return evolution (this, from:"Grovyle", hp:HP120, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -1084,7 +1084,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCEPTILE_31:
         return evolution (this, from:"Grovyle", hp:HP130, type:GRASS, retreatCost:1) {
           weakness R, PLUS30
@@ -1111,7 +1111,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPIRITOMB_32:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           resistance C, MINUS20
@@ -1146,7 +1146,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_33:
         return evolution (this, from:"Bronzor", hp:HP090, type:METAL, retreatCost:3) {
           weakness R, PLUS20
@@ -1171,7 +1171,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_34:
         return basic (this, hp:HP050, type:METAL, retreatCost:2) {
           weakness R, PLUS10
@@ -1194,7 +1194,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMELEON_35:
         return evolution (this, from:"Charmander", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -1215,7 +1215,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_36:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -1241,7 +1241,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRAVELER_37:
         return evolution (this, from:"Geodude", hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness G, PLUS20
@@ -1262,7 +1262,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROVYLE_38:
         return evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1284,7 +1284,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROVYLE_39:
         return evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1307,7 +1307,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GULPIN_40:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -1339,7 +1339,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_41:
         return evolution (this, from:"Gastly", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1359,7 +1359,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_42:
         return evolution (this, from:"Gastly", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1380,7 +1380,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXIO_43:
         return evolution (this, from:"Shinx", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1408,7 +1408,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_44:
         return evolution (this, from:"Electrike", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1428,7 +1428,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PELIPPER_45:
         return evolution (this, from:"Wingull", hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -1448,7 +1448,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_46:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -1465,7 +1465,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_47:
         return evolution (this, from:"Ponyta", hp:HP090, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1485,7 +1485,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELGON_48:
         return evolution (this, from:"Bagon", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -1509,7 +1509,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WORMADAM_PLANT_CLOAK_49:
         return evolution (this, from:"Burmy Plant Cloak", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1536,7 +1536,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WORMADAM_SANDY_CLOAK_50:
         return evolution (this, from:"Burmy Sandy Cloak", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness R, PLUS20
@@ -1559,7 +1559,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WORMADAM_TRASH_CLOAK_51:
         return evolution (this, from:"Burmy Trash Cloak", hp:HP090, type:METAL, retreatCost:1) {
           weakness R, PLUS20
@@ -1585,7 +1585,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAGON_52:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -1607,7 +1607,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEEDRILL_G_53:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -1631,7 +1631,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_54:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness R, PLUS10
@@ -1654,7 +1654,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNEARY_55:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1669,7 +1669,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BURMY_PLANT_CLOAK_56:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1692,7 +1692,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BURMY_SANDY_CLOAK_57:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1715,7 +1715,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BURMY_TRASH_CLOAK_58:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1738,7 +1738,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER_59:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -1761,7 +1761,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERUBI_60:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1781,7 +1781,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROAGUNK_61:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -1800,7 +1800,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_62:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1823,7 +1823,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_63:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1836,7 +1836,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_64:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -1856,7 +1856,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GEODUDE_65:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS10
@@ -1871,7 +1871,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GULPIN_66:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1893,7 +1893,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTO_67:
         return evolution (this, from:"Dome Fossil", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -1916,7 +1916,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAKUHITA_68:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS10
@@ -1935,7 +1935,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOSEPASS_69:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -1969,7 +1969,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMANYTE_70:
         return evolution (this, from:"Helix Fossil", hp:HP080, type:WATER, retreatCost:1) {
           weakness G, PLUS20
@@ -1994,7 +1994,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_71:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2017,7 +2017,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_72:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2039,7 +2039,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA_73:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:0) {
           weakness F, PLUS10
@@ -2053,7 +2053,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_74:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2076,7 +2076,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORUNT_75:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness M, PLUS10
@@ -2099,7 +2099,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_76:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2121,7 +2121,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_77:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2147,7 +2147,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREECKO_78:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2163,7 +2163,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREECKO_79:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2183,7 +2183,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WINGULL_80:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2204,7 +2204,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WINGULL_81:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2217,7 +2217,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEGINNING_DOOR_82:
         return basicTrainer (this) {
           text "Search your deck for Arceus, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2228,7 +2228,7 @@ public enum Arceus implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is emtpy"
           }
-        };
+        }
       case BENCH_SHIELD_83:
         return pokemonTool (this) {
           text "Attach Bench Shield to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nAs long as the Pokémon this card is attached to is on your Bench, prevent all damage done to that Pokémon by attacks (both yours and your opponent’s)."
@@ -2248,9 +2248,9 @@ public enum Arceus implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case BUFFER_PIECE_84:
-        return copy (DragonFrontiers.BUFFER_PIECE_72, this);
+        return copy (DragonFrontiers.BUFFER_PIECE_72, this)
       case DEPARTMENT_STORE_GIRL_85:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your deck for up to 3 Pokémon Tool cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2261,9 +2261,9 @@ public enum Arceus implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case ENERGY_RESTORE_86:
-        return copy (Expedition.ENERGY_RESTORE_141, this);
+        return copy (Expedition.ENERGY_RESTORE_141, this)
       case EXPERT_BELT_87:
         return pokemonTool (this) {
           text "Attach Expert Belt to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nThe Pokémon this card is attached to gets +20 HP and that Pokémon’s attacks do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance). When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 more Prize card."
@@ -2292,13 +2292,13 @@ public enum Arceus implements LogicCardInfo {
             eff2.unregister()
             effPrize.unregister()
           }
-        };
+        }
       case LUCKY_EGG_88:
-        return copy(SwordShield.LUCKY_EGG_167, this);
+        return copy(SwordShield.LUCKY_EGG_167, this)
       case OLD_AMBER_89:
-        return copy(MajesticDawn.OLD_AMBER_84, this);
+        return copy(MajesticDawn.OLD_AMBER_84, this)
       case PROFESSOR_OAK_S_VISIT_90:
-        return copy(SecretWonders.PROFESSOR_OAK_S_VISIT_122, this);
+        return copy(SecretWonders.PROFESSOR_OAK_S_VISIT_122, this)
       case ULTIMATE_ZONE_91:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nDuring each player’s turn, the player may move an Energy card attached to 1 of his or her Benched Pokémon to his or her Active Arceus as often as he or she likes."
@@ -2317,11 +2317,11 @@ public enum Arceus implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case DOME_FOSSIL_92:
-        return copy(MajesticDawn.DOME_FOSSIL_89, this);
+        return copy(MajesticDawn.DOME_FOSSIL_89, this)
       case HELIX_FOSSIL_93:
-        return copy(MajesticDawn.HELIX_FOSSIL_91, this);
+        return copy(MajesticDawn.HELIX_FOSSIL_91, this)
       case ARCEUS_LV_X_94:
         return levelUp (this, from:"Arceus", hp:HP120, type:COLORLESS, retreatCost:1) {
           pokeBody "Multitype", {
@@ -2336,7 +2336,7 @@ public enum Arceus implements LogicCardInfo {
             metronomeA delegate, { self.owner.pbg.bench.findAll { it.name == "Arceus" } }
           }
           // text "You may have as many of this card in your deck as you like."
-        };
+        }
       case ARCEUS_LV_X_95:
         return levelUp (this, from:"Arceus", hp:HP120, type:COLORLESS, retreatCost:1) {
           pokeBody "Multitype", {
@@ -2357,7 +2357,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
           // text "You may have as many of this card in your deck as you like."
-        };
+        }
       case ARCEUS_LV_X_96:
         return levelUp (this, from:"Arceus", hp:HP120, type:COLORLESS, retreatCost:1) {
           pokeBody "Multitype", {
@@ -2375,7 +2375,7 @@ public enum Arceus implements LogicCardInfo {
               discardSelfEnergyAfterDamage L, P
             }
           }
-        };
+        }
       case GENGAR_LV_X_97:
         return levelUp (this, from:"Gengar", hp:HP140, type:PSYCHIC, retreatCost:0) {
           weakness D
@@ -2409,7 +2409,7 @@ public enum Arceus implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SALAMENCE_LV_X_98:
         return levelUp (this, from:"Salamence", hp:HP160, type:COLORLESS, retreatCost:2) {
           weakness C
@@ -2450,7 +2450,7 @@ public enum Arceus implements LogicCardInfo {
               discardSelfEnergyAfterDamage()
             }
           }
-        };
+        }
       case TANGROWTH_LV_X_99:
         return levelUp (this, from:"Tangrowth", hp:HP130, type:GRASS, retreatCost:3) {
           weakness R
@@ -2481,7 +2481,7 @@ public enum Arceus implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BAGON_SH10:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -2501,7 +2501,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_SH11:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2524,7 +2524,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_SH12:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2548,7 +2548,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR1:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2564,7 +2564,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR2:
         return basic (this, hp:HP090, type:GRASS, retreatCost:2) {
           weakness R
@@ -2582,7 +2582,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR3:
         return basic (this, hp:HP080, type:FIRE, retreatCost:1) {
           weakness W
@@ -2597,7 +2597,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR4:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -2609,7 +2609,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR5:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -2650,7 +2650,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR6:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -2666,7 +2666,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR7:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -2679,7 +2679,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR8:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness W
@@ -2697,7 +2697,7 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_AR9:
         return basic (this, hp:HP090, type:METAL, retreatCost:2) {
           weakness R
@@ -2711,9 +2711,9 @@ public enum Arceus implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
+++ b/src/tcgwars/logic/impl/gen4/CallOfLegends.groovy
@@ -1,23 +1,23 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.impl.gen3.RubySapphire;
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
-import tcgwars.logic.impl.gen3.DeltaSpecies;
+import tcgwars.logic.impl.gen3.RubySapphire
+import tcgwars.logic.impl.gen3.TeamRocketReturns
+import tcgwars.logic.impl.gen3.DeltaSpecies
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
-import static tcgwars.logic.groovy.TcgStatics.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
+import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.card.Resistance.ResistanceType.*;
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
-import static tcgwars.logic.effect.special.SpecialConditionType.*;
+import static tcgwars.logic.card.Resistance.ResistanceType.*
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
+import static tcgwars.logic.effect.special.SpecialConditionType.*
 
-import tcgwars.logic.card.*;
-import tcgwars.logic.util.*;
-import tcgwars.logic.WinCondition;
+import tcgwars.logic.card.*
+import tcgwars.logic.util.*
+import tcgwars.logic.WinCondition
 
 /**
  * @author axpendix@hotmail.com
@@ -132,60 +132,60 @@ public enum CallOfLegends implements LogicCardInfo {
   RAYQUAZA_SL10 ("Rayquaza", "SL10", Rarity.HOLORARE, [BASIC, POKEMON, _COLORLESS_]),
   SUICUNE_SL11 ("Suicune", "SL11", Rarity.HOLORARE, [BASIC, POKEMON, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   CallOfLegends(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CALL_OF_LEGENDS;
+    return tcgwars.logic.card.Collection.CALL_OF_LEGENDS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case CLEFABLE_1:
-        return copy(HeartgoldSoulsilver.CLEFABLE_3, this);
+        return copy(HeartgoldSoulsilver.CLEFABLE_3, this)
       case DEOXYS_2:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -199,7 +199,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIALGA_3:
         return basic (this, hp:HP100, type:METAL, retreatCost:3) {
           weakness R
@@ -215,11 +215,11 @@ public enum CallOfLegends implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ESPEON_4:
-        return copy(Undaunted.ESPEON_2, this);
+        return copy(Undaunted.ESPEON_2, this)
       case FORRETRESS_5:
-        return copy(Undaunted.FORRETRESS_3, this);
+        return copy(Undaunted.FORRETRESS_3, this)
       case GROUDON_6:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:4) {
           weakness G
@@ -238,11 +238,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_7:
-        return copy(HeartgoldSoulsilver.GYARADOS_4, this);
+        return copy(HeartgoldSoulsilver.GYARADOS_4, this)
       case HITMONTOP_8:
-        return copy(HeartgoldSoulsilver.HITMONTOP_5, this);
+        return copy(HeartgoldSoulsilver.HITMONTOP_5, this)
       case HO_OH_9:
         return basic (this, hp:HP100, type:FIRE, retreatCost:3) {
           weakness W
@@ -267,11 +267,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOOM_10:
-        return copy(Undaunted.HOUNDOOM_5, this);
+        return copy(Undaunted.HOUNDOOM_5, this)
       case JIRACHI_11:
-        return copy(Unleashed.JIRACHI_1, this);
+        return copy(Unleashed.JIRACHI_1, this)
       case KYOGRE_12:
         return basic (this, hp:HP100, type:WATER, retreatCost:4) {
           weakness L
@@ -291,9 +291,9 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_13:
-        return copy(Undaunted.LEAFEON_17, this);
+        return copy(Undaunted.LEAFEON_17, this)
       case LUCARIO_14:
         return evolution (this, from:"Riolu", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -313,7 +313,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUGIA_15:
         return basic (this, hp:HP100, type:WATER, retreatCost:3) {
           weakness L
@@ -333,11 +333,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_16:
-        return copy(Unleashed.MAGMORTAR_2, this);
+        return copy(Unleashed.MAGMORTAR_2, this)
       case NINETALES_17:
-        return copy(HeartgoldSoulsilver.NINETALES_7, this);
+        return copy(HeartgoldSoulsilver.NINETALES_7, this)
       case PACHIRISU_18:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -362,7 +362,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_19:
         return basic (this, hp:HP100, type:WATER, retreatCost:3) {
           weakness L
@@ -378,7 +378,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_20:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness C
@@ -392,23 +392,23 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SMEARGLE_21:
-        return copy(Undaunted.SMEARGLE_8, this);
+        return copy(Undaunted.SMEARGLE_8, this)
       case UMBREON_22:
-        return copy(Undaunted.UMBREON_10, this);
+        return copy(Undaunted.UMBREON_10, this)
       case AMPHAROS_23:
-        return copy(HeartgoldSoulsilver.AMPHAROS_14, this);
+        return copy(HeartgoldSoulsilver.AMPHAROS_14, this)
       case CLEFFA_24:
-        return copy(HeartgoldSoulsilver.CLEFFA_17, this);
+        return copy(HeartgoldSoulsilver.CLEFFA_17, this)
       case FERALIGATR_25:
-        return copy(HeartgoldSoulsilver.FERALIGATR_20, this);
+        return copy(HeartgoldSoulsilver.FERALIGATR_20, this)
       case GRANBULL_26:
-        return copy(HeartgoldSoulsilver.GRANBULL_22, this);
+        return copy(HeartgoldSoulsilver.GRANBULL_22, this)
       case MEGANIUM_27:
-        return copy(HeartgoldSoulsilver.MEGANIUM_26, this);
+        return copy(HeartgoldSoulsilver.MEGANIUM_26, this)
       case MISMAGIUS_28:
-        return copy(Undaunted.MISMAGIUS_19, this);
+        return copy(Undaunted.MISMAGIUS_19, this)
       case MR__MIME_29:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -432,13 +432,13 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOT_30:
-        return copy(Triumphant.PIDGEOT_29, this);
+        return copy(Triumphant.PIDGEOT_29, this)
       case SKARMORY_31:
-        return copy(Undaunted.SKARMORY_21, this);
+        return copy(Undaunted.SKARMORY_21, this)
       case SLOWKING_32:
-        return copy(HeartgoldSoulsilver.SLOWKING_12, this);
+        return copy(HeartgoldSoulsilver.SLOWKING_12, this)
       case SNORLAX_33:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -461,7 +461,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGROWTH_34:
         return evolution (this, from:"Tangela", hp:HP110, type:GRASS, retreatCost:4) {
           weakness R
@@ -493,15 +493,15 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPHLOSION_35:
-        return copy(HeartgoldSoulsilver.TYPHLOSION_32, this);
+        return copy(HeartgoldSoulsilver.TYPHLOSION_32, this)
       case TYROGUE_36:
-        return copy(HeartgoldSoulsilver.TYROGUE_33, this);
+        return copy(HeartgoldSoulsilver.TYROGUE_33, this)
       case URSARING_37:
-        return copy(Unleashed.URSARING_27, this);
+        return copy(Unleashed.URSARING_27, this)
       case WEEZING_38:
-        return copy(HeartgoldSoulsilver.WEEZING_34, this);
+        return copy(HeartgoldSoulsilver.WEEZING_34, this)
       case ZANGOOSE_39:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -523,21 +523,21 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAYLEEF_40:
-        return copy(HeartgoldSoulsilver.BAYLEEF_35, this);
+        return copy(HeartgoldSoulsilver.BAYLEEF_35, this)
       case CROCONAW_41:
-        return copy(HeartgoldSoulsilver.CROCONAW_38, this);
+        return copy(HeartgoldSoulsilver.CROCONAW_38, this)
       case DONPHAN_42:
-        return copy(HeartgoldSoulsilver.DONPHAN_40, this);
+        return copy(HeartgoldSoulsilver.DONPHAN_40, this)
       case FLAAFFY_43:
-        return copy(HeartgoldSoulsilver.FLAAFFY_42, this);
+        return copy(HeartgoldSoulsilver.FLAAFFY_42, this)
       case FLAREON_44:
-        return copy(Undaunted.FLAREON_26, this);
+        return copy(Undaunted.FLAREON_26, this)
       case JOLTEON_45:
-        return copy(Undaunted.JOLTEON_28, this);
+        return copy(Undaunted.JOLTEON_28, this)
       case MAGBY_46:
-        return copy(Triumphant.MAGBY_41, this);
+        return copy(Triumphant.MAGBY_41, this)
       case MIME_JR__47:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -564,11 +564,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOTTO_48:
-        return copy(Triumphant.PIDGEOTTO_47, this);
+        return copy(Triumphant.PIDGEOTTO_47, this)
       case QUILAVA_49:
-        return copy(HeartgoldSoulsilver.QUILAVA_49, this);
+        return copy(HeartgoldSoulsilver.QUILAVA_49, this)
       case RIOLU_50:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -581,7 +581,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEVIPER_51:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -606,9 +606,9 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_52:
-        return copy(Undaunted.VAPOREON_41, this);
+        return copy(Undaunted.VAPOREON_41, this)
       case CHIKORITA_53:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -632,9 +632,9 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_54:
-        return copy(HeartgoldSoulsilver.CLEFAIRY_60, this);
+        return copy(HeartgoldSoulsilver.CLEFAIRY_60, this)
       case CYNDAQUIL_55:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness W
@@ -647,21 +647,21 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_56:
-        return copy(Undaunted.EEVEE_47, this);
+        return copy(Undaunted.EEVEE_47, this)
       case HITMONCHAN_57:
-        return copy(Undaunted.HITMONCHAN_51, this);
+        return copy(Undaunted.HITMONCHAN_51, this)
       case HITMONLEE_58:
-        return copy(Undaunted.HITMONLEE_52, this);
+        return copy(Undaunted.HITMONLEE_52, this)
       case HOUNDOUR_59:
-        return copy(Undaunted.HOUNDOUR_54, this);
+        return copy(Undaunted.HOUNDOUR_54, this)
       case KOFFING_60:
-        return copy(HeartgoldSoulsilver.KOFFING_70, this);
+        return copy(HeartgoldSoulsilver.KOFFING_70, this)
       case MAGIKARP_61:
-        return copy(HeartgoldSoulsilver.MAGIKARP_72, this);
+        return copy(HeartgoldSoulsilver.MAGIKARP_72, this)
       case MAGMAR_62:
-        return copy(Unleashed.MAGMAR_52, this);
+        return copy(Unleashed.MAGMAR_52, this)
       case MAREEP_63:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -674,11 +674,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAWILE_64:
-        return copy(Undaunted.MAWILE_56, this);
+        return copy(Undaunted.MAWILE_56, this)
       case MISDREAVUS_65:
-        return copy(Undaunted.MISDREAVUS_57, this);
+        return copy(Undaunted.MISDREAVUS_57, this)
       case PHANPY_66:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness W
@@ -705,11 +705,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEY_67:
-        return copy(Triumphant.PIDGEY_71, this);
+        return copy(Triumphant.PIDGEY_71, this)
       case PINECO_68:
-        return copy(Undaunted.PINECO_63, this);
+        return copy(Undaunted.PINECO_63, this)
       case RELICANTH_69:
         return basic (this, hp:HP080, type:WATER, retreatCost:2) {
           weakness G
@@ -735,11 +735,11 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_70:
-        return copy(HeartgoldSoulsilver.SLOWPOKE_81, this);
+        return copy(HeartgoldSoulsilver.SLOWPOKE_81, this)
       case SNUBBULL_71:
-        return copy(HeartgoldSoulsilver.SNUBBULL_82, this);
+        return copy(HeartgoldSoulsilver.SNUBBULL_82, this)
       case TANGELA_72:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness R
@@ -764,7 +764,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TEDDIURSA_73:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -787,7 +787,7 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOTODILE_74:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L
@@ -802,15 +802,15 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VULPIX_75:
-        return copy(HeartgoldSoulsilver.VULPIX_87, this);
+        return copy(HeartgoldSoulsilver.VULPIX_87, this)
       case CHEERLEADER_S_CHEER_76:
-      return copy(Unleashed.CHEERLEADER_S_CHEER_71, this);
+      return copy(Unleashed.CHEERLEADER_S_CHEER_71, this)
       case COPYCAT_77:
-        return copy(TeamRocketReturns.COPYCAT_83, this);
+        return copy(TeamRocketReturns.COPYCAT_83, this)
       case DUAL_BALL_78:
-        return copy(DeltaSpecies.DUAL_BALL_89, this);
+        return copy(DeltaSpecies.DUAL_BALL_89, this)
       case INTERVIEWER_S_QUESTIONS_79:
         return copy(Unleashed.INTERVIEWER_S_QUESTIONS_77, this)
       case LOST_REMOVER_80:
@@ -823,7 +823,7 @@ public enum CallOfLegends implements LogicCardInfo {
           playRequirement{
             assert opp.all.find{it.cards.filterByType(SPECIAL_ENERGY)} : "Your opponent's Pokemon have no special energy attached"
           }
-        };
+        }
       case LOST_WORLD_81:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nOnce during each player’s turn, if this player’s opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game."
@@ -835,17 +835,17 @@ public enum CallOfLegends implements LogicCardInfo {
               assert opp.lostZone.filterByType(POKEMON).size() >= 6 : "Your opponent has fewer than 6 Pokémon in the Lost Zone"
               bc "Used Lost World."
               lastTurn = bg().turnCount
-              bg.getGameManager().endGame(bg.currentTurn, WinCondition.OTHER);
+              bg.getGameManager().endGame(bg.currentTurn, WinCondition.OTHER)
             }
           }
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case PROFESSOR_ELM_S_TRAINING_METHOD_82:
-        return copy(HeartgoldSoulsilver.PROFESSOR_ELM_S_TRAINING_METHOD_100, this);
+        return copy(HeartgoldSoulsilver.PROFESSOR_ELM_S_TRAINING_METHOD_100, this)
       case PROFESSOR_OAK_S_NEW_THEORY_83:
-        return copy(HeartgoldSoulsilver.PROFESSOR_OAK_S_NEW_THEORY_101, this);
+        return copy(HeartgoldSoulsilver.PROFESSOR_OAK_S_NEW_THEORY_101, this)
       case RESEARCH_RECORD_84:
         return basicTrainer (this) {
           text "Look at the top 4 cards of your deck and put as many of them as you like back on top of your deck in any order. Then, put the remaining cards on the bottom of your deck in any order."
@@ -865,33 +865,33 @@ public enum CallOfLegends implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case SAGE_S_TRAINING_85:
-        return copy(Undaunted.SAGE_S_TRAINING_77, this);
+        return copy(Undaunted.SAGE_S_TRAINING_77, this)
       case DARKNESS_ENERGY_86:
-        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this)
       case METAL_ENERGY_87:
-        return copy (RubySapphire.METAL_ENERGY_94, this);
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case GRASS_ENERGY_88:
-        return basicEnergy (this, GRASS);
+        return basicEnergy (this, GRASS)
       case FIRE_ENERGY_89:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case WATER_ENERGY_90:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       case LIGHTNING_ENERGY_91:
-        return basicEnergy (this, LIGHTNING);
+        return basicEnergy (this, LIGHTNING)
       case PSYCHIC_ENERGY_92:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case FIGHTING_ENERGY_93:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       case DARKNESS_ENERGY_94:
-        return basicEnergy (this, DARKNESS);
+        return basicEnergy (this, DARKNESS)
       case METAL_ENERGY_95:
-        return basicEnergy (this, METAL);
+        return basicEnergy (this, METAL)
       case DEOXYS_SL1:
-        return copy (DEOXYS_2, this);
+        return copy (DEOXYS_2, this)
       case DIALGA_SL2:
-        return copy (DIALGA_3, this);
+        return copy (DIALGA_3, this)
       case ENTEI_SL3:
         return basic (this, hp:HP090, type:FIRE, retreatCost:2) {
           weakness W
@@ -914,17 +914,17 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROUDON_SL4:
-        return copy (GROUDON_6, this);
+        return copy (GROUDON_6, this)
       case HO_OH_SL5:
-        return copy (HO_OH_9, this);
+        return copy (HO_OH_9, this)
       case KYOGRE_SL6:
-        return copy (KYOGRE_12, this);
+        return copy (KYOGRE_12, this)
       case LUGIA_SL7:
-        return copy (LUGIA_15, this);
+        return copy (LUGIA_15, this)
       case PALKIA_SL8:
-        return copy (PALKIA_19, this);
+        return copy (PALKIA_19, this)
       case RAIKOU_SL9:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness F
@@ -946,9 +946,9 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_SL10:
-        return copy (RAYQUAZA_20, this);
+        return copy (RAYQUAZA_20, this)
       case SUICUNE_SL11:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -970,9 +970,9 @@ public enum CallOfLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1,41 +1,41 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.impl.gen1.BaseSet;
-import tcgwars.logic.impl.gen2.Expedition;
-import tcgwars.logic.impl.gen3.Sandstorm;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen5.PlasmaStorm;
-import tcgwars.logic.impl.gen5.BlackWhite;
+import tcgwars.logic.impl.gen1.BaseSet
+import tcgwars.logic.impl.gen2.Expedition
+import tcgwars.logic.impl.gen3.Sandstorm
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen5.PlasmaStorm
+import tcgwars.logic.impl.gen5.BlackWhite
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix
@@ -176,53 +176,53 @@ public enum DiamondPearl implements LogicCardInfo {
   DARKNESS_ENERGY_129 ("Darkness Energy", "129", Rarity.COMMON, [BASIC_ENERGY, ENERGY]),
   METAL_ENERGY_130 ("Metal Energy", "130", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DiamondPearl(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DIAMOND_PEARL;
+    return tcgwars.logic.card.Collection.DIAMOND_PEARL
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -257,7 +257,7 @@ public enum DiamondPearl implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUSKNOIR_2:
         return evolution (this, from:"Dusclops", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness D, PLUS30
@@ -287,7 +287,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTIVIRE_3:
         return evolution (this, from:"Electabuzz", hp:HP100, type:LIGHTNING, retreatCost:3) {
           weakness F, PLUS20
@@ -319,7 +319,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMPOLEON_4:
         return evolution (this, from:"Prinplup", hp:HP130, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -341,7 +341,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_5:
         return evolution (this, from:"Monferno", hp:HP100, type:FIRE, retreatCost:0) {
           weakness W, PLUS30
@@ -365,7 +365,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_6:
         return evolution (this, from:"Riolu", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20
@@ -389,7 +389,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXRAY_7:
         return evolution (this, from:"Luxio", hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS30
@@ -426,7 +426,7 @@ public enum DiamondPearl implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGNEZONE_8:
         return evolution (this, from:"Magneton", hp:HP120, type:METAL, retreatCost:4) {
           weakness R, PLUS30
@@ -449,7 +449,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANAPHY_9:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -472,7 +472,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_10:
         return evolution (this, from:"Misdreavus", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -494,7 +494,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_11:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -534,7 +534,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYPERIOR_12:
         return evolution (this, from:"Rhydon", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness W, PLUS30
@@ -558,7 +558,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_13:
         return evolution (this, from:"Roselia", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -583,7 +583,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIFTRY_14:
         return evolution (this, from:"Nuzleaf", hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness F, PLUS30
@@ -613,7 +613,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKUNTANK_15:
         return evolution (this, from:"Stunky", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -641,7 +641,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAPTOR_16:
         return evolution (this, from:"Staravia", hp:HP100, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS30
@@ -677,7 +677,7 @@ public enum DiamondPearl implements LogicCardInfo {
               flip 1, {}, { damage 100, self }
             }
           }
-        };
+        }
       case TORTERRA_17:
         return evolution (this, from:"Grotle", hp:HP140, type:GRASS, retreatCost:4) {
           weakness R, PLUS30
@@ -700,7 +700,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZUMARILL_18:
         return evolution (this, from:"Marill", hp:HP080, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -725,7 +725,7 @@ public enum DiamondPearl implements LogicCardInfo {
                 flip { apply PARALYZED }
             }
           }
-        };
+        }
       case BEAUTIFLY_19:
         return evolution (this, from:"Silcoon", hp:HP100, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -749,7 +749,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BIBAREL_20:
         return evolution (this, from:"Bidoof", hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -773,7 +773,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARNIVINE_21:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -801,7 +801,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE_22:
         return evolution (this, from:"Clefairy", hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -822,7 +822,7 @@ public enum DiamondPearl implements LogicCardInfo {
               def moveList = []
               def labelList = []
 
-              moveList.addAll(defending.topPokemonCard.moves);
+              moveList.addAll(defending.topPokemonCard.moves)
               labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
               def move=choose(moveList, labelList)
@@ -832,7 +832,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAPION_23:
         return evolution (this, from:"Skorupi", hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -855,7 +855,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFBLIM_24:
         return evolution (this, from:"Drifloon", hp:HP080, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS20
@@ -886,7 +886,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSTOX_25:
         return evolution (this, from:"Cascoon", hp:HP120, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -910,7 +910,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOATZEL_26:
         return evolution (this, from:"Buizel", hp:HP090, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -933,7 +933,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_27:
         return evolution (this, from:"Haunter", hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS30
@@ -970,7 +970,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_28:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -993,7 +993,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOWDON_29:
         return evolution (this, from:"Hippopotas", hp:HP110, type:FIGHTING, retreatCost:3) {
           weakness W, PLUS20
@@ -1036,7 +1036,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOPUNNY_30:
         return evolution (this, from:"Buneary", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1069,7 +1069,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_31:
         return evolution (this, from:"Machoke", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness P, PLUS30
@@ -1094,7 +1094,7 @@ public enum DiamondPearl implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEDICHAM_32:
         return evolution (this, from:"Meditite", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS20
@@ -1116,7 +1116,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUNCHLAX_33:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS10
@@ -1141,7 +1141,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOCTOWL_34:
         return evolution (this, from:"Hoothoot", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -1174,7 +1174,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PACHIRISU_35:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1201,7 +1201,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PURUGLY_36:
         return evolution (this, from:"Glameow", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1223,7 +1223,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_37:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS20
@@ -1246,7 +1246,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STEELIX_38:
         return evolution (this, from:"Onix", hp:HP110, type:METAL, retreatCost:4) {
           weakness R, PLUS20
@@ -1269,7 +1269,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VESPIQUEN_39:
         return evolution (this, from:"Combee", hp:HP100, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1297,7 +1297,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEAVILE_40:
         return evolution (this, from:"Sneasel", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1322,7 +1322,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOBBUFFET_41:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -1342,7 +1342,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WYNAUT_42:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1364,7 +1364,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUDEW_43:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1389,7 +1389,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CASCOON_44:
         return evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1424,7 +1424,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERRIM_45:
         return evolution (this, from:"Cherubi", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1451,7 +1451,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_46:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -1484,7 +1484,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_47:
         return evolution (this, from:"Duskull", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness D, PLUS20
@@ -1511,7 +1511,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELEKID_48:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1537,7 +1537,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROTLE_49:
         return evolution (this, from:"Turtwig", hp:HP090, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1562,7 +1562,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_50:
         return evolution (this, from:"Gastly", hp:HP070, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS20
@@ -1584,7 +1584,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOPOTAS_51:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS10
@@ -1607,7 +1607,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXIO_52:
         return evolution (this, from:"Shinx", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1631,7 +1631,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOKE_53:
         return evolution (this, from:"Machop", hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS20
@@ -1652,7 +1652,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_54:
         return evolution (this, from:"Magnemite", hp:HP070, type:METAL, retreatCost:2) {
           weakness R, PLUS20
@@ -1681,7 +1681,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANTYKE_55:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1705,7 +1705,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MONFERNO_56:
         return evolution (this, from:"Chimchar", hp:HP070, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1729,7 +1729,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUZLEAF_57:
         return evolution (this, from:"Seedot", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1760,7 +1760,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRINPLUP_58:
         return evolution (this, from:"Piplup", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1785,7 +1785,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_59:
         return evolution (this, from:"Ponyta", hp:HP080, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1812,7 +1812,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON_60:
         return evolution (this, from:"Rhyhorn", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS20
@@ -1848,7 +1848,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIOLU_61:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -1861,7 +1861,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEAKING_62:
         return evolution (this, from:"Goldeen", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1882,7 +1882,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SILCOON_63:
         return evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1917,7 +1917,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAVIA_64:
         return evolution (this, from:"Starly", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1941,7 +1941,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_A_65:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1965,7 +1965,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_B_66:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1993,7 +1993,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_C_67:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2021,7 +2021,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_D_68:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2048,7 +2048,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZURILL_69:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2070,7 +2070,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BIDOOF_70:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2093,7 +2093,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BONSLY_71:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS10
@@ -2127,7 +2127,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUIZEL_72:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2143,7 +2143,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNEARY_73:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2166,7 +2166,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHATOT_74:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2189,7 +2189,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERUBI_75:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2219,7 +2219,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMCHAR_76:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2243,7 +2243,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_77:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2267,7 +2267,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFFA_78:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2289,7 +2289,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMBEE_79:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2314,7 +2314,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_80:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2338,7 +2338,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTABUZZ_81:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness F, PLUS10
@@ -2365,7 +2365,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_82:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2383,7 +2383,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLAMEOW_83:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2404,7 +2404,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDEEN_84:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2426,7 +2426,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOOTHOOT_85:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2448,7 +2448,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP_86:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS10
@@ -2461,7 +2461,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_87:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R, PLUS10
@@ -2484,7 +2484,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARILL_88:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2508,7 +2508,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEDITITE_89:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -2529,7 +2529,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MIME_JR__90:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2553,7 +2553,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_91:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2576,7 +2576,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_92:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness G, PLUS20
@@ -2604,7 +2604,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIPLUP_93:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2626,7 +2626,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_94:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2647,7 +2647,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_95:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS10
@@ -2670,7 +2670,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSELIA_96:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2695,7 +2695,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEDOT_97:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2731,7 +2731,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_98:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2747,7 +2747,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKORUPI_99:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2768,7 +2768,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNEASEL_100:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2790,7 +2790,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARLY_101:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2813,7 +2813,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNKY_102:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2836,7 +2836,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_103:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2858,7 +2858,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WURMPLE_104:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2881,11 +2881,11 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DOUBLE_FULL_HEAL_105:
-        return copy (Sandstorm.DOUBLE_FULL_HEAL_86, this);
+        return copy (Sandstorm.DOUBLE_FULL_HEAL_86, this)
       case ENERGY_RESTORE_106:
-        return copy (Expedition.ENERGY_RESTORE_141, this);
+        return copy (Expedition.ENERGY_RESTORE_141, this)
       case ENERGY_SWITCH_107:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case NIGHT_POKEMON_CENTER_108:
@@ -2898,18 +2898,18 @@ public enum DiamondPearl implements LogicCardInfo {
             switch (headCount) {
               case 0:
                 pcs.cards.filterByType(ENERGY).discard()
-                break;
+                break
               case 2:
                 if (pcs.numberOfDamageCounters) healAll pcs
-                break;
+                break
               default:
-                break;
+                break
             }
           }
           playRequirement {
             assert my.all.findAll{it.numberOfDamageCounters || it.cards.energyCount()} : "You have no Pokémon with either damage counters, energy attached, or both."
           }
-        };
+        }
       case PLUSPOWER_109:
       // This print increases before W/R, do not use it as copy for older prints that do it after W/R. Another diference is it affecting damage to any active, not just the defending like old prints.
       return itemCard (this) {
@@ -2944,7 +2944,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case POKE_BALL_110:
       return itemCard (this) {
           text "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2957,7 +2957,7 @@ public enum DiamondPearl implements LogicCardInfo {
           playRequirement{
             assert my.deck: "There are no more cards in your deck."
           }
-        };
+        }
       case POKEDEX_HANDY910IS_111:
         return basicTrainer (this) {
           text "Look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck."
@@ -2969,7 +2969,7 @@ public enum DiamondPearl implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case PROFESSOR_ROWAN_112:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nChoose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can’t play this card.)"
@@ -2983,7 +2983,7 @@ public enum DiamondPearl implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard) : "This is the only card in your hand."
           }
-        };
+        }
       case RIVAL_113:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nReveal the top 5 cards of your deck. Your opponent choose 3 of those cards. Put those cards into your hand and put other 2 cards on top of your deck. Shuffle your deck afterward."
@@ -2996,7 +2996,7 @@ public enum DiamondPearl implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case SPEED_STADIUM_114:
         return stadium(this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nOnce during each player's turn, the player may flip a coin until he or she gets tails. For each heads, that player draws a card."
@@ -3015,17 +3015,17 @@ public enum DiamondPearl implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg.gm().unregisterAction(it) }
           }
-        };
+        }
       case SUPER_SCOOP_UP_115:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case WARP_POINT_116:
-        return copy(PlasmaStorm.ESCAPE_ROPE_120, this);
+        return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case ENERGY_SEARCH_117:
-        return copy(BlackWhite.ENERGY_SEARCH_93, this);
+        return copy(BlackWhite.ENERGY_SEARCH_93, this)
       case POTION_118:
-        return copy(FireRedLeafGreen.POTION_101, this);
+        return copy(FireRedLeafGreen.POTION_101, this)
       case SWITCH_119:
-        return copy(FireRedLeafGreen.SWITCH_102, this);
+        return copy(FireRedLeafGreen.SWITCH_102, this)
       case EMPOLEON_LV_X_120:
         return levelUp (this, from:"Empoleon", hp:HP140, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -3069,7 +3069,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_LV_X_121:
         return levelUp (this, from:"Infernape", hp:HP120, type:FIRE, retreatCost:0) {
           weakness W, PLUS30
@@ -3101,7 +3101,7 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_LV_X_122:
         return levelUp (this, from:"Torterra", hp:HP160, type:GRASS, retreatCost:4) {
           weakness R, PLUS30
@@ -3128,25 +3128,25 @@ public enum DiamondPearl implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRASS_ENERGY_123:
-        return basicEnergy (this, GRASS);
+        return basicEnergy (this, GRASS)
       case FIRE_ENERGY_124:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case WATER_ENERGY_125:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       case LIGHTNING_ENERGY_126:
-        return basicEnergy (this, LIGHTNING);
+        return basicEnergy (this, LIGHTNING)
       case PSYCHIC_ENERGY_127:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case FIGHTING_ENERGY_128:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       case DARKNESS_ENERGY_129:
-        return basicEnergy (this, DARKNESS);
+        return basicEnergy (this, DARKNESS)
       case METAL_ENERGY_130:
-        return basicEnergy (this, METAL);
+        return basicEnergy (this, METAL)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -9,23 +9,23 @@ import tcgwars.logic.effect.ability.PokeBody
 import tcgwars.logic.effect.basic.LevelUp
 import tcgwars.logic.impl.gen3.NintendoBlackStarPromos
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
 import static tcgwars.logic.effect.EffectPriority.BEFORE_LAST
 import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.POKEBODY
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.OTHER
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -89,104 +89,104 @@ public enum DiamondPearlPromos implements LogicCardInfo {
   ULTIMATE_ZONE_DP55 ("Ultimate Zone", "DP55", Rarity.PROMO, [TRAINER, STADIUM]),
   ARCEUS_LV_X_DP56 ("Arceus Lv.X", "DP56", Rarity.PROMO, [LVL_X, POKEMON, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DiamondPearlPromos(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DIAMOND_PEARL_PROMOS;
+    return tcgwars.logic.card.Collection.DIAMOND_PEARL_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case TURTWIG_DP01:
-        return copy(DiamondPearl.TURTWIG_103, this);
+        return copy(DiamondPearl.TURTWIG_103, this)
       case CHIMCHAR_DP02:
-        return copy(DiamondPearl.CHIMCHAR_76, this);
+        return copy(DiamondPearl.CHIMCHAR_76, this)
       case PIPLUP_DP03:
-        return copy(DiamondPearl.PIPLUP_93, this);
+        return copy(DiamondPearl.PIPLUP_93, this)
       case PACHIRISU_DP04:
-        return copy(DiamondPearl.PACHIRISU_35, this);
+        return copy(DiamondPearl.PACHIRISU_35, this)
       case TROPICAL_WIND_DP05:
-        return copy(NintendoBlackStarPromos.TROPICAL_WIND_26, this);
+        return copy(NintendoBlackStarPromos.TROPICAL_WIND_26, this)
       case BUNEARY_DP06:
-        return copy(DiamondPearl.BUNEARY_73, this);
+        return copy(DiamondPearl.BUNEARY_73, this)
       case CRANIDOS_DP07:
-        return copy(MysteriousTreasures.CRANIDOS_43, this);
+        return copy(MysteriousTreasures.CRANIDOS_43, this)
       case SHIELDON_DP08:
-        return copy(MysteriousTreasures.SHIELDON_63, this);
+        return copy(MysteriousTreasures.SHIELDON_63, this)
       case TORTERRA_LV_X_DP09:
-        return copy(DiamondPearl.TORTERRA_LV_X_122, this);
+        return copy(DiamondPearl.TORTERRA_LV_X_122, this)
       case INFERNAPE_LV_X_DP10:
-        return copy(DiamondPearl.INFERNAPE_LV_X_121, this);
+        return copy(DiamondPearl.INFERNAPE_LV_X_121, this)
       case EMPOLEON_LV_X_DP11:
-        return copy(DiamondPearl.EMPOLEON_LV_X_120, this);
+        return copy(DiamondPearl.EMPOLEON_LV_X_120, this)
       case LUCARIO_LV_X_DP12:
-        return copy(MysteriousTreasures.LUCARIO_LV_X_122, this);
+        return copy(MysteriousTreasures.LUCARIO_LV_X_122, this)
       case BUIZEL_DP13:
-        return copy(DiamondPearl.BUIZEL_72, this);
+        return copy(DiamondPearl.BUIZEL_72, this)
       case CHATOT_DP14:
-        return copy(DiamondPearl.CHATOT_74, this);
+        return copy(DiamondPearl.CHATOT_74, this)
       case SHINX_DP15:
-        return copy(DiamondPearl.SHINX_98, this);
+        return copy(DiamondPearl.SHINX_98, this)
       case PIKACHU_DP16:
-        return copy(MysteriousTreasures.PIKACHU_94, this);
+        return copy(MysteriousTreasures.PIKACHU_94, this)
       case DIALGA_LV_X_DP17:
-        return copy(GreatEncounters.DIALGA_LV_X_105, this);
+        return copy(GreatEncounters.DIALGA_LV_X_105, this)
       case PALKIA_LV_X_DP18:
-        return copy(GreatEncounters.PALKIA_LV_X_106, this);
+        return copy(GreatEncounters.PALKIA_LV_X_106, this)
       case DARKRAI_LV_X_DP19:
-        return copy(GreatEncounters.DARKRAI_LV_X_104, this);
+        return copy(GreatEncounters.DARKRAI_LV_X_104, this)
       case MAGMORTAR_DP20:
-        return copy(MysteriousTreasures.MAGMORTAR_12, this);
+        return copy(MysteriousTreasures.MAGMORTAR_12, this)
       case RAICHU_DP21:
-        return copy(MysteriousTreasures.RAICHU_15, this);
+        return copy(MysteriousTreasures.RAICHU_15, this)
       case MIME_JR__DP22:
-        return copy(DiamondPearl.MIME_JR__90, this);
+        return copy(DiamondPearl.MIME_JR__90, this)
       case GLAMEOW_DP23:
-        return copy(DiamondPearl.GLAMEOW_83, this);
+        return copy(DiamondPearl.GLAMEOW_83, this)
       case DARKRAI_DP24:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -239,21 +239,21 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TROPICAL_WIND_DP25:
         return copy (TROPICAL_WIND_DP05, this)
       case DIALGA_DP26:
-        return copy(DiamondPearl.DIALGA_1, this);
+        return copy(DiamondPearl.DIALGA_1, this)
       case PALKIA_DP27:
-        return copy(DiamondPearl.PALKIA_11, this);
+        return copy(DiamondPearl.PALKIA_11, this)
       case MEWTWO_LV_X_DP28:
-        return copy(LegendsAwakened.MEWTWO_LV_X_144, this);
+        return copy(LegendsAwakened.MEWTWO_LV_X_144, this)
       case RHYPERIOR_LV_X_DP29:
-        return copy(LegendsAwakened.RHYPERIOR_LV_X_145, this);
+        return copy(LegendsAwakened.RHYPERIOR_LV_X_145, this)
       case REGIGIGAS_LV_X_DP30:
-        return copy(Stormfront.REGIGIGAS_LV_X_100, this);
+        return copy(Stormfront.REGIGIGAS_LV_X_100, this)
       case HEATRAN_LV_X_DP31:
-        return copy(Stormfront.HEATRAN_LV_X_97, this);
+        return copy(Stormfront.HEATRAN_LV_X_97, this)
       case MAGNEZONE_DP32:
         return evolution (this, from:"Magneton", hp:HP130, type:METAL, retreatCost:2) {
           weakness R, PLUS30
@@ -278,7 +278,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUSKNOIR_DP33:
         return evolution (this, from:"Dusclops", hp:HP130, type:PSYCHIC, retreatCost:2) {
           weakness D, PLUS30
@@ -320,9 +320,9 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRIFBLIM_DP34:
-        return copy(DiamondPearl.DRIFBLIM_24, this);
+        return copy(DiamondPearl.DRIFBLIM_24, this)
       case PORYGON_Z_DP35:
         return evolution (this, from:"Porygon2", hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS30
@@ -379,7 +379,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               damage 40 + (20 * self.cards.filterByType(TECHNICAL_MACHINE).size())
             }
           }
-        };
+        }
       case GLISCOR_DP36:
         return evolution (this, from:"Gligar", hp:HP090, type:FIGHTING, retreatCost:0) {
           weakness W, PLUS20
@@ -416,13 +416,13 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIALGA_LV_X_DP37:
-        return copy(GreatEncounters.DIALGA_LV_X_105, this);
+        return copy(GreatEncounters.DIALGA_LV_X_105, this)
       case GIRATINA_LV_X_DP38:
-        return copy(Platinum.GIRATINA_LV_X_124, this);
+        return copy(Platinum.GIRATINA_LV_X_124, this)
       case SHAYMIN_LV_X_DP39:
-        return copy(Platinum.SHAYMIN_LV_X_127, this);
+        return copy(Platinum.SHAYMIN_LV_X_127, this)
       case REGIGIGAS_DP40:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -451,7 +451,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case TOXICROAK_G_DP41:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -479,7 +479,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CARNIVINE_G_DP42:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -503,7 +503,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PROBOPASS_G_DP43:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness W
@@ -547,7 +547,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_DP44:
         return evolution (this, from:"Magneton", hp:HP130, type:LIGHTNING, retreatCost:2) {
           weakness F, PLUS30
@@ -575,13 +575,13 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_G_LV_X_DP45:
-        return copy(SupremeVictors.CHARIZARD_G_LV_X_143, this);
+        return copy(SupremeVictors.CHARIZARD_G_LV_X_143, this)
       case GARCHOMP_C_LV_X_DP46:
-        return copy(SupremeVictors.GARCHOMP_C_LV_X_145, this);
+        return copy(SupremeVictors.GARCHOMP_C_LV_X_145, this)
       case RAYQUAZA_C_LV_X_DP47:
-        return copy(SupremeVictors.RAYQUAZA_C_LV_X_146, this);
+        return copy(SupremeVictors.RAYQUAZA_C_LV_X_146, this)
       case TROPICAL_WIND_DP48:
         return copy (TROPICAL_WIND_DP05, this)
       case DIALGA_DP49:
@@ -609,7 +609,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_DP50:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -625,7 +625,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CRESSELIA_DP51:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -647,7 +647,7 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               damage 80 - (10 * self.numberOfDamageCounters)
             }
           }
-        };
+        }
       case DARKRAI_DP52:
         return basic (this, hp:HP090, type:DARKNESS, retreatCost:2) {
           weakness F
@@ -676,17 +676,17 @@ public enum DiamondPearlPromos implements LogicCardInfo {
               flipThenApplySC(ASLEEP)
             }
           }
-        };
+        }
       case ARCEUS_LV_X_DP53:
-        return copy(Arceus.ARCEUS_LV_X_94, this);
+        return copy(Arceus.ARCEUS_LV_X_94, this)
       case BEGINNING_DOOR_DP54:
-        return copy(Arceus.BEGINNING_DOOR_82, this);
+        return copy(Arceus.BEGINNING_DOOR_82, this)
       case ULTIMATE_ZONE_DP55:
-        return copy(Arceus.ULTIMATE_ZONE_91, this);
+        return copy(Arceus.ULTIMATE_ZONE_91, this)
       case ARCEUS_LV_X_DP56:
-        return copy(Arceus.ARCEUS_LV_X_95, this);
+        return copy(Arceus.ARCEUS_LV_X_95, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -146,53 +146,53 @@ public enum GreatEncounters implements LogicCardInfo {
   DIALGA_LV_X_105 ("Dialga Lv.X", "105", Rarity.HOLORARE, [LVL_X, POKEMON, _METAL_]),
   PALKIA_LV_X_106 ("Palkia Lv.X", "106", Rarity.HOLORARE, [LVL_X, POKEMON, _WATER_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   GreatEncounters(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.GREAT_ENCOUNTERS;
+    return tcgwars.logic.card.Collection.GREAT_ENCOUNTERS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -219,7 +219,7 @@ public enum GreatEncounters implements LogicCardInfo {
               discardSelfEnergyAfterDamage R, R
             }
           }
-        };
+        }
       case CRESSELIA_2:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -244,7 +244,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARKRAI_3:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -269,7 +269,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARKRAI_4:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -296,7 +296,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PACHIRISU_5:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -325,7 +325,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PORYGON_Z_6:
         return evolution (this, from:"Porygon2", hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS30
@@ -363,7 +363,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ROTOM_7:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness D, PLUS20
@@ -387,7 +387,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SCEPTILE_8:
         return evolution (this, from:"Grovyle", hp:HP100, type:GRASS, retreatCost:3) {
           weakness R, PLUS30
@@ -413,7 +413,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SWAMPERT_9:
         return evolution (this, from:"Marshtomp", hp:HP130, type:WATER, retreatCost:2) {
           weakness G, PLUS30
@@ -440,7 +440,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TANGROWTH_10:
         return evolution (this, from:"Tangela", hp:HP110, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -465,7 +465,7 @@ public enum GreatEncounters implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case TOGEKISS_11:
         return evolution (this, from:"Togetic", hp:HP120, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS30
@@ -496,7 +496,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALTARIA_12:
         return evolution (this, from:"Swablu", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -533,7 +533,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BEEDRILL_13:
         return evolution (this, from:"Kakuna", hp:HP110, type:GRASS, retreatCost:0) {
           weakness R, PLUS30
@@ -556,7 +556,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUTTERFREE_14:
         return evolution (this, from:"Metapod", hp:HP120, type:GRASS, retreatCost:0) {
           weakness R, PLUS30
@@ -591,7 +591,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CLAYDOL_15:
         return evolution (this, from:"Baltoy", hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS20
@@ -615,9 +615,9 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case DIALGA_16:
-        return copy(DiamondPearl.DIALGA_1, this);
+        return copy(DiamondPearl.DIALGA_1, this)
       case EXPLOUD_17:
         return evolution (this, from:"Loudred", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS30
@@ -653,7 +653,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case HOUNDOOM_18:
         return evolution (this, from:"Houndour", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness W, PLUS20
@@ -689,7 +689,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HYPNO_19:
         return evolution (this, from:"Drowzee", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -713,7 +713,7 @@ public enum GreatEncounters implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case KINGLER_20:
         return evolution (this, from:"Krabby", hp:HP090, type:WATER, retreatCost:3) {
           weakness L, PLUS20
@@ -741,7 +741,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LAPRAS_21:
         return basic (this, hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -765,7 +765,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LATIAS_22:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -789,7 +789,7 @@ public enum GreatEncounters implements LogicCardInfo {
               discardSelfEnergyAfterDamage R, W
             }
           }
-        };
+        }
       case LATIOS_23:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness C, PLUS20
@@ -814,7 +814,7 @@ public enum GreatEncounters implements LogicCardInfo {
               discardSelfEnergyAfterDamage C, C, C
             }
           }
-        };
+        }
       case MAWILE_24:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness R, PLUS10
@@ -855,7 +855,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MILOTIC_25:
         return evolution (this, from:"Feebas", hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -899,9 +899,9 @@ public enum GreatEncounters implements LogicCardInfo {
                 }]
             }
           }
-        };
+        }
       case PALKIA_26:
-        return copy(DiamondPearl.PALKIA_11, this);
+        return copy(DiamondPearl.PALKIA_11, this)
       case PRIMEAPE_27:
         return evolution (this, from:"Mankey", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20
@@ -931,7 +931,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SLOWKING_28:
         return evolution (this, from:"Slowpoke", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -965,7 +965,7 @@ public enum GreatEncounters implements LogicCardInfo {
               increasedBaseDamageNextTurn("Psych Up", hp(30))
             }
           }
-        };
+        }
       case UNOWN_H_29:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -996,7 +996,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WAILORD_30:
         return evolution (this, from:"Wailmer", hp:HP200, type:WATER, retreatCost:4) {
           weakness L
@@ -1023,7 +1023,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WEEZING_31:
         return evolution (this, from:"Koffing", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -1044,7 +1044,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WIGGLYTUFF_32:
         return evolution (this, from:"Jigglypuff", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1068,7 +1068,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARBOK_33:
         return evolution (this, from:"Ekans", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -1094,7 +1094,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CACTURNE_34:
         return evolution (this, from:"Cacnea", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness R, PLUS20
@@ -1118,7 +1118,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case COMBUSKEN_35:
         return evolution (this, from:"Torchic", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -1141,7 +1141,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DELIBIRD_36:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -1165,7 +1165,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case FLOATZEL_37:
         return evolution (this, from:"Buizel", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1191,7 +1191,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOREBYSS_38:
         return evolution (this, from:"Clamperl", hp:HP080, type:WATER, retreatCost:0) {
           weakness L, PLUS20
@@ -1218,7 +1218,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GRANBULL_39:
         return evolution (this, from:"Snubbull", hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1237,7 +1237,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 40 + 10 * self.numberOfDamageCounters
             }
           }
-        };
+        }
       case GROVYLE_40:
         return evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1261,7 +1261,7 @@ public enum GreatEncounters implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case HARIYAMA_41:
         return evolution (this, from:"Makuhita", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness P, PLUS30
@@ -1285,7 +1285,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HUNTAIL_42:
         return evolution (this, from:"Clamperl", hp:HP090, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1311,7 +1311,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LINOONE_43:
         return evolution (this, from:"Zigzagoon", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness F, PLUS20
@@ -1344,7 +1344,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LOUDRED_44:
         return evolution (this, from:"Whismur", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1365,7 +1365,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case MAGCARGO_45:
         return evolution (this, from:"Slugma", hp:HP090, type:FIRE, retreatCost:3) {
           weakness W, PLUS20
@@ -1395,7 +1395,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MARSHTOMP_46:
         return evolution (this, from:"Mudkip", hp:HP090, type:WATER, retreatCost:2) {
           weakness G, PLUS20
@@ -1420,7 +1420,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METAPOD_47:
         return evolution (this, from:"Caterpie", hp:HP070, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1449,7 +1449,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case PELIPPER_48:
         return evolution (this, from:"Wingull", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1479,7 +1479,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PORYGON2_49:
         return evolution (this, from:"Porygon", hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1504,7 +1504,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case PURUGLY_50:
         return evolution (this, from:"Glameow", hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1525,7 +1525,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip 3, { damage 40 }
             }
           }
-        };
+        }
       case RELICANTH_51:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1556,7 +1556,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SEVIPER_52:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -1590,7 +1590,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKARMORY_53:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness R, PLUS20
@@ -1613,7 +1613,7 @@ public enum GreatEncounters implements LogicCardInfo {
               reduceDamageNextTurn(hp(20), thisMove)
             }
           }
-        };
+        }
       case SLOWBRO_54:
         return evolution (this, from:"Slowpoke", hp:HP080, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -1634,7 +1634,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case TOGETIC_55:
         return evolution (this, from:"Togepi", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -1660,7 +1660,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_F_56:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1687,7 +1687,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_G_57:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1744,7 +1744,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WAILMER_58:
         return basic (this, hp:HP090, type:WATER, retreatCost:3) {
           weakness L, PLUS20
@@ -1769,7 +1769,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case ZANGOOSE_59:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1792,7 +1792,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BALTOY_60:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS10
@@ -1811,7 +1811,7 @@ public enum GreatEncounters implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case BUIZEL_61:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1831,7 +1831,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case CACNEA_62:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1853,7 +1853,7 @@ public enum GreatEncounters implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case CATERPIE_63:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1879,7 +1879,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case CLAMPERL_64:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1902,7 +1902,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case DROWZEE_65:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1922,7 +1922,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case EKANS_66:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -1943,7 +1943,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip { apply POISONED }
             }
           }
-        };
+        }
       case FEEBAS_67:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1966,7 +1966,7 @@ public enum GreatEncounters implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case GLAMEOW_68:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1988,7 +1988,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HOUNDOUR_69:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2009,7 +2009,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case IGGLYBUFF_70:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2037,7 +2037,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ILLUMISE_71:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -2066,13 +2066,13 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
               def hasPokeBody = false
               for (Ability ability : defending.getAbilities().keySet()) {
-                if (ability instanceof PokeBody) hasPokeBody = true;
+                if (ability instanceof PokeBody) hasPokeBody = true
               }
               if (hasPokeBody)
                 applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case JIGGLYPUFF_72:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2093,7 +2093,7 @@ public enum GreatEncounters implements LogicCardInfo {
               reduceDamageNextTurn(hp(20), thisMove)
             }
           }
-        };
+        }
       case KAKUNA_73:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -2114,7 +2114,7 @@ public enum GreatEncounters implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case KOFFING_74:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2136,7 +2136,7 @@ public enum GreatEncounters implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case KRABBY_75:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L, PLUS10
@@ -2156,7 +2156,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case LUNATONE_76:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20
@@ -2187,7 +2187,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUVDISC_77:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2217,7 +2217,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAKUHITA_78:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS10
@@ -2240,7 +2240,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MANKEY_79:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -2260,7 +2260,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 10 + 10 * self.numberOfDamageCounters
             }
           }
-        };
+        }
       case MUDKIP_80:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness G, PLUS10
@@ -2281,7 +2281,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case PORYGON_81:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2304,7 +2304,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SLOWPOKE_82:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L, PLUS10
@@ -2327,7 +2327,7 @@ public enum GreatEncounters implements LogicCardInfo {
               cantAttackNextTurn(self)
             }
           }
-        };
+        }
       case SLUGMA_83:
         return basic (this, hp:HP060, type:FIRE, retreatCost:2) {
           weakness W, PLUS10
@@ -2350,7 +2350,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SNUBBULL_84:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2370,7 +2370,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SOLROCK_85:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -2399,7 +2399,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SWABLU_86:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2423,7 +2423,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TANGELA_87:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2446,7 +2446,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20 + 10 * defending.retreatCost
             }
           }
-        };
+        }
       case TOGEPI_88:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2472,7 +2472,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORCHIC_89:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2492,7 +2492,7 @@ public enum GreatEncounters implements LogicCardInfo {
               apply BURNED
             }
           }
-        };
+        }
       case TREECKO_90:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2515,7 +2515,7 @@ public enum GreatEncounters implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case UNOWN_L_91:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2558,7 +2558,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VOLBEAT_92:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -2583,7 +2583,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip { apply CONFUSED }
             }
           }
-        };
+        }
       case WEEDLE_93:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2600,7 +2600,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip { apply PARALYZED }
             }
           }
-        };
+        }
       case WHISMUR_94:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2622,7 +2622,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WINGULL_95:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2643,7 +2643,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ZIGZAGOON_96:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2666,7 +2666,7 @@ public enum GreatEncounters implements LogicCardInfo {
               flip 2, { damage 10 }
             }
           }
-        };
+        }
       case AMULET_COIN_97:
         return pokemonTool (this) {
           text "Attach Amulet Coin to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nIf the Pokémon Amulet Coin is attached to is your Active Pokémon at the end of your turn, draw a card."
@@ -2684,7 +2684,7 @@ public enum GreatEncounters implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case FELICITY_S_DRAWING_98:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDiscard up to 2 cards from your hand. If you discard 1 card, draw 3 cards. If you discard 2 cards, draw 4 cards."
@@ -2701,7 +2701,7 @@ public enum GreatEncounters implements LogicCardInfo {
             }
             toDiscard.discard()
           }
-        };
+        }
       case LEFTOVERS_99:
         return pokemonTool (this) {
           text "Attach Leftovers to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nIf the Pokémon Leftovers is attached to is your Active Pokémon at the end of your turn, remove 1 damage counter from the Pokémon."
@@ -2719,7 +2719,7 @@ public enum GreatEncounters implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case MOONLIGHT_STADIUM_100:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nThe Retreat Cost for each [P] and [D] Pokémon (both yours and your opponent's) is 0."
@@ -2734,7 +2734,7 @@ public enum GreatEncounters implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case PREMIER_BALL_101:
         return basicTrainer (this) {
           text "Search your deck or your discard pile for a Pokémon LV.X, show it to your opponent, and put it into your hand. If you search your deck, shuffle your deck afterward."
@@ -2764,9 +2764,9 @@ public enum GreatEncounters implements LogicCardInfo {
           playRequirement{
             assert my.discard || my.deck : "Your deck or discard needs to be not empty"
           }
-        };
+        }
       case RARE_CANDY_102:
-        return copy (Sandstorm.RARE_CANDY_88, this);
+        return copy (Sandstorm.RARE_CANDY_88, this)
       case CRESSELIA_LV_X_103:
         return levelUp (this, from:"Cresselia", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -2814,7 +2814,7 @@ public enum GreatEncounters implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case DARKRAI_LV_X_104:
         return levelUp (this, from:"Darkrai", hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2851,7 +2851,7 @@ public enum GreatEncounters implements LogicCardInfo {
                     delayed {
                       before ASLEEP_SPC, null, null, BEGIN_TURN, {
                         flip "Asleep (Endless Darkness)", 2, {}, {}, [2: {
-                          ef.unregisterItself(bg.em());
+                          ef.unregisterItself(bg.em())
                         }, 1:{
                           bc "$pcs is still asleep."
                         }, 0:{
@@ -2874,7 +2874,7 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DIALGA_LV_X_105:
         return levelUp (this, from:"Dialga", hp:HP110, type:METAL, retreatCost:2) {
           weakness R
@@ -2912,7 +2912,7 @@ public enum GreatEncounters implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case PALKIA_LV_X_106:
         return levelUp (this, from:"Palkia", hp:HP120, type:WATER, retreatCost:3) {
           weakness L
@@ -2957,9 +2957,9 @@ public enum GreatEncounters implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -1,28 +1,28 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.impl.gen1.BaseSet;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
-import tcgwars.logic.impl.gen5.BlackWhite;
-import tcgwars.logic.impl.gen6.KalosStarterSet;
-import tcgwars.logic.impl.gen7.CelestialStorm;
-import tcgwars.logic.impl.gen7.UnbrokenBonds;
+import tcgwars.logic.impl.gen1.BaseSet
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen3.TeamRocketReturns
+import tcgwars.logic.impl.gen5.BlackWhite
+import tcgwars.logic.impl.gen6.KalosStarterSet
+import tcgwars.logic.impl.gen7.CelestialStorm
+import tcgwars.logic.impl.gen7.UnbrokenBonds
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -154,7 +154,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
   GYARADOS_123 ("Gyarados", "123", Rarity.HOLORARE, [STAGE1, EVOLUTION, POKEMON, _WATER_]),
   ALPH_LITHOGRAPH_ONE ("Alph Lithograph", "ONE", Rarity.HOLORARE, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
   static SimpleDeck growthClash() {
     def d = new SimpleDeck("Growth Clash Theme Deck")
@@ -175,51 +175,51 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
     d
   }
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   HeartgoldSoulsilver(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.HEARTGOLD_SOULSILVER;
+    return tcgwars.logic.card.Collection.HEARTGOLD_SOULSILVER
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -243,7 +243,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZUMARILL_2:
         return evolution (this, from:"Marill", hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -263,7 +263,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE_3:
         return evolution (this, from:"Clefairy", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -286,7 +286,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_4:
         return evolution (this, from:"Magikarp", hp:HP130, type:WATER, retreatCost:3) {
           weakness L
@@ -307,7 +307,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONTOP_5:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -341,7 +341,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JUMPLUFF_6:
         return evolution (this, from:"Skiploom", hp:HP090, type:GRASS, retreatCost:0) {
           weakness R
@@ -362,7 +362,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINETALES_7:
         return evolution (this, from:"Vulpix", hp:HP090, type:FIRE, retreatCost:1) {
           weakness W
@@ -385,7 +385,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOCTOWL_8:
         return evolution (this, from:"Hoothoot", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -410,7 +410,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUAGSIRE_9:
         return evolution (this, from:"Wooper", hp:HP100, type:WATER, retreatCost:3) {
           weakness G
@@ -431,7 +431,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_10:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -454,7 +454,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHUCKLE_11:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R
@@ -480,7 +480,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWKING_12:
         return evolution (this, from:"Slowpoke", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -519,7 +519,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOBBUFFET_13:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -531,7 +531,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMPHAROS_14:
         return evolution (this, from:"Flaaffy", hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -560,7 +560,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARIADOS_15:
         return evolution (this, from:"Spinarak", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -581,7 +581,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUTTERFREE_16:
         return evolution (this, from:"Metapod", hp:HP120, type:GRASS, retreatCost:0) {
           weakness L
@@ -602,7 +602,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFFA_17:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -629,7 +629,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGUTOR_18:
         return evolution (this, from:"Exeggcute", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -652,7 +652,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FARFETCH_D_19:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -678,7 +678,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FERALIGATR_20:
         return evolution (this, from:"Croconaw", hp:HP130, type:WATER, retreatCost:2) {
           weakness G
@@ -697,7 +697,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FURRET_21:
         return evolution (this, from:"Sentret", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -721,7 +721,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               flip {damage 20}
             }
           }
-        };
+        }
       case GRANBULL_22:
         return evolution (this, from:"Snubbull", hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -747,7 +747,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYPNO_23:
         return evolution (this, from:"Drowzee", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -769,7 +769,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAPRAS_24:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness M
@@ -789,7 +789,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDIAN_25:
         return evolution (this, from:"Ledyba", hp:HP080, type:GRASS, retreatCost:0) {
           weakness R
@@ -810,7 +810,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEGANIUM_26:
         return evolution (this, from:"Bayleef", hp:HP130, type:GRASS, retreatCost:2) {
           weakness R
@@ -832,7 +832,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_27:
         return evolution (this, from:"Meowth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -856,7 +856,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PICHU_28:
         return basic (this, hp:HP030, type:LIGHTNING, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -892,7 +892,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSLASH_29:
         return evolution (this, from:"Sandshrew", hp:HP080, type:FIGHTING, retreatCost:0) {
           weakness W
@@ -913,7 +913,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SMOOCHUM_30:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -943,7 +943,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
 
           }
 
-        };
+        }
       case SUNFLORA_31:
         return evolution (this, from:"Sunkern", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -967,7 +967,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPHLOSION_32:
         return evolution (this, from:"Quilava", hp:HP130, type:FIRE, retreatCost:1) {
           weakness W
@@ -989,7 +989,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYROGUE_33:
         return basic (this, hp:HP030, type:FIGHTING, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -1014,7 +1014,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING_34:
         return evolution (this, from:"Koffing", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1034,7 +1034,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAYLEEF_35:
         return evolution (this, from:"Chikorita", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R
@@ -1054,7 +1054,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLISSEY_36:
         return evolution (this, from:"Chansey", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -1077,7 +1077,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CORSOLA_37:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness G
@@ -1098,7 +1098,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROCONAW_38:
         return evolution (this, from:"Totodile", hp:HP080, type:WATER, retreatCost:2) {
           weakness G
@@ -1118,7 +1118,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DELIBIRD_39:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness M
@@ -1145,7 +1145,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DONPHAN_40:
         return evolution (this, from:"Phanpy", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness W
@@ -1166,7 +1166,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUNSPARCE_41:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1189,7 +1189,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAAFFY_42:
         return evolution (this, from:"Mareep", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1210,7 +1210,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_43:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R
@@ -1233,7 +1233,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case IGGLYBUFF_44:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -1257,7 +1257,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               defendingAttacksCostsMore(defending, [C])
             }
           }
-        };
+        }
       case MANTINE_45:
         return basic (this, hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -1282,7 +1282,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAPOD_46:
         return evolution (this, from:"Caterpie", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R
@@ -1305,7 +1305,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MILTANK_47:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -1327,7 +1327,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARASECT_48:
         return evolution (this, from:"Paras", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R
@@ -1347,7 +1347,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUILAVA_49:
         return evolution (this, from:"Cyndaquil", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W
@@ -1369,7 +1369,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QWILFISH_50:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L
@@ -1382,7 +1382,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKIPLOOM_51:
         return evolution (this, from:"Hoppip", hp:HP060, type:GRASS, retreatCost:0) {
           weakness R
@@ -1396,7 +1396,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_52:
         return evolution (this, from:"Slowpoke", hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -1417,7 +1417,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARMIE_53:
         return evolution (this, from:"Staryu", hp:HP090, type:WATER, retreatCost:0) {
           weakness L
@@ -1445,7 +1445,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_54:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1467,7 +1467,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_55:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1489,7 +1489,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIGGLYTUFF_56:
         return evolution (this, from:"Jigglypuff", hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -1509,7 +1509,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CATERPIE_57:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness R
@@ -1521,7 +1521,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANSEY_58:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -1541,7 +1541,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIKORITA_59:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R
@@ -1561,7 +1561,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_60:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1580,7 +1580,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CYNDAQUIL_61:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W
@@ -1599,7 +1599,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DROWZEE_62:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1623,7 +1623,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGCUTE_63:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1635,7 +1635,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIRAFARIG_64:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness P
@@ -1658,7 +1658,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROWLITHE_65:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W
@@ -1677,7 +1677,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOOTHOOT_66:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1697,7 +1697,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOPPIP_67:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness R
@@ -1711,7 +1711,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_68:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1724,7 +1724,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JYNX_69:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1746,7 +1746,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_70:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1766,7 +1766,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDYBA_71:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -1786,7 +1786,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_72:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness L
@@ -1798,7 +1798,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAREEP_73:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1825,7 +1825,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARILL_74:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -1845,7 +1845,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH_75:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1865,7 +1865,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARAS_76:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -1885,7 +1885,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHANPY_77:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness W
@@ -1898,7 +1898,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_78:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1919,7 +1919,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSHREW_79:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1939,7 +1939,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SENTRET_80:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1960,7 +1960,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_81:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L
@@ -1972,7 +1972,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNUBBULL_82:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -1994,7 +1994,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPINARAK_83:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -2013,7 +2013,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARYU_84:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L
@@ -2025,7 +2025,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUNKERN_85:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R
@@ -2048,7 +2048,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOTODILE_86:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness G
@@ -2067,7 +2067,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VULPIX_87:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W
@@ -2089,7 +2089,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOOPER_88:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness G
@@ -2109,7 +2109,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BILL_89:
         return supporter (this) {
           text "Draw 2 cards."
@@ -2119,9 +2119,9 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       case COPYCAT_90:
-        return copy(TeamRocketReturns.COPYCAT_83, this);
+        return copy(TeamRocketReturns.COPYCAT_83, this)
       case ENERGY_SWITCH_91:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case FISHERMAN_92:
@@ -2143,7 +2143,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.active.specialConditions : "No special conditions on your active"
           }
-        };
+        }
       case MOOMOO_MILK_94:
         return itemCard (this) {
           text "Choose 1 of your Pokémon. Flip 2 coins. For each heads, remove 3 damage counters from that Pokémon."
@@ -2154,7 +2154,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.all.find{it.numberOfDamageCounters} : "Your Pokémon have no damage"
           }
-        };
+        }
       case POKE_BALL_95:
         return copy (BlackWhite.POKE_BALL_97, this)
       case POKEGEAR_3_0_96:
@@ -2169,7 +2169,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       case POKEMON_COMMUNICATION_98:
         return copy (BlackWhite.POKEMON_COMMUNICATION_99, this)
       case POKEMON_REVERSAL_99:
@@ -2184,7 +2184,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       case PROFESSOR_OAK_S_NEW_THEORY_101:
         return supporter (this) {
           text "Shuffle your hand into your deck. Then, draw 6 cards."
@@ -2196,7 +2196,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || (my.hand.getExcludedList(thisCard).size() != 0)
           }
-        };
+        }
       case SWITCH_102:
         return copy (FireRedLeafGreen.SWITCH_102, this)
       case DOUBLE_COLORLESS_ENERGY_103:
@@ -2227,7 +2227,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLISSEY_106:
         return evolution (this, from:"Chansey", hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -2255,7 +2255,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DONPHAN_107:
         return evolution (this, from:"Phanpy", hp:HP120, type:FIGHTING, retreatCost:4) {
           weakness W
@@ -2289,7 +2289,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FERALIGATR_108:
         return evolution (this, from:"Croconaw", hp:HP140, type:WATER, retreatCost:3) {
           weakness G
@@ -2309,7 +2309,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEGANIUM_109:
         return evolution (this, from:"Bayleef", hp:HP150, type:GRASS, retreatCost:2) {
           weakness R
@@ -2337,7 +2337,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPHLOSION_110:
         return evolution (this, from:"Quilava", hp:HP140, type:FIRE, retreatCost:2) {
           weakness W
@@ -2367,7 +2367,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HO_OH_LEGEND_111:
         return basic (this, hp:HP140, type:FIRE, retreatCost:2) {
           weakness W
@@ -2392,7 +2392,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HO_OH_LEGEND_112:
         return copy(HO_OH_LEGEND_111, this)
       case LUGIA_LEGEND_113:
@@ -2423,25 +2423,25 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUGIA_LEGEND_114:
         return copy(LUGIA_LEGEND_113, this)
       case GRASS_ENERGY_115:
-        return basicEnergy (this, GRASS);
+        return basicEnergy (this, GRASS)
       case FIRE_ENERGY_116:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case WATER_ENERGY_117:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       case LIGHTNING_ENERGY_118:
-        return basicEnergy (this, LIGHTNING);
+        return basicEnergy (this, LIGHTNING)
       case PSYCHIC_ENERGY_119:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case FIGHTING_ENERGY_120:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       case DARKNESS_ENERGY_121:
-        return basicEnergy (this, DARKNESS);
+        return basicEnergy (this, DARKNESS)
       case METAL_ENERGY_122:
-        return basicEnergy (this, METAL);
+        return basicEnergy (this, METAL)
       case GYARADOS_123:
         return evolution (this, from:"Magikarp", hp:HP130, type:WATER, retreatCost:3) {
           weakness L
@@ -2462,7 +2462,7 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALPH_LITHOGRAPH_ONE:
         return itemCard (this) {
           text "LOOK AT YOUR OPPONENTS HAND!"
@@ -2472,9 +2472,9 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
           playRequirement{
             assert opp.hand : "Opponent has no cards in hand."
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilverPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilverPromos.groovy
@@ -1,10 +1,10 @@
 package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.impl.gen3.NintendoBlackStarPromos
-import tcgwars.logic.impl.gen8.SwordShield;
+import tcgwars.logic.impl.gen8.SwordShield
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
 import static tcgwars.logic.effect.EffectPriority.BEFORE_LAST
 import static tcgwars.logic.effect.EffectType.APPLY_SPECIAL_CONDITION
@@ -13,14 +13,14 @@ import static tcgwars.logic.effect.EffectType.GET_RETREAT_COST
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.PLAY_FROM_HAND
 import static tcgwars.logic.effect.special.SpecialConditionType.ASLEEP
-import static tcgwars.logic.effect.special.SpecialConditionType.ASLEEP;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.special.SpecialConditionType.ASLEEP
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -53,53 +53,53 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
   HITMONCHAN_HGSS24 ("Hitmonchan", "24", Rarity.PROMO, [BASIC, POKEMON, _FIGHTING_]),
   HITMONLEE_HGSS25 ("Hitmonlee", "25", Rarity.PROMO, [BASIC, POKEMON, _FIGHTING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   HeartgoldSoulsilverPromos(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.HEARTGOLD_SOULSILVER_PROMOS;
+    return tcgwars.logic.card.Collection.HEARTGOLD_SOULSILVER_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -128,7 +128,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUGIA_HGSS02:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -153,7 +153,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_HGSS03:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -178,7 +178,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               afterDamage { discardAllSelfEnergy() }
             }
           }
-        };
+        }
       case WOBBUFFET_HGSS04:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness P
@@ -199,7 +199,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case HOOTHOOT_HGSS05:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -226,7 +226,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case NOCTOWL_HGSS06:
         return evolution (this, from:"Hoothoot", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -250,13 +250,13 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               applyAfterDamage(ASLEEP)
             }
           }
-        };
+        }
       case FERALIGATR_HGSS07:
-        return copy (HeartgoldSoulsilver.FERALIGATR_108, this);
+        return copy (HeartgoldSoulsilver.FERALIGATR_108, this)
       case MEGANIUM_HGSS08:
-        return copy (HeartgoldSoulsilver.MEGANIUM_109, this);
+        return copy (HeartgoldSoulsilver.MEGANIUM_109, this)
       case TYPHLOSION_HGSS09:
-        return copy (HeartgoldSoulsilver.TYPHLOSION_110, this);
+        return copy (HeartgoldSoulsilver.TYPHLOSION_110, this)
       case LATIAS_HGSS10:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C
@@ -282,7 +282,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIOS_HGSS11:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness C
@@ -303,11 +303,11 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case CLEFFA_HGSS12:
-        return copy (HeartgoldSoulsilver.CLEFFA_17, this);
+        return copy (HeartgoldSoulsilver.CLEFFA_17, this)
       case SMOOCHUM_HGSS13:
-        return copy (HeartgoldSoulsilver.SMOOCHUM_30, this);
+        return copy (HeartgoldSoulsilver.SMOOCHUM_30, this)
       case LAPRAS_HGSS14:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness M
@@ -331,7 +331,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case SHUCKLE_HGSS15:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -354,13 +354,13 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               flip { preventAllDamageNextTurn() }
             }
           }
-        };
+        }
       case PLUSLE_HGSS16:
-        return copy (Unleashed.PLUSLE_36, this);
+        return copy (Unleashed.PLUSLE_36, this)
       case MINUN_HGSS17:
-        return copy (Unleashed.MINUN_34, this);
+        return copy (Unleashed.MINUN_34, this)
       case TROPICAL_TIDAL_WAVE_HGSS18:
-        return copy (NintendoBlackStarPromos.TROPICAL_TIDAL_WAVE_27, this);
+        return copy (NintendoBlackStarPromos.TROPICAL_TIDAL_WAVE_27, this)
       case RAIKOU_HGSS19:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -374,7 +374,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case ENTEI_HGSS20:
         return basic (this, hp:HP080, type:FIRE, retreatCost:1) {
           weakness W
@@ -389,7 +389,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SUICUNE_HGSS21:
         return basic (this, hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -402,7 +402,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               flip { cantAttackNextTurn(defending) }
             }
           }
-        };
+        }
       case PORYGON_HGSS22:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -426,7 +426,7 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case PORYGON2_HGSS23:
         return evolution (this, from:"Porygon", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -448,13 +448,13 @@ public enum HeartgoldSoulsilverPromos implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case HITMONCHAN_HGSS24:
-        return copy (Undaunted.HITMONCHAN_51, this);
+        return copy (Undaunted.HITMONCHAN_51, this)
       case HITMONLEE_HGSS25:
-        return copy (Undaunted.HITMONLEE_52, this);
+        return copy (Undaunted.HITMONLEE_52, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -1,36 +1,36 @@
 package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.impl.gen3.LegendMaker;
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import tcgwars.logic.impl.gen3.LegendMaker
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -184,53 +184,53 @@ public enum LegendsAwakened implements LogicCardInfo {
   RHYPERIOR_LV_X_145 ("Rhyperior Lv.X", "145", Rarity.HOLORARE, [LVL_X, POKEMON, _FIGHTING_]),
   UXIE_LV_X_146 ("Uxie Lv.X", "146", Rarity.HOLORARE, [LVL_X, POKEMON, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   LegendsAwakened(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.LEGENDS_AWAKENED;
+    return tcgwars.logic.card.Collection.LEGENDS_AWAKENED
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -257,7 +257,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20 + 10 * addDmg
             }
           }
-        };
+        }
       case DRAGONITE_2:
         return evolution (this, from:"Dragonair", hp:HP140, type:C, retreatCost:3) {
           weakness C, '+30'
@@ -281,7 +281,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FROSLASS_3:
         return evolution (this, from:"Snorunt", hp:HP090, type:W, retreatCost:1) {
           weakness M, '+20'
@@ -321,7 +321,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIRATINA_4:
         return basic (this, hp:HP100, type:P, retreatCost:3) {
           weakness D
@@ -343,7 +343,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 50 + 10 * defending.numberOfDamageCounters
             }
           }
-        };
+        }
       case GLISCOR_5:
         return evolution (this, from:"Gligar", hp:HP080, type:F, retreatCost:1) {
           weakness W, '+20'
@@ -373,7 +373,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               if (defending.specialConditions) damage 40
             }
           }
-        };
+        }
       case HEATRAN_6:
         return basic (this, hp:HP100, type:R, retreatCost:4) {
           weakness W
@@ -405,7 +405,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KINGDRA_7:
         return evolution (this, from:"Seadra", hp:HP130, type:W, retreatCost:1) {
           weakness L, '+30'
@@ -438,7 +438,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUXRAY_8:
         return evolution (this, from:"Luxio", hp:HP120, type:L, retreatCost:0) {
           weakness F, '+30'
@@ -478,7 +478,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               afterDamage { discardAllSelfEnergy(L) }
             }
           }
-        };
+        }
       case MAMOSWINE_9:
         return evolution (this, from:"Piloswine", hp:HP140, type:W, retreatCost:4) {
           weakness M, '+40'
@@ -510,7 +510,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METAGROSS_10:
         return evolution (this, from:"Metang", hp:HP120, type:M, retreatCost:3) {
           weakness R, '+30'
@@ -536,7 +536,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               increasedBaseDamageNextTurn("Extra Comet Punch", hp(50))
             }
           }
-        };
+        }
       case MEWTWO_11:
         return basic (this, hp:HP080, type:P, retreatCost:2) {
           weakness P, '+20'
@@ -557,7 +557,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 40 + 10 * defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case POLITOED_12:
         return evolution (this, from:"Poliwhirl", hp:HP120, type:W, retreatCost:1) {
           weakness G, '+30'
@@ -593,7 +593,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 40 }
             }
           }
-        };
+        }
       case PROBOPASS_13:
         return evolution (this, from:"Nosepass", hp:HP090, type:F, retreatCost:3) {
           weakness W, '+20'
@@ -623,7 +623,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAYQUAZA_14:
         return basic (this, hp:HP100, type:C, retreatCost:3) {
           weakness C
@@ -655,7 +655,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REGIGIGAS_15:
         return basic (this, hp:HP120, type:C, retreatCost:4) {
           weakness F
@@ -682,7 +682,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SPIRITOMB_16:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           resistance C, MINUS20
@@ -715,7 +715,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               checkFaint()
             }
           }
-        };
+        }
       case YANMEGA_17:
         return evolution (this, from:"Yanma", hp:HP090, type:G, retreatCost:0) {
           weakness L, '+20'
@@ -748,7 +748,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARMALDO_18:
         return evolution (this, from:"Anorith", hp:HP140, type:F, retreatCost:2) {
           weakness G, '+30'
@@ -776,7 +776,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case AZELF_19:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P, '+20'
@@ -810,7 +810,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               cantRetreat(defending)
             }
           }
-        };
+        }
       case BELLOSSOM_20:
         return evolution (this, from:"Gloom", hp:HP100, type:G, retreatCost:1) {
           weakness R, '+30'
@@ -840,7 +840,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CRADILY_21:
         return evolution (this, from:"Lileep", hp:HP120, type:G, retreatCost:3) {
           weakness R, '+30'
@@ -876,7 +876,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               cantRetreat(defending)
             }
           }
-        };
+        }
       case CRAWDAUNT_22:
         return evolution (this, from:"Corphish", hp:HP090, type:W, retreatCost:2) {
           weakness L, '+20'
@@ -902,7 +902,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DELCATTY_23:
         return evolution (this, from:"Skitty", hp:HP080, type:C, retreatCost:1) {
           weakness F, '+20'
@@ -924,7 +924,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               attachEnergyFrom(basic: true, my.discard, my.bench)
             }
           }
-        };
+        }
       case DEOXYS_ATTACK_FORME_24:
         return basic (this, hp:HP080, type:P, retreatCost:2) {
           weakness P
@@ -945,7 +945,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DEOXYS_DEFENSE_FORME_25:
         return basic (this, hp:HP100, type:P, retreatCost:2) {
           weakness P
@@ -965,7 +965,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               reduceDamageNextTurn(hp(20), thisMove)
             }
           }
-        };
+        }
       case DEOXYS_SPEED_FORME_26:
         return basic (this, hp:HP070, type:P, retreatCost:0) {
           weakness P
@@ -983,7 +983,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               swiftDamage 30, opp.all.select("Deal damage to?")
             }
           }
-        };
+        }
       case DITTO_27:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F, '+20'
@@ -1000,7 +1000,7 @@ public enum LegendsAwakened implements LogicCardInfo {
             }
             metronomeA delegate, { self.owner.opposite.pbg.active }
           }
-        };
+        }
       case FORRETRESS_28:
         return evolution (this, from:"Pineco", hp:HP090, type:M, retreatCost:2) {
           weakness R, '+20'
@@ -1031,7 +1031,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 40, self
             }
           }
-        };
+        }
       case GROUDON_29:
         return basic (this, hp:HP100, type:F, retreatCost:3) {
           weakness G
@@ -1057,7 +1057,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HEATRAN_30:
         return basic (this, hp:HP100, type:M, retreatCost:3) {
           weakness W
@@ -1086,7 +1086,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case JIRACHI_31:
         return basic (this, hp:HP070, type:M, retreatCost:1) {
           weakness R, '+20'
@@ -1121,7 +1121,7 @@ public enum LegendsAwakened implements LogicCardInfo {
                     if (activatedTurn < bg.turnCount) {
                       if (defending.inPlay) {
                         bc "Doom Desire activates"
-                        new Knockout(defending).run(bg);
+                        new Knockout(defending).run(bg)
                       }
                       unregister()
                     }
@@ -1137,7 +1137,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KYOGRE_32:
         return basic (this, hp:HP100, type:W, retreatCost:3) {
           weakness L
@@ -1162,7 +1162,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               discardSelfEnergyAfterDamage W, W
             }
           }
-        };
+        }
       case LOPUNNY_33:
         return evolution (this, from:"Buneary", hp:HP080, type:C, retreatCost:1) {
           weakness F, '+20'
@@ -1200,7 +1200,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MESPRIT_34:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P, '+20'
@@ -1240,7 +1240,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case POLIWRATH_35:
         return evolution (this, from:"Poliwhirl", hp:HP130, type:W, retreatCost:2) {
           weakness L, '+30'
@@ -1275,7 +1275,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case REGICE_36:
         return basic (this, hp:HP090, type:W, retreatCost:3) {
           weakness M
@@ -1319,7 +1319,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REGIGIGAS_37:
         return basic (this, hp:HP100, type:C, retreatCost:4) {
           weakness F
@@ -1347,7 +1347,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REGIROCK_38:
         return basic (this, hp:HP090, type:F, retreatCost:3) {
           weakness W
@@ -1373,7 +1373,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case REGISTEEL_39:
         return basic (this, hp:HP090, type:M, retreatCost:4) {
           weakness R
@@ -1404,7 +1404,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHEDINJA_40:
         return evolution (this, from:"Nincada", hp:HP060, type:G, retreatCost:0) {
           pokePower "Resent", {
@@ -1440,7 +1440,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORKOAL_41:
         return basic (this, hp:HP080, type:R, retreatCost:2) {
           weakness W, '+20'
@@ -1478,7 +1478,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_EXCLAMATION_MARK_42:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -1508,7 +1508,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UXIE_43:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P, '+20'
@@ -1536,7 +1536,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VICTREEBEL_44:
         return evolution (this, from:"Weepinbell", hp:HP120, type:G, retreatCost:3) {
           weakness R, '+30'
@@ -1576,7 +1576,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VILEPLUME_45:
         return evolution (this, from:"Gloom", hp:HP120, type:G, retreatCost:2) {
           weakness P, '+30'
@@ -1617,7 +1617,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ANORITH_46:
         return evolution (this, from:"Claw Fossil", hp:HP080, type:F, retreatCost:1) {
           weakness G, '+20'
@@ -1639,7 +1639,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case CAMERUPT_47:
         return evolution (this, from:"Numel", hp:HP100, type:R, retreatCost:3) {
           weakness W, '+20'
@@ -1673,7 +1673,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case CASTFORM_48:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F, '+10'
@@ -1698,7 +1698,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASTFORM_RAIN_FORM_49:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -1717,7 +1717,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case CASTFORM_SNOW_CLOUD_FORM_50:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness M, '+10'
@@ -1737,7 +1737,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASTFORM_SUNNY_FORM_51:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W, '+10'
@@ -1756,7 +1756,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               discardSelfEnergyAfterDamage R
             }
           }
-        };
+        }
       case DRAGONAIR_52:
         return evolution (this, from:"Dratini", hp:HP070, type:C, retreatCost:1) {
           weakness C, '+20'
@@ -1779,7 +1779,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRIFBLIM_53:
         return evolution (this, from:"Drifloon", hp:HP090, type:P, retreatCost:0) {
           weakness D, '+20'
@@ -1804,7 +1804,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case EXEGGUTOR_54:
         return evolution (this, from:"Exeggcute", hp:HP080, type:P, retreatCost:1) {
           weakness P, '+20'
@@ -1838,11 +1838,11 @@ public enum LegendsAwakened implements LogicCardInfo {
                 def pl = my.all.findAll {
                   it.cards.filterByType(ENERGY).any { energy -> !toBeDiscarded.contains(energy) }
                 }
-                if (!pl) break;
+                if (!pl) break
 
                 def info = "Current number of energy cards to discard + ${toBeDiscarded.size()}\n. Discard an Energy card from which Pokémon? (cancel to stop)"
                 def src = pl.select(info, false)
-                if (!src) break;
+                if (!src) break
 
                 def selection = src.cards.filterByType(ENERGY).findAll{!toBeDiscarded.contains(it)}.select("Card to discard")
                 toBeDiscarded.addAll(selection)
@@ -1851,7 +1851,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               afterDamage { toBeDiscarded.discard() }
             }
           }
-        };
+        }
       case GLISCOR_55:
         return evolution (this, from:"Gligar", hp:HP090, type:F, retreatCost:1) {
           weakness W, '+20'
@@ -1874,7 +1874,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 40 }
             }
           }
-        };
+        }
       case GRUMPIG_56:
         return evolution (this, from:"Spoink", hp:HP090, type:P, retreatCost:2) {
           weakness P, '+20'
@@ -1894,7 +1894,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20 * self.cards.energyCount(C)
             }
           }
-        };
+        }
       case HOUNDOOM_57:
         return evolution (this, from:"Houndour", hp:HP080, type:R, retreatCost:1) {
           weakness W, '+20'
@@ -1933,7 +1933,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 1, {}, { discardSelfEnergyAfterDamage R, R }
             }
           }
-        };
+        }
       case LANTURN_58:
         return evolution (this, from:"Chinchou", hp:HP090, type:W, retreatCost:1) {
           weakness G, '+20'
@@ -1955,7 +1955,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case LANTURN_59:
         return evolution (this, from:"Chinchou", hp:HP090, type:L, retreatCost:2) {
           weakness F, '+20'
@@ -1979,7 +1979,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 60 + 10 * self.cards.energyCount(W)
             }
           }
-        };
+        }
       case LEDIAN_60:
         return evolution (this, from:"Ledyba", hp:HP080, type:G, retreatCost:1) {
           weakness R, '+20'
@@ -2010,7 +2010,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUCARIO_61:
         return evolution (this, from:"Riolu", hp:HP090, type:F, retreatCost:1) {
           weakness P, '+20'
@@ -2033,7 +2033,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUXIO_62:
         return evolution (this, from:"Shinx", hp:HP080, type:L, retreatCost:1) {
           weakness F, '+20'
@@ -2062,7 +2062,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAROWAK_63:
         return evolution (this, from:"Cubone", hp:HP090, type:F, retreatCost:2) {
           weakness W, '+20'
@@ -2088,7 +2088,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METANG_64:
         return evolution (this, from:"Beldum", hp:HP080, type:M, retreatCost:2) {
           weakness R, '+20'
@@ -2110,7 +2110,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case METANG_65:
         return evolution (this, from:"Beldum", hp:HP080, type:M, retreatCost:2) {
           weakness R, '+20'
@@ -2135,7 +2135,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case MIGHTYENA_66:
         return evolution (this, from:"Poochyena", hp:HP090, type:D, retreatCost:1) {
           weakness F, '+20'
@@ -2183,7 +2183,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10 * my.all.size()
             }
           }
-        };
+        }
       case NINJASK_67:
         return evolution (this, from:"Nincada", hp:HP080, type:G, retreatCost:0) {
           weakness R, '+20'
@@ -2223,7 +2223,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PERSIAN_68:
         return evolution (this, from:"Meowth", hp:HP080, type:C, retreatCost:0) {
           weakness F, '+20'
@@ -2244,7 +2244,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 10 }
             }
           }
-        };
+        }
       case PILOSWINE_69:
         return evolution (this, from:"Swinub", hp:HP100, type:W, retreatCost:3) {
           weakness M, '+20'
@@ -2270,7 +2270,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case SEADRA_70:
         return evolution (this, from:"Horsea", hp:HP080, type:W, retreatCost:1) {
           weakness L, '+20'
@@ -2302,7 +2302,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case STARMIE_71:
         return evolution (this, from:"Staryu", hp:HP080, type:W, retreatCost:0) {
           weakness L, '+20'
@@ -2335,7 +2335,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 50, validTargets.select(text)
             }
           }
-        };
+        }
       case SWALOT_72:
         return evolution (this, from:"Gulpin", hp:HP090, type:P, retreatCost:2) {
           weakness P, '+20'
@@ -2360,7 +2360,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case SWELLOW_73:
         return evolution (this, from:"Taillow", hp:HP080, type:C, retreatCost:1) {
           weakness L, '+20'
@@ -2386,7 +2386,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TAUROS_74:
         return basic (this, hp:HP080, type:C, retreatCost:2) {
           weakness F, '+20'
@@ -2409,7 +2409,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 1, {damage 20}, {damage 10, self}
             }
           }
-        };
+        }
       case TENTACRUEL_75:
         return evolution (this, from:"Tentacool", hp:HP090, type:W, retreatCost:1) {
           weakness L, '+20'
@@ -2440,7 +2440,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_J_76:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2466,7 +2466,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_R_77:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2486,18 +2486,18 @@ public enum LegendsAwakened implements LogicCardInfo {
             onAttack {
               while(1) {
                 def pl = (my.all.findAll { it.cards.filterByType(BASIC_ENERGY) })
-                if (!pl) break;
+                if (!pl) break
                 def src = pl.select("Source for energy (cancel to stop)", false)
-                if (!src) break;
+                if (!src) break
                 def card = src.cards.select("Card to move", cardTypeFilter(BASIC_ENERGY)).first()
 
                 def tar = my.all.select("Target for energy (cancel to stop)", false)
-                if (!tar) break;
+                if (!tar) break
                 energySwitch(src, tar, card)
               }
             }
           }
-        };
+        }
       case UNOWN_U_78:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2536,7 +2536,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case UNOWN_V_79:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2564,7 +2564,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_W_80:
         return basic (this, hp:HP090, type:P, retreatCost:3) {
           weakness P, '+30'
@@ -2590,7 +2590,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               draw 1
             }
           }
-        };
+        }
       case UNOWN_Y_81:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2617,7 +2617,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case UNOWN_QUESTION_MARK_82:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2659,7 +2659,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               draw num
             }
           }
-        };
+        }
       case BELDUM_83:
         return basic (this, hp:HP050, type:M, retreatCost:2) {
           weakness R, '+10'
@@ -2688,7 +2688,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case BELDUM_84:
         return basic (this, hp:HP050, type:M, retreatCost:1) {
           weakness R, '+10'
@@ -2709,7 +2709,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BELLSPROUT_85:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, '+10'
@@ -2749,7 +2749,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case BUNEARY_86:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness F, '+10'
@@ -2771,7 +2771,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case CHINCHOU_87:
         return basic (this, hp:HP060, type:W, retreatCost:2) {
           weakness G, '+10'
@@ -2791,7 +2791,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CHINCHOU_88:
         return basic (this, hp:HP050, type:L, retreatCost:1) {
           weakness F, '+10'
@@ -2812,7 +2812,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               if (self.cards.energyCount(W)) damage 10
             }
           }
-        };
+        }
       case CORPHISH_89:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -2834,7 +2834,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case CUBONE_90:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness W, '+10'
@@ -2855,7 +2855,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case DRATINI_91:
         return basic (this, hp:HP040, type:C, retreatCost:1) {
           weakness C, '+10'
@@ -2875,7 +2875,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case DRIFLOON_92:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness D, '+10'
@@ -2897,7 +2897,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case EXEGGCUTE_93:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -2915,7 +2915,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case GLIGAR_94:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness W, '+10'
@@ -2939,7 +2939,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 10 }
             }
           }
-        };
+        }
       case GLIGAR_95:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness W, '+10'
@@ -2960,7 +2960,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GLOOM_96:
         return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:1) {
           weakness R, '+20'
@@ -2985,7 +2985,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }.select("Deal 30 damage to which Pokémon?")
             }
           }
-        };
+        }
       case GLOOM_97:
         return evolution (this, from:"Oddish", hp:HP080, type:P, retreatCost:2) {
           weakness P, '+20'
@@ -3009,7 +3009,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GULPIN_98:
         return basic (this, hp:HP060, type:P, retreatCost:2) {
           weakness P, '+10'
@@ -3029,7 +3029,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { apply PARALYZED }
             }
           }
-        };
+        }
       case HITMONCHAN_99:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness P, '+20'
@@ -3055,7 +3055,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HITMONLEE_100:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
           weakness P, '+20'
@@ -3079,7 +3079,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case HITMONTOP_101:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
           weakness P, '+20'
@@ -3102,7 +3102,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HORSEA_102:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -3123,7 +3123,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case HOUNDOUR_103:
         return basic (this, hp:HP050, type:D, retreatCost:1) {
           weakness W, '+10'
@@ -3144,7 +3144,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LEDYBA_104:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, '+10'
@@ -3166,7 +3166,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case LILEEP_105:
         return evolution (this, from:"Root Fossil", hp:HP080, type:G, retreatCost:2) {
           weakness R, '+20'
@@ -3190,7 +3190,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               heal 20, self
             }
           }
-        };
+        }
       case MEOWTH_106:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness F, '+10'
@@ -3211,7 +3211,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip 3, { damage 10 }
             }
           }
-        };
+        }
       case MISDREAVUS_107:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness D, '+10'
@@ -3237,7 +3237,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NINCADA_108:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R, '+10'
@@ -3257,7 +3257,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               cantRetreat(defending)
             }
           }
-        };
+        }
       case NOSEPASS_109:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness W, '+20'
@@ -3278,7 +3278,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               if (my.bench.find { it.name == "Probopass" }) damage 20
             }
           }
-        };
+        }
       case NUMEL_110:
         return basic (this, hp:HP060, type:R, retreatCost:2) {
           weakness W, '+10'
@@ -3301,7 +3301,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ODDISH_111:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R, '+10'
@@ -3322,7 +3322,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case ODDISH_112:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -3342,7 +3342,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PINECO_113:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, '+10'
@@ -3369,7 +3369,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 50, self
             }
           }
-        };
+        }
       case POLIWAG_114:
         return basic (this, hp:HP040, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -3393,7 +3393,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case POLIWHIRL_115:
         return evolution (this, from:"Poliwag", hp:HP080, type:W, retreatCost:1) {
           weakness L, '+20'
@@ -3416,7 +3416,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case POOCHYENA_116:
         return basic (this, hp:HP050, type:D, retreatCost:1) {
           weakness F, '+10'
@@ -3438,7 +3438,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case RIOLU_117:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness P, '+10'
@@ -3458,7 +3458,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SHINX_118:
         return basic (this, hp:HP050, type:L, retreatCost:1) {
           weakness F, '+10'
@@ -3483,7 +3483,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKITTY_119:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness F, '+10'
@@ -3503,7 +3503,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case SNEASEL_120:
         return basic (this, hp:HP060, type:D, retreatCost:1) {
           weakness F, '+10'
@@ -3528,7 +3528,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SPOINK_121:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, '+10'
@@ -3549,7 +3549,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               switchYourActive(may: true)
             }
           }
-        };
+        }
       case STARYU_122:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -3572,7 +3572,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SWINUB_123:
         return basic (this, hp:HP060, type:W, retreatCost:2) {
           weakness M, '+10'
@@ -3597,7 +3597,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case TAILLOW_124:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness L, '+10'
@@ -3618,7 +3618,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case TENTACOOL_125:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, '+10'
@@ -3638,7 +3638,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { discardDefendingEnergy() }
             }
           }
-        };
+        }
       case TYROGUE_126:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness P, '+10'
@@ -3670,7 +3670,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WEEPINBELL_127:
         return evolution (this, from:"Bellsprout", hp:HP080, type:G, retreatCost:2) {
           weakness R, '+20'
@@ -3691,7 +3691,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case YANMA_128:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
           weakness L, '+20'
@@ -3714,7 +3714,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               flip { preventAllEffectsNextTurn() }
             }
           }
-        };
+        }
       case BUBBLE_COAT_129:
         return pokemonTool (this) {
           text "Attach Bubble Coat to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card."+
@@ -3745,7 +3745,7 @@ public enum LegendsAwakened implements LogicCardInfo {
             effect1.unregister()
             effect2.unregister()
           }
-        };
+        }
       case BUCK_S_TRAINING_130:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."+
@@ -3766,7 +3766,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case CYNTHIA_S_FEELINGS_131:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card."+
@@ -3789,7 +3789,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case ENERGY_PICKUP_132:
         return itemCard (this) {
           text "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to 1 of your Pokémon."
@@ -3801,7 +3801,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC_ENERGY) : "There are no basic Energy cards in your discard pile"
           }
-        };
+        }
       case POKE_RADAR_133:
         return itemCard (this) {
           text "Look at the top 5 cards of your deck, choose as many Pokémon as you like, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward."
@@ -3812,7 +3812,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Deck is empty"
           }
-        };
+        }
       case SNOWPOINT_TEMPLE_134:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."+
@@ -3828,7 +3828,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case STARK_MOUNTAIN_135:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."+
@@ -3854,7 +3854,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case TECHNICAL_MACHINE_TS_1_136:
         return basicTrainer (this) {
           text "Evoluter - Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. " + "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward."
@@ -3863,7 +3863,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case TECHNICAL_MACHINE_TS_2_137:
         return basicTrainer (this) {
           text "Devoluter - Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. " + "Choose 1 of your opponent's Evolved Pokémon (excluding Pokémon LV.X). Remove the highest Stage Evolution card from that Pokémon and put that card back into your opponent's hand.\n"
@@ -3872,7 +3872,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case CLAW_FOSSIL_138:
         return itemCard (this) {
           text "Play Claw Fossil as if it were a [C] Basic Pokémon. (Claw Fossil counts as a Trainer card as well, but if Claw Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Claw Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Claw Fossil from play. (This doesn't count as a Knocked Out Pokémon.)" +
@@ -3934,7 +3934,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case ROOT_FOSSIL_139:
         return itemCard (this) {
           text "Play Root Fossil as if it were a [C] Basic Pokémon. (Root Fossil counts as a Trainer card as well, but if Root Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Root Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Root Fossil from play. (This doesn't count as a Knocked Out Pokémon.)" +
@@ -4001,7 +4001,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case AZELF_LV_X_140:
         return levelUp (this, from:"Azelf", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -4027,7 +4027,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               directDamage 10*count, tar
             }
           }
-        };
+        }
       case GLISCOR_LV_X_141:
         return levelUp (this, from:"Gliscor", hp:HP110, type:F, retreatCost:0) {
           weakness W
@@ -4051,7 +4051,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               switchYourActive(may: true)
             }
           }
-        };
+        }
       case MAGNEZONE_LV_X_142:
         return levelUp (this, from:"Magnezone", hp:HP140, type:M, retreatCost:4) {
           weakness R
@@ -4083,7 +4083,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               applyAfterDamage PARALYZED
             }
           }
-        };
+        }
       case MESPRIT_LV_X_143:
         return levelUp (this, from:"Mesprit", hp:HP090, type:P, retreatCost:1) {
           weakness P
@@ -4115,7 +4115,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEWTWO_LV_X_144:
         return levelUp (this, from:"Mewtwo", hp:HP120, type:P, retreatCost:2) {
           weakness P
@@ -4149,7 +4149,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               afterDamage {discardAllSelfEnergy()}
             }
           }
-        };
+        }
       case RHYPERIOR_LV_X_145:
         return levelUp (this, from:"Rhyperior", hp:HP170, type:F, retreatCost:4) {
           weakness W
@@ -4177,7 +4177,7 @@ public enum LegendsAwakened implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UXIE_LV_X_146:
         return levelUp (this, from:"Uxie", hp:HP090, type:P, retreatCost:1) {
           weakness P
@@ -4204,9 +4204,9 @@ public enum LegendsAwakened implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
+++ b/src/tcgwars/logic/impl/gen4/MajesticDawn.groovy
@@ -2,42 +2,42 @@ package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.Action
 import tcgwars.logic.effect.Source
-import tcgwars.logic.impl.gen2.Expedition;
+import tcgwars.logic.impl.gen2.Expedition
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
-import tcgwars.logic.impl.gen3.RubySapphire;
-import tcgwars.logic.impl.gen5.PlasmaStorm;
-import tcgwars.logic.impl.gen5.BlackWhite;
+import tcgwars.logic.impl.gen3.RubySapphire
+import tcgwars.logic.impl.gen5.PlasmaStorm
+import tcgwars.logic.impl.gen5.BlackWhite
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
-import static tcgwars.logic.effect.EffectPriority.BEFORE_LAST;
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectPriority.BEFORE_LAST
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import tcgwars.logic.effect.gm.PlayTrainer
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 
 
@@ -148,53 +148,53 @@ public enum MajesticDawn implements LogicCardInfo {
   LEAFEON_LV_X_99 ("Leafeon Lv.X", "99", Rarity.HOLORARE, [LVL_X, POKEMON, _GRASS_]),
   PORYGON_Z_LV_X_100 ("Porygon-Z Lv.X", "100", Rarity.HOLORARE, [LVL_X, POKEMON, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   MajesticDawn(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.MAJESTIC_DAWN;
+    return tcgwars.logic.card.Collection.MAJESTIC_DAWN
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -222,7 +222,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRESSELIA_2:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -240,7 +240,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_3:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:2) {
           weakness F, PLUS20
@@ -327,7 +327,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLACEON_5:
         return evolution (this, from:"Eevee", hp:HP080, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -347,7 +347,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTOPS_6:
         return evolution (this, from:"Kabuto", hp:HP120, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS30
@@ -375,7 +375,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_7:
         return evolution (this, from:"Eevee", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -398,7 +398,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANAPHY_8:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -439,7 +439,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEWTWO_9:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -474,7 +474,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOLTRES_10:
         return basic (this, hp:HP100, type:FIRE, retreatCost:2) {
           weakness W
@@ -504,7 +504,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_11:
         return basic (this, hp:HP100, type:WATER, retreatCost:3) {
           weakness L, PLUS20
@@ -547,7 +547,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHIONE_12:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -570,7 +570,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROTOM_13:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness D, PLUS20
@@ -600,7 +600,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZAPDOS_14:
         return basic (this, hp:HP100, type:LIGHTNING, retreatCost:2) {
           weakness L
@@ -627,7 +627,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AERODACTYL_15:
         return evolution (this, from:"Old Amber", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -654,7 +654,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_16:
         return evolution (this, from:"Bronzor", hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -669,7 +669,7 @@ public enum MajesticDawn implements LogicCardInfo {
 
                   self.owner.opposite.pbg.all.each {
                     for (Ability ability : it.getAbilities().keySet()) {
-                      if (ability instanceof PokePower) hasPokePower = true;
+                      if (ability instanceof PokePower) hasPokePower = true
                     }
                     if (hasPokePower) {
                       if (once) {
@@ -705,7 +705,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMPOLEON_17:
         return evolution (this, from:"Prinplup", hp:HP130, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -731,7 +731,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPEON_18:
         return evolution (this, from:"Eevee", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -780,7 +780,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_19:
         return evolution (this, from:"Eevee", hp:HP090, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -804,7 +804,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLACEON_20:
         return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -829,7 +829,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOWDON_21:
         return evolution (this, from:"Hippopotas", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness W, PLUS20
@@ -852,7 +852,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_22:
         return evolution (this, from:"Monferno", hp:HP110, type:FIRE, retreatCost:0) {
           weakness W, PLUS30
@@ -880,7 +880,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JOLTEON_23:
         return evolution (this, from:"Eevee", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -907,7 +907,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_24:
         return evolution (this, from:"Eevee", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -931,7 +931,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_25:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -954,7 +954,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMASTAR_26:
         return evolution (this, from:"Omanyte", hp:HP110, type:WATER, retreatCost:1) {
           weakness G, PLUS30
@@ -981,7 +981,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHIONE_27:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1003,7 +1003,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PLUSLE_28:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1024,7 +1024,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCIZOR_29:
         return evolution (this, from:"Scyther", hp:HP090, type:METAL, retreatCost:1) {
           weakness R, PLUS30
@@ -1050,7 +1050,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_30:
         return evolution (this, from:"Grotle", hp:HP140, type:GRASS, retreatCost:4) {
           weakness R, PLUS30
@@ -1073,7 +1073,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_31:
         return evolution (this, from:"Croagunk", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1096,7 +1096,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UMBREON_32:
         return evolution (this, from:"Eevee", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1126,7 +1126,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_P_33:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1154,7 +1154,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_34:
         return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1192,7 +1192,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMBIPOM_35:
         return evolution (this, from:"Aipom", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1214,7 +1214,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEAROW_36:
         return evolution (this, from:"Spearow", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1236,7 +1236,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROTLE_37:
         return evolution (this, from:"Turtwig", hp:HP090, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1263,7 +1263,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KANGASKHAN_38:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS20
@@ -1284,7 +1284,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_39:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1308,7 +1308,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_40:
         return evolution (this, from:"Electrike", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1336,7 +1336,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MONFERNO_41:
         return evolution (this, from:"Chimchar", hp:HP070, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1359,7 +1359,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOTHIM_42:
         return evolution (this, from:["Burmy","Burmy Plant Cloak","Burmy Sandy Cloak","Burmy Trash Cloak"], hp:HP080, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
@@ -1418,7 +1418,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PACHIRISU_43:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1444,7 +1444,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRINPLUP_44:
         return evolution (this, from:"Piplup", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1468,7 +1468,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_45:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1496,7 +1496,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_46:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1518,7 +1518,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAVIA_47:
         return evolution (this, from:"Starly", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1541,7 +1541,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUDOWOODO_48:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS20
@@ -1561,7 +1561,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_Q_49:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           weakness P, PLUS10
@@ -1606,7 +1606,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AIPOM_50:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1634,7 +1634,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AIPOM_51:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1655,7 +1655,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_52:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1679,7 +1679,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNEARY_53:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1704,7 +1704,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BURMY_SANDY_CLOAK_54:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1725,7 +1725,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHATOT_55:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1751,7 +1751,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMCHAR_56:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -1772,7 +1772,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMCHAR_57:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -1797,7 +1797,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHINGLING_58:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1826,7 +1826,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMBEE_59:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -1849,7 +1849,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROAGUNK_60:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1870,7 +1870,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_61:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -1896,7 +1896,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_62:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1924,7 +1924,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_63:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1943,7 +1943,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_64:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1963,7 +1963,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLAMEOW_65:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1983,7 +1983,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOPOTAS_66:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS10
@@ -2007,7 +2007,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTO_67:
         return evolution (this, from:"Dome Fossil", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -2037,7 +2037,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUNCHLAX_68:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS10
@@ -2065,7 +2065,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMANYTE_69:
         return evolution (this, from:"Helix Fossil", hp:HP070, type:WATER, retreatCost:1) {
           weakness G, PLUS20
@@ -2096,7 +2096,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_70:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2120,7 +2120,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIPLUP_71:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2142,7 +2142,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIPLUP_72:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2165,7 +2165,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLOS_EAST_SEA_73:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L, PLUS10
@@ -2187,7 +2187,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEAROW_74:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2209,7 +2209,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARLY_75:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2230,7 +2230,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNKY_76:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2252,7 +2252,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_77:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2272,7 +2272,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_78:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2296,7 +2296,7 @@ public enum MajesticDawn implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DAWN_STADIUM_79:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nWhenever any player attaches an Energy card from his or her hand to [G] Pokémon or [W] Pokémon, remove 1 damage counter and all Special Conditions from that Pokémon."
@@ -2318,13 +2318,13 @@ public enum MajesticDawn implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case DUSK_BALL_80:
-        return copy (MysteriousTreasures.DUSK_BALL_110, this);
+        return copy (MysteriousTreasures.DUSK_BALL_110, this)
       case ENERGY_RESTORE_81:
-        return copy (Expedition.ENERGY_RESTORE_141, this);
+        return copy (Expedition.ENERGY_RESTORE_141, this)
       case FOSSIL_EXCAVATOR_82:
-        return copy (MysteriousTreasures.FOSSIL_EXCAVATOR_111, this);
+        return copy (MysteriousTreasures.FOSSIL_EXCAVATOR_111, this)
       case MOM_S_KINDNESS_83:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 2 cards."
@@ -2334,7 +2334,7 @@ public enum MajesticDawn implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case OLD_AMBER_84:
         return basicTrainer (this) {
           text "Play Old Amber as if it were a [C] Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn’t count as a Knocked Out Pokémon.)\nPoké-BODY: Hard Amber As long as Old Amber is on your Bench, prevent all damage done to Old Amber by attacks (both yours and your opponent’s)."
@@ -2402,15 +2402,15 @@ public enum MajesticDawn implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case POKE_BALL_85:
-        return copy(FireRedLeafGreen.POKE_BALL_95, this);
+        return copy(FireRedLeafGreen.POKE_BALL_95, this)
       case QUICK_BALL_86:
-        return copy (MysteriousTreasures.QUICK_BALL_114, this);
+        return copy (MysteriousTreasures.QUICK_BALL_114, this)
       case SUPER_SCOOP_UP_87:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case WARP_POINT_88:
-        return copy(PlasmaStorm.ESCAPE_ROPE_120, this);
+        return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case DOME_FOSSIL_89:
         return basicTrainer (this) {
           text "Play Dome Fossil as if it were a [C] Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)\nPoké-BODY: Rock Reaction When you attach a [F] Energy card from your hand to Dome Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Dome Fossil and put it onto Dome Fossil (this counts as evolving Dome Fossil). Shuffle your deck afterward."
@@ -2479,9 +2479,9 @@ public enum MajesticDawn implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case ENERGY_SEARCH_90:
-        return copy(BlackWhite.ENERGY_SEARCH_93, this);
+        return copy(BlackWhite.ENERGY_SEARCH_93, this)
       case HELIX_FOSSIL_91:
         return basicTrainer (this) {
           text "Play Helix Fossil as if it were a [C] Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)\nPoké-BODY: Aqua Reaction When you attach a [W] Energy card from your hand to Helix Fossil (excluding effects of attacks or Poké-Powers), search your deck for a card that evolves from Helix Fossil and put it onto Helix Fossil (this counts as evolving Helix Fossil). Shuffle your deck afterwards."
@@ -2550,7 +2550,7 @@ public enum MajesticDawn implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case CALL_ENERGY_92:
         return specialEnergy (this, [[C]]) {
           text "Call Energy provides [C] Energy. Once during your turn, if the Pokémon Call Energy is attached to is your Active Pokémon, you may search your deck for up to 2 Basic Pokémon and put them onto your Bench. If you do, shuffle your deck and your turn ends."
@@ -2575,9 +2575,9 @@ public enum MajesticDawn implements LogicCardInfo {
           onRemoveFromPlay {
             actions.each { bg().gm().unregisterAction(it as Action) }
           }
-        };
+        }
       case DARKNESS_ENERGY_93:
-        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this)
       case HEALTH_ENERGY_94:
         return specialEnergy (this, [[C]]) {
           text "Health Energy provides [C] Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter from that Pokémon."
@@ -2586,7 +2586,7 @@ public enum MajesticDawn implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case METAL_ENERGY_95:
         return copy (RubySapphire.METAL_ENERGY_94, this)
       case RECOVER_ENERGY_96:
@@ -2597,7 +2597,7 @@ public enum MajesticDawn implements LogicCardInfo {
               clearSpecialCondition(self)
             }
           }
-        };
+        }
       case GARCHOMP_LV_X_97:
         return levelUp (this, from:"Garchomp", hp:HP140, type:COLORLESS, retreatCost:0) {
           weakness C
@@ -2629,7 +2629,7 @@ public enum MajesticDawn implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GLACEON_LV_X_98:
         return levelUp (this, from:"Glaceon", hp:HP100, type:WATER, retreatCost:1) {
           weakness M, PLUS30
@@ -2667,7 +2667,7 @@ public enum MajesticDawn implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LEAFEON_LV_X_99:
         return levelUp (this, from:"Leafeon", hp:HP110, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -2694,7 +2694,7 @@ public enum MajesticDawn implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PORYGON_Z_LV_X_100:
         return levelUp (this, from:"Porygon-Z", hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -2723,9 +2723,9 @@ public enum MajesticDawn implements LogicCardInfo {
               my.deck.addAll(0, list)
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1,38 +1,38 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.effect.gm.Attack;
-import tcgwars.logic.impl.gen3.RubySapphire;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.effect.gm.Attack
+import tcgwars.logic.impl.gen3.RubySapphire
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
+import java.util.*
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
 import tcgwars.logic.effect.special.*
-import tcgwars.logic.exception.NotEnoughEnergyException;
+import tcgwars.logic.exception.NotEnoughEnergyException
 import tcgwars.logic.util.*
 
 /**
@@ -165,53 +165,53 @@ public enum MysteriousTreasures implements LogicCardInfo {
   MAGMORTAR_LV_X_123 ("Magmortar Lv.X", "123", Rarity.HOLORARE, [LVL_X, POKEMON, _FIRE_]),
   TIME_SPACE_DISTORTION_124 ("Time-Space Distortion", "124", Rarity.HOLORARE, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   MysteriousTreasures(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.MYSTERIOUS_TREASURES;
+    return tcgwars.logic.card.Collection.MYSTERIOUS_TREASURES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -253,7 +253,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALAKAZAM_2:
         return evolution (this, from:"Kadabra", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS30
@@ -306,7 +306,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMBIPOM_3:
         return evolution (this, from:"Aipom", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -337,7 +337,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZELF_4:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -399,7 +399,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLISSEY_5:
         return evolution (this, from:"Chansey", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS30
@@ -433,7 +433,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_6:
         return evolution (this, from:"Bronzor", hp:HP090, type:METAL, retreatCost:3) {
           weakness R, PLUS30
@@ -463,7 +463,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CELEBI_7:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -489,19 +489,19 @@ public enum MysteriousTreasures implements LogicCardInfo {
                 if (my.bench && confirm("Do you want to move any amount of basic [G] Energy cards from your Pokémon to your other Pokémon in any way you like?"))
                 while (true) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(G) })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for energy (cancel to stop)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(G).select("Energy to move").first()
 
                   def tar = my.all.findAll { it != src }.select("Target for energy (cancel to stop)", false)
-                  if (!tar) break;
+                  if (!tar) break
                   energySwitch(src, tar, card)
                 }
               }
             }
           }
-        };
+        }
       case FERALIGATR_8:
         return evolution (this, from:"Croconaw", hp:HP130, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -536,7 +536,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARCHOMP_9:
         return evolution (this, from:"Gabite", hp:HP130, type:COLORLESS, retreatCost:0) {
           weakness C, PLUS30
@@ -565,7 +565,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_10:
         return evolution (this, from:"Murkrow", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness L, PLUS20
@@ -596,7 +596,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUMINEON_11:
         return evolution (this, from:"Finneon", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -621,7 +621,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_12:
         return evolution (this, from:"Magmar", hp:HP100, type:FIRE, retreatCost:3) {
           weakness W, PLUS30
@@ -653,7 +653,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEGANIUM_13:
         return evolution (this, from:"Bayleef", hp:HP130, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -679,7 +679,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MESPRIT_14:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -706,7 +706,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_15:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -737,7 +737,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPHLOSION_16:
         return evolution (this, from:"Quilava", hp:HP110, type:FIRE, retreatCost:2) {
           weakness W, PLUS30
@@ -769,7 +769,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYRANITAR_17:
         return evolution (this, from:"Pupitar", hp:HP140, type:DARKNESS, retreatCost:4) {
           weakness F, PLUS30
@@ -805,7 +805,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UXIE_18:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -834,7 +834,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABOMASNOW_19:
         return evolution (this, from:"Snover", hp:HP100, type:GRASS, retreatCost:3) {
           weakness R, PLUS30
@@ -855,7 +855,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARIADOS_20:
         return evolution (this, from:"Spinarak", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -879,7 +879,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BASTIODON_21:
         return evolution (this, from:"Shieldon", hp:HP130, type:METAL, retreatCost:3) {
           weakness R, PLUS40
@@ -922,7 +922,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMECHO_22:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -947,7 +947,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROBAT_23:
         return evolution (this, from:"Golbat", hp:HP100, type:PSYCHIC, retreatCost:0) {
           weakness P, PLUS30
@@ -977,7 +977,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGUTOR_24:
         return evolution (this, from:"Exeggcute", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1008,7 +1008,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLALIE_25:
         return evolution (this, from:"Snorunt", hp:HP090, type:WATER, retreatCost:2) {
           weakness M, PLUS20
@@ -1050,7 +1050,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_26:
         return evolution (this, from:"Magikarp", hp:HP120, type:WATER, retreatCost:3) {
           weakness L, PLUS30
@@ -1099,7 +1099,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRICKETUNE_27:
         return evolution (this, from:"Kricketot", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1121,7 +1121,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANECTRIC_28:
         return evolution (this, from:"Electrike", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1148,7 +1148,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANTINE_29:
         return basic (this, hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1171,7 +1171,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR_MIME_30:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1210,7 +1210,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_31:
         return evolution (this, from:"Nidorina", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS30
@@ -1242,7 +1242,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINETALES_32:
         return evolution (this, from:"Vulpix", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -1283,7 +1283,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAMPARDOS_33:
         return evolution (this, from:"Cranidos", hp:HP120, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS30
@@ -1306,7 +1306,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLAKING_34:
         return evolution (this, from:"Vigoroth", hp:HP140, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS30
@@ -1357,7 +1357,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUDOWOODO_35:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1388,7 +1388,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_36:
         return evolution (this, from:"Croagunk", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1413,7 +1413,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_I_37:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1491,7 +1491,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case URSARING_38:
         return evolution (this, from:"Teddiursa", hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1528,7 +1528,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WALREIN_39:
         return evolution (this, from:"Sealeo", hp:HP130, type:WATER, retreatCost:3) {
           weakness M, PLUS30
@@ -1565,7 +1565,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHISCASH_40:
         return evolution (this, from:"Barboach", hp:HP090, type:WATER, retreatCost:3) {
           weakness G, PLUS30
@@ -1592,7 +1592,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAYLEEF_41:
         return evolution (this, from:"Chikorita", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1617,7 +1617,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHINGLING_42:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1642,7 +1642,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRANIDOS_43:
         return evolution (this, from:"Skull Fossil", hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -1664,7 +1664,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROCONAW_44:
         return evolution (this, from:"Totodile", hp:HP080, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -1690,7 +1690,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWGONG_45:
         return evolution (this, from:"Seel", hp:HP090, type:WATER, retreatCost:2) {
           weakness M, PLUS20
@@ -1716,7 +1716,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               afterDamage { apply ASLEEP, self }
             }
           }
-        };
+        }
       case DODRIO_46:
         return evolution (this, from:"Doduo", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1741,7 +1741,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUNSPARCE_47:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1763,7 +1763,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GABITE_48:
         return evolution (this, from:"Gible", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -1791,7 +1791,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIRAFARIG_49:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness P, PLUS20
@@ -1818,7 +1818,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT_50:
         return evolution (this, from:"Zubat", hp:HP070, type:PSYCHIC, retreatCost:0) {
           weakness P, PLUS20
@@ -1835,7 +1835,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRAVELER_51:
         return evolution (this, from:"Geodude", hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness G, PLUS20
@@ -1864,7 +1864,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAPPINY_52:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1888,7 +1888,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_53:
         return evolution (this, from:"Aron", hp:HP080, type:METAL, retreatCost:3) {
           weakness R, PLUS20
@@ -1917,7 +1917,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_54:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -1941,7 +1941,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MASQUERAIN_55:
         return evolution (this, from:"Surskit", hp:HP070, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
@@ -1967,7 +1967,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA_56:
         return evolution (this, from:"Nidoran♀", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1990,7 +1990,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OCTILLERY_57:
         return evolution (this, from:"Remoraid", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -2017,7 +2017,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARASECT_58:
         return evolution (this, from:"Paras", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -2044,7 +2044,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PUPITAR_59:
         return evolution (this, from:"Larvitar", hp:HP070, type:FIGHTING, retreatCost:0) {
           weakness G, PLUS20
@@ -2070,7 +2070,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUILAVA_60:
         return evolution (this, from:"Cyndaquil", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -2084,7 +2084,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSLASH_61:
         return evolution (this, from:"Sandshrew", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS20
@@ -2110,7 +2110,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEALEO_62:
         return evolution (this, from:"Spheal", hp:HP080, type:WATER, retreatCost:2) {
           weakness M, PLUS20
@@ -2123,7 +2123,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIELDON_63:
         return evolution (this, from:"Armor Fossil", hp:HP080, type:METAL, retreatCost:2) {
           weakness R, PLUS20
@@ -2147,7 +2147,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TROPIUS_64:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -2172,7 +2172,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_E_65:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2228,7 +2228,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_M_66:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2252,7 +2252,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_T_67:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2289,7 +2289,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIGOROTH_68:
         return evolution (this, from:"Slakoth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -2324,7 +2324,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABRA_69:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2352,7 +2352,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AIPOM_70:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2375,7 +2375,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARON_71:
         return basic (this, hp:HP050, type:METAL, retreatCost:2) {
           weakness R, PLUS10
@@ -2390,7 +2390,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BARBOACH_72:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness G, PLUS10
@@ -2404,7 +2404,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BIDOOF_73:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS10
@@ -2432,7 +2432,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_74:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R, PLUS10
@@ -2447,7 +2447,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUIZEL_75:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2473,7 +2473,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANSEY_76:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -2493,7 +2493,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIKORITA_77:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2516,7 +2516,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROAGUNK_78:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2540,7 +2540,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CYNDAQUIL_79:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2561,7 +2561,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODUO_80:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2584,7 +2584,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRIKE_81:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2612,7 +2612,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGCUTE_82:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2629,7 +2629,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FINNEON_83:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2650,7 +2650,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GEODUDE_84:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS10
@@ -2670,7 +2670,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIBLE_85:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -2684,7 +2684,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRICKETOT_86:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -2702,7 +2702,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_87:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS10
@@ -2729,7 +2729,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGBY_88:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2751,7 +2751,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_89:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2775,7 +2775,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_90:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2795,7 +2795,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE_91:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2816,7 +2816,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARAS_92:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2838,7 +2838,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PICHU_93:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2861,7 +2861,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_94:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2887,7 +2887,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REMORAID_95:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2909,7 +2909,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSHREW_96:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -2931,7 +2931,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEL_97:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness M, PLUS10
@@ -2945,7 +2945,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_98:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2973,7 +2973,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLAKOTH_99:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2987,7 +2987,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORUNT_100:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness M, PLUS10
@@ -3008,7 +3008,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNOVER_101:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -3031,7 +3031,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPHEAL_102:
         return basic (this, hp:HP050, type:WATER, retreatCost:2) {
           weakness M, PLUS10
@@ -3052,7 +3052,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPINARAK_103:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3073,7 +3073,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SURSKIT_104:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3089,7 +3089,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TEDDIURSA_105:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -3113,7 +3113,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOTODILE_106:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -3135,7 +3135,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VULPIX_107:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -3150,7 +3150,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_108:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -3172,7 +3172,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEBE_S_SEARCH_109:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nChoose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)"
@@ -3184,7 +3184,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard) : "You don't have other cards in your hand"
           }
-        };
+        }
       case DUSK_BALL_110:
         return itemCard (this) {
           text "Look at the 7 cards from the bottom of your deck. Choose 1 Pokémon you find there, show it to your opponent, and put it into your hand. Put the remaining cards back on top of your deck. Shuffle your deck afterward."
@@ -3196,7 +3196,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There is no card remaining in your deck."
           }
-        };
+        }
       case FOSSIL_EXCAVATOR_111:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your deck or discard pile for a Trainer card that has Fossil in its name or a Stage 1 or Stage 2 Evolution card that evolves from a Fossil. Show it to your opponent and put it into your hand. If you searched your deck, shuffle your deck afterward."
@@ -3223,7 +3223,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement {
             assert ( my.deck.notEmpty || my.discard.any{isValidFossilCard(it)}) : "You have no cards in deck, and there are no cards in your discard pile that satisfy this supporter's requirements"
           }
-        };
+        }
       case LAKE_BOUNDARY_112:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nApply Weakness for each Pokémon (both yours and your opponent’s) as ×2 instead."
@@ -3240,7 +3240,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case NIGHT_MAINTENANCE_113:
         return itemCard (this) {
           text "Search your discard pile for up to 3 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck."
@@ -3255,13 +3255,13 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert my.discard.findAll{it.cardTypes.is(BASIC_ENERGY) || it.cardTypes.is(POKEMON)} : "There are no basic Pokémon or basic Energy cards in your discard pile"
           }
-        };
+        }
       case QUICK_BALL_114:
         return itemCard (this) {
           text "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don’t reveal a Pokémon, shuffle all the revealed cards back into your deck.)"
           onPlay {
               //TODO: Modularize
-              def revealCard = new CardList();
+              def revealCard = new CardList()
               def ind = 0
               def curCard
               while(ind < my.deck.size()){
@@ -3281,7 +3281,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case TEAM_GALACTIC_S_WAGER_115:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nEach player shuffles his or her hand into his or her deck, and you and your opponent play a game of \"Rock-Paper-Scissors.\" The player who wins draws up to 6 cards. The player who loses draws up to 3 cards. (You draw your cards first.)"
@@ -3301,7 +3301,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case ARMOR_FOSSIL_116:
         return itemCard (this) {
           text "Play Armor Fossil as if it were a [C] Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)\n" +
@@ -3375,7 +3375,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case SKULL_FOSSIL_117:
         return itemCard (this) {
           text "Play Skull Fossil as if it were a [C] Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can’t be affected by any Special Conditions and can’t retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn’t count as a Knocked Out Pokémon.)\n" +
@@ -3444,9 +3444,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case MULTI_ENERGY_118:
-        return copy(FireRedLeafGreen.MULTI_ENERGY_103, this);
+        return copy(FireRedLeafGreen.MULTI_ENERGY_103, this)
       case DARKNESS_ENERGY_119:
         //This version of "Darkness Energy (Special Energy)" doesn't work on "Dark ____" cards, only on [D] Type Pokémon.
         return specialEnergy (this, [[D]]) {
@@ -3474,7 +3474,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
           }
         }
       case METAL_ENERGY_120:
-        return copy (RubySapphire.METAL_ENERGY_94, this);
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case ELECTIVIRE_LV_X_121:
         return levelUp (this, from:"Electivire", hp:HP120, type:LIGHTNING, retreatCost:3) {
           weakness F
@@ -3513,7 +3513,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_LV_X_122:
         return levelUp (this, from:"Lucario", hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -3574,7 +3574,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_LV_X_123:
         return levelUp (this, from:"Magmortar", hp:HP130, type:FIRE, retreatCost:3) {
           weakness W
@@ -3624,7 +3624,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TIME_SPACE_DISTORTION_124:
         return itemCard (this) {
           text "Flip 3 coins. For each heads, search your discard pile for a Pokémon, show it to your opponent, and put it into your hand."
@@ -3638,9 +3638,9 @@ public enum MysteriousTreasures implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON)
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -2,31 +2,31 @@ package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.card.pokemon.LevelUpPokemonCard
 import tcgwars.logic.impl.gen3.CrystalGuardians
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
 import tcgwars.logic.effect.gm.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -168,53 +168,53 @@ public enum Platinum implements LogicCardInfo {
   SWABLU_SH5 ("Swablu", "SH5", Rarity.HOLORARE, [BASIC, POKEMON, _COLORLESS_]),
   VULPIX_SH6 ("Vulpix", "SH6", Rarity.HOLORARE, [BASIC, POKEMON, _FIRE_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Platinum(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.PLATINUM;
+    return tcgwars.logic.card.Collection.PLATINUM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -270,7 +270,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLASTOISE_2:
         return evolution (this, from:"Wartortle", hp:HP130, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -319,7 +319,7 @@ public enum Platinum implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case BLAZIKEN_3:
         return evolution (this, from:"Combusken", hp:HP130, type:FIRE, retreatCost:1) {
           weakness W, PLUS30
@@ -348,7 +348,7 @@ public enum Platinum implements LogicCardInfo {
               discardSelfEnergyAfterDamage C, C
             }
           }
-        };
+        }
       case DELCATTY_4:
         return evolution (this, from:"Skitty", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -383,7 +383,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case DIALGA_5:
         return basic (this, hp:HP100, type:METAL, retreatCost:3) {
           weakness R
@@ -415,7 +415,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DIALGA_6:
         return basic (this, hp:HP100, type:METAL, retreatCost:2) {
           weakness R, PLUS20
@@ -446,7 +446,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DIALGA_G_7:
         return basic (this, hp:HP100, type:METAL, retreatCost:2) {
           weakness R
@@ -477,7 +477,7 @@ public enum Platinum implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case GARDEVOIR_8:
         return evolution (this, from:"Kirlia", hp:HP120, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS30
@@ -520,7 +520,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIRATINA_9:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness D
@@ -551,7 +551,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIRATINA_10:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness D
@@ -582,7 +582,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case MANECTRIC_11:
         return evolution (this, from:"Electrike", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -617,7 +617,7 @@ public enum Platinum implements LogicCardInfo {
               attachEnergyFrom(type:L, my.deck, my.all)
             }
           }
-        };
+        }
       case PALKIA_G_12:
         return basic (this, hp:HP100, type:WATER, retreatCost:2) {
           weakness L
@@ -639,7 +639,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAMPARDOS_13:
         return evolution (this, from:"Cranidos", hp:HP130, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS30
@@ -694,7 +694,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHAYMIN_14:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -721,7 +721,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHAYMIN_15:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -745,7 +745,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SLAKING_16:
         return evolution (this, from:"Vigoroth", hp:HP150, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS30
@@ -792,7 +792,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WEAVILE_G_17:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:0) {
           weakness F
@@ -819,7 +819,7 @@ public enum Platinum implements LogicCardInfo {
               damage 10 + 10 * my.all.findAll{it.topPokemonCard.cardTypes.is(POKEMON_SP)}.size()
             }
           }
-        };
+        }
       case ALTARIA_18:
         return evolution (this, from:"Swablu", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -873,7 +873,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BANETTE_19:
         return evolution (this, from:"Shuppet", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -897,9 +897,9 @@ public enum Platinum implements LogicCardInfo {
             onAttack {
               discardSelfEnergy C
               targeted (opp.active) {
-                def tmp = opp.active.damage;
-                opp.active.damage = self.damage;
-                self.damage = tmp;
+                def tmp = opp.active.damage
+                opp.active.damage = self.damage
+                self.damage = tmp
                 checkFaint()
               }
             }
@@ -917,7 +917,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BASTIODON_20:
         return evolution (this, from:"Shieldon", hp:HP130, type:METAL, retreatCost:4) {
           weakness R, PLUS30
@@ -953,7 +953,7 @@ public enum Platinum implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case BEAUTIFLY_21:
         return evolution (this, from:"Silcoon", hp:HP120, type:GRASS, retreatCost:0) {
           weakness L, PLUS30
@@ -983,7 +983,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLISSEY_22:
         return evolution (this, from:"Chansey", hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS30
@@ -1021,7 +1021,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60, self
             }
           }
-        };
+        }
       case DIALGA_23:
         return basic (this, hp:HP100, type:METAL, retreatCost:3) {
           weakness R, PLUS30
@@ -1046,7 +1046,7 @@ public enum Platinum implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case DUGTRIO_24:
         return evolution (this, from:"Diglett", hp:HP090, type:FIGHTING, retreatCost:0) {
           weakness W, PLUS20
@@ -1082,7 +1082,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUSTOX_25:
         return evolution (this, from:"Cascoon", hp:HP130, type:PSYCHIC, retreatCost:0) {
           weakness R, PLUS30
@@ -1131,7 +1131,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case EMPOLEON_26:
         return evolution (this, from:"Prinplup", hp:HP130, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -1153,7 +1153,7 @@ public enum Platinum implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case GIRATINA_27:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness D
@@ -1189,7 +1189,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIRATINA_28:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness D, PLUS30
@@ -1211,7 +1211,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOLDUCK_29:
         return evolution (this, from:"Psyduck", hp:HP090, type:WATER, retreatCost:0) {
           weakness L, PLUS20
@@ -1241,7 +1241,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GYARADOS_G_30:
         return basic (this, hp:HP110, type:WATER, retreatCost:3) {
           weakness L
@@ -1267,7 +1267,7 @@ public enum Platinum implements LogicCardInfo {
               damage 100 - 10 * self.numberOfDamageCounters
             }
           }
-        };
+        }
       case INFERNAPE_31:
         return evolution (this, from:"Monferno", hp:HP110, type:FIRE, retreatCost:0) {
           weakness W, PLUS30
@@ -1302,7 +1302,7 @@ public enum Platinum implements LogicCardInfo {
               damage 30 + 10 * self.numberOfDamageCounters
             }
           }
-        };
+        }
       case KRICKETUNE_32:
         return evolution (this, from:"Kricketot", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1327,7 +1327,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LICKILICKY_33:
         return evolution (this, from:"Lickitung", hp:HP120, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS20
@@ -1353,7 +1353,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUDICOLO_34:
         return evolution (this, from:"Lombre", hp:HP120, type:GRASS, retreatCost:2) {
           weakness L, PLUS30
@@ -1398,7 +1398,7 @@ public enum Platinum implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case LUVDISC_35:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -1440,7 +1440,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NINETALES_36:
         return evolution (this, from:"Vulpix", hp:HP090, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1484,7 +1484,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PALKIA_37:
         return basic (this, hp:HP100, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -1508,7 +1508,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHAYMIN_38:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1530,7 +1530,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORTERRA_39:
         return evolution (this, from:"Grotle", hp:HP140, type:GRASS, retreatCost:4) {
           weakness R, PLUS30
@@ -1553,7 +1553,7 @@ public enum Platinum implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case TOXICROAK_G_40:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1578,7 +1578,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BRONZONG_G_41:
         return basic (this, hp:HP090, type:METAL, retreatCost:3) {
           weakness P
@@ -1609,7 +1609,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CACTURNE_42:
         return evolution (this, from:"Cacnea", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1645,7 +1645,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CARNIVINE_43:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1681,7 +1681,7 @@ public enum Platinum implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case CASCOON_44:
         return evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1697,7 +1697,7 @@ public enum Platinum implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case COMBUSKEN_45:
         return evolution (this, from:"Torchic", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -1716,7 +1716,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case CRANIDOS_46:
         return evolution (this, from:"Skull Fossil", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -1740,7 +1740,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CROBAT_G_47:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:0) {
           weakness L
@@ -1761,7 +1761,7 @@ public enum Platinum implements LogicCardInfo {
               extraPoison 1
             }
           }
-        };
+        }
       case FLAAFFY_48:
         return evolution (this, from:"Mareep", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1793,7 +1793,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GROTLE_49:
         return evolution (this, from:"Turtwig", hp:HP090, type:GRASS, retreatCost:3) {
           weakness R, PLUS20
@@ -1813,7 +1813,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case HOUNDOOM_G_50:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness F
@@ -1857,7 +1857,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KIRLIA_51:
         return evolution (this, from:"Ralts", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1876,7 +1876,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case LOMBRE_52:
         return evolution (this, from:"Lotad", hp:HP080, type:GRASS, retreatCost:1) {
           weakness L, PLUS20
@@ -1898,7 +1898,7 @@ public enum Platinum implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case LUCARIO_53:
         return evolution (this, from:"Riolu", hp:HP090, type:METAL, retreatCost:0) {
           weakness R, PLUS20
@@ -1919,7 +1919,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20 + 10 * my.bench.size()
             }
           }
-        };
+        }
       case MIGHTYENA_54:
         return evolution (this, from:"Poochyena", hp:HP090, type:DARKNESS, retreatCost:0) {
           weakness F, PLUS20
@@ -1958,7 +1958,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MISMAGIUS_55:
         return evolution (this, from:"Misdreavus", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1981,7 +1981,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MONFERNO_56:
         return evolution (this, from:"Chimchar", hp:HP080, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -2001,7 +2001,7 @@ public enum Platinum implements LogicCardInfo {
               flipThenApplySC(PARALYZED)
             }
           }
-        };
+        }
       case MUK_57:
         return evolution (this, from:"Grimer", hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -2040,7 +2040,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case OCTILLERY_58:
         return evolution (this, from:"Remoraid", hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -2065,7 +2065,7 @@ public enum Platinum implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case PRINPLUP_59:
         return evolution (this, from:"Piplup", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -2086,7 +2086,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PROBOPASS_60:
         return evolution (this, from:"Nosepass", hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness W, PLUS20
@@ -2108,7 +2108,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SEVIPER_61:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -2139,7 +2139,7 @@ public enum Platinum implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case SHIELDON_62:
         return evolution (this, from:"Armor Fossil", hp:HP080, type:METAL, retreatCost:1) {
           weakness R, PLUS20
@@ -2179,7 +2179,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SILCOON_63:
         return evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -2197,7 +2197,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VIGOROTH_64:
         return evolution (this, from:"Slakoth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -2221,7 +2221,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WARTORTLE_65:
         return evolution (this, from:"Squirtle", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -2245,7 +2245,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZANGOOSE_66:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -2289,7 +2289,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CACNEA_67:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2311,7 +2311,7 @@ public enum Platinum implements LogicCardInfo {
               flip 2, {}, {}, [2:{multiSelect(opp.all, 1, 2, "Choose up to 2 of your opponent's Pokémon").each{damage 10, it}},1:{damage 10, opp.all.select()}]
             }
           }
-        };
+        }
       case CARNIVINE_68:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -2335,7 +2335,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHANSEY_69:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -2363,7 +2363,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHIMCHAR_70:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2381,7 +2381,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case COMBEE_71:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness L, PLUS10
@@ -2406,7 +2406,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DIGLETT_72:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -2429,7 +2429,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUNSPARCE_73:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2446,7 +2446,7 @@ public enum Platinum implements LogicCardInfo {
               damage 10, opp.all.select("Deal damage to?")
             }
           }
-        };
+        }
       case ELECTRIKE_74:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS10
@@ -2471,7 +2471,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GRIMER_75:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2487,7 +2487,7 @@ public enum Platinum implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case HAPPINY_76:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2515,7 +2515,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HONCHKROW_G_77:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness L
@@ -2542,7 +2542,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20, tar
             }
           }
-        };
+        }
       case KRICKETOT_78:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2561,7 +2561,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LAPRAS_79:
         return basic (this, hp:HP080, type:WATER, retreatCost:2) {
           weakness M, PLUS20
@@ -2582,7 +2582,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LICKITUNG_80:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS20
@@ -2601,7 +2601,7 @@ public enum Platinum implements LogicCardInfo {
               discardRandomCardFromOpponentsHand()
             }
           }
-        };
+        }
       case LOTAD_81:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness L, PLUS10
@@ -2625,7 +2625,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAREEP_82:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2649,7 +2649,7 @@ public enum Platinum implements LogicCardInfo {
               reduceDamageNextTurn(hp(10), thisMove)
             }
           }
-        };
+        }
       case MISDREAVUS_83:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2673,7 +2673,7 @@ public enum Platinum implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case NOSEPASS_84:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -2694,7 +2694,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PIPLUP_85:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2715,7 +2715,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case POOCHYENA_86:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2734,7 +2734,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PSYDUCK_87:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L, PLUS10
@@ -2766,7 +2766,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PURUGLY_G_88:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -2795,7 +2795,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RALTS_89:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2814,7 +2814,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REMORAID_90:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2834,7 +2834,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RIOLU_91:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -2855,7 +2855,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHUPPET_92:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2880,7 +2880,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKITTY_93:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2904,7 +2904,7 @@ public enum Platinum implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case SKUNTANK_G_94:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness F
@@ -2933,7 +2933,7 @@ public enum Platinum implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case SLAKOTH_95:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2955,7 +2955,7 @@ public enum Platinum implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case SQUIRTLE_96:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2973,7 +2973,7 @@ public enum Platinum implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SWABLU_97:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS10
@@ -2993,7 +2993,7 @@ public enum Platinum implements LogicCardInfo {
               switchYourActive(may:true)
             }
           }
-        };
+        }
       case TAUROS_98:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -3017,7 +3017,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORCHIC_99:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -3037,7 +3037,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORKOAL_100:
         return basic (this, hp:HP080, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -3063,7 +3063,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TURTWIG_101:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -3085,7 +3085,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VULPIX_102:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -3110,7 +3110,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WURMPLE_103:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3131,7 +3131,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BROKEN_TIME_SPACE_104:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nEach player may evolve a Pokémon that he or she just played or evolved during that turn."
@@ -3146,7 +3146,7 @@ public enum Platinum implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case CYRUS_S_CONSPIRACY_105:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your deck for a Supporter card, a basic Energy card, and a Trainer card that has Team Galactic’s Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -3156,7 +3156,7 @@ public enum Platinum implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case GALACTIC_HQ_106:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nWhenever any player plays any Pokémon from his or her hand to evolve his or her Pokémon, put 2 damage counters on that Pokémon."
@@ -3176,7 +3176,7 @@ public enum Platinum implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case LEVEL_MAX_107:
         return itemCard (this) {
           text "Flip a coin. If heads, search your deck for a Pokémon LV.X that levels up from 1 of your Pokémon, and put it onto that Pokémon (this counts as leveling up that Pokémon). Shuffle your deck afterward."
@@ -3196,9 +3196,9 @@ public enum Platinum implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case LIFE_HERB_108:
-        return copy(FireRedLeafGreen.LIFE_HERB_93, this);
+        return copy(FireRedLeafGreen.LIFE_HERB_93, this)
       case LOOKER_S_INVESTIGATION_109:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nLook at your opponent’s hand, then choose you or your opponent. That player shuffles his or her hand into his or her deck and draws up to 5 cards."
@@ -3215,7 +3215,7 @@ public enum Platinum implements LogicCardInfo {
               draw choose(1..5, "Looker's Investigation: Draw how many cards?", 5)
             }
           }
-        };
+        }
       case MEMORY_BERRY_110:
         return pokemonTool (this) {
           text "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1  Evolution card. (You still have to pay for that attack’s Energy cost.)"
@@ -3232,7 +3232,7 @@ public enum Platinum implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case MIASMA_VALLEY_111:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nWhenever any player puts a Basic Pokémon (excluding [G] or [P] Pokémon) from his or hand onto his or her Bench, put 2 damage counters on that Pokémon."
@@ -3250,13 +3250,13 @@ public enum Platinum implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case PLUSPOWER_112:
-        return copy (DiamondPearl.PLUSPOWER_109, this);
+        return copy (DiamondPearl.PLUSPOWER_109, this)
       case POKE_BALL_113:
-        return copy(FireRedLeafGreen.POKE_BALL_95, this);
+        return copy(FireRedLeafGreen.POKE_BALL_95, this)
       case POKEDEX_HANDY910IS_114:
-        return copy(DiamondPearl.POKEDEX_HANDY910IS_111, this);
+        return copy(DiamondPearl.POKEDEX_HANDY910IS_111, this)
       case POKEMON_RESCUE_115:
         return itemCard (this) {
           text "Search your discard pile for a Pokémon, show it to your opponent, and put it into your hand."
@@ -3266,7 +3266,7 @@ public enum Platinum implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON) : "You have no Pokémon in your discard pile"
           }
-        };
+        }
       case ENERGY_GAIN_116:
         return pokemonTool (this) {
           text "Attach Energy Gain to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nAttach Team Galactic’s Invention G-101 Energy Gain to 1 of your Pokémon SP that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card.\nAs long as Team Galactic’s Invention G-101 Energy Gain is attached to a Pokémon, the attack cost of that Pokémon’s attacks is [C] less."
@@ -3288,7 +3288,7 @@ public enum Platinum implements LogicCardInfo {
           allowAttach { to->
             to.topPokemonCard.cardTypes.is(POKEMON_SP)
           }
-        };
+        }
       case POWER_SPRAY_117:
         return itemCard (this) {
           text "You may play this card during your opponent’s turn when your opponent’s Pokémon uses any Poké-Power. Prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) If you have 2 or less Pokémon SP in play, you can’t play this card."
@@ -3298,7 +3298,7 @@ public enum Platinum implements LogicCardInfo {
           playRequirement{
             assert bg.em().retrieveObject("Power_Spray_Can_Play_$thisCard.player") : "Play this card during your opponent’s turn when your opponent’s Pokémon uses any Poké-Power"
           }
-        };
+        }
       case POKE_TURN_118:
         return itemCard (this) {
           text "Return 1 of your Pokémon SP and all cards attached to it to your hand."
@@ -3309,11 +3309,11 @@ public enum Platinum implements LogicCardInfo {
           playRequirement {
             assert my.all.any { it.topPokemonCard.cardTypes.is(POKEMON_SP) } : "No Pokémon SP cards in play"
           }
-        };
+        }
       case ARMOR_FOSSIL_119:
-        return copy(MysteriousTreasures.ARMOR_FOSSIL_116, this);
+        return copy(MysteriousTreasures.ARMOR_FOSSIL_116, this)
       case SKULL_FOSSIL_120:
-        return copy(MysteriousTreasures.SKULL_FOSSIL_117, this);
+        return copy(MysteriousTreasures.SKULL_FOSSIL_117, this)
       case RAINBOW_ENERGY_121:
         return copy (CelestialStorm.RAINBOW_ENERGY_151, this)
       case DIALGA_G_LV_X_122:
@@ -3343,7 +3343,7 @@ public enum Platinum implements LogicCardInfo {
             attackRequirement {}
             onAttack {
               damage 80
-              int heads = 0;
+              int heads = 0
               flipUntilTails { heads += 1 }
               if (heads && opp.active.cards.filterByType(ENERGY)) {
                 afterDamage {
@@ -3352,7 +3352,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAPION_LV_X_123:
         return levelUp (this, from:"Drapion", hp:HP130, type:DARKNESS, retreatCost:3) {
           weakness P
@@ -3379,7 +3379,7 @@ public enum Platinum implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case GIRATINA_LV_X_124:
         return levelUp (this, from:"Giratina", hp:HP130, type:PSYCHIC, retreatCost:3) {
           weakness D
@@ -3426,7 +3426,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PALKIA_G_LV_X_125:
         return levelUp (this, from:"Palkia G", hp:HP120, type:WATER, retreatCost:2) {
           weakness L
@@ -3457,7 +3457,7 @@ public enum Platinum implements LogicCardInfo {
               discardSelfEnergyAfterDamage C, C
             }
           }
-        };
+        }
       case SHAYMIN_LV_X_126:
         return levelUp (this, from:"Shaymin", hp:HP100, type:GRASS, retreatCost:1) {
           weakness R
@@ -3506,7 +3506,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHAYMIN_LV_X_127:
         return levelUp (this, from:"Shaymin", hp:HP110, type:GRASS, retreatCost:0) {
           weakness R
@@ -3553,7 +3553,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ELECTABUZZ_128:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness F
@@ -3579,7 +3579,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HITMONCHAN_129:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -3597,7 +3597,7 @@ public enum Platinum implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case SCYTHER_130:
         return basic (this, hp:HP070, type:GRASS, retreatCost:0) {
           weakness R
@@ -3616,7 +3616,7 @@ public enum Platinum implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case LOTAD_SH4:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness L, PLUS10
@@ -3646,7 +3646,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SWABLU_SH5:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -3690,7 +3690,7 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VULPIX_SH6:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -3729,9 +3729,9 @@ public enum Platinum implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/PokemonRumble.groovy
+++ b/src/tcgwars/logic/impl/gen4/PokemonRumble.groovy
@@ -1,14 +1,14 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -33,53 +33,53 @@ public enum PokemonRumble implements LogicCardInfo {
   RATTATA_15 ("Rattata", "15", Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   BIBAREL_16 ("Bibarel", "16", Rarity.COMMON, [STAGE1, EVOLUTION, POKEMON, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemonRumble(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMON_RUMBLE;
+    return tcgwars.logic.card.Collection.POKEMON_RUMBLE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override

--- a/src/tcgwars/logic/impl/gen4/PopSeries6.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries6.groovy
@@ -1,20 +1,20 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.impl.gen8.SwordShield;
+import tcgwars.logic.impl.gen8.SwordShield
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
 import static tcgwars.logic.effect.EffectType.BEGIN_TURN
 import static tcgwars.logic.effect.EffectType.BETWEEN_TURNS
-import static tcgwars.logic.effect.EffectType.PREVENT_EVOLVE;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.EffectType.PREVENT_EVOLVE
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -39,70 +39,70 @@ public enum PopSeries6 implements LogicCardInfo {
   STARLY_16 ("Starly", "16", Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   TURTWIG_17 ("Turtwig", "17", Rarity.COMMON, [BASIC, POKEMON, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries6(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_6;
+    return tcgwars.logic.card.Collection.POP_SERIES_6
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case BASTIODON_1:
-        return copy (MysteriousTreasures.BASTIODON_21, this);
+        return copy (MysteriousTreasures.BASTIODON_21, this)
       case LUCARIO_2:
-        return copy (DiamondPearl.LUCARIO_6, this);
+        return copy (DiamondPearl.LUCARIO_6, this)
       case MANAPHY_3:
-        return copy (DiamondPearl.MANAPHY_9, this);
+        return copy (DiamondPearl.MANAPHY_9, this)
       case PACHIRISU_4:
-        return copy (DiamondPearl.PACHIRISU_35, this);
+        return copy (DiamondPearl.PACHIRISU_35, this)
       case RAMPARDOS_5:
-        return copy (MysteriousTreasures.RAMPARDOS_33, this);
+        return copy (MysteriousTreasures.RAMPARDOS_33, this)
       case DRIFLOON_6:
-        return copy (DiamondPearl.DRIFLOON_46, this);
+        return copy (DiamondPearl.DRIFLOON_46, this)
       case GIBLE_7:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -125,9 +125,9 @@ public enum PopSeries6 implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case RIOLU_8:
-        return copy (DiamondPearl.RIOLU_61, this);
+        return copy (DiamondPearl.RIOLU_61, this)
       case PIKACHU_9:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -156,25 +156,25 @@ public enum PopSeries6 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARAVIA_10:
-        return copy (DiamondPearl.STARAVIA_64, this);
+        return copy (DiamondPearl.STARAVIA_64, this)
       case BIDOOF_11:
-        return copy (DiamondPearl.BIDOOF_70, this);
+        return copy (DiamondPearl.BIDOOF_70, this)
       case BUNEARY_12:
-        return copy (DiamondPearl.BUNEARY_73, this);
+        return copy (DiamondPearl.BUNEARY_73, this)
       case CHERUBI_13:
-        return copy (DiamondPearl.CHERUBI_75, this);
+        return copy (DiamondPearl.CHERUBI_75, this)
       case CHIMCHAR_14:
-        return copy (DiamondPearl.CHIMCHAR_76, this);
+        return copy (DiamondPearl.CHIMCHAR_76, this)
       case PIPLUP_15:
-        return copy (DiamondPearl.PIPLUP_93, this);
+        return copy (DiamondPearl.PIPLUP_93, this)
       case STARLY_16:
-        return copy (DiamondPearl.STARLY_101, this);
+        return copy (DiamondPearl.STARLY_101, this)
       case TURTWIG_17:
-        return copy (DiamondPearl.TURTWIG_103, this);
+        return copy (DiamondPearl.TURTWIG_103, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/PopSeries7.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries7.groovy
@@ -1,15 +1,15 @@
 package tcgwars.logic.impl.gen4
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -34,94 +34,94 @@ public enum PopSeries7 implements LogicCardInfo {
   SENTRET_16 ("Sentret", "16", Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]),
   SPINDA_17 ("Spinda", "17", Rarity.COMMON, [BASIC, POKEMON, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries7(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_7;
+    return tcgwars.logic.card.Collection.POP_SERIES_7
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case AMPHAROS_1:
-        return copy (SecretWonders.AMPHAROS_1, this);
+        return copy (SecretWonders.AMPHAROS_1, this)
       case GALLADE_2:
-        return copy (SecretWonders.GALLADE_6, this);
+        return copy (SecretWonders.GALLADE_6, this)
       case LATIAS_3:
-        return copy (GreatEncounters.LATIAS_22, this);
+        return copy (GreatEncounters.LATIAS_22, this)
       case LATIOS_4:
-        return copy (GreatEncounters.LATIOS_23, this);
+        return copy (GreatEncounters.LATIOS_23, this)
       case MOTHIM_5:
-        return copy (SecretWonders.MOTHIM_33, this);
+        return copy (SecretWonders.MOTHIM_33, this)
       case DELIBIRD_6:
-        return copy (GreatEncounters.DELIBIRD_36, this);
+        return copy (GreatEncounters.DELIBIRD_36, this)
       case FLAAFFY_7:
-        return copy (SecretWonders.FLAAFFY_50, this);
+        return copy (SecretWonders.FLAAFFY_50, this)
       case KIRLIA_8:
-        return copy (SecretWonders.KIRLIA_53, this);
+        return copy (SecretWonders.KIRLIA_53, this)
       case STANTLER_9:
-        return copy (SecretWonders.STANTLER_113, this);
+        return copy (SecretWonders.STANTLER_113, this)
       case WORMADAM_SANDY_CLOAK_10:
-        return copy (SecretWonders.WORMADAM_SANDY_CLOAK_42, this);
+        return copy (SecretWonders.WORMADAM_SANDY_CLOAK_42, this)
       case BURMY_PLANT_CLOAK_11:
-        return copy (SecretWonders.BURMY_PLANT_CLOAK_78, this);
+        return copy (SecretWonders.BURMY_PLANT_CLOAK_78, this)
       case BURMY_SANDY_CLOAK_12:
-        return copy (SecretWonders.BURMY_SANDY_CLOAK_79, this);
+        return copy (SecretWonders.BURMY_SANDY_CLOAK_79, this)
       case CORSOLA_13:
-        return copy (SecretWonders.CORSOLA_84, this);
+        return copy (SecretWonders.CORSOLA_84, this)
       case MAREEP_14:
-        return copy (SecretWonders.MAREEP_94, this);
+        return copy (SecretWonders.MAREEP_94, this)
       case RALTS_15:
-        return copy (SecretWonders.RALTS_102, this);
+        return copy (SecretWonders.RALTS_102, this)
       case SENTRET_16:
-        return copy (SecretWonders.SENTRET_104, this);
+        return copy (SecretWonders.SENTRET_104, this)
       case SPINDA_17:
-        return copy (SecretWonders.SPINDA_111, this);
+        return copy (SecretWonders.SPINDA_111, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/PopSeries8.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries8.groovy
@@ -2,11 +2,11 @@ package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.impl.gen3.Sandstorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
-import static tcgwars.logic.effect.Source.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.Source.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
@@ -14,7 +14,7 @@ import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -39,53 +39,53 @@ public enum PopSeries8 implements LogicCardInfo {
   RIOLU_16 ("Riolu", "16", Rarity.COMMON, [BASIC, POKEMON, _FIGHTING_]),
   TURTWIG_17 ("Turtwig", "17", Rarity.COMMON, [BASIC, POKEMON, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries8(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_8;
+    return tcgwars.logic.card.Collection.POP_SERIES_8
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -117,7 +117,7 @@ public enum PopSeries8 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUCARIO_2:
         return evolution (this, from:"Riolu", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS20
@@ -136,7 +136,7 @@ public enum PopSeries8 implements LogicCardInfo {
               noResistanceOrAnyEffectDamage(60, defending)
             }
           }
-        };
+        }
       case LUXRAY_3:
         return evolution (this, from:"Luxio", hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS30
@@ -162,7 +162,7 @@ public enum PopSeries8 implements LogicCardInfo {
               flip 1, {}, { damage 40, self }
             }
           }
-        };
+        }
       case PROBOPASS_4:
         return evolution (this, from:"Nosepass", hp:HP090, type:METAL, retreatCost:3) {
           weakness R, PLUS30
@@ -189,7 +189,7 @@ public enum PopSeries8 implements LogicCardInfo {
               flip 3, { damage 20 }
             }
           }
-        };
+        }
       case YANMEGA_5:
         return evolution (this, from:"Yanma", hp:HP090, type:GRASS, retreatCost:0) {
           weakness L, PLUS20
@@ -209,27 +209,27 @@ public enum PopSeries8 implements LogicCardInfo {
               flip 1, {}, { discardSelfEnergyAfterDamage() }
             }
           }
-        };
+        }
       case CHERRIM_6:
-        return copy (DiamondPearl.CHERRIM_45, this);
+        return copy (DiamondPearl.CHERRIM_45, this)
       case CARNIVINE_7:
-        return copy (DiamondPearl.CARNIVINE_21, this);
+        return copy (DiamondPearl.CARNIVINE_21, this)
       case LUXIO_8:
-        return copy (DiamondPearl.LUXIO_52, this);
+        return copy (DiamondPearl.LUXIO_52, this)
       case NIGHT_MAINTENANCE_9:
-        return copy (MysteriousTreasures.NIGHT_MAINTENANCE_113, this);
+        return copy (MysteriousTreasures.NIGHT_MAINTENANCE_113, this)
       case RARE_CANDY_10:
-        return copy (Sandstorm.RARE_CANDY_88, this);
+        return copy (Sandstorm.RARE_CANDY_88, this)
       case ROSEANNE_S_RESEARCH_11:
-        return copy (SecretWonders.ROSEANNE_S_RESEARCH_125, this);
+        return copy (SecretWonders.ROSEANNE_S_RESEARCH_125, this)
       case CHIMCHAR_12:
-        return copy (DiamondPearl.CHIMCHAR_76, this);
+        return copy (DiamondPearl.CHIMCHAR_76, this)
       case CROAGUNK_13:
-        return copy (MysteriousTreasures.CROAGUNK_78, this);
+        return copy (MysteriousTreasures.CROAGUNK_78, this)
       case HAPPINY_14:
-        return copy (MysteriousTreasures.HAPPINY_52, this);
+        return copy (MysteriousTreasures.HAPPINY_52, this)
       case PIPLUP_15:
-        return copy (DiamondPearl.PIPLUP_93, this);
+        return copy (DiamondPearl.PIPLUP_93, this)
       case RIOLU_16:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -255,11 +255,11 @@ public enum PopSeries8 implements LogicCardInfo {
               flip { damage 10 }
             }
           }
-        };
+        }
       case TURTWIG_17:
-        return copy (DiamondPearl.TURTWIG_103, this);
+        return copy (DiamondPearl.TURTWIG_103, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/PopSeries9.groovy
+++ b/src/tcgwars/logic/impl/gen4/PopSeries9.groovy
@@ -1,20 +1,20 @@
 package tcgwars.logic.impl.gen4
 
-import tcgwars.logic.effect.EffectPriority;
+import tcgwars.logic.effect.EffectPriority
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
 import static tcgwars.logic.effect.EffectType.APPLY_ATTACK_DAMAGES
-import static tcgwars.logic.effect.EffectType.GET_POKEMON_TYPE;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.EffectType.GET_POKEMON_TYPE
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -39,53 +39,53 @@ public enum PopSeries9 implements LogicCardInfo {
   PIPLUP_16 ("Piplup", "16", Rarity.COMMON, [BASIC, POKEMON, _WATER_]),
   TURTWIG_17 ("Turtwig", "17", Rarity.COMMON, [BASIC, POKEMON, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PopSeries9(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POP_SERIES_9;
+    return tcgwars.logic.card.Collection.POP_SERIES_9
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -115,7 +115,7 @@ public enum PopSeries9 implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case MANAPHY_2:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -146,7 +146,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAICHU_3:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -170,7 +170,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REGIGIGAS_4:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -192,7 +192,7 @@ public enum PopSeries9 implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case ROTOM_5:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness D, PLUS20
@@ -227,7 +227,7 @@ public enum PopSeries9 implements LogicCardInfo {
               damage 30 + (10 * filteredHand.size())
             }
           }
-        };
+        }
       case BUIZEL_6:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -250,7 +250,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CROAGUNK_7:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -278,7 +278,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GABITE_8:
         return evolution (this, from:"Gible", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -299,7 +299,7 @@ public enum PopSeries9 implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case LOPUNNY_9:
         return evolution (this, from:"Buneary", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -326,7 +326,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PACHIRISU_10:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -353,7 +353,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PICHU_11:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -380,7 +380,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUNEARY_12:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -400,7 +400,7 @@ public enum PopSeries9 implements LogicCardInfo {
               flip { preventAllDamageNextTurn() }
             }
           }
-        };
+        }
       case CHIMCHAR_13:
         return basic (this, hp:HP040, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -425,9 +425,9 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIBLE_14:
-        return copy (MysteriousTreasures.GIBLE_85, this);
+        return copy (MysteriousTreasures.GIBLE_85, this)
       case PIKACHU_15:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -451,7 +451,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIPLUP_16:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -480,7 +480,7 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TURTWIG_17:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R, PLUS10
@@ -507,9 +507,9 @@ public enum PopSeries9 implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -157,53 +157,53 @@ public enum RisingRivals implements LogicCardInfo {
   WASH_ROTOM_RT5 ("Wash Rotom", "RT5", Rarity.HOLORARE, [BASIC, POKEMON, _LIGHTNING_]),
   CHARON_S_CHOICE_RT6 ("Charon's Choice", "RT6", Rarity.HOLORARE, [TRAINER, SUPPORTER]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   RisingRivals(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.RISING_RIVALS;
+    return tcgwars.logic.card.Collection.RISING_RIVALS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -242,7 +242,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BASTIODON_GL_2:
         return basic (this, hp:HP090, type:METAL, retreatCost:3) {
           weakness R
@@ -264,7 +264,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_G_3:
         return basic (this, hp:HP090, type:DARKNESS, retreatCost:2) {
           weakness F
@@ -290,7 +290,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOATZEL_GL_4:
         return basic (this, hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -313,7 +313,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLYGON_5:
         return evolution (this, from:"Vibrava", hp:HP120, type:COLORLESS, retreatCost:0) {
           weakness C, PLUS30
@@ -350,7 +350,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROSLASS_GL_6:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness M
@@ -379,7 +379,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIRACHI_7:
         return basic (this, hp:HP060, type:METAL, retreatCost:0) {
           weakness R, PLUS20
@@ -415,7 +415,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_GL_8:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -438,7 +438,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXRAY_GL_9:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -464,7 +464,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_GL_10:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -492,7 +492,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAMPARDOS_GL_11:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness G
@@ -524,7 +524,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_GL_12:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -549,7 +549,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIFTRY_13:
         return evolution (this, from:"Nuzleaf", hp:HP130, type:DARKNESS, retreatCost:1) {
           weakness R, PLUS30
@@ -609,7 +609,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AGGRON_14:
         return evolution (this, from:"Lairon", hp:HP130, type:METAL, retreatCost:3) {
           weakness R, PLUS30
@@ -660,7 +660,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEEDRILL_15:
         return evolution (this, from:"Kakuna", hp:HP110, type:GRASS, retreatCost:1) {
           weakness R, PLUS30
@@ -690,7 +690,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_E4_16:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness P
@@ -722,7 +722,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAPION_E4_17:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:3) {
           weakness F
@@ -745,7 +745,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPEON_E4_18:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -766,7 +766,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_19:
         return evolution (this, from:"Eevee", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -800,7 +800,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GALLADE_E4_20:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -827,7 +827,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTRODON_EAST_SEA_21:
         return evolution (this, from:"Shellos East Sea", hp:HP090, type:WATER, retreatCost:1) {
           weakness G, PLUS30
@@ -871,7 +871,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTRODON_WEST_SEA_22:
         return evolution (this, from:"Shellos West Sea", hp:HP110, type:FIGHTING, retreatCost:3) {
           weakness G, PLUS30
@@ -907,7 +907,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM_E4_23:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:4) {
           weakness G
@@ -930,7 +930,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_E4_24:
         return basic (this, hp:HP090, type:GRASS, retreatCost:2) {
           weakness R
@@ -953,7 +953,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOWDON_25:
         return evolution (this, from:"Hippopotas", hp:HP110, type:FIGHTING, retreatCost:4) {
           weakness W, PLUS20
@@ -1001,7 +1001,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JOLTEON_26:
         return evolution (this, from:"Eevee", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1040,7 +1040,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAMOSWINE_GL_27:
         return basic (this, hp:HP100, type:WATER, retreatCost:4) {
           weakness M
@@ -1079,7 +1079,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR__MIME_E4_28:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1114,7 +1114,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOKING_29:
         return evolution (this, from:"Nidorino", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS30
@@ -1156,7 +1156,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_30:
         return evolution (this, from:"Nidorina", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS30
@@ -1192,7 +1192,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_GL_31:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -1218,7 +1218,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYPERIOR_E4_32:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness W
@@ -1243,7 +1243,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_33:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS20
@@ -1272,7 +1272,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_34:
         return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -1311,7 +1311,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VESPIQUEN_E4_35:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness L
@@ -1339,7 +1339,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WALREIN_36:
         return evolution (this, from:"Sealeo", hp:HP140, type:WATER, retreatCost:4) {
           weakness M, PLUS30
@@ -1365,7 +1365,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMEGA_E4_37:
         return basic (this, hp:HP090, type:GRASS, retreatCost:1) {
           weakness L
@@ -1388,7 +1388,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALAKAZAM_E4_38:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1413,7 +1413,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_G_39:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1442,7 +1442,7 @@ public enum RisingRivals implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GENGAR_GL_40:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -1472,7 +1472,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLACEON_41:
         return evolution (this, from:"Eevee", hp:HP080, type:WATER, retreatCost:1) {
           weakness M, PLUS20
@@ -1511,7 +1511,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOWDON_E4_42:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness W
@@ -1541,7 +1541,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_E4_43:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness W
@@ -1564,7 +1564,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_44:
         return evolution (this, from:"Aron", hp:HP080, type:METAL, retreatCost:2) {
           weakness R, PLUS20
@@ -1590,7 +1590,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_45:
         return evolution (this, from:"Eevee", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1633,7 +1633,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_GL_46:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness P
@@ -1663,7 +1663,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_E4_47:
         return basic (this, hp:HP070, type:FIRE, retreatCost:0) {
           weakness W
@@ -1693,7 +1693,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCIZOR_E4_48:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -1717,7 +1717,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHARPEDO_49:
         return evolution (this, from:"Carvanha", hp:HP090, type:DARKNESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1754,7 +1754,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARMIE_50:
         return evolution (this, from:"Staryu", hp:HP080, type:WATER, retreatCost:0) {
           weakness L, PLUS20
@@ -1789,7 +1789,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STEELIX_GL_51:
         return basic (this, hp:HP110, type:METAL, retreatCost:4) {
           weakness R
@@ -1819,7 +1819,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TROPIUS_52:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1855,7 +1855,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIBRAVA_53:
         return evolution (this, from:"Trapinch", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS20
@@ -1886,7 +1886,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHISCASH_E4_54:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness G
@@ -1912,7 +1912,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AERODACTYL_GL_55:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:0) {
           weakness L
@@ -1963,7 +1963,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMBIPOM_G_56:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1992,7 +1992,7 @@ public enum RisingRivals implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARON_57:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R, PLUS10
@@ -2016,7 +2016,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARVANHA_58:
         return basic (this, hp:HP040, type:DARKNESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2044,7 +2044,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_59:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2071,7 +2071,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_E4_60:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness W
@@ -2095,7 +2095,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FORRETRESS_G_61:
         return basic (this, hp:HP080, type:METAL, retreatCost:2) {
           weakness R
@@ -2128,7 +2128,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLISCOR_E4_62:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -2155,7 +2155,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROWLITHE_63:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -2179,7 +2179,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOPOTAS_64:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness W, PLUS10
@@ -2207,7 +2207,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOOM_E4_65:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2231,7 +2231,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KAKUNA_66:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -2263,7 +2263,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KECLEON_67:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -2296,7 +2296,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_68:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2323,7 +2323,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUNCHLAX_69:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS10
@@ -2353,7 +2353,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUNCHLAX_70:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -2382,7 +2382,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE_71:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2406,7 +2406,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_MALE_72:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2431,7 +2431,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA_73:
         return evolution (this, from:"Nidoran♀", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -2457,7 +2457,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINO_74:
         return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -2481,7 +2481,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUZLEAF_75:
         return evolution (this, from:"Seedot", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness R, PLUS20
@@ -2504,7 +2504,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUAGSIRE_GL_76:
         return basic (this, hp:HP090, type:WATER, retreatCost:2) {
           weakness G
@@ -2532,7 +2532,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEALEO_77:
         return evolution (this, from:"Spheal", hp:HP080, type:WATER, retreatCost:2) {
           weakness M, PLUS20
@@ -2559,7 +2559,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEDOT_78:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2594,7 +2594,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLOS_EAST_SEA_79:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness G, PLUS10
@@ -2621,7 +2621,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLOS_WEST_SEA_80:
         return basic (this, hp:HP070, type:WATER, retreatCost:2) {
           weakness G, PLUS20
@@ -2645,7 +2645,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_81:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS20
@@ -2695,7 +2695,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPHEAL_82:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness M, PLUS10
@@ -2716,7 +2716,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARYU_83:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2740,7 +2740,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TRAPINCH_84:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -2764,7 +2764,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_GL_85:
         return basic (this, hp:HP090, type:GRASS, retreatCost:3) {
           weakness R
@@ -2792,7 +2792,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEDLE_86:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2819,7 +2819,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING_87:
         return evolution (this, from:"Koffing", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -2853,7 +2853,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AARON_S_COLLECTION_88:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your discard pile for up to 2 in any combination of Pokémon SP and basic Energy cards, show them to your opponent, and put them into your hand."
@@ -2867,9 +2867,9 @@ public enum RisingRivals implements LogicCardInfo {
               it.cardTypes.is(POKEMON_SP) || it.cardTypes.is(BASIC_ENERGY)
             } : "You have no Pokémon SP or basic Energy cards in your discard pile"
           }
-        };
+        }
       case BEBE_S_SEARCH_89:
-        return copy (MysteriousTreasures.BEBE_S_SEARCH_109, this);
+        return copy (MysteriousTreasures.BEBE_S_SEARCH_109, this)
       case BERTHA_S_WARMTH_90:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nRemove 5 damage counters from 1 of your Pokémon SP."
@@ -2879,7 +2879,7 @@ public enum RisingRivals implements LogicCardInfo {
           playRequirement{
             assert my.all.find{it.pokemonSP && it.numberOfDamageCounters} : "You have no damged Pokémon SP"
           }
-        };
+        }
       case FLINT_S_WILLPOWER_91:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nAttach a basic Energy card from your hand to 1 of your Pokémon SP."
@@ -2890,7 +2890,7 @@ public enum RisingRivals implements LogicCardInfo {
             assert my.all.find{it.pokemonSP} : "You have no Pokémon SP in play"
             assert my.hand.filterByType(BASIC_ENERGY) : "You have no basic Energy cards in your hand"
           }
-        };
+        }
       case LUCIAN_S_ASSIGNMENT_92:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nMove as many Energy cards attached to 1 of your Pokémon as you like to another of your Pokémon."
@@ -2906,7 +2906,7 @@ public enum RisingRivals implements LogicCardInfo {
             assert my.all.find{it.cards.energyCount(C)} : "You don't have any energy in play"
             assert my.bench : "You have no Benched Pokémon"
           }
-        };
+        }
       case POKEMON_CONTEST_HALL_93:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nOnce during each player’s turn, if that player’s Bench isn’t full, the player may flip a coin. If heads, that player searches his or her deck for a Basic Pokémon and puts it onto his or her Bench. If the player does, he or she may search his or her deck for a Pokémon Tool card and attach it to that Pokémon. If that player searched his or her deck, the player shuffles his or her deck afterward."
@@ -2933,7 +2933,7 @@ public enum RisingRivals implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case SUNYSHORE_CITY_GYM_94:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nAny damage done by attacks from [L] Pokémon (both yours and your opponent’s) to the Defending Pokémon isn’t affected by Resistance. Each [L] Pokémon in play (both yours and your opponent’s) has no Weakness."
@@ -2958,7 +2958,7 @@ public enum RisingRivals implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case TECHNICAL_MACHINE_G_95:
         return basicTrainer (this) {
           text "Attach this card to 1 of your Pokémon SP in play. That Pokémon may use this card’s attack instead of its own. When the Pokémon this card is attached to is no longer Pokémon SP, discard this card.\n[C][C][C] Damage Porter Choose 1 of your opponent’s Pokémon. This attack does 10 damage times the number of damage counters on the Pokémon this card is attached to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
@@ -2966,7 +2966,7 @@ public enum RisingRivals implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case SP_RADAR_96:
         return itemCard (this) {
           text "Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon SP, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can’t play this card.)"
@@ -2981,9 +2981,9 @@ public enum RisingRivals implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard) : "You have no other cards in your hand"
           }
-        };
+        }
       case UNDERGROUND_EXPEDITION_97:
-        return copy(CelestialStorm.UNDERGROUND_EXPEDITION_150, this);
+        return copy(CelestialStorm.UNDERGROUND_EXPEDITION_150, this)
       case VOLKNER_S_PHILOSOPHY_98:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nYou may discard a card from your hand. Then, draw cards until you have 6 cards in your hand. (If you can’t draw any cards, you can’t play this card.)"
@@ -2995,9 +2995,9 @@ public enum RisingRivals implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() <= 6
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case DARKNESS_ENERGY_99:
-        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this)
       case METAL_ENERGY_100:
         return copy (RubySapphire.METAL_ENERGY_94, this)
       case SP_ENERGY_101:
@@ -3013,7 +3013,7 @@ public enum RisingRivals implements LogicCardInfo {
               return [[C] as Set]
             }
           }
-        };
+        }
       case UPPER_ENERGY_102:
         return specialEnergy (this, [[C]]) {
           text "Upper Energy provides [C] Energy. If you have more Prize cards left than your opponent and this card is attached to a Pokémon (excluding Pokémon LV.X), Upper Energy provides [C][C]."
@@ -3027,7 +3027,7 @@ public enum RisingRivals implements LogicCardInfo {
               return [[C] as Set]
             }
           }
-        };
+        }
       case ALAKAZAM_E4_LV_X_103:
         return levelUp (this, from:"Alakazam E4", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -3058,7 +3058,7 @@ public enum RisingRivals implements LogicCardInfo {
               noWrDamage 50, defending
             }
           }
-        };
+        }
       case FLOATZEL_GL_LV_X_104:
         return levelUp (this, from:"Floatzel GL", hp:HP100, type:WATER, retreatCost:0) {
           weakness L
@@ -3102,7 +3102,7 @@ public enum RisingRivals implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FLYGON_LV_X_105:
         return levelUp (this, from:"Flygon", hp:HP140, type:COLORLESS, retreatCost:0) {
           weakness C
@@ -3128,7 +3128,7 @@ public enum RisingRivals implements LogicCardInfo {
               damage 150, opp.all.findAll{it.pokemonLevelUp}.select(text)
             }
           }
-        };
+        }
       case GALLADE_E4_LV_X_106:
         return levelUp (this, from:"Gallade E4", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -3151,7 +3151,7 @@ public enum RisingRivals implements LogicCardInfo {
               damage 40 + 10 * defending.numberOfDamageCounters
             }
           }
-        };
+        }
       case HIPPOWDON_LV_X_107:
         return levelUp (this, from:"Hippowdon", hp:HP130, type:FIGHTING, retreatCost:4) {
           weakness W
@@ -3196,7 +3196,7 @@ public enum RisingRivals implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case INFERNAPE_E4_LV_X_108:
         return levelUp (this, from:"Infernape E4", hp:HP110, type:FIRE, retreatCost:0) {
           weakness W
@@ -3219,7 +3219,7 @@ public enum RisingRivals implements LogicCardInfo {
               discardSelfEnergyAfterDamage C, C
             }
           }
-        };
+        }
       case LUXRAY_GL_LV_X_109:
         return levelUp (this, from:"Luxray GL", hp:HP110, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -3242,7 +3242,7 @@ public enum RisingRivals implements LogicCardInfo {
               noWrDamage 30, my.all.select("Choose Pokémon to do 30 damage to")
             }
           }
-        };
+        }
       case MISMAGIUS_GL_LV_X_110:
         return levelUp (this, from:"Mismagius GL", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -3282,7 +3282,7 @@ public enum RisingRivals implements LogicCardInfo {
               directDamage count * 10, defending
             }
           }
-        };
+        }
       case SNORLAX_LV_X_111:
         return levelUp (this, from:"Snorlax", hp:HP130, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -3312,7 +3312,7 @@ public enum RisingRivals implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_112:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -3336,7 +3336,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLYING_PIKACHU_113:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           resistance F, MINUS30
@@ -3363,7 +3363,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SURFING_PIKACHU_114:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -3376,7 +3376,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FAN_ROTOM_RT1:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:0) {
           weakness D, PLUS20
@@ -3424,7 +3424,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROST_ROTOM_RT2:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:3) {
           weakness D, PLUS20
@@ -3469,7 +3469,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEAT_ROTOM_RT3:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness D, PLUS20
@@ -3518,7 +3518,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOW_ROTOM_RT4:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness D, PLUS20
@@ -3570,7 +3570,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WASH_ROTOM_RT5:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness D, PLUS20
@@ -3625,7 +3625,7 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARON_S_CHOICE_RT6:
         return basicTrainer (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your deck for any Rotom and switch it with any Rotom you have in play. Any cards attached to Rotom and damage counters on it are now on the new Pokémon. (Remove all Special Conditions and effects from Rotom.) Put Rotom on top of your deck. Shuffle your deck afterward."
@@ -3652,9 +3652,9 @@ public enum RisingRivals implements LogicCardInfo {
             assert my.deck : "Your deck is empty"
             assert my.all.find{it.name.contains("Rotom")} : "You have no Rotoms in play"
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -2,42 +2,42 @@ package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.effect.gm.ActivateSimpleTrainer
 import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.exception.EffectRequirementException;
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.exception.EffectRequirementException
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen3.RubySapphire
 
 import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -178,53 +178,53 @@ public enum SecretWonders implements LogicCardInfo {
   GARDEVOIR_LV_X_131 ("Gardevoir Lv.X", "131", Rarity.HOLORARE, [LVL_X, POKEMON, _PSYCHIC_]),
   HONCHKROW_LV_X_132 ("Honchkrow Lv.X", "132", Rarity.HOLORARE, [LVL_X, POKEMON, _DARKNESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SecretWonders(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SECRET_WONDERS;
+    return tcgwars.logic.card.Collection.SECRET_WONDERS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -263,7 +263,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLASTOISE_2:
         return evolution (this, from:"Wartortle", hp:HP120, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -297,7 +297,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_3:
         return evolution (this, from:"Charmeleon", hp:HP130, type:FIRE, retreatCost:3) {
           weakness W, PLUS40
@@ -342,7 +342,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ENTEI_4:
         return basic (this, hp:HP080, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -385,7 +385,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLYGON_5:
         return evolution (this, from:"Vibrava", hp:HP120, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS30
@@ -422,7 +422,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GALLADE_6:
         return evolution (this, from:"Kirlia", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS30
@@ -452,7 +452,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARDEVOIR_7:
         return evolution (this, from:"Kirlia", hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS30
@@ -463,7 +463,7 @@ public enum SecretWonders implements LogicCardInfo {
               checkNoSPC()
               assert bg.em().retrieveObject("Telepass") != bg.turnCount : "You can't use more than 1 Telepass Poke-Power each turn."
               assert opp.discard.hasType(SUPPORTER) : "Your opponent has no supporters discarded."
-              bg.em().storeObject("Telepass", bg.turnCount);
+              bg.em().storeObject("Telepass", bg.turnCount)
               powerUsed()
               def card = opp.discard.select("Opponent's discard. Select a supporter.", cardTypeFilter(SUPPORTER)).first()
               bg.em().run(new ActivateSimpleTrainer(card))
@@ -494,7 +494,7 @@ public enum SecretWonders implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GASTRODON_EAST_SEA_8:
         return evolution (this, from:"Shellos East Sea", hp:HP100, type:WATER, retreatCost:4) {
           weakness G, PLUS30
@@ -522,7 +522,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTRODON_WEST_SEA_9:
         return evolution (this, from:"Shellos West Sea", hp:HP100, type:FIGHTING, retreatCost:4) {
           weakness G, PLUS30
@@ -549,7 +549,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HO_OH_10:
         return basic (this, hp:HP090, type:FIRE, retreatCost:2) {
           weakness W
@@ -606,7 +606,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JUMPLUFF_11:
         return evolution (this, from:"Skiploom", hp:HP090, type:GRASS, retreatCost:0) {
           weakness R, PLUS30
@@ -638,7 +638,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKILICKY_12:
         return evolution (this, from:"Lickitung", hp:HP110, type:COLORLESS, retreatCost:4) {
           weakness F, PLUS30
@@ -663,7 +663,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUDICOLO_13:
         return evolution (this, from:"Lombre", hp:HP100, type:WATER, retreatCost:2) {
           weakness L, PLUS30
@@ -695,7 +695,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUGIA_14:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness P, PLUS20
@@ -723,7 +723,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEW_15:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -760,7 +760,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAIKOU_16:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:2) {
           weakness F, PLUS20
@@ -797,7 +797,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_17:
         return evolution (this, from:"Roselia", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -822,7 +822,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAMENCE_18:
         return evolution (this, from:"Shelgon", hp:HP140, type:COLORLESS, retreatCost:3) {
           weakness C, PLUS30
@@ -853,7 +853,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUICUNE_19:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -875,7 +875,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENUSAUR_20:
         return evolution (this, from:"Ivysaur", hp:HP130, type:GRASS, retreatCost:3) {
           weakness R, PLUS30
@@ -902,7 +902,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABSOL_21:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS20
@@ -931,7 +931,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCANINE_22:
         return evolution (this, from:"Growlithe", hp:HP100, type:FIRE, retreatCost:2) {
           weakness W, PLUS30
@@ -958,7 +958,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BANETTE_23:
         return evolution (this, from:"Shuppet", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -990,7 +990,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUGTRIO_24:
         return evolution (this, from:"Diglett", hp:HP090, type:FIGHTING, retreatCost:0) {
           weakness W, PLUS20
@@ -1026,7 +1026,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTIVIRE_25:
         return evolution (this, from:"Electabuzz", hp:HP100, type:LIGHTNING, retreatCost:3) {
           weakness F, PLUS30
@@ -1058,7 +1058,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_26:
         return evolution (this, from:"Voltorb", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1108,7 +1108,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FURRET_27:
         return evolution (this, from:"Sentret", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1140,7 +1140,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDUCK_28:
         return evolution (this, from:"Psyduck", hp:HP090, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1185,7 +1185,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM_29:
         return evolution (this, from:"Graveler", hp:HP130, type:FIGHTING, retreatCost:4) {
           weakness G, PLUS30
@@ -1212,7 +1212,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JYNX_30:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -1253,7 +1253,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_31:
         return evolution (this, from:"Magmar", hp:HP110, type:FIRE, retreatCost:3) {
           weakness W, PLUS30
@@ -1291,7 +1291,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_32:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1330,7 +1330,7 @@ public enum SecretWonders implements LogicCardInfo {
             }
           }
 f
-        };
+        }
       case MOTHIM_33:
         return evolution (this, from:["Burmy","Burmy Plant Cloak","Burmy Sandy Cloak","Burmy Trash Cloak"], hp:HP080, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
@@ -1353,7 +1353,7 @@ f
             }
           }
 
-        };
+        }
       case NIDOKING_34:
         return evolution (this, from:"Nidorino", hp:HP130, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS30
@@ -1379,7 +1379,7 @@ f
             }
           }
 
-        };
+        }
       case PIDGEOT_35:
         return evolution (this, from:"Pidgeotto", hp:HP120, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS30
@@ -1415,7 +1415,7 @@ f
             }
           }
 
-        };
+        }
       case PLUSLE_36:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1450,7 +1450,7 @@ f
             }
           }
 
-        };
+        }
       case SHARPEDO_37:
         return evolution (this, from:"Carvanha", hp:HP080, type:DARKNESS, retreatCost:0) {
           weakness L, PLUS20
@@ -1470,7 +1470,7 @@ f
             }
           }
 
-        };
+        }
       case SUNFLORA_38:
         return evolution (this, from:"Sunkern", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1507,7 +1507,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_S_39:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1533,7 +1533,7 @@ f
             }
           }
 
-        };
+        }
       case WEAVILE_40:
         return evolution (this, from:"Sneasel", hp:HP080, type:WATER, retreatCost:0) {
           weakness M, PLUS20
@@ -1586,7 +1586,7 @@ f
             }
           }
 
-        };
+        }
       case WORMADAM_PLANT_CLOAK_41:
         return evolution (this, from:"Burmy Plant Cloak", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1609,7 +1609,7 @@ f
             }
           }
 
-        };
+        }
       case WORMADAM_SANDY_CLOAK_42:
         return evolution (this, from:"Burmy Sandy Cloak", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness R, PLUS20
@@ -1634,7 +1634,7 @@ f
             }
           }
 
-        };
+        }
       case WORMADAM_TRASH_CLOAK_43:
         return evolution (this, from:"Burmy Trash Cloak", hp:HP070, type:METAL, retreatCost:1) {
           weakness R, PLUS20
@@ -1661,7 +1661,7 @@ f
             }
           }
 
-        };
+        }
       case XATU_44:
         return evolution (this, from:"Natu", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -1687,7 +1687,7 @@ f
             }
           }
 
-        };
+        }
       case BRELOOM_45:
         return evolution (this, from:"Shroomish", hp:HP100, type:GRASS, retreatCost:2) {
           weakness R, PLUS30
@@ -1710,7 +1710,7 @@ f
             }
           }
 
-        };
+        }
       case CHARMELEON_46:
         return evolution (this, from:"Charmander", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W, PLUS20
@@ -1734,7 +1734,7 @@ f
             }
           }
 
-        };
+        }
       case CLOYSTER_47:
         return evolution (this, from:"Shellder", hp:HP080, type:WATER, retreatCost:2) {
           weakness L, PLUS20
@@ -1757,7 +1757,7 @@ f
             }
           }
 
-        };
+        }
       case DONPHAN_48:
         return evolution (this, from:"Phanpy", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness W, PLUS20
@@ -1788,7 +1788,7 @@ f
             }
           }
 
-        };
+        }
       case FARFETCH_D_49:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -1809,7 +1809,7 @@ f
             }
           }
 
-        };
+        }
       case FLAAFFY_50:
         return evolution (this, from:"Mareep", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1837,7 +1837,7 @@ f
             }
           }
 
-        };
+        }
       case IVYSAUR_51:
         return evolution (this, from:"Bulbasaur", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R, PLUS20
@@ -1857,7 +1857,7 @@ f
             }
           }
 
-        };
+        }
       case KECLEON_52:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -1887,7 +1887,7 @@ f
             }
           }
 
-        };
+        }
       case KIRLIA_53:
         return evolution (this, from:"Ralts", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -1910,7 +1910,7 @@ f
             }
           }
 
-        };
+        }
       case LOMBRE_54:
         return evolution (this, from:"Lotad", hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -1933,7 +1933,7 @@ f
             }
           }
 
-        };
+        }
       case MILTANK_55:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1959,7 +1959,7 @@ f
             }
           }
 
-        };
+        }
       case MUK_56:
         return evolution (this, from:"Grimer", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS20
@@ -1984,7 +1984,7 @@ f
             }
           }
 
-        };
+        }
       case NIDORINO_57:
         return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS20
@@ -2022,7 +2022,7 @@ f
             }
           }
 
-        };
+        }
       case PIDGEOTTO_58:
         return evolution (this, from:"Pidgey", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -2045,7 +2045,7 @@ f
             }
           }
 
-        };
+        }
       case PINSIR_59:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -2066,7 +2066,7 @@ f
             }
           }
 
-        };
+        }
       case QUAGSIRE_60:
         return evolution (this, from:"Wooper", hp:HP090, type:WATER, retreatCost:3) {
           weakness G, PLUS30
@@ -2092,7 +2092,7 @@ f
             }
           }
 
-        };
+        }
       case RATICATE_61:
         return evolution (this, from:"Rattata", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness F, PLUS20
@@ -2117,7 +2117,7 @@ f
             }
           }
 
-        };
+        }
       case ROSELIA_62:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2136,7 +2136,7 @@ f
             }
           }
 
-        };
+        }
       case SABLEYE_63:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           resistance C, MINUS20
@@ -2163,7 +2163,7 @@ f
             }
           }
 
-        };
+        }
       case SHELGON_64:
         return evolution (this, from:"Bagon", hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness C, PLUS20
@@ -2184,7 +2184,7 @@ f
             }
           }
 
-        };
+        }
       case SKIPLOOM_65:
         return evolution (this, from:"Hoppip", hp:HP060, type:GRASS, retreatCost:0) {
           weakness R, PLUS20
@@ -2211,7 +2211,7 @@ f
             }
           }
 
-        };
+        }
       case SMEARGLE_66:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2237,7 +2237,7 @@ f
             }
           }
 
-        };
+        }
       case SMOOCHUM_67:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2267,7 +2267,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_K_68:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2288,7 +2288,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_N_69:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2319,7 +2319,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_O_70:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2346,7 +2346,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_X_71:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2372,7 +2372,7 @@ f
             }
           }
 
-        };
+        }
       case UNOWN_Z_72:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2407,7 +2407,7 @@ f
             }
           }
 
-        };
+        }
       case VENOMOTH_73:
         return evolution (this, from:"Venonat", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -2433,7 +2433,7 @@ f
             }
           }
 
-        };
+        }
       case VIBRAVA_74:
         return evolution (this, from:"Trapinch", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS20
@@ -2458,7 +2458,7 @@ f
             }
           }
 
-        };
+        }
       case WARTORTLE_75:
         return evolution (this, from:"Squirtle", hp:HP080, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -2478,7 +2478,7 @@ f
             }
           }
 
-        };
+        }
       case BAGON_76:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -2498,7 +2498,7 @@ f
             }
           }
 
-        };
+        }
       case BULBASAUR_77:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2519,7 +2519,7 @@ f
             }
           }
 
-        };
+        }
       case BURMY_PLANT_CLOAK_78:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2544,7 +2544,7 @@ f
             }
           }
 
-        };
+        }
       case BURMY_SANDY_CLOAK_79:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2569,7 +2569,7 @@ f
             }
           }
 
-        };
+        }
       case BURMY_TRASH_CLOAK_80:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2594,7 +2594,7 @@ f
             }
           }
 
-        };
+        }
       case CARVANHA_81:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2618,7 +2618,7 @@ f
             }
           }
 
-        };
+        }
       case CHARMANDER_82:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2640,7 +2640,7 @@ f
             }
           }
 
-        };
+        }
       case CLEFAIRY_83:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2665,7 +2665,7 @@ f
             }
           }
 
-        };
+        }
       case CORSOLA_84:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness G, PLUS20
@@ -2701,7 +2701,7 @@ f
             }
           }
 
-        };
+        }
       case DIGLETT_85:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -2722,7 +2722,7 @@ f
             }
           }
 
-        };
+        }
       case DUSKULL_86:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2748,7 +2748,7 @@ f
             }
           }
 
-        };
+        }
       case ELECTABUZZ_87:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness F, PLUS20
@@ -2775,7 +2775,7 @@ f
             }
           }
 
-        };
+        }
       case GRIMER_88:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2794,7 +2794,7 @@ f
             }
           }
 
-        };
+        }
       case GROWLITHE_89:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -2813,7 +2813,7 @@ f
             }
           }
 
-        };
+        }
       case HOPPIP_90:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2835,7 +2835,7 @@ f
             }
           }
 
-        };
+        }
       case LICKITUNG_91:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:3) {
           weakness F, PLUS20
@@ -2860,7 +2860,7 @@ f
             }
           }
 
-        };
+        }
       case LOTAD_92:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2882,7 +2882,7 @@ f
             }
           }
 
-        };
+        }
       case MAGMAR_93:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W, PLUS20
@@ -2902,7 +2902,7 @@ f
             }
           }
 
-        };
+        }
       case MAREEP_94:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2925,7 +2925,7 @@ f
             }
           }
 
-        };
+        }
       case MURKROW_95:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2946,7 +2946,7 @@ f
               swiftDamage(20, opp.all.select())
             }
           }
-        };
+        }
       case NATU_96:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2967,7 +2967,7 @@ f
             foresight(5, delegate)
           }
 
-        };
+        }
       case NIDORAN_MALE_97:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -2989,7 +2989,7 @@ f
             }
           }
 
-        };
+        }
       case PHANPY_98:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -3013,7 +3013,7 @@ f
             }
           }
 
-        };
+        }
       case PIDGEY_99:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -3033,7 +3033,7 @@ f
             }
           }
 
-        };
+        }
       case PSYDUCK_100:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -3064,7 +3064,7 @@ f
             }
           }
 
-        };
+        }
       case QWILFISH_101:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness L, PLUS20
@@ -3091,7 +3091,7 @@ f
             }
           }
 
-        };
+        }
       case RALTS_102:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P, PLUS10
@@ -3112,7 +3112,7 @@ f
             }
           }
 
-        };
+        }
       case RATTATA_103:
         return basic (this, hp:HP030, type:COLORLESS, retreatCost:0) {
           weakness F, PLUS10
@@ -3133,7 +3133,7 @@ f
             }
           }
 
-        };
+        }
       case SENTRET_104:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS10
@@ -3157,7 +3157,7 @@ f
             }
           }
 
-        };
+        }
       case SHELLDER_105:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -3179,7 +3179,7 @@ f
             }
           }
 
-        };
+        }
       case SHELLOS_EAST_SEA_106:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L, PLUS10
@@ -3196,7 +3196,7 @@ f
             }
           }
 
-        };
+        }
       case SHELLOS_WEST_SEA_107:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -3219,7 +3219,7 @@ f
             }
           }
 
-        };
+        }
       case SHROOMISH_108:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3242,7 +3242,7 @@ f
             }
           }
 
-        };
+        }
       case SHUCKLE_109:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -3309,7 +3309,7 @@ f
             }
           }
 
-        };
+        }
       case SHUPPET_110:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -3329,7 +3329,7 @@ f
             }
           }
 
-        };
+        }
       case SPINDA_111:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -3355,7 +3355,7 @@ f
             }
           }
 
-        };
+        }
       case SQUIRTLE_112:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -3379,7 +3379,7 @@ f
             }
           }
 
-        };
+        }
       case STANTLER_113:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -3404,7 +3404,7 @@ f
             }
           }
 
-        };
+        }
       case SUNKERN_114:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3432,7 +3432,7 @@ f
             }
           }
 
-        };
+        }
       case TRAPINCH_115:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness W, PLUS10
@@ -3456,7 +3456,7 @@ f
             }
           }
 
-        };
+        }
       case VENONAT_116:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -3480,7 +3480,7 @@ f
             }
           }
 
-        };
+        }
       case VOLTORB_117:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -3501,7 +3501,7 @@ f
             }
           }
 
-        };
+        }
       case WOOPER_118:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness G, PLUS20
@@ -3521,13 +3521,13 @@ f
             }
           }
 
-        };
+        }
       case BEBE_S_SEARCH_119:
-        return copy (MysteriousTreasures.BEBE_S_SEARCH_109, this);
+        return copy (MysteriousTreasures.BEBE_S_SEARCH_109, this)
       case NIGHT_MAINTENANCE_120:
-        return copy (MysteriousTreasures.NIGHT_MAINTENANCE_113, this);
+        return copy (MysteriousTreasures.NIGHT_MAINTENANCE_113, this)
       case PLUSPOWER_121:
-        return copy (DiamondPearl.PLUSPOWER_109, this);
+        return copy (DiamondPearl.PLUSPOWER_109, this)
       case PROFESSOR_OAK_S_VISIT_122:
         return basicTrainer (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 3 cards. Then, choose a card from your hand and put it on the bottom of your deck."
@@ -3538,7 +3538,7 @@ f
           playRequirement{
             assert my.deck || my.hand.getExcludedList(thisCard) : "Both your deck and your hand are empty"
           }
-        };
+        }
       case PROFESSOR_ROWAN_123:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nChoose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can’t play this card.)"
@@ -3553,9 +3553,9 @@ f
           playRequirement{
             assert my.hand.getExcludedList(thisCard) : "You have no other cards in your hand"
           }
-        };
+        }
       case RIVAL_124:
-        return copy (DiamondPearl.RIVAL_113, this);
+        return copy (DiamondPearl.RIVAL_113, this)
       case ROSEANNE_S_RESEARCH_125:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your deck for up to 2 in any combination of Basic Pokémon and basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -3566,7 +3566,7 @@ f
           playRequirement{
             assert my.deck : "Your deck is empty!"
           }
-        };
+        }
       case TEAM_GALACTIC_S_MARS_126:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 2 cards. Then, choose a card from your opponent’s hand without looking and put it on the bottom of his or her deck."
@@ -3577,15 +3577,15 @@ f
           playRequirement{
             assert my.deck : "There are no cards left in your deck."
           }
-        };
+        }
       case POTION_127:
         return copy (FireRedLeafGreen.POTION_101, this)
       case SWITCH_128:
-        return copy(FireRedLeafGreen.SWITCH_102, this);
+        return copy(FireRedLeafGreen.SWITCH_102, this)
       case DARKNESS_ENERGY_129:
-        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this)
       case METAL_ENERGY_130:
-        return copy (RubySapphire.METAL_ENERGY_94, this);
+        return copy (RubySapphire.METAL_ENERGY_94, this)
       case GARDEVOIR_LV_X_131:
         return levelUp (this, from:"Gardevoir", hp:HP130, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -3608,7 +3608,7 @@ f
             energyCost P, P
             bringDown(delegate)
           }
-        };
+        }
       case HONCHKROW_LV_X_132:
         return levelUp (this, from:"Honchkrow", hp:HP110, type:DARKNESS, retreatCost:0) {
           weakness L, PLUS30
@@ -3636,9 +3636,9 @@ f
               damage 60
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -3,17 +3,17 @@ package tcgwars.logic.impl.gen4
 import tcgwars.logic.impl.gen2.Aquapolis
 import tcgwars.logic.impl.gen3.UnseenForces
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
-import tcgwars.logic.impl.gen4.GreatEncounters;
-import tcgwars.logic.impl.gen5.BlackWhite;
+import tcgwars.logic.impl.gen4.GreatEncounters
+import tcgwars.logic.impl.gen5.BlackWhite
 
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.effect.gm.PlayStadium
 import tcgwars.logic.effect.special.SpecialConditionType
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.EffectType.*
@@ -23,22 +23,22 @@ import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
 
-import java.util.*;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 import tcgwars.logic.effect.ability.Ability.ActivationReason
 import tcgwars.logic.effect.gm.*
@@ -165,53 +165,53 @@ public enum Stormfront implements LogicCardInfo {
   DUSKULL_SH2 ("Duskull", "SH2", Rarity.HOLORARE, [BASIC, POKEMON, _PSYCHIC_]),
   VOLTORB_SH3 ("Voltorb", "SH3", Rarity.HOLORARE, [BASIC, POKEMON, _LIGHTNING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Stormfront(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.STORMFRONT;
+    return tcgwars.logic.card.Collection.STORMFRONT
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -272,7 +272,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMPOLEON_2:
         return evolution (this, from:"Prinplup", hp:HP130, type:METAL, retreatCost:2) {
           weakness L, PLUS30
@@ -313,7 +313,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_3:
         return evolution (this, from:"Monferno", hp:HP120, type:FIGHTING, retreatCost:0) {
           weakness P, PLUS30
@@ -368,7 +368,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUMINEON_4:
         return evolution (this, from:"Finneon", hp:HP080, type:WATER, retreatCost:0) {
           weakness L, PLUS20
@@ -408,7 +408,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_5:
         return evolution (this, from:"Magneton", hp:HP120, type:METAL, retreatCost:2) {
           weakness R, PLUS30
@@ -440,7 +440,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_6:
         return evolution (this, from:"Magneton", hp:HP120, type:LIGHTNING, retreatCost:3) {
           weakness F, PLUS30
@@ -471,7 +471,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_7:
         return evolution (this, from:"Misdreavus", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -539,7 +539,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_8:
         return evolution (this, from:"Pikachu", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -581,7 +581,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGIGIGAS_9:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -618,7 +618,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCEPTILE_10:
         return evolution (this, from:"Grovyle", hp:HP110, type:GRASS, retreatCost:1) {
           weakness R, PLUS30
@@ -656,7 +656,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_11:
         return evolution (this, from:"Grotle", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness W, PLUS30
@@ -700,7 +700,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABOMASNOW_12:
         return evolution (this, from:"Snover", hp:HP100, type:WATER, retreatCost:3) {
           weakness R, PLUS30
@@ -740,7 +740,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_13:
         return evolution (this, from:"Bronzor", hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness P, PLUS20
@@ -781,7 +781,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERRIM_14:
         return evolution (this, from:"Cherubi", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -819,7 +819,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAPION_15:
         return evolution (this, from:"Skorupi", hp:HP110, type:DARKNESS, retreatCost:3) {
           weakness P, PLUS20
@@ -862,7 +862,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFBLIM_16:
         return evolution (this, from:"Drifloon", hp:HP090, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS20
@@ -909,7 +909,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKNOIR_17:
         return evolution (this, from:"Dusclops", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness D, PLUS30
@@ -940,7 +940,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_18:
         return evolution (this, from:"Haunter", hp:HP110, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS30
@@ -979,7 +979,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_19:
         return evolution (this, from:"Magikarp", hp:HP130, type:WATER, retreatCost:3) {
           weakness L, PLUS30
@@ -1025,7 +1025,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_20:
         return evolution (this, from:"Machoke", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS30
@@ -1060,7 +1060,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAMOSWINE_21:
         return evolution (this, from:"Piloswine", hp:HP140, type:FIGHTING, retreatCost:5) {
           weakness G, PLUS30
@@ -1096,7 +1096,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_22:
         return evolution (this, from:"Ponyta", hp:HP080, type:FIRE, retreatCost:0) {
           weakness W, PLUS20
@@ -1123,7 +1123,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_23:
         return evolution (this, from:"Roselia", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness R, PLUS20
@@ -1162,7 +1162,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAMENCE_24:
         return evolution (this, from:"Shelgon", hp:HP140, type:COLORLESS, retreatCost:3) {
           weakness C, PLUS30
@@ -1197,7 +1197,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCIZOR_25:
         return evolution (this, from:"Scyther", hp:HP100, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1239,7 +1239,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKUNTANK_26:
         return evolution (this, from:"Stunky", hp:HP100, type:DARKNESS, retreatCost:2) {
           weakness F, PLUS20
@@ -1286,7 +1286,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAPTOR_27:
         return evolution (this, from:"Staravia", hp:HP120, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS30
@@ -1339,7 +1339,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STEELIX_28:
         return evolution (this, from:"Onix", hp:HP130, type:METAL, retreatCost:4) {
           weakness R, PLUS30
@@ -1364,7 +1364,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGROWTH_29:
         return evolution (this, from:"Tangela", hp:HP110, type:GRASS, retreatCost:3) {
           weakness R, PLUS30
@@ -1403,7 +1403,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYRANITAR_30:
         return evolution (this, from:"Pupitar", hp:HP140, type:DARKNESS, retreatCost:4) {
           weakness F, PLUS30
@@ -1438,7 +1438,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VESPIQUEN_31:
         return evolution (this, from:"Combee", hp:HP100, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1479,7 +1479,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BIBAREL_32:
         return evolution (this, from:"Bidoof", hp:HP100, type:WATER, retreatCost:3) {
           weakness F, PLUS30
@@ -1510,7 +1510,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUDEW_33:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness R, PLUS10
@@ -1563,7 +1563,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_34:
         return evolution (this, from:"Duskull", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1592,7 +1592,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_35:
         return evolution (this, from:"Duskull", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1622,7 +1622,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_36:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1666,7 +1666,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_37:
         return evolution (this, from:"Voltorb", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F, PLUS20
@@ -1692,7 +1692,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FARFETCH_D_38:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS20
@@ -1715,7 +1715,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROVYLE_39:
         return evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R, PLUS20
@@ -1738,7 +1738,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_40:
         return evolution (this, from:"Gastly", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS20
@@ -1762,7 +1762,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOKE_41:
         return evolution (this, from:"Machop", hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness P, PLUS20
@@ -1784,7 +1784,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_42:
         return evolution (this, from:"Magnemite", hp:HP080, type:METAL, retreatCost:1) {
           weakness R, PLUS20
@@ -1809,7 +1809,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_43:
         return evolution (this, from:"Magnemite", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS20
@@ -1836,7 +1836,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MILTANK_44:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F, PLUS20
@@ -1876,7 +1876,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PICHU_45:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -1905,7 +1905,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PILOSWINE_46:
         return evolution (this, from:"Swinub", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness G, PLUS20
@@ -1931,7 +1931,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PUPITAR_47:
         return evolution (this, from:"Larvitar", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS20
@@ -1961,7 +1961,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SABLEYE_48:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           resistance C, MINUS20
@@ -1995,7 +1995,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_49:
         return basic (this, hp:HP060, type:GRASS, retreatCost:0) {
           weakness R, PLUS10
@@ -2017,7 +2017,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELGON_50:
         return evolution (this, from:"Bagon", hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness C, PLUS20
@@ -2041,7 +2041,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKARMORY_51:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness L, PLUS20
@@ -2066,7 +2066,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAVIA_52:
         return evolution (this, from:"Starly", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness L, PLUS20
@@ -2089,7 +2089,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BAGON_53:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C, PLUS10
@@ -2112,7 +2112,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BIDOOF_54:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness F, PLUS10
@@ -2135,7 +2135,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_55:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P, PLUS10
@@ -2161,7 +2161,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERUBI_56:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2186,7 +2186,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMBEE_57:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2208,7 +2208,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_58:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2230,7 +2230,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_59:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2253,7 +2253,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_60:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2275,7 +2275,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FINNEON_61:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2300,7 +2300,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_62:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2329,7 +2329,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_63:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS10
@@ -2354,7 +2354,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP_64:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P, PLUS10
@@ -2374,7 +2374,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_65:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness L, PLUS10
@@ -2398,7 +2398,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_66:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R, PLUS10
@@ -2422,7 +2422,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_67:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2442,7 +2442,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_68:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -2466,7 +2466,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_69:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness G, PLUS20
@@ -2500,7 +2500,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_70:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness F, PLUS10
@@ -2523,7 +2523,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_71:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W, PLUS10
@@ -2545,7 +2545,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSELIA_72:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness R, PLUS10
@@ -2572,7 +2572,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKORUPI_73:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness P, PLUS10
@@ -2597,7 +2597,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNOVER_74:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness R, PLUS10
@@ -2619,7 +2619,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARLY_75:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L, PLUS10
@@ -2641,7 +2641,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNKY_76:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness F, PLUS10
@@ -2664,7 +2664,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWINUB_77:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness G, PLUS10
@@ -2691,7 +2691,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_78:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2725,7 +2725,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREECKO_79:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R, PLUS10
@@ -2749,7 +2749,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_80:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2771,7 +2771,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_81:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -2798,7 +2798,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CONDUCTIVE_QUARRY_82:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nOnce during each player’s turn, the player may flip a coin. If heads, that player searches his or her discard pile for a [L] or [M] Energy card, shows it to the opponent, and puts it into his or her hand."
@@ -2818,7 +2818,7 @@ public enum Stormfront implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case ENERGY_LINK_83:
         return pokemonTool (this) {
           text "Attach Energy Link to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\nAs long as Energy Link is attached to a Pokémon, you may move an Energy card attached to that Pokémon to another of your Pokémon that has Energy Link attached to it. You may use this effect as often as you like during your turn."
@@ -2844,11 +2844,11 @@ public enum Stormfront implements LogicCardInfo {
               actions.each { bg().gm().unregisterAction(it) }
             }
           }
-        };
+        }
       case ENERGY_SWITCH_84:
         return copy(FireRedLeafGreen.ENERGY_SWITCH_90, this)
       case GREAT_BALL_85:
-        return copy(FireRedLeafGreen.GREAT_BALL_92, this);
+        return copy(FireRedLeafGreen.GREAT_BALL_92, this)
       case LUXURY_BALL_86:
         return basicTrainer (this) {
           text "Search your deck for a Pokémon (excluding Pokémon LV.X), show it to your opponent, and put it into your hand. Shuffle your deck afterward. If any Luxury Ball is in your discard pile, you can’t play this card."
@@ -2860,7 +2860,7 @@ public enum Stormfront implements LogicCardInfo {
             assert my.deck : "Your deck is empty"
             assert !my.discard.find{it.name == "Luxury Ball"}
           }
-        };
+        }
       case MARLEY_S_REQUEST_87:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your discard pile for 2 different Trainer, Supporter, or Stadium cards, show them to your opponent, and your opponent chooses 1 of them. Put that card into your hand, and discard the other card. (If all Trainer, Supporter, and Stadium cards in your discard pile have the same name, choose 1 of them. Show that card to your opponent and put it into your hand.)"
@@ -2891,7 +2891,7 @@ public enum Stormfront implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(ITEM,SUPPORTER,STADIUM) : "You have no Trainer, Supporter, or Stadium cards in your discard pile"
           }
-        };
+        }
       case POKE_BLOWER_PLUS_88:
         return basicTrainer (this) {
           text "You may play 2 Poké Blower + at the same time. If you play 1 Poké Blower +, flip a coin. If heads, put 1 damage counter on 1 of your opponent’s Pokémon. If you play 2 Poké Blower +, choose 1 of your opponent’s Benched Pokémon and switch it with 1 of your opponent’s Active Pokémon."
@@ -2907,7 +2907,7 @@ public enum Stormfront implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case POKE_DRAWER_PLUS_89:
         return basicTrainer (this) {
           text "You may play 2 Poké Drawer + at the same time. If you play 1 Poké Drawer +, draw a card. If you play 2 Poké Drawer +, search your deck for up to 2 cards, and put them into your hand. Shuffle your deck afterward."
@@ -2923,7 +2923,7 @@ public enum Stormfront implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case POKE_HEALER_PLUS_90:
         return basicTrainer (this) {
           text "You may play 2 Poké Healer + at the same time. If you play 1 Poké Healer +, remove 1 damage counter and a Special Condition from 1 of your Active Pokémon. If you play 2 Poké Healer +, remove 8 damage counters and all Special Conditions from 1 of your Active Pokémon."
@@ -2943,13 +2943,13 @@ public enum Stormfront implements LogicCardInfo {
           playRequirement{
             assert my.active.numberOfDamageCounters || my.active.specialConditions : "$my.active is healthy"
           }
-        };
+        }
       case PREMIER_BALL_91:
-        return copy (GreatEncounters.PREMIER_BALL_101, this);
+        return copy (GreatEncounters.PREMIER_BALL_101, this)
       case POTION_92:
-        return copy (FireRedLeafGreen.POTION_101, this);
+        return copy (FireRedLeafGreen.POTION_101, this)
       case SWITCH_93:
-        return copy(FireRedLeafGreen.SWITCH_102, this);
+        return copy(FireRedLeafGreen.SWITCH_102, this)
       case CYCLONE_ENERGY_94:
         return copy (UnseenForces.CYCLONE_ENERGY_99, this)
       case WARP_ENERGY_95:
@@ -3013,7 +3013,7 @@ public enum Stormfront implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HEATRAN_LV_X_97:
         return levelUp (this, from:"Heatran", hp:HP120, type:FIRE, retreatCost:4) {
           weakness W
@@ -3083,7 +3083,7 @@ public enum Stormfront implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MACHAMP_LV_X_98:
         return levelUp (this, from:"Machamp", hp:HP150, type:FIGHTING, retreatCost:3) {
           weakness P, PLUS40
@@ -3131,7 +3131,7 @@ public enum Stormfront implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAICHU_LV_X_99:
         return levelUp (this, from:"Raichu", hp:HP110, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -3186,7 +3186,7 @@ public enum Stormfront implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REGIGIGAS_LV_X_100:
         return levelUp (this, from:"Regigigas", hp:HP150, type:COLORLESS, retreatCost:4) {
           weakness F
@@ -3219,7 +3219,7 @@ public enum Stormfront implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case CHARMANDER_101:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness W
@@ -3239,7 +3239,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMELEON_102:
         return evolution (this, from:"Charmander", hp:HP080, type:FIRE, retreatCost:1) {
           weakness W
@@ -3259,7 +3259,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_103:
         return evolution (this, from:"Charmeleon", hp:HP120, type:FIRE, retreatCost:3) {
           weakness W
@@ -3285,7 +3285,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_SH1:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:0) {
           weakness D, PLUS10
@@ -3314,7 +3314,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKULL_SH2:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D, PLUS10
@@ -3362,7 +3362,7 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_SH3:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F, PLUS10
@@ -3398,9 +3398,9 @@ public enum Stormfront implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -16,25 +16,25 @@ import tcgwars.logic.effect.gm.PlayPokemonToolFlare
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.effect.special.SpecialConditionType
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
-import tcgwars.logic.impl.gen7.CelestialStorm;
+import tcgwars.logic.impl.gen7.CelestialStorm
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
-import static tcgwars.logic.effect.Source.POKEPOWER;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.Source.POKEPOWER
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Weakness.*
-import tcgwars.logic.effect.basic.Knockout;
+import tcgwars.logic.effect.basic.Knockout
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author ufodynasty12@gmail.com
@@ -195,53 +195,53 @@ public enum SupremeVictors implements LogicCardInfo {
   RELICANTH_SH8 ("Relicanth", "SH8", Rarity.HOLORARE, [BASIC, POKEMON, _FIGHTING_]),
   YANMA_SH9 ("Yanma", "SH9", Rarity.HOLORARE, [BASIC, POKEMON, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SupremeVictors(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SUPREME_VICTORS;
+    return tcgwars.logic.card.Collection.SUPREME_VICTORS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -284,7 +284,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLAZIKEN_FB_2:
         return basic (this, hp:HP080, type:R, retreatCost:1) {
           weakness W
@@ -310,7 +310,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRIFBLIM_FB_3:
         return basic (this, hp:HP080, type:P, retreatCost:2) {
           weakness D
@@ -336,7 +336,7 @@ public enum SupremeVictors implements LogicCardInfo {
               new ResolvedDamage(hp(40), my.active, pcs, Source.ATTACK, DamageManager.DamageFlag.FORCE_WEAKNESS_RESISTANCE).run(bg)
             }
           }
-        };
+        }
       case ELECTIVIRE_FB_4:
         return basic (this, hp:HP090, type:L, retreatCost:3) {
           weakness F
@@ -369,7 +369,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GARCHOMP_5:
         return evolution (this, from:"Gabite", hp:HP130, type:C, retreatCost:0) {
           weakness C, PLUS30
@@ -399,7 +399,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 120 - 20 * defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case MAGMORTAR_6:
         return evolution (this, from:"Magmar", hp:HP110, type:R, retreatCost:2) {
           weakness W, PLUS30
@@ -436,7 +436,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METAGROSS_7:
         return evolution (this, from:"Metang", hp:HP130, type:M, retreatCost:3) {
           weakness R, PLUS30
@@ -483,7 +483,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAYQUAZA_C_8:
         return basic (this, hp:HP100, type:C, retreatCost:3) {
           weakness C
@@ -517,7 +517,7 @@ public enum SupremeVictors implements LogicCardInfo {
                 }]
             }
           }
-        };
+        }
       case REGIGIGAS_FB_9:
         return basic (this, hp:HP100, type:C, retreatCost:4) {
           weakness F
@@ -543,7 +543,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RHYPERIOR_10:
         return evolution (this, from:"Rhydon", hp:HP140, type:F, retreatCost:4) {
           weakness W, PLUS30
@@ -574,7 +574,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARAPTOR_FB_11:
         return basic (this, hp:HP080, type:C, retreatCost:1) {
           weakness L
@@ -601,7 +601,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SWAMPERT_12:
         return evolution (this, from:"Marshtomp", hp:HP130, type:W, retreatCost:2) {
           weakness G, PLUS30
@@ -637,7 +637,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 60 + 10 * self.cards.energyCount(F)
             }
           }
-        };
+        }
       case VENUSAUR_13:
         return evolution (this, from:"Ivysaur", hp:HP140, type:G, retreatCost:4) {
           weakness R, PLUS40
@@ -684,7 +684,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40 + 40 * defending.specialConditions.size()
             }
           }
-        };
+        }
       case YANMEGA_14:
         return evolution (this, from:"Yanma", hp:HP100, type:G, retreatCost:0) {
           weakness L, PLUS20
@@ -722,7 +722,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case ARCANINE_G_15:
         return basic (this, hp:HP090, type:R, retreatCost:2) {
           weakness W
@@ -745,7 +745,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARTICUNO_16:
         return basic (this, hp:HP100, type:W, retreatCost:2) {
           weakness M, PLUS30
@@ -772,7 +772,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUTTERFREE_FB_17:
         return basic (this, hp:HP090, type:G, retreatCost:1) {
           weakness R
@@ -801,7 +801,7 @@ public enum SupremeVictors implements LogicCardInfo {
               afterDamage {apply spc, defending}
             }
           }
-        };
+        }
       case CAMERUPT_18:
         return evolution (this, from:"Numel", hp:HP120, type:R, retreatCost:4) {
           weakness W, PLUS30
@@ -839,7 +839,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CAMERUPT_G_19:
         return basic (this, hp:HP100, type:R, retreatCost:3) {
           weakness W
@@ -865,7 +865,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARIZARD_G_20:
         return basic (this, hp:HP100, type:R, retreatCost:3) {
           weakness W
@@ -888,7 +888,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case CHIMECHO_21:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P, PLUS20
@@ -915,7 +915,7 @@ public enum SupremeVictors implements LogicCardInfo {
               directDamage 10*tar.cards.energyCount(C), tar
             }
           }
-        };
+        }
       case CLAYDOL_22:
         return evolution (this, from:"Baltoy", hp:HP090, type:P, retreatCost:1) {
           weakness P, PLUS20
@@ -938,7 +938,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CRAWDAUNT_G_23:
         return basic (this, hp:HP080, type:D, retreatCost:1) {
           weakness L
@@ -962,7 +962,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DEWGONG_24:
         return evolution (this, from:"Seel", hp:HP100, type:W, retreatCost:3) {
           weakness M, PLUS20
@@ -998,7 +998,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case DODRIO_25:
         return evolution (this, from:"Doduo", hp:HP080, type:C, retreatCost:0) {
           weakness L, PLUS20
@@ -1021,7 +1021,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case DUSKNOIR_FB_26:
         return basic (this, hp:HP090, type:P, retreatCost:2) {
           weakness D
@@ -1047,7 +1047,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10 * my.discard.filterByType(POKEMON_SP).size()
             }
           }
-        };
+        }
       case EMPOLEON_FB_27:
         return basic (this, hp:HP090, type:W, retreatCost:2) {
           weakness L
@@ -1075,7 +1075,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case EXPLOUD_28:
         return evolution (this, from:"Loudred", hp:HP130, type:C, retreatCost:2) {
           weakness F, PLUS30
@@ -1109,7 +1109,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HONCHKROW_29:
         return evolution (this, from:"Murkrow", hp:HP090, type:D, retreatCost:1) {
           weakness L, PLUS20
@@ -1135,7 +1135,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 30 + 10 * all.findAll{!it.evolution}.size()
             }
           }
-        };
+        }
       case LICKILICKY_C_30:
         return basic (this, hp:HP090, type:C, retreatCost:2) {
           weakness F
@@ -1165,7 +1165,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUCARIO_C_31:
         return basic (this, hp:HP090, type:F, retreatCost:2) {
           weakness P
@@ -1188,7 +1188,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUNATONE_32:
         return basic (this, hp:HP070, type:P, retreatCost:0) {
           weakness P, PLUS20
@@ -1231,7 +1231,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAWILE_33:
         return basic (this, hp:HP070, type:M, retreatCost:1) {
           weakness R, PLUS20
@@ -1262,7 +1262,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MEDICHAM_34:
         return evolution (this, from:"Meditite", hp:HP090, type:P, retreatCost:1) {
           weakness P, PLUS20
@@ -1285,7 +1285,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10 + 10 * self.owner.opposite.pbg.hand.size()
             }
           }
-        };
+        }
       case MILOTIC_C_35:
         return basic (this, hp:HP090, type:W, retreatCost:1) {
           weakness L
@@ -1311,7 +1311,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MOLTRES_36:
         return basic (this, hp:HP100, type:R, retreatCost:2) {
           weakness W, PLUS30
@@ -1334,7 +1334,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MR__MIME_37:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           pokeBody "Focus Wall", {
@@ -1368,7 +1368,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PARASECT_38:
         return evolution (this, from:"Paras", hp:HP080, type:G, retreatCost:1) {
           weakness R, PLUS20
@@ -1398,7 +1398,7 @@ public enum SupremeVictors implements LogicCardInfo {
                     delayed {
                       before ASLEEP_SPC, null, null, BEGIN_TURN, {
                         flip "Asleep (Hibernation Spore)", 2, {}, {}, [2: {
-                          ef.unregisterItself(bg.em());
+                          ef.unregisterItself(bg.em())
                         }, 1:{
                           bc "$pcs is still asleep."
                         }, 0:{
@@ -1420,7 +1420,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PRIMEAPE_39:
         return evolution (this, from:"Mankey", hp:HP090, type:F, retreatCost:1) {
           weakness P, PLUS20
@@ -1448,7 +1448,7 @@ public enum SupremeVictors implements LogicCardInfo {
               noResistanceOrAnyEffectDamage(40, defending)
             }
           }
-        };
+        }
       case ROSERADE_C_40:
         return basic (this, hp:HP090, type:P, retreatCost:2) {
           weakness P
@@ -1474,7 +1474,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SABLEYE_G_41:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           resistance C, MINUS20
@@ -1495,7 +1495,7 @@ public enum SupremeVictors implements LogicCardInfo {
               astonish()
             }
           }
-        };
+        }
       case SANDSLASH_42:
         return evolution (this, from:"Sandshrew", hp:HP090, type:F, retreatCost:1) {
           weakness W, PLUS20
@@ -1526,7 +1526,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SEAKING_43:
         return evolution (this, from:"Goldeen", hp:HP090, type:W, retreatCost:1) {
           weakness L, PLUS20
@@ -1560,7 +1560,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHEDINJA_44:
         return evolution (this, from:"Nincada", hp:HP060, type:G, retreatCost:1) {
           weakness R, PLUS20
@@ -1599,7 +1599,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 30, opp.all.findAll{it.numberOfDamageCounters}.select(text)
             }
           }
-        };
+        }
       case SOLROCK_45:
         return basic (this, hp:HP080, type:P, retreatCost:1) {
           weakness G, PLUS20
@@ -1632,7 +1632,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SPINDA_46:
         return basic (this, hp:HP070, type:C, retreatCost:1) {
           weakness F, PLUS20
@@ -1673,7 +1673,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WAILORD_47:
         return evolution (this, from:"Wailmer", hp:HP180, type:W, retreatCost:4) {
           weakness L
@@ -1696,7 +1696,7 @@ public enum SupremeVictors implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case ZAPDOS_48:
         return basic (this, hp:HP100, type:L, retreatCost:2) {
           weakness L, PLUS30
@@ -1720,7 +1720,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALTARIA_C_49:
         return basic (this, hp:HP080, type:C, retreatCost:1) {
           weakness C
@@ -1743,7 +1743,7 @@ public enum SupremeVictors implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case ARCANINE_50:
         return evolution (this, from:"Growlithe", hp:HP080, type:R, retreatCost:3) {
           weakness W, PLUS20
@@ -1766,7 +1766,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case BIBAREL_51:
         return evolution (this, from:"Bidoof", hp:HP090, type:C, retreatCost:3) {
           weakness F, PLUS20
@@ -1788,7 +1788,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BRELOOM_52:
         return evolution (this, from:"Shroomish", hp:HP090, type:F, retreatCost:1) {
           weakness R, PLUS20
@@ -1831,7 +1831,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CARNIVINE_53:
         return basic (this, hp:HP080, type:G, retreatCost:2) {
           weakness R, PLUS20
@@ -1855,7 +1855,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHATOT_G_54:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -1885,7 +1885,7 @@ public enum SupremeVictors implements LogicCardInfo {
               removePCS(self)
             }
           }
-        };
+        }
       case CHERRIM_55:
         return evolution (this, from:"Cherubi", hp:HP080, type:G, retreatCost:1) {
           weakness R, PLUS20
@@ -1911,7 +1911,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAGONITE_FB_56:
         return basic (this, hp:HP100, type:C, retreatCost:3) {
           weakness C
@@ -1937,7 +1937,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRIFBLIM_57:
         return evolution (this, from:"Drifloon", hp:HP080, type:P, retreatCost:1) {
           weakness D, PLUS20
@@ -1958,7 +1958,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case FLOATZEL_58:
         return evolution (this, from:"Buizel", hp:HP070, type:W, retreatCost:1) {
           weakness L, PLUS20
@@ -1981,7 +1981,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GABITE_59:
         return evolution (this, from:"Gible", hp:HP080, type:C, retreatCost:1) {
           weakness C, PLUS20
@@ -2006,7 +2006,7 @@ public enum SupremeVictors implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case GARCHOMP_C_60:
         return basic (this, hp:HP080, type:C, retreatCost:1) {
           weakness C
@@ -2029,7 +2029,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HIPPOPOTAS_61:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness W, PLUS10
@@ -2051,7 +2051,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case IVYSAUR_62:
         return evolution (this, from:"Bulbasaur", hp:HP080, type:G, retreatCost:2) {
           weakness R, PLUS20
@@ -2072,7 +2072,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case LOPUNNY_63:
         return evolution (this, from:"Buneary", hp:HP080, type:C, retreatCost:1) {
           weakness F, PLUS20
@@ -2095,7 +2095,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case LOUDRED_64:
         return evolution (this, from:"Whismur", hp:HP080, type:C, retreatCost:2) {
           weakness F, PLUS20
@@ -2120,7 +2120,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGMAR_65:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W, PLUS20
@@ -2143,7 +2143,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MANECTRIC_G_66:
         return basic (this, hp:HP080, type:L, retreatCost:1) {
           weakness F
@@ -2169,7 +2169,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MARSHTOMP_67:
         return evolution (this, from:"Mudkip", hp:HP080, type:W, retreatCost:1) {
           weakness G, PLUS20
@@ -2197,7 +2197,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case MASQUERAIN_68:
         return evolution (this, from:"Surskit", hp:HP080, type:G, retreatCost:0) {
           weakness L, PLUS20
@@ -2226,7 +2226,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METANG_69:
         return evolution (this, from:"Beldum", hp:HP080, type:M, retreatCost:2) {
           weakness R, PLUS20
@@ -2247,7 +2247,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40 + 10 * defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case MILOTIC_70:
         return evolution (this, from:"Feebas", hp:HP090, type:W, retreatCost:1) {
           weakness L, PLUS20
@@ -2274,7 +2274,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 90 - 10 * my.hand.size()
             }
           }
-        };
+        }
       case MINUN_71:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -2293,7 +2293,7 @@ public enum SupremeVictors implements LogicCardInfo {
               attachEnergyFrom(type:L,my.discard,my.all)
             }
           }
-        };
+        }
       case MURKROW_72:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness L, PLUS10
@@ -2325,7 +2325,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case NINJASK_73:
         return evolution (this, from:"Nincada", hp:HP080, type:G, retreatCost:0) {
           weakness R, PLUS20
@@ -2361,7 +2361,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NUMEL_74:
         return basic (this, hp:HP070, type:R, retreatCost:2) {
           weakness W, PLUS20
@@ -2383,7 +2383,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case PINSIR_75:
         return basic (this, hp:HP090, type:G, retreatCost:2) {
           weakness R, PLUS20
@@ -2408,7 +2408,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PLUSLE_76:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -2435,7 +2435,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAICHU_77:
         return evolution (this, from:"Pikachu", hp:HP090, type:L, retreatCost:0) {
           weakness F, PLUS20
@@ -2464,7 +2464,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RATICATE_G_78:
         return basic (this, hp:HP070, type:C, retreatCost:0) {
           weakness F
@@ -2489,7 +2489,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RELICANTH_79:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
           weakness G, PLUS20
@@ -2519,7 +2519,7 @@ public enum SupremeVictors implements LogicCardInfo {
               amnesia delegate
             }
           }
-        };
+        }
       case RHYDON_80:
         return evolution (this, from:"Rhyhorn", hp:HP090, type:F, retreatCost:3) {
           weakness W, PLUS20
@@ -2543,7 +2543,7 @@ public enum SupremeVictors implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case ROSERADE_81:
         return evolution (this, from:"Roselia", hp:HP080, type:G, retreatCost:2) {
           weakness R, PLUS20
@@ -2564,7 +2564,7 @@ public enum SupremeVictors implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case ROTOM_82:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           weakness D, PLUS20
@@ -2593,7 +2593,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKARMORY_FB_83:
         return basic (this, hp:HP080, type:M, retreatCost:1) {
           weakness L
@@ -2629,7 +2629,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SPIRITOMB_C_84:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           resistance C, MINUS20
@@ -2650,7 +2650,7 @@ public enum SupremeVictors implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case STARAVIA_85:
         return evolution (this, from:"Starly", hp:HP070, type:C, retreatCost:1) {
           weakness L, PLUS20
@@ -2676,7 +2676,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TOGEKISS_C_86:
         return basic (this, hp:HP070, type:C, retreatCost:0) {
           weakness L
@@ -2700,7 +2700,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case WAILMER_87:
         return basic (this, hp:HP080, type:W, retreatCost:3) {
           weakness L, PLUS20
@@ -2722,7 +2722,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case YANMA_88:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
           weakness L, PLUS20
@@ -2748,7 +2748,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BALTOY_89:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -2770,7 +2770,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BELDUM_90:
         return basic (this, hp:HP050, type:M, retreatCost:2) {
           weakness R, PLUS10
@@ -2794,7 +2794,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case BIDOOF_91:
         return basic (this, hp:HP060, type:C, retreatCost:2) {
           weakness F, PLUS10
@@ -2808,7 +2808,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUIZEL_92:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -2828,7 +2828,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BULBASAUR_93:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -2848,7 +2848,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BUNEARY_94:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness F, PLUS10
@@ -2871,7 +2871,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHATOT_95:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L, PLUS10
@@ -2892,7 +2892,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHERUBI_96:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -2915,7 +2915,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CHIMCHAR_97:
         return basic (this, hp:HP050, type:R, retreatCost:1) {
           weakness W, PLUS10
@@ -2938,7 +2938,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHINGLING_98:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -2966,7 +2966,7 @@ public enum SupremeVictors implements LogicCardInfo {
               bg.em().run(new ActivateSimpleTrainer(card))
             }
           }
-        };
+        }
       case COMBEE_99:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -2989,7 +2989,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case CORPHISH_100:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -3012,7 +3012,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CROAGUNK_101:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -3032,7 +3032,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case DODUO_102:
         return basic (this, hp:HP050, type:C, retreatCost:0) {
           weakness L, PLUS10
@@ -3046,7 +3046,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case DRIFLOON_103:
         return basic (this, hp:HP040, type:P, retreatCost:1) {
           weakness D, PLUS10
@@ -3070,7 +3070,7 @@ public enum SupremeVictors implements LogicCardInfo {
               draw 1
             }
           }
-        };
+        }
       case FEEBAS_104:
         return basic (this, hp:HP030, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -3095,7 +3095,7 @@ public enum SupremeVictors implements LogicCardInfo {
               draw opp.all.findAll{!it.evolution}.size()
             }
           }
-        };
+        }
       case GEODUDE_105:
         return basic (this, hp:HP060, type:F, retreatCost:2) {
           weakness W, PLUS10
@@ -3117,7 +3117,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GIBLE_106:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness C, PLUS10
@@ -3137,7 +3137,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case GOLDEEN_107:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -3161,7 +3161,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GROWLITHE_108:
         return basic (this, hp:HP060, type:R, retreatCost:1) {
           weakness W, PLUS10
@@ -3184,7 +3184,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KRICKETOT_109:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3204,7 +3204,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MAGIKARP_110:
         return basic (this, hp:HP030, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -3218,7 +3218,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGNEMITE_111:
         return basic (this, hp:HP040, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -3242,7 +3242,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MANKEY_112:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness P, PLUS10
@@ -3257,7 +3257,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEDITITE_113:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -3279,7 +3279,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 30 - 10 * self.numberOfDamageCounters
             }
           }
-        };
+        }
       case MEOWTH_114:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F, PLUS10
@@ -3301,7 +3301,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MIME_JR__115:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -3341,7 +3341,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MUDKIP_116:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G, PLUS10
@@ -3364,7 +3364,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case NINCADA_117:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3383,7 +3383,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 10, opp.bench.select(text)
             }
           }
-        };
+        }
       case PACHIRISU_118:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -3407,7 +3407,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PARAS_119:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3430,7 +3430,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_120:
         return basic (this, hp:HP050, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -3454,7 +3454,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIPLUP_121:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness L, PLUS10
@@ -3474,7 +3474,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case RHYHORN_122:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness W, PLUS10
@@ -3498,7 +3498,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ROSELIA_123:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3521,7 +3521,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SANDSHREW_124:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness W, PLUS10
@@ -3534,7 +3534,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SEEL_125:
         return basic (this, hp:HP060, type:W, retreatCost:2) {
           weakness M, PLUS10
@@ -3557,7 +3557,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHINX_126:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F, PLUS10
@@ -3570,7 +3570,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SHROOMISH_127:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3593,7 +3593,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SKORUPI_128:
         return basic (this, hp:HP050, type:P, retreatCost:2) {
           weakness P, PLUS10
@@ -3618,7 +3618,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARLY_129:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness L, PLUS10
@@ -3631,7 +3631,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SURSKIT_130:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R, PLUS10
@@ -3646,7 +3646,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TURTWIG_131:
         return basic (this, hp:HP060, type:G, retreatCost:2) {
           weakness R, PLUS10
@@ -3670,7 +3670,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WHISMUR_132:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F, PLUS10
@@ -3692,7 +3692,7 @@ public enum SupremeVictors implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ZUBAT_133:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P, PLUS10
@@ -3707,7 +3707,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BATTLE_TOWER_134:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -3726,7 +3726,7 @@ public enum SupremeVictors implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case CHAMPION_S_ROOM_135:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card." +
@@ -3742,7 +3742,7 @@ public enum SupremeVictors implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case CYNTHIA_S_GUIDANCE_136:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -3754,7 +3754,7 @@ public enum SupremeVictors implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case CYRUS_S_INITIATIVE_137:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -3771,7 +3771,7 @@ public enum SupremeVictors implements LogicCardInfo {
           playRequirement{
             assert opp.hand : "Your opponent's hand is empty"
           }
-        };
+        }
       case NIGHT_TELEPORTER_138:
         return itemCard (this) {
           text "Flip a coin. If heads, put all cards in your hand on top of your deck. Then, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
@@ -3786,7 +3786,7 @@ public enum SupremeVictors implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard) || my.deck : "You have no other cards in your hand or deck"
           }
-        };
+        }
       case PALMER_S_CONTRIBUTION_139:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card." +
@@ -3801,9 +3801,9 @@ public enum SupremeVictors implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON, BASIC_ENERGY) : "You have no Pokémon or basic Energy cards in your discard pile"
           }
-        };
+        }
       case VS_SEEKER_140:
-        return copy(FireRedLeafGreen.VS_SEEKER_100, this);
+        return copy(FireRedLeafGreen.VS_SEEKER_100, this)
       case ABSOL_G_LV_X_141:
         return levelUp (this, from:"Absol G", hp:HP100, type:D, retreatCost:1) {
           weakness F
@@ -3836,7 +3836,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLAZIKEN_FB_LV_X_142:
         return levelUp (this, from:"Blaziken FB", hp:HP110, type:R, retreatCost:1) {
           weakness W
@@ -3879,7 +3879,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARIZARD_G_LV_X_143:
         return levelUp (this, from:"Charizard G", hp:HP120, type:R, retreatCost:3) {
           weakness W
@@ -3908,7 +3908,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ELECTIVIRE_FB_LV_X_144:
         return levelUp (this, from:"Electivire FB", hp:HP120, type:L, retreatCost:3) {
           weakness F
@@ -3938,7 +3938,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GARCHOMP_C_LV_X_145:
         return levelUp (this, from:"Garchomp C", hp:HP110, type:C, retreatCost:0) {
           weakness C
@@ -3965,7 +3965,7 @@ public enum SupremeVictors implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case RAYQUAZA_C_LV_X_146:
         return levelUp (this, from:"Rayquaza C", hp:HP120, type:C, retreatCost:3) {
           weakness C
@@ -3999,7 +3999,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARAPTOR_FB_LV_X_147:
         return levelUp (this, from:"Staraptor FB", hp:HP100, type:C, retreatCost:0) {
           weakness L
@@ -4026,7 +4026,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARTICUNO_148:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           resistance F, MINUS30
@@ -4045,7 +4045,7 @@ public enum SupremeVictors implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOLTRES_149:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           resistance F, MINUS30
@@ -4067,7 +4067,7 @@ public enum SupremeVictors implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZAPDOS_150:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           resistance F, MINUS30
@@ -4086,7 +4086,7 @@ public enum SupremeVictors implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MILOTIC_SH7:
         return evolution (this, from:"Feebas", hp:HP080, type:W, retreatCost:1) {
           weakness L, PLUS20
@@ -4114,7 +4114,7 @@ public enum SupremeVictors implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RELICANTH_SH8:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
           weakness G, PLUS20
@@ -4139,7 +4139,7 @@ public enum SupremeVictors implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMA_SH9:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
           weakness L, PLUS20
@@ -4170,9 +4170,9 @@ public enum SupremeVictors implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/Triumphant.groovy
+++ b/src/tcgwars/logic/impl/gen4/Triumphant.groovy
@@ -1,33 +1,33 @@
 package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.effect.EffectPriority
-import tcgwars.logic.effect.basic.Knockout;
+import tcgwars.logic.effect.basic.Knockout
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
 import static tcgwars.logic.effect.EffectPriority.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.EffectType.ATTACH_ENERGY
 import static tcgwars.logic.effect.EffectType.DEVOLVE
 import static tcgwars.logic.effect.EffectType.EVOLVE
 import static tcgwars.logic.effect.EffectType.KNOCKOUT
-import static tcgwars.logic.effect.EffectType.KNOCKOUT;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.EffectType.KNOCKOUT
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
-import tcgwars.logic.util.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.*
+import tcgwars.logic.util.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.*;
+import tcgwars.logic.*
 
 
 
@@ -142,53 +142,53 @@ public enum Triumphant implements LogicCardInfo {
   PALKIA_AND_DIALGA_LEGEND_102 ("Palkia & Dialga LEGEND", "102", Rarity.HOLORARE, [POKEMON, _WATER_, LEGEND]),
   ALPH_LITHOGRAPH_FOUR ("Alph Lithograph", "FOUR", Rarity.HOLORARE, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Triumphant(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.TRIUMPHANT;
+    return tcgwars.logic.card.Collection.TRIUMPHANT
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -217,7 +217,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALTARIA_2:
         return evolution (this, from:"Swablu", hp:HP090, type:COLORLESS, retreatCost:0) {
           weakness C
@@ -241,7 +241,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CELEBI_3:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -283,7 +283,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAPION_4:
         return evolution (this, from:"Skorupi", hp:HP100, type:DARKNESS, retreatCost:3) {
           weakness F
@@ -307,7 +307,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAMOSWINE_5:
         return evolution (this, from:"Piloswine", hp:HP140, type:WATER, retreatCost:4) {
           weakness M
@@ -330,7 +330,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOKING_6:
         return evolution (this, from:"Nidorino", hp:HP140, type:FIGHTING, retreatCost:3) {
           weakness W
@@ -350,7 +350,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_Z_7:
         return evolution (this, from:"Porygon2", hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -380,7 +380,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAPIDASH_8:
         return evolution (this, from:"Ponyta", hp:HP090, type:FIRE, retreatCost:1) {
           weakness W
@@ -408,7 +408,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SOLROCK_9:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness G
@@ -432,7 +432,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPIRITOMB_10:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           resistance C, MINUS20
@@ -458,7 +458,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_11:
         return evolution (this, from:"Venonat", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -486,7 +486,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTREEBEL_12:
         return evolution (this, from:"Weepinbell", hp:HP110, type:GRASS, retreatCost:2) {
           weakness R
@@ -509,7 +509,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMBIPOM_13:
         return evolution (this, from:"Aipom", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -535,7 +535,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BANETTE_14:
         return evolution (this, from:"Shuppet", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -564,7 +564,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_15:
         return evolution (this, from:"Bronzor", hp:HP090, type:METAL, retreatCost:3) {
           weakness R
@@ -601,7 +601,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARNIVINE_16:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness R
@@ -626,7 +626,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DITTO_17:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -654,7 +654,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGONITE_18:
         return evolution (this, from:"Dragonair", hp:HP140, type:COLORLESS, retreatCost:4) {
           weakness C
@@ -680,7 +680,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUGTRIO_19:
         return evolution (this, from:"Diglett", hp:HP080, type:FIGHTING, retreatCost:0) {
           weakness W
@@ -703,7 +703,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTIVIRE_20:
         return evolution (this, from:"Electabuzz", hp:HP100, type:LIGHTNING, retreatCost:3) {
           weakness F
@@ -731,7 +731,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELEKID_21:
         return basic (this, hp:HP030, type:LIGHTNING, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -758,7 +758,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDUCK_22:
         return evolution (this, from:"Psyduck", hp:HP090, type:WATER, retreatCost:1) {
           weakness L
@@ -783,7 +783,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUMPIG_23:
         return evolution (this, from:"Spoink", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -820,7 +820,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRICKETUNE_24:
         return evolution (this, from:"Kricketot", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -843,7 +843,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUNATONE_25:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness G
@@ -869,7 +869,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_26:
         return evolution (this, from:"Machoke", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -892,7 +892,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_27:
         return evolution (this, from:"Magmar", hp:HP100, type:FIRE, retreatCost:2) {
           weakness W
@@ -919,7 +919,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_28:
         return evolution (this, from:"Nidorina", hp:HP130, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -944,7 +944,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOT_29:
         return evolution (this, from:"Pidgeotto", hp:HP120, type:COLORLESS, retreatCost:0) {
           weakness L
@@ -968,7 +968,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHARPEDO_30:
         return evolution (this, from:"Carvanha", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness L
@@ -988,7 +988,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WAILORD_31:
         return evolution (this, from:"Wailmer", hp:HP180, type:WATER, retreatCost:4) {
           weakness L
@@ -1016,7 +1016,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGONAIR_32:
         return evolution (this, from:"Dratini", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness C
@@ -1041,7 +1041,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTABUZZ_33:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness F
@@ -1066,7 +1066,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_34:
         return evolution (this, from:"Voltorb", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1091,7 +1091,7 @@ public enum Triumphant implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HAUNTER_35:
         return evolution (this, from:"Gastly", hp:HP070, type:PSYCHIC, retreatCost:0) {
           weakness D
@@ -1112,7 +1112,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KANGASKHAN_36:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -1134,7 +1134,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_37:
         return evolution (this, from:"Aron", hp:HP080, type:METAL, retreatCost:3) {
           weakness R
@@ -1148,7 +1148,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKILICKY_38:
         return evolution (this, from:"Lickitung", hp:HP100, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -1169,7 +1169,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUVDISC_39:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -1195,7 +1195,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOKE_40:
         return evolution (this, from:"Machop", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -1214,7 +1214,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGBY_41:
         return basic (this, hp:HP030, type:FIRE, retreatCost:0) {
           pokeBody "Sweet Sleeping Face", {
@@ -1239,7 +1239,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_42:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness W
@@ -1270,7 +1270,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_43:
         return evolution (this, from:"Magnemite", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1292,7 +1292,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAROWAK_44:
         return evolution (this, from:"Cubone", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1320,7 +1320,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA_45:
         return evolution (this, from:"Nidoran♀", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1342,7 +1342,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINO_46:
         return evolution (this, from:"Nidoran♂", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1363,7 +1363,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOTTO_47:
         return evolution (this, from:"Pidgey", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1395,7 +1395,7 @@ public enum Triumphant implements LogicCardInfo {
                 }]
             }
           }
-        };
+        }
       case PILOSWINE_48:
         return evolution (this, from:"Swinub", hp:HP100, type:WATER, retreatCost:3) {
           weakness M
@@ -1423,7 +1423,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON2_49:
         return evolution (this, from:"Porygon", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1447,7 +1447,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACRUEL_50:
         return evolution (this, from:"Tentacool", hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -1475,7 +1475,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_51:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1496,7 +1496,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WAILMER_52:
         return basic (this, hp:HP090, type:WATER, retreatCost:3) {
           weakness L
@@ -1517,7 +1517,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEPINBELL_53:
         return evolution (this, from:"Bellsprout", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -1541,7 +1541,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMEGA_54:
         return evolution (this, from:"Yanma", hp:HP090, type:GRASS, retreatCost:1) {
           weakness L
@@ -1567,7 +1567,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AIPOM_55:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1589,7 +1589,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARON_56:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness R
@@ -1613,7 +1613,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELLSPROUT_57:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R
@@ -1638,7 +1638,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_58:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness R
@@ -1660,7 +1660,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARVANHA_59:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness L
@@ -1679,7 +1679,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_60:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1708,7 +1708,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGLETT_61:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1733,7 +1733,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRATINI_62:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness C
@@ -1753,7 +1753,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_63:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -1766,7 +1766,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ILLUMISE_64:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R
@@ -1793,7 +1793,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRICKETOT_65:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -1805,7 +1805,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_66:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -1827,7 +1827,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP_67:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -1849,7 +1849,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_68:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1875,7 +1875,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE_69:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1900,7 +1900,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_MALE_70:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1922,7 +1922,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEY_71:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1946,7 +1946,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PONYTA_72:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W
@@ -1965,7 +1965,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_73:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1988,7 +1988,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK_74:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -2004,7 +2004,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHUPPET_75:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -2029,7 +2029,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKORUPI_76:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -2044,7 +2044,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPOINK_77:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -2057,7 +2057,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWABLU_78:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -2073,7 +2073,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWINUB_79:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness M
@@ -2092,7 +2092,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACOOL_80:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -2105,7 +2105,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENONAT_81:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -2125,7 +2125,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLBEAT_82:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R
@@ -2150,7 +2150,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_83:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -2168,7 +2168,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMA_84:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness L
@@ -2189,7 +2189,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLACK_BELT_85:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nYou may use this card only if you have more Prize cards left than your opponent. During this turn, each of your Active Pokémon’s attacks does 40 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
@@ -2209,7 +2209,7 @@ public enum Triumphant implements LogicCardInfo {
           playRequirement{
             assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You don't have more prize cards remaining than your opponent"
           }
-        };
+        }
       case INDIGO_PLATEAU_86:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nEach Pokémon LEGEND in play (both yours and your opponent’s) gets +30 HP."
@@ -2224,7 +2224,7 @@ public enum Triumphant implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case JUNK_ARM_87:
         return basicTrainer (this) {
           text "Discard 2 cards from you hand. Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand. You can’t choose Junk Arm with the effect of this card."
@@ -2236,7 +2236,7 @@ public enum Triumphant implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "You don't have 2 other cards to discard"
             assert my.discard.filterByType(ITEM).any{it.name != "Junk Arm"} : "You don't have any Trainer-Item cards not named \"Junk Arm\""
           }
-        };
+        }
       case SEEKER_88:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nEach player returns 1 of his or her Benched Pokémon and all cards attached to it to his or her hand. (You return your Pokémon first.)"
@@ -2254,7 +2254,7 @@ public enum Triumphant implements LogicCardInfo {
           playRequirement{
             assert my.bench || opp.bench : "No benched Pokémon in play"
           }
-        };
+        }
       case TWINS_89:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nYou may use this card only if you have more Prize cards left than your opponent. Search your deck for any 2 cards and put them into your hand. Shuffle your deck afterward."
@@ -2267,7 +2267,7 @@ public enum Triumphant implements LogicCardInfo {
             assert my.deck : "Your deck is empty"
             assert my.prizeCardSet.size() > opp.prizeCardSet.size() : "You don't have more prize cards remaining than your opponent"
           }
-        };
+        }
       case RESCUE_ENERGY_90:
         return specialEnergy (this, [[C]]) {
           text "Rescue Energy provides 1 [C] Energy. If the Pokémon this card is attached to is Knocked Out by damage from an attack, put that Pokémon back into your hand. (Discard all cards attached to that Pokémon.)"
@@ -2295,7 +2295,7 @@ public enum Triumphant implements LogicCardInfo {
             if (self) return [[C] as Set]
             else return [[] as Set]
           }
-        };
+        }
       case ABSOL_91:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2324,7 +2324,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CELEBI_92:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R
@@ -2348,7 +2348,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_93:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -2378,7 +2378,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_94:
         return evolution (this, from:"Haunter", hp:HP130, type:PSYCHIC, retreatCost:0) {
           weakness D
@@ -2428,7 +2428,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_95:
         return evolution (this, from:"Machoke", hp:HP150, type:FIGHTING, retreatCost:3) {
           weakness P
@@ -2459,7 +2459,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_96:
         return evolution (this, from:"Magneton", hp:HP140, type:LIGHTNING, retreatCost:3) {
           weakness F
@@ -2497,7 +2497,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEW_97:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:0) {
           weakness P
@@ -2522,7 +2522,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMEGA_98:
         return evolution (this, from:"Yanma", hp:HP110, type:GRASS, retreatCost:0) {
           weakness L
@@ -2556,7 +2556,7 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_AND_CRESSELIA_LEGEND_99:
         return basic (this, hp:HP150, type:[PSYCHIC, D], retreatCost:2) {
           weakness P
@@ -2576,13 +2576,13 @@ public enum Triumphant implements LogicCardInfo {
               }
               while(1){
                 def pl=(opp.all.findAll {it.numberOfDamageCounters})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("Source for damage counter (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def tar = opp.all
                 tar.remove(src)
                 tar = tar.select("Target for damage counter (cancel to stop)", false)
-                if(!tar) break;
+                if(!tar) break
 
                 src.damage-=hp(10)
                 directDamage 10, tar
@@ -2616,9 +2616,9 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_AND_CRESSELIA_LEGEND_100:
-        return copy (DARKRAI_AND_CRESSELIA_LEGEND_99, this);
+        return copy (DARKRAI_AND_CRESSELIA_LEGEND_99, this)
       case PALKIA_AND_DIALGA_LEGEND_101:
         return basic (this, hp:HP160, type:[WATER, M], retreatCost:3) {
           weakness R
@@ -2646,9 +2646,9 @@ public enum Triumphant implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_AND_DIALGA_LEGEND_102:
-        return copy (PALKIA_AND_DIALGA_LEGEND_101, this);
+        return copy (PALKIA_AND_DIALGA_LEGEND_101, this)
       case ALPH_LITHOGRAPH_FOUR:
         return basicTrainer (this) {
           text "LOOK AT ALL OF YOUR FACE DOWN PRIZE CARDS!"
@@ -2658,9 +2658,9 @@ public enum Triumphant implements LogicCardInfo {
           playRequirement{
             assert my.prizeCardSet.faceDownCards : "You have no face down Prize cards"
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -2,30 +2,30 @@ package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.effect.gm.ActivateSimpleTrainer
 import tcgwars.logic.effect.special.SpecialConditionType
-import tcgwars.logic.impl.gen3.RubySapphire;
+import tcgwars.logic.impl.gen3.RubySapphire
 
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.effect.ability.Ability
 import tcgwars.logic.effect.ability.PokeBody
 import tcgwars.logic.effect.ability.PokePower
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.Source.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -125,53 +125,53 @@ public enum Undaunted implements LogicCardInfo {
   RAYQUAZA_AND_DEOXYS_LEGEND_90 ("Rayquaza & Deoxys LEGEND", "90", Rarity.HOLORARE, [POKEMON, _PSYCHIC_, LEGEND]),
   ALPH_LITHOGRAPH_THREE ("Alph Lithograph", "THREE", Rarity.HOLORARE, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Undaunted(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.UNDAUNTED;
+    return tcgwars.logic.card.Collection.UNDAUNTED
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -200,7 +200,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPEON_2:
         return evolution (this, from:"Eevee", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -214,13 +214,13 @@ public enum Undaunted implements LogicCardInfo {
               def numMoved = 0
               while(1) {
                 def pcs = my.all.findAll{it.numberOfDamageCounters}.select("Choose the pokémon to move the damage counter from", false)
-                if(!pcs) break;
+                if(!pcs) break
                 def tar = opp.all.select("Select the pokémon to recieve the damage counter", false)
-                if(!tar) break;
+                if(!tar) break
                 pcs.damage-=hp(10)
                 tar.damage+=hp(10)
                 numMoved++
-                if(numMoved >= 4) break;
+                if(numMoved >= 4) break
               }
             }
           }
@@ -233,7 +233,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FORRETRESS_3:
         return evolution (this, from:"Pineco", hp:HP090, type:METAL, retreatCost:3) {
           weakness R
@@ -257,7 +257,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLISCOR_4:
         return evolution (this, from:"Gligar", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -282,7 +282,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOOM_5:
         return evolution (this, from:"Houndour", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -308,7 +308,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGCARGO_6:
         return evolution (this, from:"Slugma", hp:HP100, type:FIRE, retreatCost:3) {
           weakness W
@@ -331,7 +331,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCIZOR_7:
         return evolution (this, from:"Scyther", hp:HP090, type:METAL, retreatCost:1) {
           weakness R
@@ -351,7 +351,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SMEARGLE_8:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -380,7 +380,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEKISS_9:
         return evolution (this, from:"Togetic", hp:HP120, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -407,7 +407,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UMBREON_10:
         return evolution (this, from:"Eevee", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -449,7 +449,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO_11:
         return evolution (this, from:"Doduo", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -473,7 +473,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFBLIM_12:
         return evolution (this, from:"Drifloon", hp:HP090, type:PSYCHIC, retreatCost:0) {
           weakness D
@@ -499,7 +499,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FORRETRESS_13:
         return evolution (this, from:"Pineco", hp:HP080, type:METAL, retreatCost:2) {
           weakness R
@@ -528,7 +528,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HARIYAMA_14:
         return evolution (this, from:"Makuhita", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness P
@@ -551,7 +551,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_15:
         return evolution (this, from:"Murkrow", hp:HP090, type:DARKNESS, retreatCost:2) {
           weakness L
@@ -577,7 +577,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_16:
         return evolution (this, from:"Murkrow", hp:HP090, type:DARKNESS, retreatCost:2) {
           weakness L
@@ -598,7 +598,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_17:
         return evolution (this, from:"Eevee", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R
@@ -622,7 +622,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAGROSS_18:
         return evolution (this, from:"Metang", hp:HP130, type:METAL, retreatCost:4) {
           weakness R
@@ -644,7 +644,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_19:
         return evolution (this, from:"Misdreavus", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -670,7 +670,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROTOM_20:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness D
@@ -701,7 +701,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKARMORY_21:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness R
@@ -724,7 +724,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TROPIUS_22:
         return basic (this, hp:HP090, type:GRASS, retreatCost:2) {
           weakness L
@@ -746,7 +746,7 @@ public enum Undaunted implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case VESPIQUEN_23:
         return evolution (this, from:"Combee", hp:HP100, type:GRASS, retreatCost:3) {
           weakness R
@@ -787,7 +787,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_24:
         return evolution (this, from:"Gloom", hp:HP120, type:GRASS, retreatCost:2) {
           weakness P
@@ -815,7 +815,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEAVILE_25:
         return evolution (this, from:"Sneasel", hp:HP080, type:DARKNESS, retreatCost:0) {
           weakness F
@@ -837,7 +837,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_26:
         return evolution (this, from:"Eevee", hp:HP090, type:FIRE, retreatCost:1) {
           weakness W
@@ -857,7 +857,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLOOM_27:
         return evolution (this, from:"Oddish", hp:HP080, type:GRASS, retreatCost:1) {
           weakness P
@@ -874,7 +874,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JOLTEON_28:
         return evolution (this, from:"Eevee", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -897,7 +897,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_29:
         return evolution (this, from:"Aron", hp:HP090, type:METAL, retreatCost:3) {
           weakness R
@@ -922,7 +922,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METANG_30:
         return evolution (this, from:"Beldum", hp:HP080, type:METAL, retreatCost:2) {
           weakness R
@@ -944,7 +944,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUK_31:
         return evolution (this, from:"Grimer", hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness P
@@ -972,7 +972,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PINSIR_32:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R
@@ -994,7 +994,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_33:
         return evolution (this, from:"Pikachu", hp:HP080, type:LIGHTNING, retreatCost:0) {
           weakness F
@@ -1017,7 +1017,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATICATE_34:
         return evolution (this, from:"Rattata", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness F
@@ -1040,7 +1040,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SABLEYE_35:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           resistance C, MINUS20
@@ -1065,7 +1065,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_36:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R
@@ -1093,7 +1093,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKUNTANK_37:
         return evolution (this, from:"Stunky", hp:HP080, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -1119,7 +1119,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_38:
         return evolution (this, from:"Slowpoke", hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -1149,7 +1149,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGETIC_39:
         return evolution (this, from:"Togepi", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1176,7 +1176,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNOWN_40:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness P
@@ -1198,7 +1198,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_41:
         return evolution (this, from:"Eevee", hp:HP090, type:WATER, retreatCost:2) {
           weakness L
@@ -1218,7 +1218,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARON_42:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R
@@ -1240,7 +1240,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELDUM_43:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness R
@@ -1262,7 +1262,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMBEE_44:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness R
@@ -1278,7 +1278,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODUO_45:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1298,7 +1298,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_46:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -1324,7 +1324,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_47:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1343,7 +1343,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_48:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1363,7 +1363,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLIGAR_49:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1380,7 +1380,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER_50:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1399,7 +1399,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONCHAN_51:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -1421,7 +1421,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONLEE_52:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -1440,7 +1440,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOUR_53:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -1453,7 +1453,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOUR_54:
         return basic (this, hp:HP050, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -1469,7 +1469,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAKUHITA_55:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness P
@@ -1491,7 +1491,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAWILE_56:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness R
@@ -1525,7 +1525,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_57:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -1549,7 +1549,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_58:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness L
@@ -1567,7 +1567,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_59:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness L
@@ -1587,7 +1587,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH_60:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness P
@@ -1612,7 +1612,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_61:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1627,7 +1627,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PINECO_62:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R
@@ -1639,7 +1639,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PINECO_63:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness R
@@ -1660,7 +1660,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA_64:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1672,7 +1672,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_65:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R
@@ -1692,7 +1692,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_66:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness L
@@ -1725,7 +1725,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLUGMA_67:
         return basic (this, hp:HP060, type:FIRE, retreatCost:2) {
           weakness W
@@ -1753,7 +1753,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNEASEL_68:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:0) {
           weakness F
@@ -1777,7 +1777,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNKY_69:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -1792,7 +1792,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEPI_70:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1809,7 +1809,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BURNED_TOWER_71:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nOnce during each player’s turn, that player may flip a coin. If heads, the player searches his or her discard pile for a basic Energy card, shows it to his or her opponent, and put it into his or her hand."
@@ -1829,7 +1829,7 @@ public enum Undaunted implements LogicCardInfo {
           onRemoveFromPlay {
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case DEFENDER_72:
         return basicTrainer (this) {
           text "Attach Defender to 1 of your Pokémon. Discard this card at the end of your opponent’s next turn. Any damage done to the Pokémon Defender is attached to by an opponent’s attack is reduced by 20 (after applying Weakness and Resistance)."
@@ -1864,7 +1864,7 @@ public enum Undaunted implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ENERGY_EXCHANGER_73:
         return basicTrainer (this) {
           text "Choose an Energy card from you hand, show it to your opponent, and put it on top of your deck. Search your deck for an Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -1876,7 +1876,7 @@ public enum Undaunted implements LogicCardInfo {
           playRequirement{
             assert my.hand.filterByType(ENERGY) : "You have no energy cards in your hand"
           }
-        };
+        }
       case FLOWER_SHOP_LADY_74:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nSearch your discard pile for 3 Pokémon and 3 basic Energy cards. Show them to your opponent and shuffle them into your deck."
@@ -1894,7 +1894,7 @@ public enum Undaunted implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON) || my.discard.filterByType(BASIC_ENERGY) : "Your discard pile has no Pokémon or basic Energy cards"
           }
-        };
+        }
       case LEGEND_BOX_75:
         return basicTrainer (this) {
           text "Reveal the top 10 cards of your deck. If you reveal both halves of a Pokémon LEGEND, put those cards onto your Bench and attach all revealed Energy cards to that Pokémon LEGEND. Shuffle the other cards back into your deck. (You can play only 1 Pokémon LEGEND in this way.)"
@@ -1924,7 +1924,7 @@ public enum Undaunted implements LogicCardInfo {
             assert my.deck : "Your deck is empty"
             assert my.bench.notFull : "Your bench is full"
           }
-        };
+        }
       case RUINS_OF_ALPH_76:
         return stadium (this) {
           text "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card.\nEach Pokémon in play has no Resistance."
@@ -1937,7 +1937,7 @@ public enum Undaunted implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case SAGE_S_TRAINING_77:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nLook at the top 5 cards of your deck. Choose any 2 cards you find there and put them into your hand. Discard the other cards."
@@ -1951,7 +1951,7 @@ public enum Undaunted implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty"
           }
-        };
+        }
       case TEAM_ROCKET_S_TRICKERY_78:
         return supporter (this) {
           text "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card.\nDraw 2 cards. Then, your opponent discards a card from his or her hand."
@@ -1964,9 +1964,9 @@ public enum Undaunted implements LogicCardInfo {
           playRequirement{
             assert my.deck || opp.hand : "Your deck is empty and your opponent has no cards in hand"
           }
-        };
+        }
       case DARKNESS_ENERGY_79:
-        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this);
+        return copy (MysteriousTreasures.DARKNESS_ENERGY_119, this)
       case METAL_ENERGY_80:
         return copy (RubySapphire.METAL_ENERGY_94, this)
       case ESPEON_81:
@@ -1989,7 +1989,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOOM_82:
         return evolution (this, from:"Houndour", hp:HP110, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2014,7 +2014,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_83:
         return evolution (this, from:"Pikachu", hp:HP100, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -2041,7 +2041,7 @@ public enum Undaunted implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SCIZOR_84:
         return evolution (this, from:"Scyther", hp:HP100, type:METAL, retreatCost:2) {
           weakness R
@@ -2067,7 +2067,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWKING_85:
         return evolution (this, from:"Slowpoke", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -2091,7 +2091,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UMBREON_86:
         return evolution (this, from:"Eevee", hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness F
@@ -2116,7 +2116,7 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KYOGRE_AND_GROUDON_LEGEND_87:
         return basic (this, hp:HP150, type:[WATER, F], retreatCost:3) {
           weakness G
@@ -2150,9 +2150,9 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KYOGRE_AND_GROUDON_LEGEND_88:
-        return copy (KYOGRE_AND_GROUDON_LEGEND_87, this);
+        return copy (KYOGRE_AND_GROUDON_LEGEND_87, this)
       case RAYQUAZA_AND_DEOXYS_LEGEND_89:
         return basic (this, hp:HP140, type:[PSYCHIC, C], retreatCost:3) {
           weakness P
@@ -2178,9 +2178,9 @@ public enum Undaunted implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_AND_DEOXYS_LEGEND_90:
-        return copy (RAYQUAZA_AND_DEOXYS_LEGEND_89, this);
+        return copy (RAYQUAZA_AND_DEOXYS_LEGEND_89, this)
       case ALPH_LITHOGRAPH_THREE:
         return basicTrainer (this) {
           text "RETURN ANY STADIUM CARD IN PLAY TO ITS PLAYERS HAND!"
@@ -2191,9 +2191,9 @@ public enum Undaunted implements LogicCardInfo {
             assert bg.stadiumInfoStruct : "There is no stadium card in play"
             assert stadiumCanBeAffectedByItemAndSupporter() : "The stadium in play can't be affected by trainer cards"
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/Unleashed.groovy
+++ b/src/tcgwars/logic/impl/gen4/Unleashed.groovy
@@ -1,26 +1,26 @@
 package tcgwars.logic.impl.gen4
 
 import tcgwars.logic.effect.blocking.CantRetreat
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
-import tcgwars.logic.impl.gen5.*;
-import tcgwars.logic.impl.gen7.*;
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
+import tcgwars.logic.impl.gen5.*
+import tcgwars.logic.impl.gen7.*
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -124,7 +124,7 @@ public enum Unleashed implements LogicCardInfo {
   SUICUNE_AND_ENTEI_LEGEND_95 ("Suicune & Entei LEGEND", "95", Rarity.HOLORARE, [POKEMON, _WATER_, LEGEND]),
   ALPH_LITHOGRAPH_TWO ("Alph Lithograph", "TWO", Rarity.HOLORARE, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
   static SimpleDeck chaosControl() {
     def d = new SimpleDeck("Chaos Control Theme Deck")
@@ -139,51 +139,51 @@ public enum Unleashed implements LogicCardInfo {
     d
   }
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   Unleashed(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.UNLEASHED;
+    return tcgwars.logic.card.Collection.UNLEASHED
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -216,7 +216,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_2:
         return evolution (this, from:"Magmar", hp:HP110, type:FIRE, retreatCost:2) {
           weakness W
@@ -239,7 +239,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANAPHY_3:
         return basic (this, hp:HP060, type:WATER, retreatCost:0) {
           weakness L
@@ -259,7 +259,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAGROSS_4:
         return evolution (this, from:"Metang", hp:HP130, type:PSYCHIC, retreatCost:4) {
           weakness P
@@ -294,7 +294,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_5:
         return evolution (this, from:"Misdreavus", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -318,7 +318,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OCTILLERY_6:
         return evolution (this, from:"Remoraid", hp:HP080, type:WATER, retreatCost:2) {
           weakness L
@@ -338,7 +338,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLITOED_7:
         return evolution (this, from:"Poliwhirl", hp:HP120, type:WATER, retreatCost:2) {
           weakness L
@@ -360,7 +360,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHAYMIN_8:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness R
@@ -372,13 +372,13 @@ public enum Unleashed implements LogicCardInfo {
                 powerUsed()
                 while(1){
                   def pl=(my.all.findAll {it.cards.filterByType(ENERGY)})
-                  if(!pl) break;
+                  if(!pl) break
                   def src =pl.select("Source for energy (cancel to stop)", false)
-                  if(!src) break;
+                  if(!src) break
                   def card=src.cards.filterByType(ENERGY).select("Energy to move").first()
 
                   def tar=my.all.select("Target for energy (cancel to stop)", false)
-                  if(!tar) break;
+                  if(!tar) break
                   energySwitch(src, tar, card)
                 }
               }
@@ -393,7 +393,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUDOWOODO_9:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness W
@@ -413,7 +413,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_10:
         return evolution (this, from:"Grotle", hp:HP140, type:GRASS, retreatCost:4) {
           weakness R
@@ -433,7 +433,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case XATU_11:
         return evolution (this, from:"Natu", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness L
@@ -454,7 +454,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEEDRILL_12:
         return evolution (this, from:"Kakuna", hp:HP110, type:GRASS, retreatCost:0) {
           weakness R
@@ -475,7 +475,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLASTOISE_13:
         return evolution (this, from:"Wartortle", hp:HP130, type:WATER, retreatCost:3) {
           weakness L
@@ -498,7 +498,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROBAT_14:
         return evolution (this, from:"Golbat", hp:HP110, type:PSYCHIC, retreatCost:0) {
           weakness P
@@ -519,7 +519,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEAROW_15:
         return evolution (this, from:"Spearow", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -539,7 +539,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOATZEL_16:
         return evolution (this, from:"Buizel", hp:HP080, type:WATER, retreatCost:0) {
           weakness L
@@ -561,7 +561,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGDRA_17:
         return evolution (this, from:"Seadra", hp:HP130, type:WATER, retreatCost:1) {
           weakness L
@@ -584,7 +584,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LANTURN_18:
         return evolution (this, from:"Chinchou", hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness F
@@ -607,7 +607,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_19:
         return evolution (this, from:"Riolu", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -627,7 +627,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NINETALES_20:
         return evolution (this, from:"Vulpix", hp:HP090, type:FIRE, retreatCost:1) {
           weakness W
@@ -650,7 +650,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWRATH_21:
         return evolution (this, from:"Poliwhirl", hp:HP130, type:WATER, retreatCost:3) {
           weakness L
@@ -674,7 +674,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRIMEAPE_22:
         return evolution (this, from:"Mankey", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -694,7 +694,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_23:
         return evolution (this, from:"Roselia", hp:HP090, type:GRASS, retreatCost:1) {
           weakness R
@@ -723,7 +723,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STEELIX_24:
         return evolution (this, from:"Onix", hp:HP120, type:METAL, retreatCost:4) {
           weakness R
@@ -744,7 +744,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORKOAL_25:
         return basic (this, hp:HP080, type:FIRE, retreatCost:2) {
           weakness W
@@ -764,7 +764,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYRANITAR_26:
         return evolution (this, from:"Pupitar", hp:HP140, type:DARKNESS, retreatCost:3) {
           weakness F
@@ -785,7 +785,7 @@ public enum Unleashed implements LogicCardInfo {
               discardDefendingEnergy()
             }
           }
-        };
+        }
       case URSARING_27:
         return evolution (this, from:"Teddiursa", hp:HP100, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -805,7 +805,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERRIM_28:
         return evolution (this, from:"Cherubi", hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -828,7 +828,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUNSPARCE_29:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -841,7 +841,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT_30:
         return evolution (this, from:"Zubat", hp:HP080, type:PSYCHIC, retreatCost:0) {
           weakness L
@@ -855,7 +855,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROTLE_31:
         return evolution (this, from:"Turtwig", hp:HP090, type:GRASS, retreatCost:2) {
           weakness R
@@ -876,7 +876,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KAKUNA_32:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:2) {
           weakness R
@@ -896,7 +896,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METANG_33:
         return evolution (this, from:"Beldum", hp:HP080, type:PSYCHIC, retreatCost:3) {
           weakness P
@@ -915,7 +915,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_34:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -934,7 +934,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUMEL_35:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W
@@ -956,7 +956,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PLUSLE_36:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -977,7 +977,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWHIRL_37:
         return evolution (this, from:"Poliwag", hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -997,7 +997,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PUPITAR_38:
         return evolution (this, from:"Larvitar", hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1017,7 +1017,7 @@ public enum Unleashed implements LogicCardInfo {
               damage 20 + 10*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case PUPITAR_39:
         return evolution (this, from:"Larvitar", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1037,7 +1037,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEADRA_40:
         return evolution (this, from:"Horsea", hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -1057,7 +1057,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAUROS_41:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:2) {
           weakness F
@@ -1077,7 +1077,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WARTORTLE_42:
         return evolution (this, from:"Squirtle", hp:HP080, type:WATER, retreatCost:1) {
           weakness L
@@ -1096,7 +1096,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AIPOM_43:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1117,7 +1117,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELDUM_44:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness P
@@ -1130,7 +1130,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUIZEL_45:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -1145,7 +1145,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARNIVINE_46:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -1166,7 +1166,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERUBI_47:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -1179,7 +1179,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHINCHOU_48:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness F
@@ -1198,7 +1198,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HORSEA_49:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L
@@ -1217,7 +1217,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_50:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1239,7 +1239,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVITAR_51:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness W
@@ -1259,7 +1259,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_52:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness W
@@ -1278,7 +1278,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY_53:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -1297,7 +1297,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_54:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness D
@@ -1310,7 +1310,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NATU_55:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness L
@@ -1330,7 +1330,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_56:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:4) {
           weakness G
@@ -1353,7 +1353,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ONIX_57:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness G
@@ -1366,7 +1366,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWAG_58:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L
@@ -1383,7 +1383,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REMORAID_59:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L
@@ -1402,7 +1402,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIOLU_60:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness P
@@ -1421,7 +1421,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSELIA_61:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness R
@@ -1436,7 +1436,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEAROW_62:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness L
@@ -1457,7 +1457,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SQUIRTLE_63:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness L
@@ -1476,7 +1476,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STANTLER_64:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1494,7 +1494,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TEDDIURSA_65:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness F
@@ -1507,7 +1507,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TROPIUS_66:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness R
@@ -1532,7 +1532,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_67:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness R
@@ -1560,7 +1560,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VULPIX_68:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness W
@@ -1575,7 +1575,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEDLE_69:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness R
@@ -1597,7 +1597,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_70:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness L
@@ -1621,7 +1621,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHEERLEADER_S_CHEER_71:
         return supporter (this) {
           text "Draw 3 cards. Your opponent may draw a card."
@@ -1634,7 +1634,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards left in your deck"
           }
-        };
+        }
       case DUAL_BALL_72:
         return basicTrainer (this) {
           text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon, show it to your opponent, and put it into your hand. If you do, shuffle your deck afterward."
@@ -1647,7 +1647,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty
           }
-        };
+        }
       case EMCEE_S_CHATTER_73:
         return supporter (this) {
           text "Flip a coin. If heads, draw 3 cards. If tails, draw 2 cards."
@@ -1657,7 +1657,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty
           }
-        };
+        }
       case ENERGY_RETURNER_74:
         return basicTrainer (this) {
           text "Search your discard pile for 4 basic Energy cards, show them to your opponent, and shuffle them into your deck."
@@ -1668,7 +1668,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC_ENERGY) : "No basic Energy in your discard"
           }
-        };
+        }
       case ENGINEER_S_ADJUSTMENTS_75:
         return supporter (this) {
           text "Discard an Energy card from your hand. Then, draw 4 cards."
@@ -1680,7 +1680,7 @@ public enum Unleashed implements LogicCardInfo {
             assert my.hand.filterByType(ENERGY) : "No Energy card in hand"
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       case GOOD_ROD_76:
         return basicTrainer (this) {
           text "Flip a coin. If heads, search your discard pile for a Pokémon, show it to your opponent, and put it on top of your deck. If tails, search your discard pile for a Trainer card, show it to your opponent, and put it on top of your deck."
@@ -1698,7 +1698,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON,TRAINER) : "No Pokémon or Trainer in your discard"
           }
-        };
+        }
       case INTERVIEWER_S_QUESTIONS_77:
         return supporter (this) {
           text "Look at the top 8 cards of your deck. Choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Shuffle the other cards back into your deck."
@@ -1709,9 +1709,9 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       case JUDGE_78:
-        return copy (ForbiddenLight.JUDGE_108, this);
+        return copy (ForbiddenLight.JUDGE_108, this)
       case LIFE_HERB_79:
         return basicTrainer (this) {
           text "Flip a coin. If heads, choose 1 of your Pokémon, and remove all Special Conditions and 6 damage counters from that Pokémon (all if there are less than 6)."
@@ -1726,7 +1726,7 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll {it.numberOfDamageCounters || it.specialConditions} : "No valid targets"
           }
-        };
+        }
       case PLUSPOWER_80:
         return basicTrainer (this) {
           text "During this turn, your Pokémon’s attacks do 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
@@ -1743,13 +1743,13 @@ public enum Unleashed implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case POKEMON_CIRCULATOR_81:
-        return copy (SunMoon.REPEL_130, this);
+        return copy (SunMoon.REPEL_130, this)
       case RARE_CANDY_82:
         return copy(DarkExplorers.RARE_CANDY_100, this)
       case SUPER_SCOOP_UP_83:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case CROBAT_84:
         return evolution (this, from:"Golbat", hp:HP130, type:PSYCHIC, retreatCost:0) {
           weakness L
@@ -1770,7 +1770,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGDRA_85:
         return evolution (this, from:"Seadra", hp:HP130, type:WATER, retreatCost:1) {
           weakness L
@@ -1795,7 +1795,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LANTURN_86:
         return evolution (this, from:"Chinchou", hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness F
@@ -1832,7 +1832,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STEELIX_87:
         return evolution (this, from:"Onix", hp:HP140, type:METAL, retreatCost:4) {
           weakness R
@@ -1874,7 +1874,7 @@ public enum Unleashed implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TYRANITAR_88:
         return evolution (this, from:"Pupitar", hp:HP160, type:DARKNESS, retreatCost:3) {
           weakness F
@@ -1905,7 +1905,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case URSARING_89:
         return evolution (this, from:"Teddiursa", hp:HP110, type:COLORLESS, retreatCost:3) {
           weakness F
@@ -1940,7 +1940,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ENTEI_AND_RAIKOU_LEGEND_90:
         return basic (this, hp:HP140, type:[FIRE, L], retreatCost:0) {
           weakness W
@@ -1967,7 +1967,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ENTEI_AND_RAIKOU_LEGEND_91:
         return copy (ENTEI_AND_RAIKOU_LEGEND_90, this)
       case RAIKOU_AND_SUICUNE_LEGEND_92:
@@ -1991,7 +1991,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAIKOU_AND_SUICUNE_LEGEND_93:
         return copy (RAIKOU_AND_SUICUNE_LEGEND_92, this)
       case SUICUNE_AND_ENTEI_LEGEND_94:
@@ -2021,7 +2021,7 @@ public enum Unleashed implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUICUNE_AND_ENTEI_LEGEND_95:
         return copy (SUICUNE_AND_ENTEI_LEGEND_94, this)
       case ALPH_LITHOGRAPH_TWO:
@@ -2033,9 +2033,9 @@ public enum Unleashed implements LogicCardInfo {
           playRequirement{
             assert my.deck : "No cards in deck"
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen4/WorldCollection.groovy
+++ b/src/tcgwars/logic/impl/gen4/WorldCollection.groovy
@@ -1,14 +1,14 @@
-package tcgwars.logic.impl.gen4;
+package tcgwars.logic.impl.gen4
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -26,53 +26,53 @@ public enum WorldCollection implements LogicCardInfo {
   PIKACHU_P8 ("Pikachu", "8", Rarity.COMMON, [BASIC, POKEMON, _LIGHTNING_]),
   PIKACHU_P9 ("Pikachu", "9", Rarity.COMMON, [BASIC, POKEMON, _LIGHTNING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   WorldCollection(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.WORLD_COLLECTION;
+    return tcgwars.logic.card.Collection.WORLD_COLLECTION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -105,7 +105,7 @@ public enum WorldCollection implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_P2:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -128,7 +128,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P3:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -151,7 +151,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P4:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -174,7 +174,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P5:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -197,7 +197,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P6:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -220,7 +220,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P7:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -243,7 +243,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P8:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -266,7 +266,7 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       case PIKACHU_P9:
         return copy (PIKACHU_P1, this)
         /*basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
@@ -289,9 +289,9 @@ public enum WorldCollection implements LogicCardInfo {
 						}
 					}
 
-				}*/;
+				}*/
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
+++ b/src/tcgwars/logic/impl/gen7/BurningShadows.groovy
@@ -3,25 +3,25 @@ package tcgwars.logic.impl.gen7
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen5.PlasmaStorm
-import tcgwars.logic.impl.gen6.PrimalClash;
+import tcgwars.logic.impl.gen6.PrimalClash
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -198,53 +198,53 @@ public enum BurningShadows implements LogicCardInfo {
   DARKNESS_ENERGY_168 ("Darkness Energy", "168", Rarity.SECRET, [BASIC_ENERGY, ENERGY]),
   FAIRY_ENERGY_169 ("Fairy Energy", "169", Rarity.SECRET, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   BurningShadows(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.BURNING_SHADOWS;
+    return tcgwars.logic.card.Collection.BURNING_SHADOWS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -261,7 +261,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAPOD_2:
         return evolution (this, from:"Caterpie", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -280,7 +280,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUTTERFREE_3:
         return evolution (this, from:"Metapod", hp:HP120, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -306,7 +306,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH_4:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -318,7 +318,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLOOM_5:
         return evolution (this, from:"Oddish", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -337,7 +337,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_6:
         return evolution (this, from:"Gloom", hp:HP140, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -366,7 +366,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_7:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -379,7 +379,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGROWTH_8:
         return evolution (this, from:"Tangela", hp:HP140, type:GRASS, retreatCost:4) {
           weakness FIRE
@@ -399,7 +399,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDYBA_9:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -412,7 +412,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEDIAN_10:
         return evolution (this, from:"Ledyba", hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -431,7 +431,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_11:
         return basic (this, hp:HP110, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -458,7 +458,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANSAGE_12:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -470,7 +470,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SIMISAGE_13:
         return evolution (this, from:"Pansage", hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -492,7 +492,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWPIDER_14:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -505,7 +505,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARAQUANID_15:
         return evolution (this, from:"Dewpider", hp:HP100, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -541,7 +541,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIMPOD_16:
         return basic (this, hp:HP070, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -561,7 +561,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLISOPOD_GX_17:
         return evolution (this, from:"Wimpod", hp:HP210, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -595,7 +595,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER_18:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -614,7 +614,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMELEON_19:
         return evolution (this, from:"Charmander", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -633,7 +633,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_GX_20:
         return evolution (this, from:"Charmeleon", hp:HP250, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -667,7 +667,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HO_OH_GX_21:
         return basic (this, hp:HP190, type:FIRE, retreatCost:2) {
           weakness LIGHTNING
@@ -698,12 +698,12 @@ public enum BurningShadows implements LogicCardInfo {
             onAttack {
               gxPerform()
               my.discard.filterByType(POKEMON_GX, POKEMON_EX).filterByType(_FIRE_).select(max: Math.min(3, my.bench.freeBenchCount)).each {
-                benchPCS(it);
+                benchPCS(it)
               }
             }
           }
 
-        };
+        }
       case PANSEAR_22:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -715,7 +715,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SIMISEAR_23:
         return evolution (this, from:"Pansear", hp:HP090, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -737,7 +737,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEATMOR_24:
         return basic (this, hp:HP110, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -757,7 +757,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAZZLE_GX_25:
         return evolution (this, from:"Salandit", hp:HP200, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -789,7 +789,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTONATOR_26:
         return copy (SunMoonPromos.TURTONATOR_SM27, this)
       case ALOLAN_VULPIX_27:
@@ -809,7 +809,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_NINETALES_28:
         return evolution (this, from:"Alolan Vulpix", hp:HP110, type:WATER, retreatCost:1) {
           weakness METAL
@@ -825,7 +825,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HORSEA_29:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -837,7 +837,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEADRA_30:
         return evolution (this, from:"Horsea", hp:HP080, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -849,7 +849,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGDRA_31:
         return evolution (this, from:"Seadra", hp:HP140, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -875,7 +875,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_32:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -888,7 +888,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_33:
         return evolution (this, from:"Magikarp", hp:HP150, type:WATER, retreatCost:4) {
           weakness LIGHTNING
@@ -908,7 +908,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARILL_34:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -927,7 +927,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZUMARILL_35:
         return evolution (this, from:"Marill", hp:HP120, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -954,7 +954,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANPOUR_36:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -966,7 +966,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SIMIPOUR_37:
         return evolution (this, from:"Panpour", hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -988,7 +988,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRUXISH_38:
         return basic (this, hp:HP100, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1011,7 +1011,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAPU_FINI_GX_39:
         return basic (this, hp:HP170, type:WATER, retreatCost:1) {
           move "Aqua Ring", {
@@ -1046,7 +1046,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_40:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1067,7 +1067,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_41:
         return evolution (this, from:"Pikachu", hp:HP110, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1090,7 +1090,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTABUZZ_42:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1111,7 +1111,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTIVIRE_43:
         return evolution (this, from:"Electabuzz", hp:HP140, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1133,7 +1133,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYNAMO_44:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1147,7 +1147,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EELEKTRIK_45:
         return evolution (this, from:"Tynamo", hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1163,7 +1163,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EELEKTROSS_46:
         return evolution (this, from:"Eelektrik", hp:HP140, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -1188,7 +1188,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEDEMARU_47:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1209,7 +1209,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWKING_48:
         return evolution (this, from:"Slowpoke", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1233,7 +1233,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOBBUFFET_49:
         return basic (this, hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1245,7 +1245,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEVIPER_50:
         return copy (SunMoonPromos.SEVIPER_SM46, this)
       case DUSKULL_51:
@@ -1272,7 +1272,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSCLOPS_52:
         return evolution (this, from:"Duskull", hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -1295,7 +1295,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSKNOIR_53:
         return evolution (this, from:"Dusclops", hp:HP150, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -1324,7 +1324,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROAGUNK_54:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1344,7 +1344,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_55:
         return evolution (this, from:"Croagunk", hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1368,7 +1368,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENIPEDE_56:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1388,7 +1388,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHIRLIPEDE_57:
         return evolution (this, from:"Venipede", hp:HP090, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1408,7 +1408,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCOLIPEDE_58:
         return evolution (this, from:"Whirlipede", hp:HP160, type:PSYCHIC, retreatCost:4) {
           weakness PSYCHIC
@@ -1429,7 +1429,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPURR_59:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1460,7 +1460,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWSTIC_60:
         return evolution (this, from:"Espurr", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1479,7 +1479,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDYGAST_61:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -1493,7 +1493,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALOSSAND_62:
         return evolution (this, from:"Sandygast", hp:HP130, type:PSYCHIC, retreatCost:4) {
           weakness DARKNESS
@@ -1520,7 +1520,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NECROZMA_GX_63:
         return basic (this, hp:HP180, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1560,7 +1560,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_GX_64:
         return evolution (this, from:"Machoke", hp:HP250, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -1593,7 +1593,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_65:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1612,7 +1612,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON_66:
         return evolution (this, from:"Rhyhorn", hp:HP110, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -1632,7 +1632,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYPERIOR_67:
         return evolution (this, from:"Rhydon", hp:HP160, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -1654,7 +1654,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUNATONE_68:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1677,7 +1677,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SOLROCK_69:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1697,7 +1697,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIOLU_70:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1716,7 +1716,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_71:
         return evolution (this, from:"Riolu", hp:HP120, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1759,7 +1759,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SAWK_72:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1779,7 +1779,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRABRAWLER_73:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1791,7 +1791,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRABOMINABLE_74:
         return copy (SunMoonPromos.CRABOMINABLE_SM47, this)
       case LYCANROC_75:
@@ -1814,7 +1814,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LYCANROC_76:
         return evolution (this, from:"Rockruff", hp:HP110, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1833,7 +1833,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDBRAY_77:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1846,7 +1846,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDSDALE_78:
         return evolution (this, from:"Mudbray", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1868,7 +1868,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PASSIMIAN_79:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1891,7 +1891,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARSHADOW_GX_80:
         return basic (this, hp:HP150, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1918,7 +1918,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_RATTATA_81:
         return basic (this, hp:HP040, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1937,7 +1937,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_RATICATE_82:
         return evolution (this, from:"Alolan Rattata", hp:HP120, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -1957,7 +1957,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GRIMER_83:
         return basic (this, hp:HP080, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -1983,7 +1983,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_MUK_GX_84:
         return evolution (this, from:"Alolan Grimer", hp:HP220, type:DARKNESS, retreatCost:4) {
           weakness FIGHTING
@@ -2021,7 +2021,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNEASEL_85:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2041,7 +2041,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEAVILE_86:
         return evolution (this, from:"Sneasel", hp:HP090, type:DARKNESS, retreatCost:0) {
           weakness FIGHTING
@@ -2061,7 +2061,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_87:
         return basic (this, hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -2083,7 +2083,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_GX_88:
         return basic (this, hp:HP180, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -2127,7 +2127,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INKAY_89:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2147,7 +2147,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MALAMAR_90:
         return evolution (this, from:"Inkay", hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2174,7 +2174,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RALTS_91:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2188,7 +2188,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KIRLIA_92:
         return evolution (this, from:"Ralts", hp:HP080, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2208,7 +2208,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARDEVOIR_GX_93:
         return evolution (this, from:"Kirlia", hp:HP230, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2243,7 +2243,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIANCIE_94:
         return basic (this, hp:HP090, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2269,7 +2269,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUTIEFLY_95:
         return basic (this, hp:HP030, type:FAIRY, retreatCost:0) {
           weakness METAL
@@ -2282,7 +2282,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIBOMBEE_96:
         return evolution (this, from:"Cutiefly", hp:HP070, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2305,7 +2305,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MORELULL_97:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2318,7 +2318,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIINOTIC_98:
         return evolution (this, from:"Morelull", hp:HP100, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2340,7 +2340,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOIVERN_GX_99:
         return evolution (this, from:"Noibat", hp:HP200, type:DRAGON, retreatCost:0) {
           weakness FAIRY
@@ -2389,7 +2389,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZYGARDE_100:
         return copy (SunMoonPromos.ZYGARDE_SM48, this)
       case MEOWTH_101:
@@ -2404,7 +2404,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_102:
         return evolution (this, from:"Meowth", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2423,7 +2423,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_103:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2442,7 +2442,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON2_104:
         return evolution (this, from:"Porygon", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2465,7 +2465,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_Z_105:
         return evolution (this, from:"Porygon2", hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2495,7 +2495,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOOTHOOT_106:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2518,7 +2518,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOCTOWL_107:
         return evolution (this, from:"Hoothoot", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2549,7 +2549,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BOUFFALANT_108:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2574,7 +2574,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOIBAT_109:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2588,7 +2588,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUFFUL_110:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2607,7 +2607,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEWEAR_111:
         return copy (SunMoonPromos.BEWEAR_SM49, this)
       case ACEROLA_112:
@@ -2621,7 +2621,7 @@ public enum BurningShadows implements LogicCardInfo {
             assert my.all.findAll {it.numberOfDamageCounters} : "No damaged pokemon in play"
             confirmScoopLastPokemon()
           }
-        };
+        }
       case BODYBUILDING_DUMBBELLS_113:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Stage 1 Pokémon this card is attached to gets +40 HP.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2636,7 +2636,7 @@ public enum BurningShadows implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case ESCAPE_ROPE_114:
         return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case GUZMA_115:
@@ -2651,7 +2651,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert opp.bench.notEmpty
           }
-        };
+        }
       case KIAWE_116:
         return supporter (this) {
           text "Search your deck for up to 4 [R] Energy cards and attach them to 1 of your Pokémon. Then, shuffle your deck. Your turn ends.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2665,7 +2665,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case LANA_117:
         return supporter (this) {
           text "Heal 50 damage from each of your Pokémon that has any [W] Energy attached to it.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2675,7 +2675,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll {it.numberOfDamageCounters && it.cards.energyCount(W)}
           }
-        };
+        }
       case MOUNT_LANAKILA_118:
         return stadium (this) {
           text "The Retreat Cost of each Basic Pokémon in play (both yours and your opponent's) is [C] more.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2690,7 +2690,7 @@ public enum BurningShadows implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case OLIVIA_119:
         return supporter (this) {
           text "Search your deck for up to 2 Pokémon-GX, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2701,7 +2701,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case PLUMERIA_120:
         return supporter (this) {
           text "Discard 2 cards from your hand. If you do, discard an Energy attached to 1 of your opponent's Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2719,7 +2719,7 @@ public enum BurningShadows implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "You can't play $thisCard if you can't discard 2 cards from your hand"
             assert opp.all.any{it.cards.energyCount(C)} : "You can't play $thisCard if your Opponent has no Energy attached to any of their Pokémon"
           }
-        };
+        }
       case PO_TOWN_121:
         return stadium (this) {
           text "Whenever any player plays a Pokémon from their hand to evolve 1 of their Pokémon, put 3 damage counters on that Pokémon.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2739,7 +2739,7 @@ public enum BurningShadows implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case ROTOM_DEX_POKE_FINDER_MODE_122:
         return itemCard (this) {
           text "Look at the top 4 cards of your deck and put them back in any order or shuffle them into your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2753,7 +2753,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert deck
           }
-        };
+        }
       case SOPHOCLES_123:
         return supporter (this) {
           text "Discard 2 cards from your hand. If you do, draw 4 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2765,9 +2765,9 @@ public enum BurningShadows implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "You cannot play $thisCard if you can't discard 2 cards from your hand"
             assert my.deck : "You can't play $thisCard if you don't have cards in deck."
           }
-        };
+        }
       case SUPER_SCOOP_UP_124:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case TORMENTING_SPRAY_125:
         return itemCard (this) {
           text "Choose a random card from your opponent's hand. Your opponent reveals that card. If it's a Supporter card, discard it.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2777,7 +2777,7 @@ public enum BurningShadows implements LogicCardInfo {
           playRequirement{
             assert opp.hand
           }
-        };
+        }
       case WEAKNESS_POLICY_126:
         return copy (PrimalClash.WEAKNESS_POLICY_142, this)
       case WICKE_127:
@@ -2795,7 +2795,7 @@ public enum BurningShadows implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case WISHFUL_BATON_128:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the Pokémon this card is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, move up to 3 basic Energy cards from that Pokémon to 1 of your Benched Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2813,7 +2813,7 @@ public enum BurningShadows implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case GOLISOPOD_GX_129:
         return copy (GOLISOPOD_GX_17, this)
       case TAPU_BULU_GX_130:
@@ -2849,7 +2849,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HO_OH_GX_131:
         return copy (SunMoonPromos.HO_OH_GX_SM57, this)
       case SALAZZLE_GX_132:
@@ -2891,7 +2891,7 @@ public enum BurningShadows implements LogicCardInfo {
             }
           }
 
-        };
+        }
 
       case MARSHADOW_GX_137:
         return copy (MARSHADOW_GX_80, this)
@@ -2920,9 +2920,9 @@ public enum BurningShadows implements LogicCardInfo {
       case TAPU_BULU_GX_149:
         return copy (TAPU_BULU_GX_130, this)
       case CHARIZARD_GX_150:
-        return copy (CHARIZARD_GX_20, this);
+        return copy (CHARIZARD_GX_20, this)
       case SALAZZLE_GX_151:
-        return copy (SALAZZLE_GX_25, this);
+        return copy (SALAZZLE_GX_25, this)
       case TAPU_FINI_GX_152:
         return copy (TAPU_FINI_GX_39, this)
       case NECROZMA_GX_153:
@@ -2954,13 +2954,13 @@ public enum BurningShadows implements LogicCardInfo {
       case SUPER_SCOOP_UP_166:
         return copy (SUPER_SCOOP_UP_124, this)
       case FIRE_ENERGY_167:
-        return basicEnergy (this, FIRE);
+        return basicEnergy (this, FIRE)
       case DARKNESS_ENERGY_168:
-        return basicEnergy (this, DARKNESS);
+        return basicEnergy (this, DARKNESS)
       case FAIRY_ENERGY_169:
-        return basicEnergy (this, FAIRY);
+        return basicEnergy (this, FAIRY)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
+++ b/src/tcgwars/logic/impl/gen7/CelestialStorm.groovy
@@ -2,7 +2,7 @@ package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.effect.gm.PlayCard
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
+import tcgwars.logic.impl.gen3.TeamRocketReturns
 import tcgwars.logic.impl.gen5.DarkExplorers
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen6.Breakthrough
@@ -11,24 +11,24 @@ import tcgwars.logic.impl.gen6.PrimalClash
 import tcgwars.logic.impl.gen3.Dragon
 import tcgwars.logic.impl.gen3.RubySapphire
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -221,53 +221,53 @@ public enum CelestialStorm implements LogicCardInfo {
   RAINBOW_ENERGY_183("Rainbow Energy", "183", Rarity.SECRET, [ENERGY,SPECIAL_ENERGY]);
 
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   CelestialStorm(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CELESTIAL_STORM;
+    return tcgwars.logic.card.Collection.CELESTIAL_STORM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -286,7 +286,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WEEPINBELL_2:
         return 	evolution (this, from:"Bellsprout", hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -305,7 +305,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip 2,{damage 30}
             }
           }
-        };
+        }
       case VICTREEBEL_3:
         return 	evolution (this, from:"Weepinbell", hp:HP140, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -328,7 +328,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC BURNED
             }
           }
-        };
+        }
       case SCYTHER_4:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -345,7 +345,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip{preventAllEffectsNextTurn()}
             }
           }
-        };
+        }
       case SPINARAK_5:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -366,7 +366,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ARIADOS_6:
         return 	evolution (this, from:"Spinarak", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -394,7 +394,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TREECKO_7:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -406,7 +406,7 @@ public enum CelestialStorm implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case TREECKO_8:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -424,7 +424,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GROVYLE_9:
         return 	evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -436,7 +436,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip {damage 40}
             }
           }
-        };
+        }
       case SCEPTILE_10:
         return 	evolution (this, from:"Grovyle", hp:HP140, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -460,7 +460,7 @@ public enum CelestialStorm implements LogicCardInfo {
               my.all.each{damage 20*it.cards.energyCount(C)}
             }
           }
-        };
+        }
       case SEEDOT_11:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -490,7 +490,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SEEDOT_12:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -501,7 +501,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case NUZLEAF_13:
         return 	evolution (this, from:"Seedot", hp:HP090, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -528,7 +528,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHIFTRY_GX_14:
         return 	evolution (this, from:"Nuzleaf", hp:HP240, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -562,7 +562,7 @@ public enum CelestialStorm implements LogicCardInfo {
               shuffleOppDeck()
             }
           }
-        };
+        }
       case SURSKIT_15:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -573,7 +573,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case MASQUERAIN_16:
         return evolution (this, from:"Surskit", hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -593,7 +593,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip 4, {damage 40}
             }
           }
-        };
+        }
       case VOLBEAT_17:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -605,7 +605,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(bg.em().retrieveObject("Pheromone_Signal") == bg.turnCount - 2) damage 100
             }
           }
-        };
+        }
       case ILLUMISE_18:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -618,7 +618,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case CACNEA_19:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -636,7 +636,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CACTURNE_20:
         return 	evolution (this, from:"Cacnea", hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -654,7 +654,7 @@ public enum CelestialStorm implements LogicCardInfo {
               swiftDamage(50,opp.all.select("50 damage to "))
             }
           }
-        };
+        }
       case TROPIUS_21:
         return basic (this, hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -676,7 +676,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case DHELMISE_22:
         return basic (this, hp:HP130, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -696,7 +696,7 @@ public enum CelestialStorm implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case SLUGMA_23:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -715,7 +715,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MAGCARGO_24:
         return 	evolution (this, from:"Slugma", hp:HP090, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -737,7 +737,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case TORCHIC_25:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -751,7 +751,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORCHIC_26:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -769,7 +769,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case COMBUSKEN_27:
         return 	evolution (this, from:"Torchic", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -790,7 +790,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLAZIKEN_GX_28:
         return 	evolution (this, from:"Combusken", hp:HP240, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -823,7 +823,7 @@ public enum CelestialStorm implements LogicCardInfo {
               discardOpponentEnergy(Target.OPP_ALL)
             }
           }
-        };
+        }
       case TORKOAL_29:
         return basic (this, hp:HP120, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -852,7 +852,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage BURNED
             }
           }
-        };
+        }
       case ORICORIO_30:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness LIGHTNING
@@ -878,7 +878,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case ARTICUNO_GX_31:
         return basic (this, hp:HP170, type:WATER, retreatCost:2) {
           weakness METAL
@@ -890,9 +890,9 @@ public enum CelestialStorm implements LogicCardInfo {
                 sw my.active, self
                 while(1){
                   def pl=(my.all.findAll {it.cards.filterByEnergyType(W) && it!=self})
-                  if(!pl) break;
+                  if(!pl) break
                   def src=pl.select("Source for [W] energy (cancel to stop moving)", false)
-                  if(!src) break;
+                  if(!src) break
                   def card=src.cards.filterByEnergyType(W).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -918,7 +918,7 @@ public enum CelestialStorm implements LogicCardInfo {
               opp.active.cards.filterByType(ENERGY).discard()
             }
           }
-        };
+        }
       case MUDKIP_32:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -932,7 +932,7 @@ public enum CelestialStorm implements LogicCardInfo {
               my.deck.search(max:3,"Choose up to 3 [W] energy to put in your hand",basicEnergyFilter(W)).moveTo(my.hand)
             }
           }
-        };
+        }
       case MUDKIP_33:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -950,7 +950,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MARSHTOMP_34:
         return 	evolution (this, from:"Mudkip", hp:HP090, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -971,7 +971,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SWAMPERT_35:
         return 	evolution (this, from:"Marshtomp", hp:HP160, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -992,7 +992,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 80+20*self.cards.energyCount(W)
             }
           }
-        };
+        }
       case LOTAD_36:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1006,7 +1006,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LOMBRE_37:
         return 	evolution (this, from:"Lotad", hp:HP080, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1026,7 +1026,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip {damage 20}
             }
           }
-        };
+        }
       case LUDICOLO_38:
         return 	evolution (this, from:"Lombre", hp:HP140, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -1046,7 +1046,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 70+10*(my.bench.size()+opp.all.size())
             }
           }
-        };
+        }
       case WAILMER_39:
         return basic (this, hp:HP120, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -1060,7 +1060,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WAILORD_40:
         return 	evolution (this, from:"Wailmer", hp:HP220, type:WATER, retreatCost:4) {
           weakness GRASS
@@ -1071,7 +1071,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 200-40*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case CLAMPERL_41:
         return basic (this, hp:HP050, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -1093,7 +1093,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case HUNTAIL_42:
         return 	evolution (this, from:"Clamperl", hp:HP110, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1114,7 +1114,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(defending.basic) damage 80
             }
           }
-        };
+        }
       case GOREBYSS_43:
         return 	evolution (this, from:"Clamperl", hp:HP090, type:WATER, retreatCost:0) {
           weakness GRASS
@@ -1140,7 +1140,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUVDISC_44:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1164,7 +1164,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case REGICE_45:
         return basic (this, hp:HP120, type:WATER, retreatCost:3) {
           weakness METAL
@@ -1187,7 +1187,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case KYOGRE_46:
         return basic (this, hp:HP130, type:WATER, retreatCost:4) {
           weakness GRASS
@@ -1210,7 +1210,7 @@ public enum CelestialStorm implements LogicCardInfo {
               cantUseAttack thisMove, self
             }
           }
-        };
+        }
       case VOLTORB_47:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1230,7 +1230,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case ELECTRODE_GX_48:
         return evolution(this, from: "Voltorb", hp: HP190, type: LIGHTNING, retreatCost: 1) {
           weakness FIGHTING
@@ -1273,7 +1273,7 @@ public enum CelestialStorm implements LogicCardInfo {
               additionalDamageByDiscardingCardTypeFromPokemon 30, 50, ENERGY
             }
           }
-        };
+        }
       case CHINCHOU_49:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1299,7 +1299,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LANTURN_50:
         return 	evolution (this, from:"Chinchou", hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1327,7 +1327,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ELECTRIKE_51:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1339,7 +1339,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MANECTRIC_52:
         return 	evolution (this, from:"Electrike", hp:HP110, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -1366,7 +1366,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PLUSLE_53:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1390,7 +1390,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MINUN_54:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1417,7 +1417,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case ORICORIO_55:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness LIGHTNING
@@ -1441,7 +1441,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case MR_MIME_GX_56:
         return basic (this, hp:HP150, type:PSYCHIC, retreatCost:2) {
           bwAbility "Magic Evens" , {
@@ -1475,7 +1475,7 @@ public enum CelestialStorm implements LogicCardInfo {
               heal self.numberOfDamageCounters*10, self
             }
           }
-        };
+        }
       case GULPIN_57:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1493,7 +1493,7 @@ public enum CelestialStorm implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case SWALOT_58:
         return 	evolution (this, from:"Gulpin", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1513,7 +1513,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(defending.getRemainingHP() < self.getRemainingHP()) damage 80
             }
           }
-        };
+        }
       case SPOINK_59:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1527,7 +1527,7 @@ public enum CelestialStorm implements LogicCardInfo {
               switchYourActive(now: 1)
             }
           }
-        };
+        }
       case GRUMPIG_60:
         return 	evolution (this, from:"Spoink", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1547,7 +1547,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(addDmg) damage 70
             }
           }
-        };
+        }
       case LUNATONE_61:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1583,7 +1583,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case SOLROCK_62:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1602,7 +1602,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip 1, {apply PARALYZED}, {apply BURNED}
             }
           }
-        };
+        }
       case SHUPPET_63:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1621,7 +1621,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SHUPPET_64:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1633,7 +1633,7 @@ public enum CelestialStorm implements LogicCardInfo {
               apply CONFUSED
             }
           }
-        };
+        }
       case BANETTE_65:
         return 	evolution (this, from:"Shuppet", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1656,7 +1656,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BANETTE_GX_66:
         return 	evolution (this, from:"Shuppet", hp:HP190, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1668,7 +1668,7 @@ public enum CelestialStorm implements LogicCardInfo {
               assert self.active : "$self is not your active"
               assert my.all.findAll{it.numberOfDamageCounters} || opp.all.findAll{it.numberOfDamageCounters} : "There is no pokémon with damage counter on them"
               powerUsed()
-              def bothAll = new PcsList();
+              def bothAll = new PcsList()
               my.all.each{
                 bothAll.add(it)
               }
@@ -1705,7 +1705,7 @@ public enum CelestialStorm implements LogicCardInfo {
               my.discard.select(max:3,"select the card you want to put in your hand.").moveTo(my.hand)
             }
           }
-        };
+        }
       case DEOXYS_67:
         return basic (this, hp:HP120, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1727,7 +1727,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DEOXYS_68:
         return basic (this, hp:HP130, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1746,7 +1746,7 @@ public enum CelestialStorm implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case DEOXYS_69:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1765,7 +1765,7 @@ public enum CelestialStorm implements LogicCardInfo {
               noWrDamage(50,opp.all.select())
             }
           }
-        };
+        }
       case LUNALA_70:
         return 	evolution (this, from:"Cosmoem", hp:HP160, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1790,7 +1790,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 80+20*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case ONIX_71:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1820,7 +1820,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10+10*(self.numberOfDamageCounters)
             }
           }
-        };
+        }
       case PHANPY_72:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1851,7 +1851,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DONPHAN_73:
         return 	evolution (this, from:"Phanpy", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1877,7 +1877,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LARVITAR_74:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1895,7 +1895,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PUPITAR_75:
         return 	evolution (this, from:"Larvitar", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1923,7 +1923,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEDITITE_76:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1954,7 +1954,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MEDICHAM_77:
         return 	evolution (this, from:"Meditite", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1974,7 +1974,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30,self
             }
           }
-        };
+        }
       case BALTOY_78:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1986,7 +1986,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case CLAYDOL_79:
         return 	evolution (this, from:"Baltoy", hp:HP110, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -2005,7 +2005,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 40*my.discard.findAll{it.name.contains("Steven's Resolve")}.size()
             }
           }
-        };
+        }
       case REGIROCK_80:
         return basic (this, hp:HP120, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -2027,7 +2027,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GROUDON_81:
         return basic (this, hp:HP130, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -2055,7 +2055,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PALOSSAND_GX_82:
         return 	evolution (this, from:"Sandygast", hp:HP210, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -2087,7 +2087,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 60*opp.deck.subList(0,13).filterByType(POKEMON).select(min:0,max:opp.deck.subList(0,13).filterByType(POKEMON).size(),"Select the cards you want to discard.").discard().size()
             }
           }
-        };
+        }
       case MINIOR_83:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -2107,7 +2107,7 @@ public enum CelestialStorm implements LogicCardInfo {
               swiftDamage 30, defending
             }
           }
-        };
+        }
       case ALOLAN_RATTATA_84:
         return basic (this, hp:HP040, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2129,7 +2129,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ALOLAN_RATICATE_GX_85:
         return 	evolution (this, from:"Alolan Rattata", hp:HP200, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2161,7 +2161,7 @@ public enum CelestialStorm implements LogicCardInfo {
               my.deck.search(min:0,max:6,"Select up to 6 item cards",cardTypeFilter(ITEM)).showToOpponent("Selected cards").moveTo(my.hand)
             }
           }
-        };
+        }
       case SNEASEL_86:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2180,7 +2180,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip my.all.size(),{damage 30}
             }
           }
-        };
+        }
       case TYRANITAR_87:
         return 	evolution (this, from:"Pupitar", hp:HP170, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2208,7 +2208,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SABLEYE_88:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           bwAbility "Excavate" , {
@@ -2231,7 +2231,7 @@ public enum CelestialStorm implements LogicCardInfo {
               amnesia delegate
             }
           }
-        };
+        }
       case STEELIX_89:
         return 	evolution (this, from:"Onix", hp:HP190, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -2251,7 +2251,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip {damage 40}
             }
           }
-        };
+        }
       case SCIZOR_GX_90:
         return 	evolution (this, from:"Scyther", hp:HP210, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2291,7 +2291,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(defending.realEvolution) damage 100
             }
           }
-        };
+        }
       case MAWILE_91:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2319,7 +2319,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(defending.pokemonGX || defending.pokemonEX) damage 30
             }
           }
-        };
+        }
       case BELDUM_92:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2339,7 +2339,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case BELDUM_93:
         return basic (this, hp:HP070, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2351,7 +2351,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip {damage 50}
             }
           }
-        };
+        }
       case METANG_94:
         return 	evolution (this, from:"Beldum", hp:HP090, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2364,7 +2364,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flip 2,{damage 20}
             }
           }
-        };
+        }
       case METAGROSS_95:
         return 	evolution (this, from:"Metang", hp:HP170, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -2388,7 +2388,7 @@ public enum CelestialStorm implements LogicCardInfo {
               increasedBaseDamageNextTurn("Meteor Mash",hp(60))
             }
           }
-        };
+        }
       case REGISTEEL_96:
         return basic (this, hp:HP120, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2414,7 +2414,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(defending.hasModernAbility()) damage 60
             }
           }
-        };
+        }
       case JIRACHI_PRISM_STAR_97:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2467,7 +2467,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HEATRAN_98:
         return basic (this, hp:HP130, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2496,7 +2496,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case SOLGALEO_99:
         return 	evolution (this, from:"Cosmoem", hp:HP160, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2518,7 +2518,7 @@ public enum CelestialStorm implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case CELESTEELA_100:
         return basic (this, hp:HP140, type:METAL, retreatCost:4) {
           weakness LIGHTNING
@@ -2550,7 +2550,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 160
             }
           }
-        };
+        }
       case KARTANA_101:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2563,7 +2563,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(opp.prizeCardSet.size() == 6) damage 90
             }
           }
-        };
+        }
       case STAKATAKA_GX_102:
         return basic (this, hp:HP180, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2600,7 +2600,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 50*my.prizeCardSet.takenCount
             }
           }
-        };
+        }
       case BAGON_103:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2612,7 +2612,7 @@ public enum CelestialStorm implements LogicCardInfo {
               reduceDamageNextTurn(hp(10),thisMove)
             }
           }
-        };
+        }
       case BAGON_104:
         return basic (this, hp:HP070, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2624,7 +2624,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case SHELGON_105:
         return 	evolution (this, from:"Bagon", hp:HP090, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2636,7 +2636,7 @@ public enum CelestialStorm implements LogicCardInfo {
               if(self.numberOfDamageCounters) damage 50
             }
           }
-        };
+        }
       case SALAMENCE_106:
         return 	evolution (this, from:"Shelgon", hp:HP150, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2657,7 +2657,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case LATIAS_PRISM_STAR_107:
         return basic (this, hp:HP130, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2675,7 +2675,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIOS_PRISM_STAR_108:
         return basic (this, hp:HP140, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2688,7 +2688,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAYQUAZA_GX_109:
         return basic (this, hp:HP180, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2724,7 +2724,7 @@ public enum CelestialStorm implements LogicCardInfo {
               draw 10
             }
           }
-        };
+        }
       case DUNSPARCE_110:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2757,7 +2757,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case WINGULL_111:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2769,7 +2769,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case PELIPPER_112:
         return 	evolution (this, from:"Wingull", hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -2793,7 +2793,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case SLAKOTH_113:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2812,7 +2812,7 @@ public enum CelestialStorm implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case VIGOROTH_114:
         return 	evolution (this, from:"Slakoth", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2830,7 +2830,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20+10*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case SLAKING_115:
         return 	evolution (this, from:"Vigoroth", hp:HP160, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -2866,7 +2866,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WHISMUR_116:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2895,7 +2895,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case WHISMUR_117:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2911,7 +2911,7 @@ public enum CelestialStorm implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LOUDRED_118:
         return 	evolution (this, from:"Whismur", hp:HP100, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -2923,7 +2923,7 @@ public enum CelestialStorm implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case EXPLOUD_119:
         return 	evolution (this, from:"Loudred", hp:HP150, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -2944,7 +2944,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case SKITTY_120:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2956,7 +2956,7 @@ public enum CelestialStorm implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case DELCATTY_121:
         return 	evolution (this, from:"Skitty", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2976,7 +2976,7 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case KECLEON_122:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2998,11 +2998,11 @@ public enum CelestialStorm implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case ACRO_BIKE_123:
-        return copy(PrimalClash.ACRO_BIKE_122, this);
+        return copy(PrimalClash.ACRO_BIKE_122, this)
       case APRICORN_MAKER_124:
-        return copy(Skyridge.APRICORN_MAKER_121, this);
+        return copy(Skyridge.APRICORN_MAKER_121, this)
       case BEAST_BALL_125:
         return 	itemCard (this) {
           text "Look at your face-down Prize cards. You may reveal an Ultra Beast card you find there, put it into your hand, and put this Beast Ball in its place. (If you don't reveal an Ultra Beast card, put this card in the discard pile.) Then, shuffle your face-down Prize cards.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -3022,11 +3022,11 @@ public enum CelestialStorm implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case BILLS_MAINTENANCE_126:
-        return copy(FireRedLeafGreen.BILL_S_MAINTENANCE_87, this);
+        return copy(FireRedLeafGreen.BILL_S_MAINTENANCE_87, this)
       case COPYCAT_127:
-        return copy(TeamRocketReturns.COPYCAT_83, this);
+        return copy(TeamRocketReturns.COPYCAT_83, this)
       case ENERGY_RECYCLE_SYSTEM_128:
         return itemCard (this) {
           text "Choose 1:\n" +
@@ -3047,11 +3047,11 @@ public enum CelestialStorm implements LogicCardInfo {
           }
         }
       case ENERGY_SWITCH_129:
-        return copy(BlackWhite.ENERGY_SWITCH_94, this);
+        return copy(BlackWhite.ENERGY_SWITCH_94, this)
       case FISHERMAN_130:
-        return copy(Breakthrough.FISHERMAN_136, this);
+        return copy(Breakthrough.FISHERMAN_136, this)
       case FRIEND_BALL_131:
-        return copy(Skyridge.FRIEND_BALL_126, this);
+        return copy(Skyridge.FRIEND_BALL_126, this)
       case HAU_132:
         return supporter(this) {
           text "Draw 3 cards.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3061,7 +3061,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty
           }
-        };
+        }
       case HIKER_133:
         return supporter(this) {
           text "Look at the top 5 cards of either players deck and choose 1 of them. That player shuffles the other cards back into their deck. Then, put the card you chose on top of that deck.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3097,7 +3097,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || opp.deck.notEmpty
           }
-        };
+        }
       case HUSTLE_BELT_134:
         return 	pokemonTool(this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesnt already have a Pokémon Tool attached to it.\nIf the Pokémon this card is attached to has 30 HP or less remaining and has any damage counters on it, its attacks do 60 more damage to your opponents Active Pokémon (before applying Weakness and Resistance).\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -3119,7 +3119,7 @@ public enum CelestialStorm implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case LAST_CHANCE_POTION_135:
         return 	itemCard (this) {
           text "Heal 120 damage from 1 of your Pokémon that has 30 HP or less remaining.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -3130,7 +3130,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.numberOfDamageCounters && it.getRemainingHP().value <= 30}
           }
-        };
+        }
       case LIFE_HERB_136:
         return 	itemCard (this) {
           text "You may play as many Item cards as you like during your turn (before your attack).\n"
@@ -3147,7 +3147,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{(it.numberOfDamageCounters !=0 || !(it.noSPC()))}
           }
-        };
+        }
       case LISIA_137:
         return supporter(this) {
           text "Search your deck for up to 2 Prism Star cards, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3158,9 +3158,9 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case LURE_BALL_138:
-        return copy(Skyridge.LURE_BALL_128, this);
+        return copy(Skyridge.LURE_BALL_128, this)
       case THE_MASKED_ROYAL_139:
         return supporter(this) {
           text "Attach a basic Energy card from your hand to one of your Stage 2 [G], [R], or [W] Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3170,9 +3170,9 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.all.any{it.stage2 && (it.types.contains(G) || it.types.contains(R) || it.types.contains(W))} && my.hand.filterByType(BASIC_ENERGY)
           }
-        };
+        }
       case POKENAV_140:
-        return copy(RubySapphire.POKENAV_88, this);
+        return copy(RubySapphire.POKENAV_88, this)
       case RAINBOW_BRUSH_141:
         return 	itemCard (this) {
           text "Choose an Energy card attached to 1 of your Pokémon. Search your deck for a basic Energy card and switch it with that card. Shuffle the first Energy card into your deck.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -3189,9 +3189,9 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.cards.filterByType(ENERGY)} && my.deck
           }
-        };
+        }
       case RARE_CANDY_142:
-        return copy(DarkExplorers.RARE_CANDY_100, this);
+        return copy(DarkExplorers.RARE_CANDY_100, this)
       case SHRINE_OF_PUNISHMENT_143:
         return stadium(this) {
           text "Between turns, put 1 damage counter on each Pokémon-GX and Pokémon-EX (both yours and your opponents).\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you cant play this card.\n"
@@ -3215,7 +3215,7 @@ public enum CelestialStorm implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case SKY_PILLAR_144:
         return stadium(this) {
           text "Prevent all effects of the opponents attacks, including damage, done to Benched Pokémon (both yours and your opponents).\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you cant play this card.\n"
@@ -3244,7 +3244,7 @@ public enum CelestialStorm implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case STEVENS_RESOLVE_145:
         return supporter(this) {
           text "Search your deck for up to 3 cards and put them into your hand. Then, shuffle your deck. Your turn ends.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3258,11 +3258,11 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case SUPER_SCOOP_UP_146:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case SWITCH_147:
-        return copy(BlackWhite.SWITCH_104, this);
+        return copy(BlackWhite.SWITCH_104, this)
       case TATE_LIZA_148:
         return supporter(this) {
           text "Choose 1:\nShuffle your hand into your deck. Then, draw 5 cards.\nSwitch your Active Pokémon with 1 of your Benched Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3290,7 +3290,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || (my.hand.size() > 1) || my.bench
           }
-        };
+        }
       case TV_REPORTER_149:
         return supporter(this) {
           text "Draw 3 cards. Then, discard a card from your hand. If you have no cards in your deck, you can't play this card.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3301,7 +3301,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case UNDERGROUND_EXPEDITION_150:
         return supporter(this) {
           text "Look at the bottom 4 cards of your deck and put 2 of them into your hand. Put the other cards back on the bottom of your deck in any order.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -3322,7 +3322,7 @@ public enum CelestialStorm implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case RAINBOW_ENERGY_151:
         return specialEnergy (this, [[C]]) {
           text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon. (While not in play, Rainbow Energy counts as Colorless Energy.)"
@@ -3335,73 +3335,73 @@ public enum CelestialStorm implements LogicCardInfo {
           getEnergyTypesOverride {
             self != null ? [valuesBasicEnergy() as Set] : [[C] as Set]
           }
-        };
+        }
       case SHIFTRY_GX_152:
-        return copy(SHIFTRY_GX_14,this);
+        return copy(SHIFTRY_GX_14,this)
       case BLAZIKEN_GX_153:
-        return copy(BLAZIKEN_GX_28,this);
+        return copy(BLAZIKEN_GX_28,this)
       case ARTICUNO_GX_154:
-        return copy(ARTICUNO_GX_31,this);
+        return copy(ARTICUNO_GX_31,this)
       case ELECTRODE_GX_155:
         return copy(ELECTRODE_GX_48,this)
       case MR_MIME_GX_156:
-        return copy(MR_MIME_GX_56,this);
+        return copy(MR_MIME_GX_56,this)
       case BANETTE_GX_157:
-        return copy(BANETTE_GX_66,this);
+        return copy(BANETTE_GX_66,this)
       case SCIZOR_GX_158:
-        return copy(SCIZOR_GX_90,this);
+        return copy(SCIZOR_GX_90,this)
       case STAKATAKA_GX_159:
-        return copy(STAKATAKA_GX_102,this);
+        return copy(STAKATAKA_GX_102,this)
       case RAYQUAZA_GX_160:
-        return copy(RAYQUAZA_GX_109,this);
+        return copy(RAYQUAZA_GX_109,this)
       case APRICORN_MAKER_161:
-        return copy(APRICORN_MAKER_124,this);
+        return copy(APRICORN_MAKER_124,this)
       case BILLS_MAINTENANCE_162:
-        return copy(BILLS_MAINTENANCE_126,this);
+        return copy(BILLS_MAINTENANCE_126,this)
       case COPYCAT_163:
-        return copy(COPYCAT_127,this);
+        return copy(COPYCAT_127,this)
       case LISIA_164:
-        return copy(LISIA_137,this);
+        return copy(LISIA_137,this)
       case STEVENS_RESOLVE_165:
-        return copy(STEVENS_RESOLVE_145,this);
+        return copy(STEVENS_RESOLVE_145,this)
       case TATE_LIZA_166:
-        return copy(TATE_LIZA_148,this);
+        return copy(TATE_LIZA_148,this)
       case TV_REPORTER_167:
-        return copy(TV_REPORTER_149,this);
+        return copy(TV_REPORTER_149,this)
       case UNDERGROUND_EXPEDITION_168:
-        return copy(UNDERGROUND_EXPEDITION_150,this);
+        return copy(UNDERGROUND_EXPEDITION_150,this)
       case SHIFTRY_GX_169:
-        return copy(SHIFTRY_GX_14,this);
+        return copy(SHIFTRY_GX_14,this)
       case BLAZIKEN_GX_170:
-        return copy(BLAZIKEN_GX_28,this);
+        return copy(BLAZIKEN_GX_28,this)
       case ARTICUNO_GX_171:
-        return copy(ARTICUNO_GX_31,this);
+        return copy(ARTICUNO_GX_31,this)
       case ELECTRODE_GX_172:
-        return copy(ELECTRODE_GX_48,this);
+        return copy(ELECTRODE_GX_48,this)
       case MR_MIME_GX_173:
-        return copy(MR_MIME_GX_56,this);
+        return copy(MR_MIME_GX_56,this)
       case BANETTE_GX_174:
-        return copy(BANETTE_GX_66,this);
+        return copy(BANETTE_GX_66,this)
       case SCIZOR_GX_175:
-        return copy(SCIZOR_GX_90,this);
+        return copy(SCIZOR_GX_90,this)
       case STAKATAKA_GX_176:
-        return copy(STAKATAKA_GX_102,this);
+        return copy(STAKATAKA_GX_102,this)
       case RAYQUAZA_GX_177:
-        return copy(RAYQUAZA_GX_109,this);
+        return copy(RAYQUAZA_GX_109,this)
       case ACRO_BIKE_178:
-        return copy(ACRO_BIKE_123,this);
+        return copy(ACRO_BIKE_123,this)
       case HUSTLE_BELT_179:
-        return copy(HUSTLE_BELT_134,this);
+        return copy(HUSTLE_BELT_134,this)
       case LIFE_HERB_180:
-        return copy(LIFE_HERB_136,this);
+        return copy(LIFE_HERB_136,this)
       case POKENAV_181:
-        return copy(POKENAV_140,this);
+        return copy(POKENAV_140,this)
       case RAINBOW_BRUSH_182:
-        return copy(RAINBOW_BRUSH_141,this);
+        return copy(RAINBOW_BRUSH_141,this)
       case RAINBOW_ENERGY_183:
-        return copy(RAINBOW_ENERGY_151,this);
+        return copy(RAINBOW_ENERGY_151,this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
+++ b/src/tcgwars/logic/impl/gen7/CosmicEclipse.groovy
@@ -5,25 +5,25 @@ import tcgwars.logic.effect.gm.ActivateSimpleTrainer
 import tcgwars.logic.effect.gm.PlayCard
 import tcgwars.logic.effect.gm.PlayStadium
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -303,53 +303,53 @@ public enum CosmicEclipse implements LogicCardInfo {
   TAG_CALL_270 ("Tag Call", "270", Rarity.SECRET, [TRAINER, ITEM]),
   DRAW_ENERGY_271 ("Draw Energy", "271", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   CosmicEclipse(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.COSMIC_ECLIPSE;
+    return tcgwars.logic.card.Collection.COSMIC_ECLIPSE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -394,7 +394,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ODDISH_2:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -408,7 +408,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               heal 30, my.all.findAll{it.numberOfDamageCounters}.select("Select a Pokémon to heal.")
             }
           }
-        };
+        }
       case GLOOM_3:
         return evolution (this, from:"Oddish", hp:HP080, type:G, retreatCost:2) {
           weakness R
@@ -420,7 +420,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case VILEPLUME_GX_4:
         return evolution (this, from:"Gloom", hp:HP240, type:G, retreatCost:2) {
           weakness R
@@ -455,7 +455,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case TANGELA_5:
         return basic (this, hp:HP070, type:G, retreatCost:2) {
           weakness R
@@ -467,7 +467,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               extraPoison 1
             }
           }
-        };
+        }
       case TANGROWTH_6:
         return evolution (this, from:"Tangela", hp:HP140, type:G, retreatCost:3) {
           weakness R
@@ -486,7 +486,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip 2, { damage 80 }
             }
           }
-        };
+        }
       case SUNKERN_7:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -498,7 +498,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case SUNFLORA_8:
         return evolution (this, from:"Sunkern", hp:HP090, type:G, retreatCost:1) {
           weakness R
@@ -536,7 +536,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case HERACROSS_9:
         return basic (this, hp:HP130, type:G, retreatCost:3) {
           weakness R
@@ -555,7 +555,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if(opp.all.find{it.tagTeam}) damage 70
             }
           }
-        };
+        }
       case LILEEP_10:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:G, retreatCost:2) {
           weakness R
@@ -573,7 +573,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case CRADILY_11:
         return evolution (this, from:"Lileep", hp:HP150, type:G, retreatCost:3) {
           weakness R
@@ -596,7 +596,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case TROPIUS_12:
         return basic (this, hp:HP120, type:G, retreatCost:2) {
           weakness R
@@ -619,7 +619,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case KRICKETOT_13:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -637,7 +637,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case KRICKETUNE_14:
         return evolution (this, from:"Kricketot", hp:HP100, type:G, retreatCost:2) {
           weakness R
@@ -655,7 +655,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DEERLING_15:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -666,7 +666,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SAWSBUCK_16:
         return evolution (this, from:"Deerling", hp:HP100, type:G, retreatCost:2) {
           weakness R
@@ -692,7 +692,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ROWLET_17:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -710,7 +710,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case ROWLET_18:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -721,7 +721,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10, opp.all.select("Deal 10 damage to which Pokémon?")
             }
           }
-        };
+        }
       case DARTRIX_19:
         return evolution (this, from:"Rowlet", hp:HP080, type:G, retreatCost:1) {
           weakness R
@@ -740,7 +740,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               whirlwind()
             }
           }
-        };
+        }
       case DECIDUEYE_20:
         return evolution (this, from:"Dartrix", hp:HP140, type:G, retreatCost:1) {
           weakness R
@@ -763,7 +763,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUZZWOLE_21:
         return basic (this, hp:HP130, type:G, retreatCost:2) {
           weakness R
@@ -789,7 +789,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case CHARIZARD_BRAIXEN_GX_22:
         return basic (this, hp:HP270, type:R, retreatCost:3) {
           weakness W
@@ -825,7 +825,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               attachEnergyFrom(basic:true, my.discard, my.all)
             }
           }
-        };
+        }
       case PONYTA_23:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W
@@ -847,7 +847,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case RAPIDASH_24:
         return evolution (this, from:"Ponyta", hp:HP100, type:R, retreatCost:0) {
           weakness W
@@ -866,7 +866,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case FLAREON_25:
         return evolution (this, from:"Eevee", hp:HP110, type:R, retreatCost:2) {
           weakness W
@@ -894,7 +894,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case SLUGMA_26:
         return basic (this, hp:HP080, type:R, retreatCost:3) {
           weakness W
@@ -905,7 +905,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply BURNED
             }
           }
-        };
+        }
       case MAGCARGO_27:
         return evolution (this, from:"Slugma", hp:HP120, type:R, retreatCost:3) {
           weakness W
@@ -927,7 +927,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case ENTEI_28:
         return basic (this, hp:HP130, type:R, retreatCost:2) {
           weakness W
@@ -946,7 +946,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case TORKOAL_29:
         return basic (this, hp:HP110, type:R, retreatCost:2) {
           weakness W
@@ -971,7 +971,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VICTINI_30:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W
@@ -992,7 +992,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case TEPIG_31:
         return basic (this, hp:HP080, type:R, retreatCost:2) {
           weakness W
@@ -1010,7 +1010,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case PIGNITE_32:
         return evolution (this, from:"Tepig", hp:HP110, type:R, retreatCost:4) {
           weakness W
@@ -1028,7 +1028,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case EMBOAR_33:
         return evolution (this, from:"Pignite", hp:HP170, type:R, retreatCost:4) {
           weakness W
@@ -1056,7 +1056,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 160
             }
           }
-        };
+        }
       case LARVESTA_34:
         return basic (this, hp:HP080, type:R, retreatCost:3) {
           weakness W
@@ -1074,7 +1074,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case VOLCARONA_GX_35:
         return evolution (this, from:"Larvesta", hp:HP210, type:R, retreatCost:3) {
           weakness W
@@ -1111,7 +1111,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LITLEO_36:
         return basic (this, hp:HP070, type:R, retreatCost:2) {
           weakness W
@@ -1129,7 +1129,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PYROAR_37:
         return evolution (this, from:"Litleo", hp:HP130, type:R, retreatCost:2) {
           weakness W
@@ -1151,7 +1151,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 140
             }
           }
-        };
+        }
       case BLASTOISE_PIPLUP_GX_38:
         return basic (this, hp:HP270, type:W, retreatCost:3) {
           weakness G
@@ -1185,7 +1185,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_VULPIX_39:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness M
@@ -1208,7 +1208,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case PSYDUCK_40:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1228,7 +1228,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply CONFUSED, self
             }
           }
-        };
+        }
       case GOLDUCK_41:
         return evolution (this, from:"Psyduck", hp:HP110, type:W, retreatCost:1) {
           weakness G
@@ -1249,7 +1249,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VAPOREON_42:
         return evolution (this, from:"Eevee", hp:HP110, type:W, retreatCost:2) {
           weakness G
@@ -1294,7 +1294,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SNEASEL_43:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness M
@@ -1306,7 +1306,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { preventAllEffectsNextTurn() }
             }
           }
-        };
+        }
       case WEAVILE_44:
         return evolution (this, from:"Sneasel", hp:HP090, type:W, retreatCost:0) {
           weakness M
@@ -1328,7 +1328,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case WAILMER_45:
         return basic (this, hp:HP120, type:W, retreatCost:3) {
           weakness G
@@ -1339,7 +1339,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case WAILORD_46:
         return evolution (this, from:"Wailmer", hp:HP200, type:W, retreatCost:4) {
           weakness G
@@ -1357,7 +1357,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 140
             }
           }
-        };
+        }
       case SNORUNT_47:
         return basic (this, hp:HP060, type:W, retreatCost:2) {
           weakness M
@@ -1368,7 +1368,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flipUntilTails { damage 20 }
             }
           }
-        };
+        }
       case GLALIE_48:
         return evolution (this, from:"Snorunt", hp:HP120, type:W, retreatCost:3) {
           weakness M
@@ -1391,7 +1391,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case SPHEAL_49:
         return basic (this, hp:HP060, type:W, retreatCost:2) {
           weakness M
@@ -1409,7 +1409,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SPHEAL_50:
         return basic (this, hp:HP070, type:W, retreatCost:2) {
           weakness M
@@ -1421,7 +1421,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { apply PARALYZED }
             }
           }
-        };
+        }
       case SEALEO_51:
         return evolution (this, from:"Spheal", hp:HP100, type:W, retreatCost:3) {
           weakness M
@@ -1439,7 +1439,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case WALREIN_52:
         return evolution (this, from:"Sealeo", hp:HP160, type:W, retreatCost:4) {
           weakness M
@@ -1471,7 +1471,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               opp.all.each { damage 10, it }
             }
           }
-        };
+        }
       case KYOGRE_53:
         return basic (this, hp:HP130, type:W, retreatCost:3) {
           weakness G
@@ -1497,7 +1497,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case PIPLUP_54:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness L
@@ -1511,7 +1511,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PRINPLUP_55:
         return evolution (this, from:"Piplup", hp:HP080, type:W, retreatCost:2) {
           weakness L
@@ -1530,7 +1530,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (opp.bench) damage 100, opp.bench.select()
             }
           }
-        };
+        }
       case EMPOLEON_56:
         return evolution (this, from:"Prinplup", hp:HP160, type:W, retreatCost:2) {
           weakness L
@@ -1564,7 +1564,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardAllSelfEnergy()
             }
           }
-        };
+        }
       case PHIONE_57:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness G
@@ -1589,7 +1589,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case TYMPOLE_58:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1600,7 +1600,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip 3, { damage 10 }
             }
           }
-        };
+        }
       case DUCKLETT_59:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness L
@@ -1613,7 +1613,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case SWANNA_60:
         return evolution (this, from:"Ducklett", hp:HP110, type:W, retreatCost:1) {
           weakness L
@@ -1636,7 +1636,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy(C)
             }
           }
-        };
+        }
       case BLACK_KYUREM_61:
         return basic (this, hp:HP130, type:W, retreatCost:3) {
           weakness M
@@ -1658,7 +1658,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WISHIWASHI_62:
         return basic (this, hp:HP180, type:W, retreatCost:3) {
           weakness L
@@ -1683,7 +1683,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 130
             }
           }
-        };
+        }
       case WISHIWASHI_GX_63:
         return basic (this, hp:HP130, type:W, retreatCost:1) {
           weakness L
@@ -1719,7 +1719,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case DEWPIDER_64:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1737,7 +1737,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case ARAQUANID_65:
         return evolution (this, from:"Dewpider", hp:HP100, type:W, retreatCost:2) {
           weakness G
@@ -1768,7 +1768,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_66:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           weakness F
@@ -1788,7 +1788,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case RAICHU_67:
         return evolution (this, from:"Pikachu", hp:HP120, type:L, retreatCost:2) {
           weakness F
@@ -1807,7 +1807,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               my.all.each{ damage 20*it.cards.energyCount(L) }
             }
           }
-        };
+        }
       case MAGNEMITE_68:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -1820,7 +1820,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case MAGNETON_69:
         return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:2) {
           weakness F
@@ -1843,7 +1843,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case JOLTEON_70:
         return evolution (this, from:"Eevee", hp:HP100, type:L, retreatCost:1) {
           weakness F
@@ -1899,7 +1899,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case CHINCHOU_71:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -1921,7 +1921,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LANTURN_72:
         return evolution (this, from:"Chinchou", hp:HP110, type:L, retreatCost:2) {
           weakness F
@@ -1944,7 +1944,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TOGEDEMARU_73:
         return basic (this, hp:HP080, type:L, retreatCost:1) {
           weakness F
@@ -1961,7 +1961,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20, opp.all.select("Deal 20 damage to which Pokémon?")
             }
           }
-        };
+        }
       case TOGEDEMARU_74:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           weakness F
@@ -1974,7 +1974,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { apply PARALYZED}
             }
           }
-        };
+        }
       case SOLGALEO_LUNALA_GX_75:
         return basic (this, hp:HP270, type:P, retreatCost:2) {
           weakness P
@@ -2020,7 +2020,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KOFFING_76:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2036,7 +2036,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case WEEZING_77:
         return evolution (this, from:"Koffing", hp:HP100, type:P, retreatCost:2) {
           weakness P
@@ -2055,7 +2055,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NATU_78:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness L
@@ -2065,7 +2065,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost P
             foresight(4, delegate)
           }
-        };
+        }
       case XATU_79:
         return evolution (this, from:"Natu", hp:HP080, type:P, retreatCost:2) {
           weakness L
@@ -2086,7 +2086,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RALTS_80:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2107,7 +2107,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case KIRLIA_81:
         return evolution (this, from:"Ralts", hp:HP080, type:P, retreatCost:1) {
           weakness P
@@ -2125,7 +2125,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GALLADE_82:
         return evolution (this, from:"Kirlia", hp:HP160, type:P, retreatCost:2) {
           weakness P
@@ -2143,7 +2143,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               afterDamage { moveEnergy(self, my.bench) }
             }
           }
-        };
+        }
       case DUSKULL_83:
         return basic (this, hp:HP040, type:P, retreatCost:1) {
           weakness D
@@ -2174,7 +2174,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               directDamage 20, opp.all.select("Select a Pokémon to put 2 damage counters on.")
             }
           }
-        };
+        }
       case DUSCLOPS_84:
         return evolution (this, from:"Duskull", hp:HP090, type:P, retreatCost:3) {
           weakness D
@@ -2187,7 +2187,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               amnesia delegate
             }
           }
-        };
+        }
       case DUSKNOIR_85:
         return evolution (this, from:"Dusclops", hp:HP160, type:P, retreatCost:3) {
           weakness D
@@ -2213,7 +2213,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               increasedBaseDamageNextTurn("Psych Up", hp(60))
             }
           }
-        };
+        }
       case ROTOM_86:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness D
@@ -2241,7 +2241,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               attachEnergyFrom(basic:true, my.discard, my.bench.select())
             }
           }
-        };
+        }
       case WOOBAT_87:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness L
@@ -2260,7 +2260,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case SWOOBAT_88:
         return evolution (this, from:"Woobat", hp:HP090, type:P, retreatCost:1) {
           weakness L
@@ -2279,7 +2279,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 90, opp.all.oppSelect("Opponent used $thisMove. Select a Pokémon to have 90 damage dealt to it.")
             }
           }
-        };
+        }
       case GOLETT_89:
         return basic (this, hp:HP090, type:P, retreatCost:3) {
           weakness D
@@ -2295,7 +2295,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOLURK_90:
         return evolution (this, from:"Golett", hp:HP140, type:P, retreatCost:4) {
           weakness D
@@ -2317,7 +2317,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKRELP_91:
         return basic (this, hp:HP060, type:P, retreatCost:2) {
           weakness P
@@ -2328,7 +2328,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case DRAGALGE_92:
         return evolution (this, from:"Skrelp", hp:HP120, type:P, retreatCost:1) {
           weakness P
@@ -2349,7 +2349,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case PHANTUMP_93:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness D
@@ -2368,7 +2368,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TREVENANT_94:
         return evolution (this, from:"Phantump", hp:HP120, type:P, retreatCost:2) {
           weakness D
@@ -2390,7 +2390,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               directDamage 40, my.all.select()
             }
           }
-        };
+        }
       case ORICORIO_GX_95:
         return basic (this, hp:HP170, type:P, retreatCost:1) {
           weakness D
@@ -2434,7 +2434,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case MIMIKYU_96:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           move "Impersonation", {
@@ -2460,7 +2460,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MIMIKYU_97:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           bwAbility "Shadow Box", {
@@ -2495,7 +2495,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { apply CONFUSED }
             }
           }
-        };
+        }
       case DHELMISE_98:
         return basic (this, hp:HP130, type:P, retreatCost:3) {
           weakness D
@@ -2518,7 +2518,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case COSMOG_99:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P
@@ -2527,7 +2527,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             energyCost P
             ascension delegate
           }
-        };
+        }
       case COSMOG_100:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2550,7 +2550,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { damage 10 }
             }
           }
-        };
+        }
       case COSMOEM_101:
         return evolution (this, from:"Cosmog", hp:HP090, type:P, retreatCost:3) {
           weakness P
@@ -2561,7 +2561,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               reduceDamageNextTurn(hp(40),thisMove)
             }
           }
-        };
+        }
       case LUNALA_102:
         return evolution (this, from:"Cosmoem", hp:HP160, type:P, retreatCost:2) {
           weakness D
@@ -2587,7 +2587,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 130
             }
           }
-        };
+        }
       case MARSHADOW_103:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness D
@@ -2609,7 +2609,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLACEPHALON_104:
         return basic (this, hp:HP110, type:P, retreatCost:2) {
           weakness D
@@ -2623,7 +2623,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               putDamageCountersOnOpponentsPokemon(maxCountersToPlace)
             }
           }
-        };
+        }
       case ONIX_105:
         return basic (this, hp:HP110, type:F, retreatCost:4) {
           weakness G
@@ -2644,7 +2644,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { damage 100 }
             }
           }
-        };
+        }
       case NOSEPASS_106:
         return basic (this, hp:HP080, type:F, retreatCost:3) {
           weakness G
@@ -2666,7 +2666,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case TRAPINCH_107:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness G
@@ -2688,7 +2688,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case TRAPINCH_108:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness G
@@ -2702,7 +2702,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VIBRAVA_109:
         return evolution (this, from:"Trapinch", hp:HP080, type:F, retreatCost:1) {
           weakness G
@@ -2733,7 +2733,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case FLYGON_GX_110:
         return evolution (this, from:"Vibrava", hp:HP240, type:F, retreatCost:2) {
           weakness G
@@ -2772,7 +2772,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               shredDamage 220
             }
           }
-        };
+        }
       case ANORITH_111:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:F, retreatCost:1) {
           weakness G
@@ -2790,7 +2790,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case ARMALDO_112:
         return evolution (this, from:"Anorith", hp:HP150, type:F, retreatCost:2) {
           weakness G
@@ -2810,7 +2810,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case GROUDON_113:
         return basic (this, hp:HP130, type:F, retreatCost:3) {
           weakness G
@@ -2832,7 +2832,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case DRILBUR_114:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness G
@@ -2854,7 +2854,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case EXCADRILL_115:
         return evolution (this, from:"Drilbur", hp:HP140, type:F, retreatCost:4) {
           weakness G
@@ -2874,7 +2874,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (my.deck) my.deck.subList(0, 4).discard()
             }
           }
-        };
+        }
       case PALPITOAD_116:
         return evolution (this, from:"Tympole", hp:HP090, type:F, retreatCost:2) {
           weakness G
@@ -2890,7 +2890,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SEISMITOAD_117:
         return evolution (this, from:"Palpitoad", hp:HP160, type:F, retreatCost:3) {
           weakness G
@@ -2914,7 +2914,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 80 + 30*count
             }
           }
-        };
+        }
       case THROH_118:
         return basic (this, hp:HP120, type:F, retreatCost:2) {
           weakness P
@@ -2928,7 +2928,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PANCHAM_119:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness P
@@ -2939,7 +2939,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case PANGORO_120:
         return evolution (this, from:"Pancham", hp:HP130, type:F, retreatCost:2) {
           weakness P
@@ -2957,7 +2957,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case CRABRAWLER_121:
         return basic (this, hp:HP080, type:F, retreatCost:2) {
           weakness P
@@ -2975,7 +2975,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case CRABOMINABLE_122:
         return evolution (this, from:"Crabrawler", hp:HP140, type:F, retreatCost:4) {
           weakness P
@@ -3000,7 +3000,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (self.cards.energyCount(W)) damage 80
             }
           }
-        };
+        }
       case ROCKRUFF_123:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness G
@@ -3021,7 +3021,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case LYCANROC_124:
         return evolution (this, from:"Rockruff", hp:HP120, type:F, retreatCost:2) {
           weakness G
@@ -3051,7 +3051,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (defending.cards.filterByType(SPECIAL_ENERGY)) damage 70
             }
           }
-        };
+        }
       case PASSIMIAN_125:
         return basic (this, hp:HP110, type:F, retreatCost:1) {
           weakness P
@@ -3070,7 +3070,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SANDYGAST_126:
         return basic (this, hp:HP080, type:F, retreatCost:2) {
           weakness G
@@ -3089,7 +3089,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PALOSSAND_127:
         return evolution (this, from:"Sandygast", hp:HP140, type:F, retreatCost:4) {
           weakness G
@@ -3109,7 +3109,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               my.bench.each { damage 20, it }
             }
           }
-        };
+        }
       case ALOLAN_MEOWTH_128:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness F
@@ -3128,7 +3128,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ALOLAN_PERSIAN_GX_129:
         return evolution (this, from:"Alolan Meowth", hp:HP200, type:D, retreatCost:2) {
           weakness F
@@ -3170,7 +3170,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               swiftDamage(120, opp.all.select())
             }
           }
-        };
+        }
       case ALOLAN_GRIMER_130:
         return basic (this, hp:HP080, type:D, retreatCost:2) {
           weakness F
@@ -3190,7 +3190,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { apply PARALYZED }
             }
           }
-        };
+        }
       case ALOLAN_MUK_131:
         return evolution (this, from:"Alolan Grimer", hp:HP140, type:D, retreatCost:4) {
           weakness F
@@ -3212,7 +3212,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case CARVANHA_132:
         return basic (this, hp:HP050, type:D, retreatCost:1) {
           weakness F
@@ -3225,7 +3225,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { preventAllEffectsNextTurn() }
             }
           }
-        };
+        }
       case ABSOL_133:
         return basic (this, hp:HP100, type:D, retreatCost:1) {
           weakness F
@@ -3254,7 +3254,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               hand.select("Discard a card from your hand.").discard()
             }
           }
-        };
+        }
       case PAWNIARD_134:
         return basic (this, hp:HP060, type:D, retreatCost:1) {
           weakness F
@@ -3281,7 +3281,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BISHARP_135:
         return evolution (this, from:"Pawniard", hp:HP120, type:D, retreatCost:1) {
           weakness F
@@ -3302,7 +3302,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case GUZZLORD_136:
         return basic (this, hp:HP150, type:D, retreatCost:4) {
           weakness F
@@ -3343,7 +3343,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case ALOLAN_SANDSHREW_137:
         return basic (this, hp:HP060, type:M, retreatCost:1) {
           weakness R
@@ -3364,7 +3364,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ALOLAN_SANDSLASH_138:
         return evolution (this, from:"Alolan Sandshrew", hp:HP120, type:M, retreatCost:1) {
           weakness R
@@ -3384,7 +3384,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (self.cards.filterByType(POKEMON_TOOL)) damage 60
             }
           }
-        };
+        }
       case STEELIX_139:
         return evolution (this, from:"Onix", hp:HP170, type:M, retreatCost:4) {
           weakness R
@@ -3410,7 +3410,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flipUntilTails { damage 100 }
             }
           }
-        };
+        }
       case MAWILE_140:
         return basic (this, hp:HP070, type:M, retreatCost:1) {
           weakness R
@@ -3434,7 +3434,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case PROBOPASS_141:
         return evolution (this, from:"Nosepass", hp:HP130, type:M, retreatCost:3) {
           weakness R
@@ -3455,7 +3455,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip 3, { damage 40 }
             }
           }
-        };
+        }
       case SOLGALEO_142:
         return evolution (this, from:"Cosmoem", hp:HP170, type:M, retreatCost:3) {
           weakness R
@@ -3484,7 +3484,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy(C, C)
             }
           }
-        };
+        }
       case TOGEPI_CLEFFA_IGGLYBUFF_GX_143A:
       case TOGEPI_CLEFFA_IGGLYBUFF_GX_143:
         return basic (this, hp:HP240, type:Y, retreatCost:2) {
@@ -3528,7 +3528,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CLEFAIRY_144:
         return basic (this, hp:HP050, type:Y, retreatCost:1) {
           weakness M
@@ -3567,7 +3567,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_NINETALES_145:
         return evolution (this, from:"Alolan Vulpix", hp:HP110, type:Y, retreatCost:1) {
           weakness M
@@ -3578,7 +3578,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10*my.discard.filterByType(POKEMON_TOOL).size()
             }
           }
-        };
+        }
       case AZURILL_146:
         return basic (this, hp:HP060, type:Y, retreatCost:0) {
           bwAbility "Growing Up", {
@@ -3594,7 +3594,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               bg.gm().betweenTurns()
             }
           }
-        };
+        }
       case COTTONEE_147:
         return basic (this, hp:HP040, type:Y, retreatCost:1) {
           weakness M
@@ -3606,7 +3606,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20*my.lostZone.findAll{ it.cardTypes.is(POKEMON) && !it.cardTypes.is(PRISM_STAR) }.size()
             }
           }
-        };
+        }
       case WHIMSICOTT_148:
         return evolution (this, from:"Cottonee", hp:HP070, type:Y, retreatCost:0) {
           weakness M
@@ -3633,7 +3633,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20*my.lostZone.findAll{ it.cardTypes.is(POKEMON) && !it.cardTypes.is(PRISM_STAR) }.size()
             }
           }
-        };
+        }
       case FLABEBE_149:
         return basic (this, hp:HP030, type:Y, retreatCost:1) {
           weakness M
@@ -3649,7 +3649,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case FLABEBE_150:
         return basic (this, hp:HP040, type:Y, retreatCost:1) {
           weakness M
@@ -3661,7 +3661,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               opp.all.each { damage 10, it }
             }
           }
-        };
+        }
       case FLOETTE_151:
         return evolution (this, from:"Flabébé", hp:HP070, type:Y, retreatCost:1) {
           weakness M
@@ -3683,7 +3683,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case FLORGES_152:
         return evolution (this, from:"Floette", hp:HP130, type:Y, retreatCost:2) {
           weakness M
@@ -3706,7 +3706,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               apply CONFUSED, self
             }
           }
-        };
+        }
       case SWIRLIX_153:
         return basic (this, hp:HP060, type:Y, retreatCost:1) {
           weakness M
@@ -3719,7 +3719,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               reduceDamageNextTurn(hp(10),thisMove)
             }
           }
-        };
+        }
       case SLURPUFF_154:
         return evolution (this, from:"Swirlix", hp:HP110, type:Y, retreatCost:2) {
           weakness M
@@ -3741,7 +3741,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case SYLVEON_155:
         return evolution (this, from:"Eevee", hp:HP110, type:Y, retreatCost:2) {
           weakness M
@@ -3798,7 +3798,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARCEUS_DIALGA_PALKIA_GX_156:
         return basic (this, hp:HP280, type:N, retreatCost:3) {
           weakness Y
@@ -3852,7 +3852,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RESHIRAM_ZEKROM_GX_157:
         return basic (this, hp:HP270, type:N, retreatCost:3) {
           weakness Y
@@ -3894,7 +3894,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NAGANADEL_GUZZLORD_GX_158:
         return basic (this, hp:HP280, type:N, retreatCost:3) {
           weakness Y
@@ -3932,7 +3932,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAMPA_159:
         return basic (this, hp:HP120, type:N, retreatCost:1) {
           weakness Y
@@ -3958,7 +3958,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case JANGMO_O_160:
         return basic (this, hp:HP060, type:N, retreatCost:1) {
           weakness Y
@@ -3969,7 +3969,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20+10*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case JANGMO_O_161:
         return basic (this, hp:HP070, type:N, retreatCost:2) {
           weakness Y
@@ -3987,7 +3987,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case HAKAMO_O_162:
         return evolution (this, from:"Jangmo-o", hp:HP080, type:N, retreatCost:2) {
           weakness Y
@@ -4009,7 +4009,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case KOMMO_O_163:
         return evolution (this, from:"Hakamo-o", hp:HP160, type:N, retreatCost:2) {
           weakness Y
@@ -4034,7 +4034,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ULTRA_NECROZMA_164:
         return basic (this, hp:HP110, type:N, retreatCost:2) {
           weakness Y
@@ -4057,7 +4057,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardDefendingEnergy()
             }
           }
-        };
+        }
       case MEGA_LOPUNNY_JIGGLYPUFF_GX_165:
         return basic (this, hp:HP240, type:C, retreatCost:1) {
           weakness F
@@ -4083,7 +4083,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case EEVEE_166:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4104,7 +4104,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case EEVEE_167:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4129,7 +4129,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case IGGLYBUFF_168:
         return basic (this, hp:HP060, type:C, retreatCost:0) {
           bwAbility "Sleepy Voice", {
@@ -4143,7 +4143,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               bg.gm().betweenTurns()
             }
           }
-        };
+        }
       case AIPOM_169:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4163,7 +4163,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case AMBIPOM_170:
         return evolution (this, from:"Aipom", hp:HP100, type:C, retreatCost:1) {
           weakness F
@@ -4187,7 +4187,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 60 * my.hand.select(max:2).discard().size()
             }
           }
-        };
+        }
       case TEDDIURSA_171:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4205,7 +4205,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case URSARING_172:
         return evolution (this, from:"Teddiursa", hp:HP140, type:C, retreatCost:3) {
           weakness F
@@ -4224,7 +4224,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               cantAttackNextTurn defending
             }
           }
-        };
+        }
       case ZANGOOSE_173:
         return basic (this, hp:HP100, type:C, retreatCost:1) {
           weakness F
@@ -4242,7 +4242,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 20+10*defending.numberOfDamageCounters
             }
           }
-        };
+        }
       case LILLIPUP_174:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4260,7 +4260,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case HERDIER_175:
         return evolution (this, from:"Lillipup", hp:HP100, type:C, retreatCost:2) {
           weakness F
@@ -4278,7 +4278,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case STOUTLAND_176:
         return evolution (this, from:"Herdier", hp:HP150, type:C, retreatCost:3) {
           weakness F
@@ -4310,7 +4310,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               if (opp.bench) damage 30, opp.bench.select()
             }
           }
-        };
+        }
       case RUFFLET_177:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -4322,7 +4322,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip 3, {damage 10}
             }
           }
-        };
+        }
       case BRAVIARY_178:
         return evolution (this, from:"Rufflet", hp:HP130, type:C, retreatCost:1) {
           weakness L
@@ -4343,7 +4343,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy(C, C)
             }
           }
-        };
+        }
       case HELIOPTILE_179:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -4361,7 +4361,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case HELIOLISK_180:
         return evolution (this, from:"Helioptile", hp:HP100, type:C, retreatCost:1) {
           weakness F
@@ -4382,7 +4382,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case STUFFUL_181:
         return basic (this, hp:HP080, type:C, retreatCost:2) {
           weakness F
@@ -4394,7 +4394,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flipUntilTails { damage 30 }
             }
           }
-        };
+        }
       case BEWEAR_182:
         return evolution (this, from:"Stufful", hp:HP120, type:C, retreatCost:2) {
           weakness F
@@ -4413,7 +4413,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               flip { damage 120 }
             }
           }
-        };
+        }
       case TYPE_NULL_183:
         return basic (this, hp:HP110, type:C, retreatCost:2) {
           weakness F
@@ -4425,7 +4425,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case SILVALLY_GX_184:
         return evolution (this, from:"Type: Null", hp:HP210, type:C, retreatCost:2) {
           weakness F
@@ -4461,7 +4461,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BEASTITE_185:
         return pokemonTool (this) {
           text "The attacks of the Ultra Beast this card is attached to do 10 more damage to your opponent’s Active Pokémon for each Prize card you have taken (before applying Weakness and Resistance)."
@@ -4482,7 +4482,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case BELLELBA_BRYCEN_MAN_186:
         return supporter (this) {
           text "Discard 3 cards from the top of each player’s deck." +
@@ -4512,7 +4512,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement {
             assert (my.deck || opp.deck) || (my.bench.size() > 3 || opp.bench.size() > 3) : "You can only play this card if either player has cards left in their deck, or more than 3 Pokémon in their bench"
           }
-        };
+        }
       case CHAOTIC_SWELL_187:
         return stadium (this) {
           text "Whenever either player plays a Stadium card from their hand, discard that Stadium card after discarding this one. (The new Stadium card has no effect.)"
@@ -4535,7 +4535,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               eff.unregister()
             }
           }
-        };
+        }
       case CLAY_188:
         return supporter (this) {
           text "Discard the top 7 cards of your deck. If any of those cards are Item cards, put them into your hand."
@@ -4546,7 +4546,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case CYNTHIA_CAITLIN_189:
         return supporter (this) {
           text "Put a Supporter card from your discard pile into your hand. You can't choose Cynthia & Caitlin or a card you discarded with the effect of this card." +
@@ -4575,7 +4575,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             def hand = my.hand.getExcludedList(thisCard).size() >= 1
             assert (hand || my.discard.filterByType(SUPPORTER)) : "Not enough cards in hand and no Supporter cards in discard."
           }
-        };
+        }
       case DRAGONIUM_Z_DRAGON_CLAW_190:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to has the Dragon Claw attack, it can use the GX attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -4605,7 +4605,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case ERIKA_191:
         return supporter (this) {
           text "Each player may draw up to 3 cards. You draw first."
@@ -4616,7 +4616,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck || opp.deck : "Both players' decks are empty."
           }
-        };
+        }
       case GREAT_CATCHER_192:
         return itemCard (this) {
           text "You can play this card only if you discard 2 other cards from your hand." +
@@ -4636,7 +4636,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             assertOppBench(hasVariants: [POKEMON_GX, POKEMON_EX])
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "Not enough cards in your hand."
           }
-        };
+        }
       case GUZMA_HALA_193:
         return supporter (this) {
           text "Search your deck for a Stadium card, reveal it, and put it into your hand. Then, shuffle your deck." +
@@ -4663,7 +4663,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case ISLAND_CHALLENGE_AMULET_194:
         return pokemonTool (this) {
           text "The Pokémon-GX or Pokémon-EX this card is attached to gets -100 HP, and when it is Knocked Out by damage from an opponent’s attack, that player takes 1 fewer Prize card."
@@ -4687,7 +4687,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             eff.unregister()
             effPrize.unregister()
           }
-        };
+        }
       case LANA_S_FISHING_ROD_195:
         return itemCard (this) {
           text "Shuffle a Pokémon and a Pokémon Tool card from your discard pilef into your deck."
@@ -4699,7 +4699,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement {
             assert my.discard.filterByType(POKEMON_TOOL, POKEMON) : "No Pokémon or Pokémon Tool cards in your discard."
           }
-        };
+        }
       case LILLIE_S_FULL_FORCE_196:
         return supporter (this) {
           text "Draw 4 cards." +
@@ -4720,7 +4720,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             }
           }
           playRequirement {}
-        };
+        }
       case LILLIE_S_POKE_DOLL_197:
         return itemCard (this) {
           text "Play this card as if it were a 30-HP [C] Basic Pokémon. At any time during your turn (before your attack), if this Pokémon is your Active Pokémon, you may discard all cards from it and put it on the bottom of your deck." +
@@ -4780,7 +4780,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case MALLOW_LANA_198:
         return supporter (this) {
           text "Switch your Active Pokémon with 1 of your Benched Pokémon." +
@@ -4802,7 +4802,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement {
             assertMyBench()
           }
-        };
+        }
       case MISTY_LORELEI_199:
         return supporter (this) {
           text "Search your deck for up to 3 [W] Energy cards, reveal them, and put them into your hand. Then, shuffle your deck." +
@@ -4839,7 +4839,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert ( my.deck || ( my.hand.getExcludedList(thisCard).size() >= 5 && isGxPerformed() ) ) : "You can't do either of this card's effects"
           }
-        };
+        }
       case N_S_RESOLVE_200:
         return supporter (this) {
           text "Discard the top 6 cards of your deck. If any of those cards are basic Energy cards, attach them to 1 of your Benched [N] Pokémon."
@@ -4858,7 +4858,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             assert my.deck : "Your deck is empty."
             assertMyBench(hasType: N)
           }
-        };
+        }
       case PROFESSOR_OAK_S_SETUP_201:
         return supporter (this) {
           text "Search your deck for up to 3 Basic Pokémon of different types and put them onto your Bench. Then, shuffle your deck."
@@ -4882,7 +4882,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             assert my.deck : "Deck is empty"
             assert my.bench.notFull : "Bench is full"
           }
-        };
+        }
       case RED_BLUE_202:
         return supporter (this) {
           text "Search your deck for a Pokémon-GX that evolves from 1 of your Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can't use this card during your first turn or on a Pokémon that was put into play this turn.)" +
@@ -4921,7 +4921,7 @@ public enum CosmicEclipse implements LogicCardInfo {
               { it.turnCount < bg.turnCount && it.lastEvolved < bg.turnCount && bg().gm().hasGxEvolution(it.name) }
             )
           }
-        };
+        }
       case ROLLER_SKATER_203:
         return supporter (this) {
           text "Discard a card from your hand. If you do, draw 2 cards. If you discarded an Energy card in this way, draw 2 more cards."
@@ -4937,7 +4937,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard)
           }
-        };
+        }
       case ROSA_204:
         return supporter (this) {
           text "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn." +
@@ -4961,7 +4961,7 @@ public enum CosmicEclipse implements LogicCardInfo {
             assert bg.turnCount
             assert keyStore("Rosa_KO", thisCard, null) == bg.turnCount - 1: "No Pokémon was Knocked Out during your opponent’s last turn"
           }
-        };
+        }
       case ROXIE_205:
         return supporter (this) {
           text "Discard up to 2 Pokémon that aren't Pokémon-GX or Pokémon-EX from your hand. Draw 3 cards for each card you discarded in this way."
@@ -4986,7 +4986,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert list() : "You do not have any non-GX/EX Pokémon in your hand."
           }
-        };
+        }
       case TAG_CALL_206:
         return itemCard (this) {
           text "Search your deck for up to 2 TAG TEAM cards, reveal them, and put them into your hand. Then, shuffle your deck."
@@ -4997,9 +4997,9 @@ public enum CosmicEclipse implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case UNIDENTIFIED_FOSSIL_207:
-        return copy (UnifiedMinds.UNIDENTIFIED_FOSSIL_210, this);
+        return copy (UnifiedMinds.UNIDENTIFIED_FOSSIL_210, this)
       case WILL_208:
         return supporter (this) {
           text "The next time you flip any number of coins for the effect of an attack, Ability, or Trainer card this turn, choose heads or tails for the first coin flip."
@@ -5021,7 +5021,7 @@ public enum CosmicEclipse implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case DRAW_ENERGY_209:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy." +
@@ -5031,133 +5031,133 @@ public enum CosmicEclipse implements LogicCardInfo {
               draw 1
             }
           }
-        };
+        }
       case VENUSAUR_SNIVY_GX_210:
-        return copy (VENUSAUR_SNIVY_GX_1, this);
+        return copy (VENUSAUR_SNIVY_GX_1, this)
       case VILEPLUME_GX_211:
-        return copy (VILEPLUME_GX_4, this);
+        return copy (VILEPLUME_GX_4, this)
       case CHARIZARD_BRAIXEN_GX_212:
-        return copy (CHARIZARD_BRAIXEN_GX_22, this);
+        return copy (CHARIZARD_BRAIXEN_GX_22, this)
       case VOLCARONA_GX_213:
-        return copy (VOLCARONA_GX_35, this);
+        return copy (VOLCARONA_GX_35, this)
       case BLASTOISE_PIPLUP_GX_214:
-        return copy (BLASTOISE_PIPLUP_GX_38, this);
+        return copy (BLASTOISE_PIPLUP_GX_38, this)
       case BLASTOISE_PIPLUP_GX_215:
-        return copy (BLASTOISE_PIPLUP_GX_38, this);
+        return copy (BLASTOISE_PIPLUP_GX_38, this)
       case SOLGALEO_LUNALA_GX_216:
-        return copy (SOLGALEO_LUNALA_GX_75, this);
+        return copy (SOLGALEO_LUNALA_GX_75, this)
       case ORICORIO_GX_217:
-        return copy (ORICORIO_GX_95, this);
+        return copy (ORICORIO_GX_95, this)
       case FLYGON_GX_218:
-        return copy (FLYGON_GX_110, this);
+        return copy (FLYGON_GX_110, this)
       case ALOLAN_PERSIAN_GX_219:
-        return copy (ALOLAN_PERSIAN_GX_129, this);
+        return copy (ALOLAN_PERSIAN_GX_129, this)
       case ARCEUS_DIALGA_PALKIA_GX_220:
-        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this);
+        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this)
       case ARCEUS_DIALGA_PALKIA_GX_221:
-        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this);
+        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this)
       case RESHIRAM_ZEKROM_GX_222:
-        return copy (RESHIRAM_ZEKROM_GX_157, this);
+        return copy (RESHIRAM_ZEKROM_GX_157, this)
       case NAGANADEL_GUZZLORD_GX_223:
-        return copy (NAGANADEL_GUZZLORD_GX_158, this);
+        return copy (NAGANADEL_GUZZLORD_GX_158, this)
       case NAGANADEL_GUZZLORD_GX_224:
-        return copy (NAGANADEL_GUZZLORD_GX_158, this);
+        return copy (NAGANADEL_GUZZLORD_GX_158, this)
       case MEGA_LOPUNNY_JIGGLYPUFF_GX_225:
-        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this);
+        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this)
       case MEGA_LOPUNNY_JIGGLYPUFF_GX_226:
-        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this);
+        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this)
       case SILVALLY_GX_227:
-        return copy (SILVALLY_GX_184, this);
+        return copy (SILVALLY_GX_184, this)
       case CYNTHIA_CAITLIN_228:
-        return copy (CYNTHIA_CAITLIN_189, this);
+        return copy (CYNTHIA_CAITLIN_189, this)
       case GUZMA_HALA_229:
-        return copy (GUZMA_HALA_193, this);
+        return copy (GUZMA_HALA_193, this)
       case LILLIE_S_FULL_FORCE_230:
-        return copy (LILLIE_S_FULL_FORCE_196, this);
+        return copy (LILLIE_S_FULL_FORCE_196, this)
       case MALLOW_LANA_231:
-        return copy (MALLOW_LANA_198, this);
+        return copy (MALLOW_LANA_198, this)
       case N_S_RESOLVE_232:
-        return copy (N_S_RESOLVE_200, this);
+        return copy (N_S_RESOLVE_200, this)
       case PROFESSOR_OAK_S_SETUP_233:
-        return copy (PROFESSOR_OAK_S_SETUP_201, this);
+        return copy (PROFESSOR_OAK_S_SETUP_201, this)
       case RED_BLUE_234:
-        return copy (RED_BLUE_202, this);
+        return copy (RED_BLUE_202, this)
       case ROLLER_SKATER_235:
-        return copy (ROLLER_SKATER_203, this);
+        return copy (ROLLER_SKATER_203, this)
       case ROSA_236:
-        return copy (ROSA_204, this);
+        return copy (ROSA_204, this)
       case TORKOAL_237:
-        return copy (TORKOAL_29, this);
+        return copy (TORKOAL_29, this)
       case WEAVILE_238:
-        return copy (WEAVILE_44, this);
+        return copy (WEAVILE_44, this)
       case PIPLUP_239:
-        return copy (PIPLUP_54, this);
+        return copy (PIPLUP_54, this)
       case WISHIWASHI_240:
-        return copy (WISHIWASHI_62, this);
+        return copy (WISHIWASHI_62, this)
       case PIKACHU_241:
-        return copy (PIKACHU_66, this);
+        return copy (PIKACHU_66, this)
       case MAGNEMITE_242:
-        return copy (MAGNEMITE_68, this);
+        return copy (MAGNEMITE_68, this)
       case KOFFING_243:
-        return copy (KOFFING_76, this);
+        return copy (KOFFING_76, this)
       case GALLADE_244:
-        return copy (GALLADE_82, this);
+        return copy (GALLADE_82, this)
       case MIMIKYU_245:
-        return copy (MIMIKYU_96, this);
+        return copy (MIMIKYU_96, this)
       case EXCADRILL_246:
-        return copy (EXCADRILL_115, this);
+        return copy (EXCADRILL_115, this)
       case STEELIX_247:
-        return copy (STEELIX_139, this);
+        return copy (STEELIX_139, this)
       case STOUTLAND_248:
-        return copy (STOUTLAND_176, this);
+        return copy (STOUTLAND_176, this)
       case VENUSAUR_SNIVY_GX_249:
-        return copy (VENUSAUR_SNIVY_GX_1, this);
+        return copy (VENUSAUR_SNIVY_GX_1, this)
       case VILEPLUME_GX_250:
-        return copy (VILEPLUME_GX_211, this);
+        return copy (VILEPLUME_GX_211, this)
       case CHARIZARD_BRAIXEN_GX_251:
-        return copy (CHARIZARD_BRAIXEN_GX_22, this);
+        return copy (CHARIZARD_BRAIXEN_GX_22, this)
       case VOLCARONA_GX_252:
-        return copy (VOLCARONA_GX_35, this);
+        return copy (VOLCARONA_GX_35, this)
       case BLASTOISE_PIPLUP_GX_253:
-        return copy (BLASTOISE_PIPLUP_GX_38, this);
+        return copy (BLASTOISE_PIPLUP_GX_38, this)
       case SOLGALEO_LUNALA_GX_254:
-        return copy (SOLGALEO_LUNALA_GX_75, this);
+        return copy (SOLGALEO_LUNALA_GX_75, this)
       case ORICORIO_GX_255:
-        return copy (ORICORIO_GX_95, this);
+        return copy (ORICORIO_GX_95, this)
       case FLYGON_GX_256:
-        return copy (FLYGON_GX_110, this);
+        return copy (FLYGON_GX_110, this)
       case ALOLAN_PERSIAN_GX_257:
-        return copy (ALOLAN_PERSIAN_GX_129, this);
+        return copy (ALOLAN_PERSIAN_GX_129, this)
       case ARCEUS_DIALGA_PALKIA_GX_258:
-        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this);
+        return copy (ARCEUS_DIALGA_PALKIA_GX_156, this)
       case RESHIRAM_ZEKROM_GX_259:
-        return copy (RESHIRAM_ZEKROM_GX_157, this);
+        return copy (RESHIRAM_ZEKROM_GX_157, this)
       case NAGANADEL_GUZZLORD_GX_260:
-        return copy (NAGANADEL_GUZZLORD_GX_158, this);
+        return copy (NAGANADEL_GUZZLORD_GX_158, this)
       case MEGA_LOPUNNY_JIGGLYPUFF_GX_261:
-        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this);
+        return copy (MEGA_LOPUNNY_JIGGLYPUFF_GX_165, this)
       case SILVALLY_GX_262:
-        return copy (SILVALLY_GX_184, this);
+        return copy (SILVALLY_GX_184, this)
       case GIANT_HEARTH_263:
-        return copy (UnifiedMinds.GIANT_HEARTH_197, this);
+        return copy (UnifiedMinds.GIANT_HEARTH_197, this)
       case GREAT_CATCHER_264:
-        return copy (GREAT_CATCHER_192, this);
+        return copy (GREAT_CATCHER_192, this)
       case ISLAND_CHALLENGE_AMULET_265:
-        return copy (ISLAND_CHALLENGE_AMULET_194, this);
+        return copy (ISLAND_CHALLENGE_AMULET_194, this)
       case LANA_S_FISHING_ROD_266:
-        return copy (LANA_S_FISHING_ROD_195, this);
+        return copy (LANA_S_FISHING_ROD_195, this)
       case LILLIE_S_POKE_DOLL_267:
-        return copy (LILLIE_S_POKE_DOLL_197, this);
+        return copy (LILLIE_S_POKE_DOLL_197, this)
       case MARTIAL_ARTS_DOJO_268:
-        return copy (UnbrokenBonds.MARTIAL_ARTS_DOJO_179, this);
+        return copy (UnbrokenBonds.MARTIAL_ARTS_DOJO_179, this)
       case POWER_PLANT_269:
-        return copy (UnbrokenBonds.POWER_PLANT_183, this);
+        return copy (UnbrokenBonds.POWER_PLANT_183, this)
       case TAG_CALL_270:
-        return copy (TAG_CALL_206, this);
+        return copy (TAG_CALL_206, this)
       case DRAW_ENERGY_271:
-        return copy (DRAW_ENERGY_209, this);
+        return copy (DRAW_ENERGY_209, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
+++ b/src/tcgwars/logic/impl/gen7/CrimsonInvasion.groovy
@@ -3,24 +3,24 @@ package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.impl.gen2.Aquapolis
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author itrezad@gmail.com
@@ -154,53 +154,53 @@ public enum CrimsonInvasion implements LogicCardInfo {
   WARP_ENERGY_123 ("Warp Energy", "123", Rarity.SECRET, [SPECIAL_ENERGY, ENERGY]),
   WATER_ENERGY_124 ("Water Energy", "124", Rarity.SECRET, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   CrimsonInvasion(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CRIMSON_INVASION;
+    return tcgwars.logic.card.Collection.CRIMSON_INVASION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -217,7 +217,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KAKUNA_2:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -237,7 +237,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEEDRILL_3:
         return evolution (this, from:"Kakuna", hp:HP120, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -260,7 +260,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGCUTE_4:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -279,7 +279,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CACNEA_5:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -293,7 +293,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CACTURNE_6:
         return evolution (this, from:"Cacnea", hp:HP110, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -318,7 +318,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KARRABLAST_7:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -345,7 +345,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELMET_8:
         return basic (this, hp:HP060, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -358,7 +358,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ACCELGOR_9:
         return evolution (this, from:"Shelmet", hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -378,7 +378,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKIDDO_10:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -390,7 +390,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOGOAT_11:
         return evolution (this, from:"Skiddo", hp:HP120, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -416,7 +416,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_MAROWAK_12:
         return evolution (this, from:"Cubone", hp:HP100, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -441,7 +441,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NUMEL_13:
         return basic (this, hp:HP080, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -453,7 +453,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CAMERUPT_14:
         return evolution (this, from:"Numel", hp:HP140, type:FIRE, retreatCost:4) {
           weakness WATER
@@ -473,7 +473,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARYU_15:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -485,7 +485,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARMIE_16:
         return evolution (this, from:"Staryu", hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -507,7 +507,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_17:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -540,7 +540,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GYARADOS_GX_18:
         return evolution (this, from:"Magikarp", hp:HP240, type:WATER, retreatCost:4) {
           weakness LIGHTNING
@@ -577,7 +577,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWINUB_19:
         return basic (this, hp:HP060, type:WATER, retreatCost:3) {
           weakness METAL
@@ -589,7 +589,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PILOSWINE_20:
         return evolution (this, from:"Swinub", hp:HP100, type:WATER, retreatCost:4) {
           weakness METAL
@@ -609,7 +609,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAMOSWINE_21:
         return evolution (this, from:"Piloswine", hp:HP180, type:WATER, retreatCost:4) {
           weakness METAL
@@ -638,7 +638,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case REMORAID_22:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -650,7 +650,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OCTILLERY_23:
         return evolution (this, from:"Remoraid", hp:HP100, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -674,7 +674,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CORPHISH_24:
         return basic (this, hp:HP070, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -686,7 +686,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRAWDAUNT_25:
         return evolution (this, from:"Corphish", hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -700,7 +700,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEEBAS_26:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -713,7 +713,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MILOTIC_27:
         return evolution (this, from:"Feebas", hp:HP120, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -739,7 +739,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGICE_28:
         return basic (this, hp:HP130, type:WATER, retreatCost:3) {
           weakness METAL
@@ -776,7 +776,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLOS_29:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -795,7 +795,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_30:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -820,7 +820,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_RAICHU_31:
         return evolution (this, from:"Pikachu", hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -841,7 +841,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GEODUDE_32:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -860,7 +860,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GRAVELER_33:
         return evolution (this, from:"Alolan Geodude", hp:HP100, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -881,7 +881,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GOLEM_GX_34:
         return evolution (this, from:"Alolan Graveler", hp:HP250, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -940,7 +940,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMOLGA_35:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness LIGHTNING
@@ -967,7 +967,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_36:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -980,7 +980,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_37:
         return evolution (this, from:"Gastly", hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -998,7 +998,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_38:
         return evolution (this, from:"Haunter", hp:HP130, type:PSYCHIC, retreatCost:0) {
           weakness DARKNESS
@@ -1021,7 +1021,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_39:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1034,7 +1034,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_40:
         return evolution (this, from:"Misdreavus", hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1069,7 +1069,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPOINK_41:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1081,7 +1081,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUMPIG_42:
         return evolution (this, from:"Spoink", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1107,7 +1107,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMECHO_43:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1136,7 +1136,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PUMPKABOO_44:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1152,7 +1152,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOURGEIST_45:
         return evolution (this, from:"Pumpkaboo", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -1171,11 +1171,11 @@ public enum CrimsonInvasion implements LogicCardInfo {
               def toolsDiscarded = 0
               while(true) {
                 def pl = my.all.findAll{ it.cards.hasType(POKEMON_TOOL) }
-                if(!pl) break;
+                if(!pl) break
 
                 def info = "Tools already discarded: ${toolsDiscarded}<br>Current base damage: 10 + ${40 * toolsDiscarded}<br>Discard a Pokémon Tool card from which Pokémon? (cancel to stop)"
                 def src = pl.select(info, false)
-                if(!src) break;
+                if(!src) break
 
                 def options = src.cards.filterByType(POKEMON_TOOL)
                 def toDiscard = options.select(min: 0, max: options.size(), "Select any tools you want to discard from ${src}. Each will add 40 damage to $thisMove's base damage.")
@@ -1186,7 +1186,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALANDIT_46:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1198,7 +1198,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAZZLE_47:
         return evolution (this, from:"Salandit", hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1222,7 +1222,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORANGURU_48:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1244,7 +1244,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIHILEGO_GX_49:
         return basic (this, hp:HP180, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1280,7 +1280,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY_50:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1292,7 +1292,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRIMEAPE_51:
         return evolution (this, from:"Mankey", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1326,7 +1326,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_52:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1345,7 +1345,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGIROCK_53:
         return basic (this, hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1373,7 +1373,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTRODON_54:
         return evolution (this, from:"Shellos", hp:HP120, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1396,7 +1396,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUFFUL_55:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1408,7 +1408,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEWEAR_56:
         return evolution (this, from:"Stufful", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -1436,7 +1436,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUZZWOLE_GX_57:
         return basic (this, hp:HP190, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1466,7 +1466,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOUR_58:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1486,7 +1486,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOUNDOOM_59:
         return evolution (this, from:"Houndour", hp:HP110, type:DARKNESS, retreatCost:1) {
           weakness FIRE
@@ -1508,7 +1508,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEINO_60:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1528,7 +1528,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZWEILOUS_61:
         return evolution (this, from:"Deino", hp:HP090, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1548,7 +1548,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYDREIGON_62:
         return evolution (this, from:"Zweilous", hp:HP160, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1584,7 +1584,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GUZZLORD_GX_63A:
       case GUZZLORD_GX_63:
         return basic (this, hp:HP210, type:DARKNESS, retreatCost:4) {
@@ -1638,7 +1638,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAWILE_64:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1667,7 +1667,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARON_65:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1687,7 +1687,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_66:
         return evolution (this, from:"Aron", hp:HP100, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -1707,7 +1707,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AGGRON_67:
         return evolution (this, from:"Lairon", hp:HP170, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -1731,7 +1731,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGISTEEL_68:
         return basic (this, hp:HP130, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -1754,7 +1754,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESCAVALIER_69:
         return evolution (this, from:"Karrablast", hp:HP120, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -1775,7 +1775,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KARTANA_GX_70:
         return basic (this, hp:HP170, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1815,7 +1815,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_71:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -1835,7 +1835,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIGGLYTUFF_72:
         return evolution (this, from:"Jigglypuff", hp:HP120, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -1858,7 +1858,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case XERNEAS_73:
         return basic (this, hp:HP130, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -1880,7 +1880,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_EXEGGUTOR_GX_74:
         return evolution (this, from:"Exeggcute", hp:HP220, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1909,19 +1909,19 @@ public enum CrimsonInvasion implements LogicCardInfo {
               damage 180
               while(1){
                 def pl=(my.all.findAll {it.cards.energyCount(C)})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("source for energy (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
 
                 def tar=my.all.select("Target for energy (cancel to stop)", false)
-                if(!tar) break;
+                if(!tar) break
                 energySwitch(src, tar, card)
               }
             }
           }
 
-        };
+        }
       case JANGMO_O_75:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1940,7 +1940,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAKAMO_O_76:
         return evolution (this, from:"Jangmo-o", hp:HP090, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1959,7 +1959,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOMMO_O_77:
         return evolution (this, from:"Hakamo-o", hp:HP160, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1992,7 +1992,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MILTANK_78:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2014,7 +2014,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWABLU_79:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2027,7 +2027,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALTARIA_80:
         return evolution (this, from:"Swablu", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2056,7 +2056,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARLY_81:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2079,7 +2079,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAVIA_82:
         return evolution (this, from:"Starly", hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2099,7 +2099,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STARAPTOR_83:
         return evolution (this, from:"Staravia", hp:HP140, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2132,7 +2132,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case REGIGIGAS_84:
         return basic (this, hp:HP180, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -2160,7 +2160,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINCCINO_85:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2173,7 +2173,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CINCCINO_86:
         return evolution (this, from:"Minccino", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2195,7 +2195,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNNELBY_87:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2207,7 +2207,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGGERSBY_88:
         return evolution (this, from:"Bunnelby", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -2228,7 +2228,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPE__NULL_89:
         return basic (this, hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2248,7 +2248,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SILVALLY_GX_90:
         return evolution (this, from:"Type: Null", hp:HP210, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2278,7 +2278,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COUNTER_CATCHER_91:
         return itemCard (this) {
           text "You can play this card only if you have more Prize cards remaining than your opponent.\nSwitch 1 of your opponent's Benched Pokémon with their Active Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2289,7 +2289,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
             assert my.prizeCardSet.size() > opp.prizeCardSet.size()
             assertOppBench()
           }
-        };
+        }
       case DASHING_POUCH_92:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the Pokémon this card is attached to discards Energy for its Retreat Cost, put that Energy into your hand instead of the discard pile.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2299,7 +2299,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onRemoveFromPlay {
             bg.em().storeObject("dashing_pouch_"+self.hashCode(), null)
           }
-        };
+        }
       case DEVOURED_FIELD_93:
         return stadium (this) {
           text "The attacks of [D] Pokémon and [N] Pokémon (both yours and your opponent's) do 10 more damage to the opponent's Active Pokémon (before applying Weakness and Resistance).\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2319,7 +2319,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case FIGHTING_MEMORY_94:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a [F] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2336,7 +2336,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case GLADION_95:
         return supporter (this) {
           text "Look at your face-down Prize cards and put 1 of them into your hand. Then, shuffle this Gladion into your remaining Prize cards and put them back face down. If you didn't play this Gladion from your hand, it does nothing.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2352,7 +2352,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case LUSAMINE_96:
         return supporter (this) {
           text "Put 2 in any combination of Supporter and Stadium cards from your discard pile into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2362,7 +2362,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(SUPPORTER,STADIUM)
           }
-        };
+        }
       case PEEKING_RED_CARD_97:
         return itemCard (this) {
           text "Your opponent reveals their hand. You may have your opponent count the cards in their hand, shuffle those cards into their deck, then draw that many cards.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2378,7 +2378,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           playRequirement{
             assert opp.hand
           }
-        };
+        }
       case PSYCHIC_MEMORY_98:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a [P] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2395,7 +2395,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case SEA_OF_NOTHINGNESS_99:
         return stadium (this) {
           text "Special Conditions are not removed when Pokémon (both yours and your opponent's) evolve or devolve.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2432,7 +2432,7 @@ public enum CrimsonInvasion implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case COUNTER_ENERGY_100:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\nIf you have more Prize cards remaining than your opponent, and if this card is attached to a Pokémon that isn't a Pokémon-GX or Pokémon-EX, this card provides every type of Energy but provides only 2 Energy at a time"
@@ -2446,57 +2446,57 @@ public enum CrimsonInvasion implements LogicCardInfo {
               return [[C] as Set]
             }
           }
-        };
+        }
       case GYARADOS_GX_101:
-        return copy (GYARADOS_GX_18, this);
+        return copy (GYARADOS_GX_18, this)
       case ALOLAN_GOLEM_GX_102:
-        return copy (ALOLAN_GOLEM_GX_34, this);
+        return copy (ALOLAN_GOLEM_GX_34, this)
       case NIHILEGO_GX_103:
-        return copy (NIHILEGO_GX_49, this);
+        return copy (NIHILEGO_GX_49, this)
       case BUZZWOLE_GX_104:
-        return copy (BUZZWOLE_GX_57, this);
+        return copy (BUZZWOLE_GX_57, this)
       case GUZZLORD_GX_105:
-        return copy (GUZZLORD_GX_63, this);
+        return copy (GUZZLORD_GX_63, this)
       case KARTANA_GX_106:
-        return copy (KARTANA_GX_70, this);
+        return copy (KARTANA_GX_70, this)
       case ALOLAN_EXEGGUTOR_GX_107:
-        return copy (ALOLAN_EXEGGUTOR_GX_74, this);
+        return copy (ALOLAN_EXEGGUTOR_GX_74, this)
       case SILVALLY_GX_108:
-        return copy (SILVALLY_GX_90, this);
+        return copy (SILVALLY_GX_90, this)
       case GLADION_109:
-        return copy (GLADION_95, this);
+        return copy (GLADION_95, this)
       case LUSAMINE_110:
-        return copy (LUSAMINE_96, this);
+        return copy (LUSAMINE_96, this)
       case OLIVIA_111:
-        return copy (BurningShadows.OLIVIA_119, this);
+        return copy (BurningShadows.OLIVIA_119, this)
       case GYARADOS_GX_112:
-        return copy (GYARADOS_GX_18, this);
+        return copy (GYARADOS_GX_18, this)
       case ALOLAN_GOLEM_GX_113:
-        return copy (ALOLAN_GOLEM_GX_34, this);
+        return copy (ALOLAN_GOLEM_GX_34, this)
       case NIHILEGO_GX_114:
-        return copy (NIHILEGO_GX_49, this);
+        return copy (NIHILEGO_GX_49, this)
       case BUZZWOLE_GX_115:
-        return copy (BUZZWOLE_GX_57, this);
+        return copy (BUZZWOLE_GX_57, this)
       case GUZZLORD_GX_116:
-        return copy (GUZZLORD_GX_63, this);
+        return copy (GUZZLORD_GX_63, this)
       case KARTANA_GX_117:
-        return copy (KARTANA_GX_70, this);
+        return copy (KARTANA_GX_70, this)
       case ALOLAN_EXEGGUTOR_GX_118:
-        return copy (ALOLAN_EXEGGUTOR_GX_74, this);
+        return copy (ALOLAN_EXEGGUTOR_GX_74, this)
       case SILVALLY_GX_119:
-        return copy (SILVALLY_GX_90, this);
+        return copy (SILVALLY_GX_90, this)
       case COUNTER_CATCHER_120:
-        return copy (COUNTER_CATCHER_91, this);
+        return copy (COUNTER_CATCHER_91, this)
       case WISHFUL_BATON_121:
         return copy(BurningShadows.WISHFUL_BATON_128, this)
       case COUNTER_ENERGY_122:
-        return copy (COUNTER_ENERGY_100, this);
+        return copy (COUNTER_ENERGY_100, this)
       case WARP_ENERGY_123:
-        return copy (Aquapolis.WARP_ENERGY_147, this);
+        return copy (Aquapolis.WARP_ENERGY_147, this)
       case WATER_ENERGY_124:
-        return basicEnergy (this, W);
+        return basicEnergy (this, W)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
+++ b/src/tcgwars/logic/impl/gen7/DetectivePikachu.groovy
@@ -1,20 +1,20 @@
-package tcgwars.logic.impl.gen7;
+package tcgwars.logic.impl.gen7
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -40,53 +40,53 @@ public enum DetectivePikachu implements LogicCardInfo {
   DITTO_17 ("Ditto", "17", Rarity.ULTRARARE, [POKEMON, BASIC, _COLORLESS_]),
   SLAKING_18 ("Slaking", "18", Rarity.RARE, [POKEMON, EVOLUTION, STAGE2, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DetectivePikachu(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DETECTIVE_PIKACHU;
+    return tcgwars.logic.card.Collection.DETECTIVE_PIKACHU
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -107,7 +107,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUDICOLO_2:
         return evolution (this, from:"Lombre", hp:HP140, type:G, retreatCost:3) {
           weakness R
@@ -130,7 +130,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MORELULL_3:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -143,7 +143,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARMANDER_4:
         return basic (this, hp:HP060, type:R, retreatCost:1) {
           weakness W
@@ -156,7 +156,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARIZARD_5:
         return evolution (this, from:"Charmeleon", hp:HP180, type:R, retreatCost:3) {
           weakness W
@@ -176,7 +176,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCANINE_6:
         return evolution (this, from:"Growlithe", hp:HP120, type:R, retreatCost:3) {
           weakness W
@@ -201,7 +201,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK_7:
         return basic (this, hp:HP080, type:W, retreatCost:3) {
           weakness G
@@ -214,7 +214,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_8:
         return basic (this, hp:HP030, type:W, retreatCost:1) {
           weakness L
@@ -229,7 +229,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRENINJA_9:
         return evolution (this, from:"Frogadier", hp:HP140, type:W, retreatCost:1) {
           weakness G
@@ -254,7 +254,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DETECTIVE_PIKACHU_10:
         return basic (this, hp:HP090, type:L, retreatCost:2) {
           weakness F
@@ -277,7 +277,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MR_MIME_11:
         return basic (this, hp:HP080, type:P, retreatCost:1) {
           weakness P
@@ -301,7 +301,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEWTWO_12:
         return basic (this, hp:HP130, type:P, retreatCost:2) {
           weakness P
@@ -322,7 +322,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_13:
         return evolution (this, from:"Machoke", hp:HP160, type:F, retreatCost:2) {
           weakness P
@@ -346,7 +346,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_14:
         return basic (this, hp:HP060, type:Y, retreatCost:1) {
           weakness M
@@ -359,7 +359,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNUBBULL_15:
         return basic (this, hp:HP070, type:Y, retreatCost:2) {
           weakness M
@@ -373,7 +373,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_16:
         return basic (this, hp:HP100, type:C, retreatCost:3) {
           weakness F
@@ -385,7 +385,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DITTO_17:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -405,7 +405,7 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLAKING_18:
         return evolution (this, from:"Vigoroth", hp:HP180, type:C, retreatCost:4) {
           weakness F
@@ -418,9 +418,9 @@ public enum DetectivePikachu implements LogicCardInfo {
             }
           }
 
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
+++ b/src/tcgwars/logic/impl/gen7/DragonMajesty.groovy
@@ -1,22 +1,22 @@
 package tcgwars.logic.impl.gen7
 
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -103,53 +103,53 @@ public enum DragonMajesty implements LogicCardInfo {
   SWITCH_RAFT_77("Switch Raft", "77", Rarity.SECRET, [TRAINER,ITEM]),
   ULTRA_NECROZMA_GX_78 ("Ultra Necrozma-GX", "78", Rarity.SECRET, [BASIC, POKEMON, POKEMON_GX, ULTRA_BEAST, _DRAGON_]),
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DragonMajesty(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DRAGON_MAJESTY;
+    return tcgwars.logic.card.Collection.DRAGON_MAJESTY
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -166,7 +166,7 @@ public enum DragonMajesty implements LogicCardInfo {
               applyAfterDamage BURNED
             }
           }
-        };
+        }
       case CHARMELEON_2:
         return 	evolution (this, from:"Charmander", hp:HP080, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -193,7 +193,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARIZARD_3:
         return 	evolution (this, from:"Charmeleon", hp:HP160, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -221,7 +221,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORCHIC_4:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -232,7 +232,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip{apply BURNED}
             }
           }
-        };
+        }
       case COMBUSKEN_5:
         return 	evolution (this, from:"Torchic", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -253,7 +253,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip 1,{damage 60},{bc "Lunge failed"}
             }
           }
-        };
+        }
       case BLAZIKEN_6:
         return 	evolution (this, from:"Combusken", hp:HP150, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -278,7 +278,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VICTINI_PRISM_STAR_7:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -292,7 +292,7 @@ public enum DragonMajesty implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case DARUMAKA_8:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -304,7 +304,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flipUntilTails{damage 30}
             }
           }
-        };
+        }
       case DARMANITAN_9:
         return 	evolution (this, from:"Darumaka", hp:HP130, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -325,7 +325,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip 4,{damage 50}
             }
           }
-        };
+        }
       case HEATMOR_10:
         return basic (this, hp:HP110, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -346,7 +346,7 @@ public enum DragonMajesty implements LogicCardInfo {
               else{bc"Charring Breath has no effect"}
             }
           }
-        };
+        }
       case RESHIRAM_GX_11:
         return basic (this, hp:HP180, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -389,7 +389,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LITTEN_12:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -400,7 +400,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip 3,{damage 10}
             }
           }
-        };
+        }
       case SALANDIT_13:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -416,7 +416,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SALAZZLE_14:
         return 	evolution (this, from:"Salandit", hp:HP110, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -441,7 +441,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HORSEA_15:
         return basic (this, hp:HP040, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -452,7 +452,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20, opp.all.select("Select the Pokémon to target")
             }
           }
-        };
+        }
       case HORSEA_16:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -463,7 +463,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 10+10*self.cards.energyCount(W)
             }
           }
-        };
+        }
       case SEADRA_17:
         return 	evolution (this, from:"Horsea", hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -474,7 +474,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 10+20*self.cards.energyCount(W)
             }
           }
-        };
+        }
       case KINGDRA_GX_18:
         return 	evolution (this, from:"Seadra", hp:HP230, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -510,7 +510,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGIKARP_19:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -522,7 +522,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip {damage 10}
             }
           }
-        };
+        }
       case GYARADOS_20:
         return 	evolution (this, from:"Magikarp", hp:HP160, type:WATER, retreatCost:4) {
           weakness LIGHTNING
@@ -545,7 +545,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LAPRAS_21:
         return basic (this, hp:HP120, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -566,7 +566,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 70+10*self.cards.energyCount(W)
             }
           }
-        };
+        }
       case TOTODILE_22:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -584,7 +584,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip 3,{damage 10}
             }
           }
-        };
+        }
       case CROCONAW_23:
         return 	evolution (this, from:"Totodile", hp:HP090, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -603,7 +603,7 @@ public enum DragonMajesty implements LogicCardInfo {
               my.deck.subList(0,3).discard()
             }
           }
-        };
+        }
       case FERALIGATR_24:
         return 	evolution (this, from:"Croconaw", hp:HP160, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -624,7 +624,7 @@ public enum DragonMajesty implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case WOOPER_25:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -642,7 +642,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case QUAGSIRE_26:
         return 	evolution (this, from:"Wooper", hp:HP120, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -661,7 +661,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 60+20*self.cards.energyCount(W)
             }
           }
-        };
+        }
       case CORSOLA_27:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -672,7 +672,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20*self.cards.energyCount(W), opp.all.select("Select the Pokémon to target")
             }
           }
-        };
+        }
       case FEEBAS_28:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -696,7 +696,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case MILOTIC_29:
         return 	evolution (this, from:"Feebas", hp:HP120, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -722,7 +722,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PHIONE_30:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -757,7 +757,7 @@ public enum DragonMajesty implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case WISHIWASHI_31:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -795,7 +795,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TRAPINCH_32:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -811,9 +811,9 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HYDREIGON_33:
-        return copy(CrimsonInvasion.HYDREIGON_62, this);
+        return copy(CrimsonInvasion.HYDREIGON_62, this)
       case DRATINI_34:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -825,7 +825,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case DRATINI_35:
         return basic (this, hp:HP070, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -836,7 +836,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case DRAGONAIR_36:
         return 	evolution (this, from:"Dratini", hp:HP100, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -854,7 +854,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case DRAGONITE_GX_37:
         return 	evolution (this, from:"Dragonair", hp:HP250, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -888,7 +888,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VIBRAVA_38:
         return 	evolution (this, from:"Trapinch", hp:HP080, type:DRAGON, retreatCost:1) {
           resistance FAIRY, MINUS20
@@ -899,7 +899,7 @@ public enum DragonMajesty implements LogicCardInfo {
               shredDamage 50
             }
           }
-        };
+        }
       case FLYGON_39:
         return 	evolution (this, from:"Vibrava", hp:HP140, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -925,7 +925,7 @@ public enum DragonMajesty implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case ALTARIA_40:
         return 	evolution (this, from:"Swablu", hp:HP080, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -951,7 +951,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ALTARIA_GX_41:
         return 	evolution (this, from:"Swablu", hp:HP200, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -986,7 +986,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BAGON_42:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1005,7 +1005,7 @@ public enum DragonMajesty implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case SHELGON_43:
         return 	evolution (this, from:"Bagon", hp:HP080, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1029,7 +1029,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SALAMENCE_GX_44:
         return 	evolution (this, from:"Shelgon", hp:HP250, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1062,7 +1062,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 120, opp.all.select("Select the Pokémon to target.")
             }
           }
-        };
+        }
       case DRUGGIDON_45:
         return basic (this, hp:HP110, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1080,7 +1080,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case ZEKROM_46:
         return basic (this, hp:HP130, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1101,7 +1101,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KYUREM_47:
         return basic (this, hp:HP130, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1122,7 +1122,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WHITE_KYUREM_GX_48:
         return basic (this, hp:HP190, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1155,7 +1155,7 @@ public enum DragonMajesty implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZYGARDE_49:
         return basic (this, hp:HP130, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1175,7 +1175,7 @@ public enum DragonMajesty implements LogicCardInfo {
               if(self.numberOfDamageCounters) damage 60
             }
           }
-        };
+        }
       case TURTONATOR_50:
         return basic (this, hp:HP110, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1195,7 +1195,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 50*count
             }
           }
-        };
+        }
       case DRAMPA_51:
         return basic (this, hp:HP120, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1216,7 +1216,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case JANGMO_O_52:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1234,7 +1234,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HAKAMO_O_53:
         return 	evolution (this, from:"Jangmo-o", hp:HP090, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1253,7 +1253,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case KOMMO_O_54:
         return 	evolution (this, from:"Hakamo-o", hp:HP160, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1273,7 +1273,7 @@ public enum DragonMajesty implements LogicCardInfo {
               if(self.numberOfDamageCounters >= 8) damage 120
             }
           }
-        };
+        }
       case KANGASKHAN_55:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1302,7 +1302,7 @@ public enum DragonMajesty implements LogicCardInfo {
               flip {damage 30}
             }
           }
-        };
+        }
       case SWABLU_56:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1324,7 +1324,7 @@ public enum DragonMajesty implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SWABLU_57:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1336,7 +1336,7 @@ public enum DragonMajesty implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case BLAINE_S_LAST_STAND_58:
         return supporter(this) {
           text "You can play this card only when it is the last card in your hand.\nDraw 2 cards for each [R] Pokémon you have in play.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -1346,7 +1346,7 @@ public enum DragonMajesty implements LogicCardInfo {
           playRequirement{
             assert !my.hand.getExcludedList(thisCard) : "this is not your only card in hand"
           }
-        };
+        }
       case DRAGON_TALON_59:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the [N] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack (even if that Pokémon is Knocked Out), put 3 damage counters on the Attacking Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -1356,7 +1356,7 @@ public enum DragonMajesty implements LogicCardInfo {
               directDamage(30, ef.attacker, TRAINER_CARD)
             }
           }
-        };
+        }
       case FIERY_FLINT_60:
         return itemCard (this) {
           text "You can play this card only if you discard 2 other cards from your hand.\nSearch your deck for up to 4 [R] Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -1369,7 +1369,7 @@ public enum DragonMajesty implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2
             assert my.deck
           }
-        };
+        }
       case LANCE_PRISM_STAR_61:
         return supporter(this) {
           text "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn.\nSearch your deck for up to 2 [N] Pokémon and put them onto your Bench. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -1393,7 +1393,7 @@ public enum DragonMajesty implements LogicCardInfo {
             assert bg.turnCount
             assert keyStore("Lance_Prism_KO", thisCard, null) == bg.turnCount - 1: "No Pokémon was Knocked Out during your opponent’s last turn"
           }
-        };
+        }
       case SWITCH_RAFT_62:
         return itemCard (this) {
           text "Switch your Active [W] Pokémon with 1 of your Benched Pokémon. If you do, heal 30 damage from the Pokémon you moved to your Bench.\nYou may play as many Item cards as you like during your turn (before your attack).\n"
@@ -1407,7 +1407,7 @@ public enum DragonMajesty implements LogicCardInfo {
             assert my.active.types.contains(W)
             assert my.bench
           }
-        };
+        }
       case WELA_VOLCANO_PARK_63:
         return stadium(this) {
           text "Whenever a player flips a coin for the Special Condition Burned between turns, that Special Condition isn't removed even if the result is heads.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\n"
@@ -1416,7 +1416,7 @@ public enum DragonMajesty implements LogicCardInfo {
           }
           onRemoveFromPlay{
           }
-        };
+        }
       case ZINNIA_64:
         return supporter(this) {
           text "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn.\nAttach up to 2 basic Energy cards from your hand to 1 of your [N] Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack).\n"
@@ -1439,37 +1439,37 @@ public enum DragonMajesty implements LogicCardInfo {
             assert keyStore("Zinnia_KO", thisCard, null) == bg.turnCount - 1: "No Pokémon was Knocked Out during your opponent’s last turn"
             assert my.all.findAll{it.types.contains(N)} : "You have no [N] type Pokémon in play"
           }
-        };
+        }
       case RESHIRAM_GX_65:
-        return copy(RESHIRAM_GX_11, this);
+        return copy(RESHIRAM_GX_11, this)
       case KINGDRA_GX_66:
-        return copy(KINGDRA_GX_18, this);
+        return copy(KINGDRA_GX_18, this)
       case DRAGONITE_GX_67:
-        return copy(DRAGONITE_GX_37, this);
+        return copy(DRAGONITE_GX_37, this)
       case ALTARIA_GX_68:
-        return copy(ALTARIA_GX_41, this);
+        return copy(ALTARIA_GX_41, this)
       case BLAINE_S_LAST_STAND_69:
-        return copy(BLAINE_S_LAST_STAND_58, this);
+        return copy(BLAINE_S_LAST_STAND_58, this)
       case ZINNIA_70:
-        return copy(ZINNIA_64, this);
+        return copy(ZINNIA_64, this)
       case RESHIRAM_GX_71:
-        return copy(RESHIRAM_GX_11, this);
+        return copy(RESHIRAM_GX_11, this)
       case ALTARIA_GX_72:
-        return copy(ALTARIA_GX_41, this);
+        return copy(ALTARIA_GX_41, this)
       case SALAMENCE_GX_73:
-        return copy(SALAMENCE_GX_44, this);
+        return copy(SALAMENCE_GX_44, this)
       case WHITE_KYUREM_GX_74:
-        return copy(WHITE_KYUREM_GX_48, this);
+        return copy(WHITE_KYUREM_GX_48, this)
       case DRAGON_TALON_75:
-        return copy(DRAGON_TALON_59, this);
+        return copy(DRAGON_TALON_59, this)
       case FIERY_FLINT_76:
-        return copy(FIERY_FLINT_60, this);
+        return copy(FIERY_FLINT_60, this)
       case SWITCH_RAFT_77:
-        return copy(SWITCH_RAFT_62, this);
+        return copy(SWITCH_RAFT_62, this)
       case ULTRA_NECROZMA_GX_78:
-        return copy(ForbiddenLight.ULTRA_NECROZMA_GX_95, this);
+        return copy(ForbiddenLight.ULTRA_NECROZMA_GX_95, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
+++ b/src/tcgwars/logic/impl/gen7/ForbiddenLight.groovy
@@ -1,26 +1,26 @@
 package tcgwars.logic.impl.gen7
 
-import tcgwars.logic.effect.gm.ActivateSimpleTrainer;
+import tcgwars.logic.effect.gm.ActivateSimpleTrainer
 import tcgwars.logic.effect.gm.Attack
 import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -174,53 +174,53 @@ public enum ForbiddenLight implements LogicCardInfo {
   MYSTERIOUS_TREASURE_145 ("Mysterious Treasure", "145", Rarity.SECRET, [ITEM, TRAINER]),
   UNIT_ENERGY_FDY_146 ("Unit Energy FDY", "146", Rarity.SECRET, [SPECIAL_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ForbiddenLight(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.FORBIDDEN_LIGHT;
+    return tcgwars.logic.card.Collection.FORBIDDEN_LIGHT
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -243,7 +243,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_EXEGGUTOR_2:
         return evolution (this, from:"Exeggcute", hp:HP160, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -262,7 +262,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNOVER_3:
         return basic (this, hp:HP080, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -275,7 +275,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABOMASNOW_4:
         return evolution (this, from:"Snover", hp:HP130, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -297,7 +297,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCATTERBUG_5:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -320,7 +320,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCATTERBUG_6:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -339,7 +339,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEWPA_7:
         return evolution (this, from:"Scatterbug", hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -352,7 +352,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIVILLON_8:
         return evolution (this, from:"Spewpa", hp:HP130, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -369,7 +369,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKIDDO_9:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -391,7 +391,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOGOAT_10:
         return evolution (this, from:"Skiddo", hp:HP120, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -411,7 +411,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHEROMOSA_11:
         return basic (this, hp:HP110, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -431,7 +431,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_MAROWAK_12:
         return evolution (this, from:"Cubone", hp:HP120, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -453,7 +453,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEATRAN_13:
         return basic (this, hp:HP130, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -476,7 +476,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FENNEKIN_14:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -491,7 +491,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FENNEKIN_15:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -510,7 +510,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRAIXEN_16:
         return evolution (this, from:"Fennekin", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -532,7 +532,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DELPHOX_17:
         return evolution (this, from:"Braixen", hp:HP150, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -555,7 +555,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LITLEO_18:
         return basic (this, hp:HP070, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -567,7 +567,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PYROAR_19:
         return evolution (this, from:"Litleo", hp:HP120, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -602,7 +602,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_GX_20:
         return basic (this, hp:HP180, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -612,9 +612,9 @@ public enum ForbiddenLight implements LogicCardInfo {
             onAttack {
               while(1){
                 def pl=(my.bench.findAll {it.cards.energyCount(C)})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("source for energy (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
                 energySwitch(src, self, card)
               }
@@ -643,7 +643,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FROAKIE_21:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -663,7 +663,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROAKIE_22:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -682,7 +682,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROGADIER_23:
         return evolution (this, from:"Froakie", hp:HP080, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -703,7 +703,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRENINJA_GX_24:
         return evolution (this, from:"Frogadier", hp:HP230, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -743,7 +743,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLAUNCHER_25:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -755,7 +755,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLAWITZER_26:
         return evolution (this, from:"Clauncher", hp:HP100, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -774,7 +774,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AMAURA_27:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:WATER, retreatCost:3) {
           weakness METAL
@@ -794,7 +794,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AURORUS_28:
         return evolution (this, from:"Amaura", hp:HP160, type:WATER, retreatCost:4) {
           weakness METAL
@@ -825,7 +825,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BERGMITE_29:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness METAL
@@ -845,7 +845,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AVALUGG_30:
         return evolution (this, from:"Bergmite", hp:HP140, type:WATER, retreatCost:4) {
           weakness METAL
@@ -873,7 +873,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLCANION_PRISM_STAR_31:
         return basic (this, hp:HP160, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -898,7 +898,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWPIDER_32:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -917,7 +917,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARAQUANID_33:
         return evolution (this, from:"Dewpider", hp:HP100, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -947,7 +947,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_34:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -971,7 +971,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_35:
         return evolution (this, from:"Magnemite", hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -992,7 +992,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_36:
         return evolution (this, from:"Magneton", hp:HP150, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1016,7 +1016,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HELIOPTILE_37:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1036,7 +1036,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HELIOLISK_38:
         return evolution (this, from:"Helioptile", hp:HP100, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1057,7 +1057,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case XURKITREE_39:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1079,7 +1079,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROTOM_40:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1108,7 +1108,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UXIE_41:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1121,7 +1121,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MESPRIT_42:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1142,7 +1142,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AZELF_43:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1169,7 +1169,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPURR_44:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1186,7 +1186,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWSTIC_45:
         return evolution (this, from:"Espurr", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1207,7 +1207,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONEDGE_46:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1231,7 +1231,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONEDGE_47:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1244,7 +1244,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DOUBLADE_48:
         return evolution (this, from:"Honedge", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness DRAGON
@@ -1259,7 +1259,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AEGISLASH_49:
         return evolution (this, from:"Doublade", hp:HP150, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1299,7 +1299,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INKAY_50:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1311,7 +1311,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MALAMAR_51:
         return evolution (this, from:"Inkay", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1333,7 +1333,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKRELP_52:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1345,7 +1345,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGALGE_53:
         return evolution (this, from:"Skrelp", hp:HP120, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1370,7 +1370,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HOOPA_54:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1391,7 +1391,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POIPOLE_55:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1424,7 +1424,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NAGANADEL_GX_56:
         return evolution (this, from:"Poipole", hp:HP210, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1461,7 +1461,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_57:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1474,7 +1474,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_58:
         return evolution (this, from:"Grotle", hp:HP180, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -1495,7 +1495,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_59:
         return evolution (this, from:"Monferno", hp:HP130, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1518,7 +1518,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIBLE_60:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1527,7 +1527,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             energyCost F
             ascension delegate
           }
-        };
+        }
       case GABITE_61:
         return evolution (this, from:"Gible", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1544,7 +1544,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARCHOMP_62:
         return evolution (this, from:"Gabite", hp:HP150, type:FIGHTING, retreatCost:0) {
           weakness GRASS
@@ -1566,7 +1566,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               }
             }
           }
-        };
+        }
 
       case CROAGUNK_63:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
@@ -1580,7 +1580,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_64:
         return evolution (this, from:"Croagunk", hp:HP100, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1601,7 +1601,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANCHAM_65:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1614,7 +1614,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BINACLE_66:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1627,7 +1627,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BARBARACLE_67:
         return evolution (this, from:"Binacle", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1647,7 +1647,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYRUNT_68:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1667,7 +1667,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYRANTRUM_69:
         return evolution (this, from:"Tyrunt", hp:HP160, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1699,7 +1699,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAWLUCHA_70:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness LIGHTNING
@@ -1719,7 +1719,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZYGARDE_71:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1751,7 +1751,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZYGARDE_72:
         return basic (this, hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1772,7 +1772,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZYGARDE_GX_73:
         return basic (this, hp:HP200, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1815,7 +1815,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIANCIE_PRISM_STAR_74:
         return basic (this, hp:HP120, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1847,7 +1847,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKRUFF_75:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1859,7 +1859,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LYCANROC_76:
         return evolution (this, from:"Rockruff", hp:HP120, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1878,7 +1878,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUZZWOLE_77:
         return basic (this, hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1899,7 +1899,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANGORO_78:
         return evolution (this, from:"Pancham", hp:HP130, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -1927,7 +1927,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YVELTAL_GX_79:
         return basic (this, hp:HP180, type:DARKNESS, retreatCost:2) {
           weakness LIGHTNING
@@ -1964,7 +1964,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GUZZLORD_80:
         return basic (this, hp:HP160, type:DARKNESS, retreatCost:4) {
           weakness FIGHTING
@@ -1981,7 +1981,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMPOLEON_81:
         return evolution (this, from:"Prinplup", hp:HP160, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2002,7 +2002,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIALGA_GX_82:
         return basic (this, hp:HP180, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2060,7 +2060,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLABEBE_83:
         return basic (this, hp:HP030, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2084,7 +2084,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLABEBE_84:
         return basic (this, hp:HP040, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2099,7 +2099,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOETTE_85:
         return evolution (this, from:"Flabébé", hp:HP070, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2118,7 +2118,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLORGES_86:
         return evolution (this, from:"Floette", hp:HP120, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2153,7 +2153,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SYLVEON_87:
         return evolution (this, from:"Eevee", hp:HP090, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2187,7 +2187,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEDENNE_88:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2212,7 +2212,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KLEFKI_89:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2233,7 +2233,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case XERNEAS_GX_90:
         return basic (this, hp:HP180, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2268,7 +2268,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOOMY_91:
         return basic (this, hp:HP040, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2294,7 +2294,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOOMY_92:
         return basic (this, hp:HP050, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2313,7 +2313,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLIGGOO_93:
         return evolution (this, from:"Goomy", hp:HP080, type:DRAGON, retreatCost:2) {
           resistance FAIRY, MINUS20
@@ -2333,7 +2333,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOODRA_94:
         return evolution (this, from:"Sliggoo", hp:HP160, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2357,7 +2357,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ULTRA_NECROZMA_GX_95:
         return basic (this, hp:HP190, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2391,7 +2391,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCEUS_PRISM_STAR_96:
         return basic (this, hp:HP160, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2420,7 +2420,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNNELBY_97:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2439,7 +2439,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGGERSBY_98:
         return evolution (this, from:"Bunnelby", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -2462,7 +2462,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FURFROU_99:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2479,7 +2479,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOIBAT_100:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2508,7 +2508,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOIVERN_101:
         return evolution (this, from:"Noibat", hp:HP120, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2530,7 +2530,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEAST_RING_102:
         return itemCard (this) {
           text "You can play this card only if your opponent has exactly 3 or 4 Prize cards remaining.\nSearch your deck for up to 2 basic Energy cards and attach them to 1 of your Ultra Beasts. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2543,7 +2543,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             assert (opp.prizeCardSet.size() == 3 || opp.prizeCardSet.size() == 4) : " Your opponent need to have exactly 3 or 4 Prize cards remaining"
             assert my.all.findAll{it.topPokemonCard.cardTypes.is(ULTRA_BEAST)} : "No Ultra Beast in play."
           }
-        };
+        }
       case BONNIE_103:
         return supporter (this) {
           text "You can play this card only if there is any Stadium card in play.\nDiscard that Stadium card. During this turn, your Zygarde-GX can use its GX attack even if you have used your GX attack.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2558,7 +2558,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           playRequirement{
             assert bg.stadiumInfoStruct : "There is no stadium in play"
           }
-        };
+        }
       case CRASHER_WAKE_104:
         return supporter (this) {
           text "Discard 2 [W] Energy cards from your hand. If you do, search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2571,7 +2571,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             assert my.hand.filterByEnergyType(W).size() >= 2
             assert my.deck
           }
-        };
+        }
       case DIANTHA_105:
         return supporter (this) {
           text "You can play this card only if 1 of your [Y] Pokémon was Knocked Out during your opponent’s last turn.\nPut 2 cards from your discard pile into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2592,7 +2592,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             assert bg.turnCount
             assert keyStore("Diantha_KO", thisCard, null) == bg.turnCount - 1: "No Fairy Pokémon was Knocked Out during your opponent’s last turn"
           }
-        };
+        }
       case ENEPORTER_106:
         return itemCard (this) {
           text "Move a Special Energy from 1 of your opponent’s Pokémon to another of their Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2605,7 +2605,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             assert opp.bench
             assert opp.all.findAll{it.cards.filterByType(SPECIAL_ENERGY)}
           }
-        };
+        }
       case FOSSIL_EXCAVATION_MAP_107:
         return itemCard (this) {
           text "Choose 1:\n Search your deck for an Unidentified Fossil card, reveal it, and put it into your hand. Then, shuffle your deck.\n Put an Unidentified Fossil card from your discard pile into your hand. \nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2625,7 +2625,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || my.discard.findAll{it.name== "Unidentified Fossil"}
           }
-        };
+        }
       case JUDGE_108:
         return supporter (this) {
           text "Each player shuffles their hand into their deck and draws 4 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2639,7 +2639,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case LADY_109:
         return supporter (this) {
           text "Search your deck for up to 4 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2650,7 +2650,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           playRequirement{
             assert my.hand
           }
-        };
+        }
       case LYSANDRE_PRISM_STAR_110:
         return supporter (this) {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\nFor each of your [R] Pokémon in play, put a card from your opponent’s discard pile in the Lost Zone.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2662,7 +2662,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           playRequirement{
             assert my.all.findAll{it.types.contains(R)}
           }
-        };
+        }
       case LYSANDRE_LABS_111:
         return stadium (this) {
           text "Pokémon Tool cards in play (both yours and your opponent’s) have no effect.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -2713,7 +2713,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
             if(count >= 0) bg.em().storeObject("Tool Concealment count", count)
           }
-        };
+        }
       case METAL_FRYING_PAN_112:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nThe [M] Pokémon this card is attached to takes 30 less damage from your opponent’s attacks (after applying Weakness and Resistance) and has no Weakness.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2743,7 +2743,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case MYSTERIOUS_TREASURE_113:
         return itemCard (this) {
           text "Discard a card from your hand. If you do, search your deck for a [P] or [N] Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2756,7 +2756,7 @@ public enum ForbiddenLight implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard)
             assert my.deck
           }
-        };
+        }
       case ULTRA_RECON_SQUAD_114:
         return supporter (this) {
           text "Discard up to 2 Ultra Beast cards from your hand. Draw 3 cards for each card you discarded in this way.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2768,7 +2768,7 @@ public enum ForbiddenLight implements LogicCardInfo {
           playRequirement{
             assert my.hand.filterByType(ULTRA_BEAST) : "You don't have any Ultra Beast cards in your hand"
           }
-        };
+        }
       case ULTRA_SPACE_115:
         return stadium (this) {
           text "Once during each player’s turn, that player may search their deck for an Ultra Beast card, reveal it, put it into their hand, and shuffle their deck.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -2787,9 +2787,9 @@ public enum ForbiddenLight implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case UNIDENTIFIED_FOSSIL_116:
-        return copy (UltraPrism.UNIDENTIFIED_FOSSIL_134, this);
+        return copy (UltraPrism.UNIDENTIFIED_FOSSIL_134, this)
       case BEAST_ENERGY_PRISM_STAR_117:
         return specialEnergy (this, [[C]]) {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\nThis card provides [C] Energy.\nWhile this card is attached to an Ultra Beast, it provides every type of Energy but provides only 1 Energy at a time. The attacks of the Ultra Beast this card is attached to do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
@@ -2819,7 +2819,7 @@ public enum ForbiddenLight implements LogicCardInfo {
               return [[C] as Set]
             }
           }
-        };
+        }
       case UNIT_ENERGY_FDY_118:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\nWhile this card is attached to a Pokémon, it provides [F], [D], and [Y] Energy but provides only 1 Energy at a time."
@@ -2829,14 +2829,14 @@ public enum ForbiddenLight implements LogicCardInfo {
           getEnergyTypesOverride {
             self != null ? [[F,D,Y] as Set] : [[C] as Set]
           }
-        };
+        }
 
       case PALKIA_GX_119:
-        return copy (PALKIA_GX_20, this);
+        return copy (PALKIA_GX_20, this)
       case GRENINJA_GX_120:
-        return copy (GRENINJA_GX_24, this);
+        return copy (GRENINJA_GX_24, this)
       case NAGANADEL_GX_121:
-        return copy (NAGANADEL_GX_56, this);
+        return copy (NAGANADEL_GX_56, this)
       case LUCARIO_GX_122:
         return evolution (this, from:"Riolu", hp:HP210, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -2869,57 +2869,57 @@ public enum ForbiddenLight implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZYGARDE_GX_123:
-        return copy (ZYGARDE_GX_73, this);
+        return copy (ZYGARDE_GX_73, this)
       case YVELTAL_GX_124:
-        return copy (YVELTAL_GX_79, this);
+        return copy (YVELTAL_GX_79, this)
       case DIALGA_GX_125:
-        return copy (DIALGA_GX_82, this);
+        return copy (DIALGA_GX_82, this)
       case XERNEAS_GX_126:
-        return copy (XERNEAS_GX_90, this);
+        return copy (XERNEAS_GX_90, this)
       case ULTRA_NECROZMA_GX_127:
-        return copy (ULTRA_NECROZMA_GX_95, this);
+        return copy (ULTRA_NECROZMA_GX_95, this)
       case BONNIE_128:
-        return copy (BONNIE_103, this);
+        return copy (BONNIE_103, this)
       case CRASHER_WAKE_129:
-        return copy (CRASHER_WAKE_104, this);
+        return copy (CRASHER_WAKE_104, this)
       case DIANTHA_130:
-        return copy (DIANTHA_105, this);
+        return copy (DIANTHA_105, this)
       case ULTRA_RECON_SQUAD_131:
-        return copy (ULTRA_RECON_SQUAD_114, this);
+        return copy (ULTRA_RECON_SQUAD_114, this)
       case PALKIA_GX_132:
-        return copy (PALKIA_GX_20, this);
+        return copy (PALKIA_GX_20, this)
       case GRENINJA_GX_133:
-        return copy (GRENINJA_GX_24, this);
+        return copy (GRENINJA_GX_24, this)
       case NAGANADEL_GX_134:
-        return copy (NAGANADEL_GX_56, this);
+        return copy (NAGANADEL_GX_56, this)
       case LUCARIO_GX_135:
-        return copy (LUCARIO_GX_122, this);
+        return copy (LUCARIO_GX_122, this)
       case ZYGARDE_GX_136:
-        return copy (ZYGARDE_GX_73, this);
+        return copy (ZYGARDE_GX_73, this)
       case YVELTAL_GX_137:
-        return copy (YVELTAL_GX_79, this);
+        return copy (YVELTAL_GX_79, this)
       case DIALGA_GX_138:
-        return copy (DIALGA_GX_82, this);
+        return copy (DIALGA_GX_82, this)
       case XERNEAS_GX_139:
-        return copy (XERNEAS_GX_90, this);
+        return copy (XERNEAS_GX_90, this)
       case ULTRA_NECROZMA_GX_140:
-        return copy (ULTRA_NECROZMA_GX_95, this);
+        return copy (ULTRA_NECROZMA_GX_95, this)
       case BEAST_RING_141:
-        return copy (BEAST_RING_102, this);
+        return copy (BEAST_RING_102, this)
       case ENEPORTER_142:
-        return copy (ENEPORTER_106, this);
+        return copy (ENEPORTER_106, this)
       case ENERGY_RECYCLER_143:
-        return copy (GuardiansRising.ENERGY_RECYCLER_123, this);
+        return copy (GuardiansRising.ENERGY_RECYCLER_123, this)
       case METAL_FRYING_PAN_144:
-        return copy (METAL_FRYING_PAN_112, this);
+        return copy (METAL_FRYING_PAN_112, this)
       case MYSTERIOUS_TREASURE_145:
-        return copy (MYSTERIOUS_TREASURE_113, this);
+        return copy (MYSTERIOUS_TREASURE_113, this)
       case UNIT_ENERGY_FDY_146:
-        return copy (UNIT_ENERGY_FDY_118, this);
+        return copy (UNIT_ENERGY_FDY_118, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
+++ b/src/tcgwars/logic/impl/gen7/GuardiansRising.groovy
@@ -4,25 +4,25 @@ import tcgwars.logic.effect.gm.Attack
 import tcgwars.logic.impl.gen5.DarkExplorers
 import tcgwars.logic.impl.gen5.EmergingPowers
 import tcgwars.logic.impl.gen6.PhantomForces
-import tcgwars.logic.impl.gen6.Xy;
+import tcgwars.logic.impl.gen6.Xy
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -199,53 +199,53 @@ public enum GuardiansRising implements LogicCardInfo {
   LIGHTNING_ENERGY_168 ("Lightning Energy", "168", Rarity.SECRET, [BASIC_ENERGY, ENERGY]),
   FIGHTING_ENERGY_169 ("Fighting Energy", "169", Rarity.SECRET, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   GuardiansRising(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.GUARDIANS_RISING;
+    return tcgwars.logic.card.Collection.GUARDIANS_RISING
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -262,7 +262,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEPINBELL_2:
         return evolution (this, from:"Bellsprout", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -275,7 +275,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTREEBEL_3:
         return evolution (this, from:"Weepinbell", hp:HP140, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -301,7 +301,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PETILIL_4:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -314,7 +314,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LILLIGANT_5:
         return evolution (this, from:"Petilil", hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -334,7 +334,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PHANTUMP_6:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -353,7 +353,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TREVENANT_7:
         return evolution (this, from:"Phantump", hp:HP120, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -377,7 +377,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIMPOD_8:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -397,7 +397,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLISOPOD_9:
         return evolution (this, from:"Wimpod", hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -421,7 +421,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTINI_10:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -460,7 +460,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LITWICK_11:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -473,7 +473,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAMPENT_12:
         return evolution (this, from:"Litwick", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -485,7 +485,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANDELURE_13:
         return evolution (this, from:"Lampent", hp:HP140, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -518,7 +518,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORICORIO_14:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -552,7 +552,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALANDIT_15:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -572,7 +572,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAZZLE_16:
         return evolution (this, from:"Salandit", hp:HP110, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -597,7 +597,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTONATOR_17:
         return basic (this, hp:HP110, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -619,7 +619,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTONATOR_GX_18:
         return basic (this, hp:HP190, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -659,7 +659,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_SANDSHREW_19:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness METAL
@@ -677,7 +677,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_SANDSLASH_20:
         return evolution (this, from:"Alolan Sandshrew", hp:HP110, type:WATER, retreatCost:2) {
           weakness METAL
@@ -699,7 +699,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_VULPIX_21:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness METAL
@@ -721,7 +721,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_NINETALES_GX_22:
         return evolution (this, from:"Alolan Vulpix", hp:HP210, type:WATER, retreatCost:1) {
           weakness METAL
@@ -759,7 +759,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACOOL_23:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -772,7 +772,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACRUEL_24:
         return evolution (this, from:"Tentacool", hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -793,7 +793,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLITOED_25:
         return evolution (this, from:"Poliwhirl", hp:HP130, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -824,7 +824,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DELIBIRD_26:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness METAL
@@ -848,7 +848,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARVANHA_27:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -860,7 +860,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHARPEDO_28:
         return evolution (this, from:"Carvanha", hp:HP090, type:WATER, retreatCost:0) {
           weakness GRASS
@@ -872,7 +872,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WAILMER_29:
         return basic (this, hp:HP120, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -891,7 +891,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WAILORD_30:
         return evolution (this, from:"Wailmer", hp:HP200, type:WATER, retreatCost:4) {
           weakness GRASS
@@ -914,7 +914,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORUNT_31:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness METAL
@@ -933,7 +933,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLALIE_32:
         return evolution (this, from:"Snorunt", hp:HP120, type:WATER, retreatCost:3) {
           weakness METAL
@@ -954,7 +954,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VANILLITE_33:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness METAL
@@ -966,7 +966,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VANILLISH_34:
         return evolution (this, from:"Vanillite", hp:HP080, type:WATER, retreatCost:2) {
           weakness METAL
@@ -979,7 +979,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VANILLUXE_35:
         return evolution (this, from:"Vanillish", hp:HP140, type:WATER, retreatCost:2) {
           weakness METAL
@@ -1004,7 +1004,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOMOMOLA_36:
         return basic (this, hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1035,7 +1035,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WISHIWASHI_37:
         return basic (this, hp:HP030, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -1061,7 +1061,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WISHIWASHI_GX_38:
         return basic (this, hp:HP210, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -1097,7 +1097,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAREANIE_39:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1119,7 +1119,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GEODUDE_40:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1146,7 +1146,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GRAVELER_41:
         return evolution (this, from:"Alolan Geodude", hp:HP110, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1168,7 +1168,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_GOLEM_42:
         return evolution (this, from:"Alolan Graveler", hp:HP160, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1188,7 +1188,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HELIOPTILE_43:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1202,7 +1202,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HELIOLISK_44:
         return evolution (this, from:"Helioptile", hp:HP100, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1224,7 +1224,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIKAVOLT_GX_45:
         return evolution (this, from:"Charjabug", hp:HP240, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1263,7 +1263,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORICORIO_46:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1283,7 +1283,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAPU_KOKO_GX_47:
         return basic (this, hp:HP170, type:LIGHTNING, retreatCost:2) {
           bwAbility "Aero Trail", {
@@ -1294,9 +1294,9 @@ public enum GuardiansRising implements LogicCardInfo {
                 def card = null
                 while(1){
                   def pl=(my.all.findAll {it.cards.filterByEnergyType(L) && it!=self})
-                  if(!pl) break;
+                  if(!pl) break
                   def src=pl.select("Source for energy (cancel to stop)", false)
-                  if(!src) break;
+                  if(!src) break
                   card=src.cards.filterByEnergyType(L).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -1324,7 +1324,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_48:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1343,7 +1343,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_49:
         return evolution (this, from:"Slowpoke", hp:HP110, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1364,7 +1364,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TRUBBISH_50:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1386,7 +1386,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARBODOR_51:
         return evolution (this, from:"Trubbish", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1406,7 +1406,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOTHITA_52:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1418,7 +1418,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOTHORITA_53:
         return evolution (this, from:"Gothita", hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1438,7 +1438,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOTHITELLE_54:
         return evolution (this, from:"Gothorita", hp:HP140, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1462,7 +1462,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORICORIO_55:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1484,7 +1484,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORICORIO_56:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1513,7 +1513,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXAPEX_GX_57:
         return evolution (this, from:"Mareanie", hp:HP210, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1543,7 +1543,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MIMIKYU_58:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           initHook {Card thisCard->
@@ -1587,7 +1587,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DHELMISE_59:
         return basic (this, hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1614,7 +1614,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAPU_LELE_GX_60:
         return basic (this, hp:HP170, type:PSYCHIC, retreatCost:1) {
           bwAbility "Wonder Tag", {
@@ -1650,7 +1650,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUNALA_61:
         return evolution (this, from:"Cosmoem", hp:HP160, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1675,7 +1675,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP_62:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1687,7 +1687,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOP_63:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1699,7 +1699,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHOKE_64:
         return evolution (this, from:"Machop", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -1737,7 +1737,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MACHAMP_65:
         return evolution (this, from:"Machoke", hp:HP160, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -1758,7 +1758,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SUDOWOODO_66:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:2) {
           weakness WATER
@@ -1786,7 +1786,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLIGAR_67:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1798,7 +1798,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLISCOR_68:
         return evolution (this, from:"Gligar", hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1820,7 +1820,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NOSEPASS_69:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1840,7 +1840,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BARBOACH_70:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1859,7 +1859,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHISCASH_71:
         return evolution (this, from:"Barboach", hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1883,7 +1883,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANCHAM_72:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -1895,7 +1895,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROCKRUFF_73:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1914,7 +1914,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LYCANROC_GX_74:
         return evolution (this, from:"Rockruff", hp:HP200, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1947,7 +1947,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDBRAY_75:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1959,7 +1959,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUDSDALE_76:
         return evolution (this, from:"Mudbray", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -1980,7 +1980,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINIOR_77:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness LIGHTNING
@@ -2003,7 +2003,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_78:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2017,7 +2017,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_79:
         return evolution (this, from:"Murkrow", hp:HP110, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2038,7 +2038,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SABLEYE_80:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           move "Limitation", {
@@ -2056,7 +2056,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABSOL_81:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2091,7 +2091,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PANGORO_82:
         return evolution (this, from:"Pancham", hp:HP130, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2112,7 +2112,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELDUM_83:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2128,7 +2128,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METANG_84:
         return evolution (this, from:"Beldum", hp:HP090, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2151,7 +2151,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAGROSS_GX_85:
         return evolution (this, from:"Metang", hp:HP250, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2184,12 +2184,12 @@ public enum GuardiansRising implements LogicCardInfo {
             }
             onAttack {
               gxPerform()
-              my.deck.select(max: 5).moveTo(hidden:true, my.hand);
+              my.deck.select(max: 5).moveTo(hidden:true, my.hand)
               shuffleDeck()
             }
           }
 
-        };
+        }
       case PROBOPASS_86:
         return evolution (this, from:"Nosepass", hp:HP130, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -2212,7 +2212,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SOLGALEO_87:
         return evolution (this, from:"Cosmoem", hp:HP160, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2233,7 +2233,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_88:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2256,7 +2256,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE_89:
         return evolution (this, from:"Clefairy", hp:HP100, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2278,7 +2278,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COTTONEE_90:
         return basic (this, hp:HP050, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2291,7 +2291,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHIMSICOTT_91:
         return evolution (this, from:"Cottonee", hp:HP080, type:FAIRY, retreatCost:0) {
           weakness METAL
@@ -2332,7 +2332,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SYLVEON_GX_92:
         return evolution (this, from:"Eevee", hp:HP200, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2370,7 +2370,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COMFEY_93:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2413,7 +2413,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOOMY_94:
         return basic (this, hp:HP050, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2432,7 +2432,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLIGGOO_95:
         return evolution (this, from:"Goomy", hp:HP070, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2459,7 +2459,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOODRA_96:
         return evolution (this, from:"Sliggoo", hp:HP160, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2479,7 +2479,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAMPA_97:
         return basic (this, hp:HP120, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2501,7 +2501,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JANGMO_O_98:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2524,7 +2524,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAKAMO_O_99:
         return evolution (this, from:"Jangmo-o", hp:HP090, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2543,7 +2543,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOMMO_O_GX_100:
         return evolution (this, from:"Hakamo-o", hp:HP240, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2574,7 +2574,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANSEY_101:
         return basic (this, hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2596,7 +2596,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLISSEY_102:
         return evolution (this, from:"Chansey", hp:HP160, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -2618,7 +2618,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAILLOW_103:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2632,7 +2632,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SWELLOW_104:
         return evolution (this, from:"Taillow", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2655,7 +2655,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CASTFORM_105:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2679,7 +2679,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAYQUAZA_106:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2706,7 +2706,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PATRAT_107:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2728,7 +2728,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WATCHOG_108:
         return evolution (this, from:"Patrat", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2750,7 +2750,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLETCHLING_109:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2770,7 +2770,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLETCHINDER_110:
         return evolution (this, from:"Fletchling", hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2790,7 +2790,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TALONFLAME_111:
         return evolution (this, from:"Fletchinder", hp:HP130, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -2814,7 +2814,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUFFUL_112:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2833,7 +2833,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEWEAR_113:
         return evolution (this, from:"Stufful", hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2855,7 +2855,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOMALA_114:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2889,7 +2889,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAMPA_GX_115:
         return basic (this, hp:HP180, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2923,7 +2923,7 @@ public enum GuardiansRising implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AETHER_PARADISE_CONSERVATION_AREA_116:
         return stadium (this) {
           text "Basic [G] and Basic [L] Pokémon (both yours and your opponent's) take 30 less damage from the opponent's attacks (after applying Weakness and Resistance).\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2943,7 +2943,7 @@ public enum GuardiansRising implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case ALTAR_OF_THE_MOONE_117:
         return stadium (this) {
           text "The Retreat Cost of each Pokémon (both yours and your opponent's) that has any [P] or [D] Energy attached to it is [C][C] less.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2959,7 +2959,7 @@ public enum GuardiansRising implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case ALTAR_OF_THE_SUNNE_118:
         return stadium (this) {
           text "[R] Pokémon and [M] Pokémon (both yours and your opponent's) have no Weakness.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -2974,7 +2974,7 @@ public enum GuardiansRising implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case AQUA_PATCH_119:
         return itemCard (this) {
           text "Attach a [W] Energy card from your discard pile to 1 of your Benched [W] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2984,7 +2984,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByEnergyType(W) && my.bench.findAll {it.types.contains(W)}
           }
-        };
+        }
       case BROOKLET_HILL_120:
         return stadium (this) {
           text "Once during each player's turn, that player may search their deck for a Basic [W] Pokémon or Basic [F] Pokémon and, put it onto their Bench, and shuffle their deck.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -3006,7 +3006,7 @@ public enum GuardiansRising implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case CHOICE_BAND_121:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active Pokémon-GX or Active Pokémon-EX (before applying Weakness and Resistance).\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3026,7 +3026,7 @@ public enum GuardiansRising implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case ENERGY_LOTO_122:
         return itemCard (this) {
           text "Look at the top 7 cards of your deck. You may reveal an Energy card you find there and put it into your hand. Shuffle the other cards back into your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3037,7 +3037,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case ENERGY_RECYCLER_123:
         return itemCard (this) {
           text "Shuffle 5 basic Energy cards from your discard pile into your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3048,9 +3048,9 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC_ENERGY)
           }
-        };
+        }
       case ENHANCED_HAMMER_124:
-        return copy(PhantomForces.ENHANCED_HAMMER_94, this);
+        return copy(PhantomForces.ENHANCED_HAMMER_94, this)
       case FIELD_BLOWER_125:
         return itemCard (this) {
           text "Choose up to 2 in any combination of Pokémon Tool cards and Stadium cards in play (yours or your opponent's) and discard them.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3077,7 +3077,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert all.findAll {it.cards.hasType(POKEMON_TOOL)} || (bg.stadiumInfoStruct)
           }
-        };
+        }
       case HALA_126:
         return supporter (this) {
           text "Shuffle your hand into your deck. If you have used your GX attack, draw 7 cards. If not, draw 4 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3088,7 +3088,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert (my.hand.getExcludedList(thisCard) || my.deck) : "You have no more cards in neither your deck nor your hand"
           }
-        };
+        }
       case MALLOW_127:
         return supporter (this) {
           text "Search your deck for 2 cards, shuffle your deck, and put those cards on top of your deck in any order.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3102,9 +3102,9 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case MAX_POTION_128:
-        return copy(EmergingPowers.MAX_POTION_94, this);
+        return copy(EmergingPowers.MAX_POTION_94, this)
       case MULTI_SWITCH_129:
         return itemCard (this) {
           text "Move an Energy from 1 of your Benched Pokémon to your Active Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3114,7 +3114,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.bench.find {it.cards.filterByType(ENERGY)}
           }
-        };
+        }
       case RESCUE_STRETCHER_130:
         return itemCard (this) {
           text "Choose 1:\n" +
@@ -3133,7 +3133,7 @@ public enum GuardiansRising implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(POKEMON)
           }
-        };
+        }
       case TURTONATOR_GX_131:
         return copy (TURTONATOR_GX_18, this)
       case ALOLAN_NINETALES_GX_132:
@@ -3207,13 +3207,13 @@ public enum GuardiansRising implements LogicCardInfo {
       case DOUBLE_COLORLESS_ENERGY_166:
         return copy(Xy.DOUBLE_COLORLESS_ENERGY_130, this)
       case GRASS_ENERGY_167:
-        return basicEnergy (this, G);
+        return basicEnergy (this, G)
       case LIGHTNING_ENERGY_168:
-        return basicEnergy (this, L);
+        return basicEnergy (this, L)
       case FIGHTING_ENERGY_169:
-        return basicEnergy (this, F);
+        return basicEnergy (this, F)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
+++ b/src/tcgwars/logic/impl/gen7/HiddenFates.groovy
@@ -4,20 +4,20 @@ import tcgwars.logic.card.pokemon.PokemonCard
 import tcgwars.logic.effect.basic.Knockout
 import tcgwars.logic.impl.gen6.*
 
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.card.HP.*;
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.card.HP.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author luongthomasdev@gmail.com
@@ -95,53 +95,53 @@ public enum HiddenFates implements LogicCardInfo {
   JESSIE_JAMES_68 ("Jessie & James", "68", Rarity.ULTRARARE, [TRAINER, SUPPORTER]),
   MOLTRES_ZAPDOS_ARTICUNO_GX_69 ("Moltres & Zapdos & Articuno-GX", "69", Rarity.SECRET, [POKEMON, BASIC, POKEMON_GX, TAG_TEAM, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   HiddenFates(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.HIDDEN_FATES;
+    return tcgwars.logic.card.Collection.HIDDEN_FATES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -158,7 +158,7 @@ public enum HiddenFates implements LogicCardInfo {
           }
         }
 
-      };
+      }
       case METAPOD_2:
       return evolution (this, from:"Caterpie", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -169,7 +169,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BUTTERFREE_3:
       return evolution (this, from:"Metapod", hp:HP130, type:G, retreatCost:1) {
         weakness R
@@ -180,7 +180,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case PARAS_4:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -198,7 +198,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SCYTHER_5:
       return basic (this, hp:HP100, type:G, retreatCost:1) {
         weakness R
@@ -216,7 +216,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PINSIR_GX_6:
       return basic (this, hp:HP180, type:G, retreatCost:2) {
         weakness R
@@ -238,7 +238,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 160
           }
         }
-      };
+      }
       case CHARMANDER_7:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -256,7 +256,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARMELEON_8:
       return evolution (this, from:"Charmander", hp:HP100, type:R, retreatCost:1) {
         weakness W
@@ -274,7 +274,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case CHARIZARD_GX_9:
       return evolution (this, from:"Charmeleon", hp:HP250, type:R, retreatCost:3) {
         weakness W
@@ -296,7 +296,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 300
           }
         }
-      };
+      }
       case MAGMAR_10:
       return basic (this, hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -307,7 +307,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PSYDUCK_11:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness G
@@ -318,7 +318,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLOWPOKE_12:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness G
@@ -329,7 +329,7 @@ public enum HiddenFates implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case STARYU_13:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -341,7 +341,7 @@ public enum HiddenFates implements LogicCardInfo {
             flip{ applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case STARMIE_GX_14:
       return evolution (this, from:"Staryu", hp:HP190, type:W, retreatCost:0) {
         weakness G
@@ -373,7 +373,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 40+40*self.cards.energyCount(W)
           }
         }
-      };
+      }
       case MAGIKARP_15:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -384,7 +384,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GYARADOS_GX_16:
       return evolution (this, from:"Magikarp", hp:HP230, type:W, retreatCost:3) {
         weakness L
@@ -406,7 +406,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 240
           }
         }
-      };
+      }
       case LAPRAS_17:
       return basic (this, hp:HP120, type:W, retreatCost:2) {
         weakness G
@@ -417,7 +417,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case VAPOREON_18:
       return evolution (this, from:"Eevee", hp:HP120, type:W, retreatCost:3) {
         weakness G
@@ -436,7 +436,7 @@ public enum HiddenFates implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case PIKACHU_19:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -455,7 +455,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case RAICHU_GX_20:
       return evolution (this, from:"Pikachu", hp:HP210, type:L, retreatCost:1) {
         weakness F
@@ -478,7 +478,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 200
           }
         }
-      };
+      }
       case VOLTORB_21:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -490,7 +490,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELECTRODE_22:
       return evolution (this, from:"Voltorb", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -510,7 +510,7 @@ public enum HiddenFates implements LogicCardInfo {
             flip 2, {damage 30}
           }
         }
-      };
+      }
       case JOLTEON_23:
       return evolution (this, from:"Eevee", hp:HP090, type:L, retreatCost:0) {
         weakness F
@@ -536,7 +536,7 @@ public enum HiddenFates implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZAPDOS_24:
       return basic (this, hp:HP120, type:L, retreatCost:2) {
         weakness L
@@ -565,7 +565,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case EKANS_25:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -577,7 +577,7 @@ public enum HiddenFates implements LogicCardInfo {
             flip { discardDefendingEnergy() }
           }
         }
-      };
+      }
       case EKANS_26:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -588,7 +588,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARBOK_27:
       return evolution (this, from:"Ekans", hp:HP120, type:P, retreatCost:2) {
         weakness P
@@ -616,7 +616,7 @@ public enum HiddenFates implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case KOFFING_28:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -627,7 +627,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WEEZING_29:
       return evolution (this, from:"Koffing", hp:HP120, type:P, retreatCost:3) {
         weakness P
@@ -642,7 +642,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case JYNX_30:
       return basic (this, hp:HP100, type:P, retreatCost:1) {
         weakness P
@@ -660,7 +660,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MEWTWO_GX_31:
       return basic (this, hp:HP180, type:P, retreatCost:2) {
         weakness P
@@ -685,7 +685,7 @@ public enum HiddenFates implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEW_32:
       return basic (this, hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -696,7 +696,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GEODUDE_33:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -707,7 +707,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRAVELER_34:
       return evolution (this, from:"Geodude", hp:HP100, type:F, retreatCost:3) {
         weakness G
@@ -726,7 +726,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 80, opp.all.select()
           }
         }
-      };
+      }
       case GOLEM_35:
       return evolution (this, from:"Graveler", hp:HP170, type:F, retreatCost:4) {
         weakness G
@@ -749,7 +749,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case ONIX_GX_36:
       return basic (this, hp:HP200, type:F, retreatCost:4) {
         weakness G
@@ -780,7 +780,7 @@ public enum HiddenFates implements LogicCardInfo {
             reduceDamageNextTurn(hp(100), thisMove)
           }
         }
-      };
+      }
       case CUBONE_37:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -791,7 +791,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20, opp.all.select()
           }
         }
-      };
+      }
       case CLEFAIRY_38:
       return basic (this, hp:HP060, type:Y, retreatCost:1) {
         weakness M
@@ -813,7 +813,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CLEFAIRY_39:
       return basic (this, hp:HP060, type:Y, retreatCost:1) {
         weakness M
@@ -832,7 +832,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CLEFABLE_40:
       return evolution (this, from:"Clefairy", hp:HP120, type:Y, retreatCost:2) {
         weakness M
@@ -851,7 +851,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case JIGGLYPUFF_41:
       return basic (this, hp:HP070, type:Y, retreatCost:1) {
         weakness M
@@ -870,7 +870,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WIGGLYTUFF_GX_42:
       return evolution (this, from:"Jigglypuff", hp:HP210, type:Y, retreatCost:2) {
         weakness M
@@ -895,7 +895,7 @@ public enum HiddenFates implements LogicCardInfo {
             healAll self
           }
         }
-      };
+      }
       case MR_MIME_43:
       return basic (this, hp:HP090, type:Y, retreatCost:1) {
         weakness M
@@ -918,7 +918,7 @@ public enum HiddenFates implements LogicCardInfo {
             flip 2, { damage 40 }
           }
         }
-      };
+      }
       case MOLTRES_ZAPDOS_ARTICUNO_GX_44:
       return basic (this, hp:HP300, type:C, retreatCost:3) {
         weakness L
@@ -951,7 +951,7 @@ public enum HiddenFates implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FARFETCH_D_45:
       return basic (this, hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -963,7 +963,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHANSEY_46:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -975,7 +975,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case KANGASKHAN_47:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -986,7 +986,7 @@ public enum HiddenFates implements LogicCardInfo {
             flipUntilTails { damage 40 }
           }
         }
-      };
+      }
       case EEVEE_48:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1008,7 +1008,7 @@ public enum HiddenFates implements LogicCardInfo {
             flipTails {damage 10, self}
           }
         }
-      };
+      }
       case EEVEE_49:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1019,7 +1019,7 @@ public enum HiddenFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNORLAX_50:
       return basic (this, hp:HP150, type:C, retreatCost:3) {
         weakness F
@@ -1030,13 +1030,13 @@ public enum HiddenFates implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case BILL_S_ANALYSIS_51:
-      return copy (TeamUp.BILLS_ANALYSIS_133, this);
+      return copy (TeamUp.BILLS_ANALYSIS_133, this)
       case BLAINE_S_LAST_STAND_52:
-      return copy (DragonMajesty.BLAINE_S_LAST_STAND_58, this);
+      return copy (DragonMajesty.BLAINE_S_LAST_STAND_58, this)
       case BROCK_S_GRIT_53:
-      return copy (TeamUp.BROCKS_GRIT_135, this);
+      return copy (TeamUp.BROCKS_GRIT_135, this)
       case BROCK_S_PEWTER_CITY_GYM_54:
       return stadium (this) {
         text "Onix-GX (both yours and your opponent's) take 40 less damage from the opponent's attacks (after applying Weakness and Resistance)."
@@ -1056,7 +1056,7 @@ public enum HiddenFates implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case BROCK_S_TRAINING_55:
       return supporter (this) {
         text "Attach an Energy card from your hand to 1 of your Geodude, Graveler, Golem, Onix-GX, Cubone, Rhyhorn, Rhydon, or Sudowoodo."
@@ -1068,11 +1068,11 @@ public enum HiddenFates implements LogicCardInfo {
           assert my.all.findAll{['Geodude', 'Graveler', 'Golem', 'Onix-GX', 'Cubone', 'Rhyhorn', 'Rhydon', 'Sudowoodo'].contains(it.topPokemonCard.name)} : "No valid targets"
           assert my.hand.filterByType(ENERGY) : "No energy in hand"
         }
-      };
+      }
       case ERIKA_S_HOSPITALITY_56:
-      return copy (TeamUp.ERIKAS_HOSPITALITY_140, this);
+      return copy (TeamUp.ERIKAS_HOSPITALITY_140, this)
       case GIOVANNI_S_EXILE_57:
-      return copy(UnbrokenBonds.GIOVANNI_S_EXILE_174, this);
+      return copy(UnbrokenBonds.GIOVANNI_S_EXILE_174, this)
       case JESSIE_JAMES_58:
       return supporter (this) {
         text "Each player discards 2 cards from their hand. Your opponent discards first."
@@ -1095,11 +1095,11 @@ public enum HiddenFates implements LogicCardInfo {
         playRequirement{
           assert opp.hand || my.hand.getExcludedList(thisCard) : "No cards to discard"
         }
-      };
+      }
       case KOGA_S_TRAP_59:
-      return copy(UnbrokenBonds.KOGA_S_TRAP_177, this);
+      return copy(UnbrokenBonds.KOGA_S_TRAP_177, this)
       case LT_SURGE_S_STRATEGY_60:
-      return copy(UnbrokenBonds.LT_SURGE_S_STRATEGY_178, this);
+      return copy(UnbrokenBonds.LT_SURGE_S_STRATEGY_178, this)
       case MISTY_S_CERULEAN_CITY_GYM_61:
       return stadium (this) {
         text "The attacks of Starmie-GX (both yours and your opponent's) do 40 more damage to the opponent's Active Pokémon (before applying Weakness and Resistance)."
@@ -1119,9 +1119,9 @@ public enum HiddenFates implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case MISTY_S_DETERMINATION_62:
-      return copy(Breakpoint.MISTY_S_DETERMINATION_104, this);
+      return copy(Breakpoint.MISTY_S_DETERMINATION_104, this)
       case MISTY_S_WATER_COMMAND_63:
       return supporter (this) {
         text "Move any number of [W] Energy from your Pokémon to your Psyduck, Horsea, Staryu, Starmie-GX, Magikarp, Gyarados, or Lapras in any way you like."
@@ -1129,13 +1129,13 @@ public enum HiddenFates implements LogicCardInfo {
         onPlay {
           while(1){
             def pl=(my.all.findAll {it.cards.energyCount(W)})
-            if(!pl) break;
+            if(!pl) break
             def src =pl.select("Source for energy (cancel to stop)", false)
-            if(!src) break;
+            if(!src) break
             def card=src.cards.filterByEnergyType(W).select("Energy to move").first()
 
             def tar=my.all.findAll{ eligible.contains(it.name) }.select("Target for energy (cancel to stop)", false)
-            if(!tar) break;
+            if(!tar) break
             energySwitch(src, tar, card)
           }
         }
@@ -1143,21 +1143,21 @@ public enum HiddenFates implements LogicCardInfo {
           assert my.all.findAll{ eligible.contains(it.name) } : "No valid targets"
           assert my.all.findAll {it.cards.energyCount(W)} : "No Water energy in play"
         }
-      };
+      }
       case POKEMON_CENTER_LADY_64:
-      return copy(Flashfire.POKEMON_CENTER_LADY_93, this);
+      return copy(Flashfire.POKEMON_CENTER_LADY_93, this)
       case SABRINA_S_SUGGESTION_65:
-      return copy(TeamUp.SABRINAS_SUGGESTION_154, this);
+      return copy(TeamUp.SABRINAS_SUGGESTION_154, this)
       case MOLTRES_ZAPDOS_ARTICUNO_GX_66:
-      return copy (MOLTRES_ZAPDOS_ARTICUNO_GX_44, this);
+      return copy (MOLTRES_ZAPDOS_ARTICUNO_GX_44, this)
       case GIOVANNI_S_EXILE_67:
-      return copy (GIOVANNI_S_EXILE_57, this);
+      return copy (GIOVANNI_S_EXILE_57, this)
       case JESSIE_JAMES_68:
-      return copy (JESSIE_JAMES_58, this);
+      return copy (JESSIE_JAMES_58, this)
       case MOLTRES_ZAPDOS_ARTICUNO_GX_69:
-      return copy (MOLTRES_ZAPDOS_ARTICUNO_GX_44, this);
+      return copy (MOLTRES_ZAPDOS_ARTICUNO_GX_44, this)
         default:
-      return null;
+      return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/LostThunder.groovy
+++ b/src/tcgwars/logic/impl/gen7/LostThunder.groovy
@@ -5,25 +5,25 @@ import tcgwars.logic.effect.gm.PlayCard
 import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.groovy.TcgStatics
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -267,53 +267,53 @@ public enum LostThunder implements LogicCardInfo {
   LOST_BLENDER_233("Lost Blender", "233", Rarity.SECRET, [TRAINER,ITEM]),
   NET_BALL_234("Net Ball", "234", Rarity.SECRET, [TRAINER,ITEM]),
   SPELL_TAG_235("Spell Tag", "235", Rarity.SECRET, [TRAINER,ITEM,POKEMON_TOOL]);
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   LostThunder(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.LOST_THUNDER;
+    return tcgwars.logic.card.Collection.LOST_THUNDER
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -337,7 +337,7 @@ public enum LostThunder implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case TANGROWTH_2:
         return 	evolution (this, from:"Tangela", hp:HP140, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -356,7 +356,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case SCYTHER_3:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -368,7 +368,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 3,{},{},[1:{damage 20},2:{damage 50},3:{damage 70}]
             }
           }
-        };
+        }
       case PINSIR_4:
         return basic (this, hp:HP110, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -387,7 +387,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case CHIKORITA_5:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -409,7 +409,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case CHIKORITA_6:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -421,7 +421,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case BAYLEEF_7:
         return 	evolution (this, from:"Chikorita", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -440,7 +440,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case MEGANIUM_8:
         return 	evolution (this, from:"Bayleef", hp:HP150, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -468,7 +468,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case SPINARAK_9:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -489,7 +489,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case ARIADOS_10:
         return 	evolution (this, from:"Spinarak", hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -523,7 +523,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case HOPPIP_11:
         return basic (this, hp:HP030, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -533,7 +533,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost C
             callForFamily(name:"Hoppip",1,delegate)
           }
-        };
+        }
       case HOPPIP_12:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -545,7 +545,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SKIPLOOM_13:
         return 	evolution (this, from:"Hoppip", hp:HP060, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -575,7 +575,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case JUMPLUFF_14:
         return 	evolution (this, from:"Skiploom", hp:HP070, type:GRASS, retreatCost:0) {
           weakness LIGHTNING
@@ -587,7 +587,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20*my.lostZone.findAll{it.cardTypes.is(POKEMON) && !it.cardTypes.is(PRISM_STAR)}.size()
             }
           }
-        };
+        }
       case PINECO_15:
         return basic (this, hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -598,7 +598,7 @@ public enum LostThunder implements LogicCardInfo {
               flipUntilTails{damage 20}
             }
           }
-        };
+        }
       case SHUCKLE_16:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -622,7 +622,7 @@ public enum LostThunder implements LogicCardInfo {
               attachEnergyFrom(basic:true,my.discard, my.all)
             }
           }
-        };
+        }
       case SHUCKLE_GX_17:
         return basic (this, hp:HP170, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -661,7 +661,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage PARALYZED
             }
           }
-        };
+        }
       case HERACROSS_18:
         return basic (this, hp:HP120, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -680,7 +680,7 @@ public enum LostThunder implements LogicCardInfo {
               if(my.bench.find{it.stage2}) damage 90
             }
           }
-        };
+        }
       case CELEBI_PRISM_STAR_19:
         return basic (this, hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -693,9 +693,9 @@ public enum LostThunder implements LogicCardInfo {
             onAttack{
               while(1){
                 def list = my.bench.findAll {it.evolution}
-                if(!list) break;
+                if(!list) break
                 def pcs = list.select("Devolve (or cancel)", false)
-                if(!pcs) break;
+                if(!pcs) break
                 devolve(pcs, my.hand)
               }
             }
@@ -708,7 +708,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 20, self
             }
           }
-        };
+        }
       case TREECKO_20:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -723,7 +723,7 @@ public enum LostThunder implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case GROVYLE_21:
         return 	evolution (this, from:"Treecko", hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -744,7 +744,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case SCEPTILE_GX_22:
         return 	evolution (this, from:"Grovyle", hp:HP230, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -785,7 +785,7 @@ public enum LostThunder implements LogicCardInfo {
 
             }
           }
-        };
+        }
       case WURMPLE_23:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -796,7 +796,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case WURMPLE_24:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -807,7 +807,7 @@ public enum LostThunder implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case SILCOON_25:
         return 	evolution (this, from:"Wurmple", hp:HP080, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -833,7 +833,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BEAUTIFLY_26:
         return 	evolution (this, from:"Silcoon", hp:HP130, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -858,7 +858,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASCOON_27:
         return 	evolution (this, from:"Wurmple", hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -884,7 +884,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case DUSTOX_28:
         return 	evolution (this, from:"Cascoon", hp:HP140, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -908,7 +908,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case NINCADA_29:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -919,7 +919,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 3, {damage 10}
             }
           }
-        };
+        }
       case NINJASK_30:
         return 	evolution (this, from:"Nincada", hp:HP080, type:GRASS, retreatCost:0) {
           bwAbility "Molting" , {
@@ -942,7 +942,7 @@ public enum LostThunder implements LogicCardInfo {
               flip {damage 40}
             }
           }
-        };
+        }
       case COMBEE_31:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -951,7 +951,7 @@ public enum LostThunder implements LogicCardInfo {
             energyCost G
             callForFamily(name:"Combee",3,delegate)
           }
-        };
+        }
       case VESPIQUEN_32:
         return 	evolution (this, from:"Combee", hp:HP120, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -965,7 +965,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case SHAYMIN_33:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -985,7 +985,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case VIRIZION_GX_34:
         return basic (this, hp:HP170, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1022,7 +1022,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SKIDDO_35:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1040,7 +1040,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GOGOAT_36:
         return 	evolution (this, from:"Skiddo", hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1059,7 +1059,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case TAPU_BULU_37:
         return basic (this, hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1078,7 +1078,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 1,{},{damage 30,self}
             }
           }
-        };
+        }
       case MOLTRES_38:
         return basic (this, hp:HP120, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1099,7 +1099,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case CYNDAQUIL_39:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1111,7 +1111,7 @@ public enum LostThunder implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case CYNDAQUIL_40:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1122,7 +1122,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case QUILAVA_41:
         return 	evolution (this, from:"Cyndaquil", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1141,7 +1141,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage BURNED
             }
           }
-        };
+        }
       case TYPHLOSION_42:
         return 	evolution (this, from:"Quilava", hp:HP160, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1178,7 +1178,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SLUGMA_43:
         return basic (this, hp:HP080, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -1199,7 +1199,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGCARGO_GX_44:
         return 	evolution (this, from:"Slugma", hp:HP210, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -1240,7 +1240,7 @@ public enum LostThunder implements LogicCardInfo {
               opp.deck.subList(0,5).discard()
             }
           }
-        };
+        }
       case HOUNDOUR_45:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1262,7 +1262,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case HOUNDOOM_46:
         return 	evolution (this, from:"Houndour", hp:HP110, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1285,7 +1285,7 @@ public enum LostThunder implements LogicCardInfo {
               if(my.hand.size() > opp.hand.size()) damage 80
             }
           }
-        };
+        }
       case ENTEI_47:
         return basic (this, hp:HP130, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1312,7 +1312,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HEATRAN_48:
         return basic (this, hp:HP140, type:FIRE, retreatCost:4) {
           weakness WATER
@@ -1334,7 +1334,7 @@ public enum LostThunder implements LogicCardInfo {
               my.deck.subList(0,5).discard()
             }
           }
-        };
+        }
       case VICTINI_49:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -1347,7 +1347,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LITLEO_50:
         return basic (this, hp:HP060, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1367,7 +1367,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case PYROAR_51:
         return 	evolution (this, from:"Litleo", hp:HP130, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1386,7 +1386,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case BLACEPHALON_GX_52:
         return basic (this, hp:HP180, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -1432,7 +1432,7 @@ public enum LostThunder implements LogicCardInfo {
               TakePrize.checkPrizes(bg)
             }
           }
-        };
+        }
       case ALOLAN_VULPIX_53:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness METAL
@@ -1451,7 +1451,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SLOWPOKE_54:
         return basic (this, hp:HP070, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1462,7 +1462,7 @@ public enum LostThunder implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case SLOWKING_55:
         return 	evolution (this, from:"Slowpoke", hp:HP120, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1483,7 +1483,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case LAPRAS_56:
         return basic (this, hp:HP120, type:WATER, retreatCost:2) {
           weakness METAL
@@ -1505,7 +1505,7 @@ public enum LostThunder implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case DELIBIRD_57:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness METAL
@@ -1533,7 +1533,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MANTINE_58:
         return basic (this, hp:HP120, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -1553,7 +1553,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case SUICUNE_59:
         return basic (this, hp:HP110, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1575,7 +1575,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case SUICUNE_GX_60:
         return basic (this, hp:HP180, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1610,7 +1610,7 @@ public enum LostThunder implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case CUBCHOO_61:
         return basic (this, hp:HP070, type:WATER, retreatCost:2) {
           weakness METAL
@@ -1631,7 +1631,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BEARTIC_62:
         return 	evolution (this, from:"Cubchoo", hp:HP140, type:WATER, retreatCost:3) {
           weakness METAL
@@ -1651,7 +1651,7 @@ public enum LostThunder implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case WHITE_KYUREM_63:
         return basic (this, hp:HP130, type:WATER, retreatCost:3) {
           weakness METAL
@@ -1675,7 +1675,7 @@ public enum LostThunder implements LogicCardInfo {
               if(self.cards.energyCount(R)) damage 80
             }
           }
-        };
+        }
       case POPPLIO_64:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1687,7 +1687,7 @@ public enum LostThunder implements LogicCardInfo {
               flipThenApplySC CONFUSED
             }
           }
-        };
+        }
       case POPPLIO_65:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1699,7 +1699,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case BRIONNE_66:
         return 	evolution (this, from:"Popplio", hp:HP090, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1720,7 +1720,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PRIMARINA_67:
         return 	evolution (this, from:"Brionne", hp:HP150, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1754,7 +1754,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case MAREANIE_68:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1765,7 +1765,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 2,{damage 30}
             }
           }
-        };
+        }
       case TOXAPEX_69:
         return 	evolution (this, from:"Mareanie", hp:HP120, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -1783,7 +1783,7 @@ public enum LostThunder implements LogicCardInfo {
               if(defending.isSPC(POISONED)) damage 50*defending.numberOfDamageCounters
             }
           }
-        };
+        }
       case BRUXISH_70:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1805,7 +1805,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60, opp.bench.findAll{it.numberOfDamageCounters}.select()
             }
           }
-        };
+        }
       case ELECTABUZZ_71:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1818,7 +1818,7 @@ public enum LostThunder implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case ELECTIVIRE_72:
         return 	evolution (this, from:"Electabuzz", hp:HP140, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1841,7 +1841,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHINCHOU_73:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1860,7 +1860,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LANTURN_74:
         return 	evolution (this, from:"Chinchou", hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1883,7 +1883,7 @@ public enum LostThunder implements LogicCardInfo {
               apply CONFUSED
             }
           }
-        };
+        }
       case MAREEP_75:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1904,7 +1904,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MAREEP_76:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1917,7 +1917,7 @@ public enum LostThunder implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case FLAAFFY_77:
         return 	evolution (this, from:"Mareep", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1930,7 +1930,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case AMPHAROS_78:
         return 	evolution (this, from:"Flaaffy", hp:HP150, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1952,7 +1952,7 @@ public enum LostThunder implements LogicCardInfo {
               multiDamage(opp.all,2,50)
             }
           }
-        };
+        }
       case RAIKOU_79:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1965,7 +1965,7 @@ public enum LostThunder implements LogicCardInfo {
               if(my.lostZone.filterByBasicEnergyType(L)) damage 90
             }
           }
-        };
+        }
       case PACHIRISU_80:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1987,7 +1987,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLITZLE_81:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2006,7 +2006,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ZEBSTRIKA_82:
         return 	evolution (this, from:"Blitzle", hp:HP110, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2027,7 +2027,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case STUNFISK_83:
         return basic (this, hp:HP110, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -2049,7 +2049,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DEDENNE_84:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2072,7 +2072,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10*my.all.findAll{it.topPokemonCard.moves.findAll{it.name=="Nuzzle"}}.size(), opp.bench.select()
             }
           }
-        };
+        }
       case TAPU_KOKO_85:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2093,7 +2093,7 @@ public enum LostThunder implements LogicCardInfo {
               cantUseAttack thisMove,self
             }
           }
-        };
+        }
       case ZERAORA_GX_86:
         return basic (this, hp:HP190, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -2130,7 +2130,7 @@ public enum LostThunder implements LogicCardInfo {
 
             }
           }
-        };
+        }
       case NATU_87:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2141,7 +2141,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20*my.lostZone.findAll{it.cardTypes.is(POKEMON) && !it.cardTypes.is(PRISM_STAR)}.size()
             }
           }
-        };
+        }
       case XATU_88:
         return 	evolution (this, from:"Natu", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2161,7 +2161,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case ESPEON_89:
         return 	evolution (this, from:"Eevee", hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2185,7 +2185,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UNOWN_90:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2200,7 +2200,7 @@ public enum LostThunder implements LogicCardInfo {
               assert count >= 66 : "You need ${66 - count} more damage counters on your Benched Pokémon."
               assert self.active : "Counters OK but $self must be active"
               powerUsed()
-              bg.getGameManager().endGame(self.owner, WinCondition.OTHER);
+              bg.getGameManager().endGame(self.owner, WinCondition.OTHER)
             }
           }
           move "Hidden Power" , {
@@ -2210,7 +2210,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case UNOWN_91:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2221,7 +2221,7 @@ public enum LostThunder implements LogicCardInfo {
               assert my.hand.size() >= 35 : "You need ${35 - my.hand.size()} more cards in your hand."
               assert self.active : "Cards OK but $self must be active"
               powerUsed()
-              bg.getGameManager().endGame(self.owner, WinCondition.OTHER);
+              bg.getGameManager().endGame(self.owner, WinCondition.OTHER)
             }
           }
           move "Hidden Power" , {
@@ -2231,7 +2231,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case UNOWN_92:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2242,7 +2242,7 @@ public enum LostThunder implements LogicCardInfo {
               assert opp.lostZone.filterByType(SUPPORTER).size() >= 12 : "Your opponent needs to have ${12 - opp.lostZone.filterByType(SUPPORTER).size()} more supporters in their Lost Zone."
               assert self.active : "Cards OK but $self must be be active"
               powerUsed()
-              bg.getGameManager().endGame(self.owner, WinCondition.OTHER);
+              bg.getGameManager().endGame(self.owner, WinCondition.OTHER)
             }
           }
           move "Hidden Power" , {
@@ -2252,7 +2252,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case WOBBUFFET_93:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -2291,7 +2291,7 @@ public enum LostThunder implements LogicCardInfo {
               flip{damage 30}
             }
           }
-        };
+        }
       case GIRAFARIG_94:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2312,7 +2312,7 @@ public enum LostThunder implements LogicCardInfo {
               noWrDamage 70, defending
             }
           }
-        };
+        }
       case SHEDINJA_95:
         return 	evolution (this, from:"Nincada", hp:HP040, type:PSYCHIC, retreatCost:1) {
           bwAbility "Vessel of Life" , {
@@ -2358,7 +2358,7 @@ public enum LostThunder implements LogicCardInfo {
               directDamage 30, defending
             }
           }
-        };
+        }
       case SABLEYE_96:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           move "Quick Hunt" , {
@@ -2376,7 +2376,7 @@ public enum LostThunder implements LogicCardInfo {
               putDamageCountersOnOpponentsPokemon(3)
             }
           }
-        };
+        }
       case GIRATINA_97:
         return basic (this, hp:HP130, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -2412,7 +2412,7 @@ public enum LostThunder implements LogicCardInfo {
               directDamage 40, my.all.select()
             }
           }
-        };
+        }
       case SIGILYPH_GX_98:
         return basic (this, hp:HP170, type:PSYCHIC, retreatCost:2) {
           weakness LIGHTNING
@@ -2460,7 +2460,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case YAMASK_99:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -2472,7 +2472,7 @@ public enum LostThunder implements LogicCardInfo {
               directDamage 10, defending
             }
           }
-        };
+        }
       case COFAGRIGUS_100:
         return 	evolution (this, from:"Yamask", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -2491,7 +2491,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LITWICK_101:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -2503,7 +2503,7 @@ public enum LostThunder implements LogicCardInfo {
               directDamage 10, defending
             }
           }
-        };
+        }
       case LAMPENT_102:
         return 	evolution (this, from:"Litwick", hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -2515,7 +2515,7 @@ public enum LostThunder implements LogicCardInfo {
               directDamage 30, defending
             }
           }
-        };
+        }
       case CHANDELURE_103:
         return 	evolution (this, from:"Lampent", hp:HP140, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -2536,7 +2536,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MELOETTA_104:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2562,7 +2562,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAREANIE_105:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2580,7 +2580,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 4,{damage 10}
             }
           }
-        };
+        }
       case NIHILEGO_106:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2595,7 +2595,7 @@ public enum LostThunder implements LogicCardInfo {
               def moveList = []
               def labelList = []
               opp.all.each {pcs->
-                moveList.addAll(pcs.topPokemonCard.moves);
+                moveList.addAll(pcs.topPokemonCard.moves)
                 labelList.addAll(pcs.topPokemonCard.moves.collect{pcs.name+"-"+it.name})
               }
               def move=choose(moveList, labelList)
@@ -2612,7 +2612,7 @@ public enum LostThunder implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case POIPOLE_107:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2630,7 +2630,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case NAGANADEL_108:
         return 	evolution (this, from:"Poipole", hp:HP130, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -2651,7 +2651,7 @@ public enum LostThunder implements LogicCardInfo {
               if(my.prizeCardSet.size() == 3) damage 80
             }
           }
-        };
+        }
       case ONIX_109:
         return basic (this, hp:HP120, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -2662,7 +2662,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case SUDOWOODO_110:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:2) {
           weakness WATER
@@ -2686,7 +2686,7 @@ public enum LostThunder implements LogicCardInfo {
               if(turnCount+1==bg.turnCount && lastDamage > hp(0)) damage 80
             }
           }
-        };
+        }
 
       case PHANPY_111:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:2) {
@@ -2698,7 +2698,7 @@ public enum LostThunder implements LogicCardInfo {
               flip {damage 50}
             }
           }
-        };
+        }
 
       case DONPHAN_112:
         return 	evolution (this, from:"Phanpy", hp:HP130, type:FIGHTING, retreatCost:3) {
@@ -2729,7 +2729,7 @@ public enum LostThunder implements LogicCardInfo {
               increasedBaseDamageNextTurn("Rolling Spin",hp(70))
             }
           }
-        };
+        }
       case HITMONTOP_113:
         return basic (this, hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -2755,7 +2755,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 3,{damage 40}
             }
           }
-        };
+        }
       case LARVITAR_114:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2779,7 +2779,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LARVITAR_115:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2791,7 +2791,7 @@ public enum LostThunder implements LogicCardInfo {
               if(defending.numberOfDamageCounters >= 3) damage 70
             }
           }
-        };
+        }
       case PUPITAR_116:
         return 	evolution (this, from:"Larvitar", hp:HP070, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -2821,7 +2821,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case CARBINK_117:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2846,7 +2846,7 @@ public enum LostThunder implements LogicCardInfo {
               reduceDamageNextTurn(hp(20),thisMove)
             }
           }
-        };
+        }
       case ALOLAN_MEOWTH_118:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2858,7 +2858,7 @@ public enum LostThunder implements LogicCardInfo {
               if(bg.turnCount == 2) damage 60
             }
           }
-        };
+        }
       case ALOLAN_PERSIAN_119:
         return 	evolution (this, from:"Alolan Meowth", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2869,7 +2869,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 90-30*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case UMBREON_120:
         return 	evolution (this, from:"Eevee", hp:HP110, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2889,7 +2889,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case TYRANITAR_GX_121:
         return 	evolution (this, from:"Pupitar", hp:HP250, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2943,7 +2943,7 @@ public enum LostThunder implements LogicCardInfo {
               shredDamage 220
             }
           }
-        };
+        }
       case ALOLAN_DIGLETT_122:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2952,7 +2952,7 @@ public enum LostThunder implements LogicCardInfo {
             text "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."
             callForFamily(basic:true,1,delegate)
           }
-        };
+        }
       case ALOLAN_DUGTRIO_123:
         return 	evolution (this, from:"Alolan Diglett", hp:HP090, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2963,7 +2963,7 @@ public enum LostThunder implements LogicCardInfo {
               noWrDamage 60, defending
             }
           }
-        };
+        }
       case FORRETRESS_124:
         return 	evolution (this, from:"Pineco", hp:HP110, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2990,7 +2990,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STEELIX_125:
         return 	evolution (this, from:"Onix", hp:HP180, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -3010,7 +3010,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 50, self
             }
           }
-        };
+        }
       case SCIZOR_126:
         return 	evolution (this, from:"Scyther", hp:HP120, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -3036,7 +3036,7 @@ public enum LostThunder implements LogicCardInfo {
               if(defending.cards.filterByType(SPECIAL_ENERGY)) damage 70
             }
           }
-        };
+        }
       case DIALGA_127:
         return basic (this, hp:HP130, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -3063,7 +3063,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DURANT_128:
         return basic (this, hp:HP080, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -3087,7 +3087,7 @@ public enum LostThunder implements LogicCardInfo {
               opp.deck.subList(0,2).discard()
             }
           }
-        };
+        }
       case COBALION_129:
         return basic (this, hp:HP120, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -3108,7 +3108,7 @@ public enum LostThunder implements LogicCardInfo {
               if(self.cards.filterByType(POKEMON_TOOL)) damage 40
             }
           }
-        };
+        }
       case GENESECT_GX_130:
         return basic (this, hp:HP180, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -3119,7 +3119,7 @@ public enum LostThunder implements LogicCardInfo {
               bg.em().storeObject("OMEGA_DOUBLE_"+self.hashCode(), 1)
             }
             onDeactivate {
-              bg.em().storeObject("OMEGA_DOUBLE_"+self.hashCode(), null);
+              bg.em().storeObject("OMEGA_DOUBLE_"+self.hashCode(), null)
               while(self.cards.filterByType(POKEMON_TOOL).size() > 1){
                 self.cards.filterByType(POKEMON_TOOL).select("Discard", {true}, self.owner).discard()
               }
@@ -3144,7 +3144,7 @@ public enum LostThunder implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case MAGEARNA_131:
         return basic (this, hp:HP090, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -3167,7 +3167,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30+20*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case ALOLAN_NINETALES_GX_132:
         return 	evolution (this, from:"Alolan Vulpix", hp:HP200, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3205,7 +3205,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case JIGGLYPUFF_133:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3224,7 +3224,7 @@ public enum LostThunder implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case WIGGLYTUFF_134:
         return 	evolution (this, from:"Jigglypuff", hp:HP120, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3245,7 +3245,7 @@ public enum LostThunder implements LogicCardInfo {
               if(self.cards.filterByType(POKEMON_TOOL).findAll{it.name.contains("Fairy Charm")}) damage 70
             }
           }
-        };
+        }
       case MARILL_135:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3257,7 +3257,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case AZUMARILL_136:
         return 	evolution (this, from:"Marill", hp:HP100, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3287,7 +3287,7 @@ public enum LostThunder implements LogicCardInfo {
               flip{damage 30}
             }
           }
-        };
+        }
       case SNUBBULL_137:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3302,7 +3302,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20*my.hand.filterByType(TRAINER).select(max:2,"discard up to 2 Trainer cards for 20 damage").discard().size()
             }
           }
-        };
+        }
       case GRANBULL_138:
         return 	evolution (this, from:"Snubbull", hp:HP130, type:FAIRY, retreatCost:3) {
           weakness METAL
@@ -3322,7 +3322,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case RALTS_139:
         return basic (this, hp:HP050, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3344,7 +3344,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case KIRLIA_140:
         return 	evolution (this, from:"Ralts", hp:HP080, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3364,7 +3364,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case GARDEVOIR_141:
         return 	evolution (this, from:"Kirlia", hp:HP130, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3388,7 +3388,7 @@ public enum LostThunder implements LogicCardInfo {
               if(bg.em().retrieveObject("last_supporter_play_turn") == bg.turnCount) damage 90
             }
           }
-        };
+        }
       case DEDENNE_142:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3403,7 +3403,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CARBINK_143:
         return basic (this, hp:HP090, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3439,7 +3439,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case XERNEAS_PRISM_STAR_144:
         return basic (this, hp:HP160, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3452,9 +3452,9 @@ public enum LostThunder implements LogicCardInfo {
                   bg.em().storeObject("Path_of_Life", bg.turnCount)
                   while(1){
                     def pl=(my.all.findAll {it.cards.filterByType(ENERGY) && it!=self})
-                    if(!pl) break;
+                    if(!pl) break
                     def src=pl.select("Source for energy (cancel to stop moving)", false)
-                    if(!src) break;
+                    if(!src) break
                     def card=src.cards.filterByType(ENERGY).select("Card to move").first()
                     energySwitch(src, self, card)
                   }
@@ -3470,7 +3470,7 @@ public enum LostThunder implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case CUTIEFLY_145:
         return basic (this, hp:HP030, type:FAIRY, retreatCost:0) {
           weakness METAL
@@ -3485,7 +3485,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 30, my.all.findAll{it.numberOfDamageCounters}.select("Heal")
             }
           }
-        };
+        }
       case RIBOMBEE_146:
         return 	evolution (this, from:"Cutiefly", hp:HP060, type:FAIRY, retreatCost:0) {
           weakness METAL
@@ -3518,7 +3518,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MORELULL_147:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3530,7 +3530,7 @@ public enum LostThunder implements LogicCardInfo {
               apply CONFUSED
             }
           }
-        };
+        }
       case SHIINOTIC_148:
         return evolution (this, from:"Morelull", hp:HP100, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -3553,7 +3553,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MIMIKYU_GX_149:
         return basic (this, hp:HP170, type:FAIRY, retreatCost:1) {
           move "Perplex" , {
@@ -3585,7 +3585,7 @@ public enum LostThunder implements LogicCardInfo {
               shuffleOppDeck()
             }
           }
-        };
+        }
       case TAPU_LELE_150:
         return basic (this, hp:HP110, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3608,7 +3608,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case TAPU_FINI_151:
         return basic (this, hp:HP120, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -3632,7 +3632,7 @@ public enum LostThunder implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case CHANSEY_152:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -3652,7 +3652,7 @@ public enum LostThunder implements LogicCardInfo {
               if(defending.numberOfDamageCounters == 0) damage 100
             }
           }
-        };
+        }
       case BLISSEY_153:
         return 	evolution (this, from:"Chansey", hp:HP160, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -3673,7 +3673,7 @@ public enum LostThunder implements LogicCardInfo {
               flip self.cards.energyCount(C), {damage 80}
             }
           }
-        };
+        }
       case DITTO_PRISM_STAR_154:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3691,7 +3691,7 @@ public enum LostThunder implements LogicCardInfo {
               evolve(self, tar.first())
             }
           }
-        };
+        }
       case EEVEE_155:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3702,7 +3702,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case STANTLER_156:
         return basic (this, hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -3721,7 +3721,7 @@ public enum LostThunder implements LogicCardInfo {
               if(self.cards.filterByType(POKEMON_TOOL)) damage 60
             }
           }
-        };
+        }
       case SMEARGLE_157:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           move "Stunning Likeness" , {
@@ -3751,7 +3751,7 @@ public enum LostThunder implements LogicCardInfo {
               flip 1,{damage 30},{bc "Tail Smash failed"}
             }
           }
-        };
+        }
       case MILTANK_158:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -3766,7 +3766,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60*milkCard.select(max:milkCard.size(),"Choose the cards you want to reveal. (60 damage for each)").showToOpponent("Revealed cards").size()
             }
           }
-        };
+        }
       case LUGIA_GX_159:
         return basic (this, hp:HP190, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -3798,7 +3798,7 @@ public enum LostThunder implements LogicCardInfo {
               removePCS(defending)
             }
           }
-        };
+        }
       case HO_OH_160:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -3814,7 +3814,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KECLEON_161:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3837,7 +3837,7 @@ public enum LostThunder implements LogicCardInfo {
               if(defending.realEvolution) damage 50
             }
           }
-        };
+        }
       case KECLEON_162:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3859,7 +3859,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case PIKIPEK_163:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -3872,7 +3872,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case PIKIPEK_164:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3894,7 +3894,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TRUMBEAK_165:
         return 	evolution (this, from:"Pikipek", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -3931,7 +3931,7 @@ public enum LostThunder implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case TOUCANNON_166:
         return 	evolution (this, from:"Trumbeak", hp:HP140, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -3953,7 +3953,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ADVENTURE_BAG_167:
         return itemCard (this) {
           text "Search your deck for up to 2 Pokémon Tool cards, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3964,7 +3964,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case AETHER_FOUNDATION_EMPLOYEE_168:
         return supporter(this) {
           text "Put 3 Pokémon that have 'Alolan' in their names from your discard pile into your hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3975,7 +3975,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.discard.findAll{it.name.contains("Alolan")}
           }
-        };
+        }
       case CHOICE_HELMET_169:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Pokémon this card is attached to takes 30 less damage from the attacks of your opponent's Pokémon-GX and Pokémon-EX (after applying Weakness and Resistance).\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3995,7 +3995,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case COUNTER_GAIN_170:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf you have more Prize cards remaining than your opponent, the attacks of the Pokémon this card is attached to cost [C] less.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4016,7 +4016,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case CUSTOM_CATCHER_171:
         return itemCard (this) {
           text "You may play 2 Custom Catcher cards at once. If you played 1 card, draw cards from your deck until you have 3 cards in your hand.If you played 2 cards, switch 1 of your opponent's Benched Pokémon with their Active Pokémon. (This effect works one time for 2 cards.)\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4041,7 +4041,7 @@ public enum LostThunder implements LogicCardInfo {
               assert toDraw > 0 : "You can't play it with no effect"
             }
           }
-        };
+        }
       case ELECTROPOWER_172:
         return itemCard (this) {
           text "During this turn, your [L] Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4062,7 +4062,7 @@ public enum LostThunder implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case FABA_173:
         return supporter(this) {
           text "Choose a Pokémon Tool or Special Energy card attached to 1 of your opponent's Pokémon, or any Stadium card in play, and put it in the Lost Zone.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4090,7 +4090,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert (bg.stadiumInfoStruct) || opp.all.findAll({it.cards.filterByType(POKEMON_TOOL) || it.cards.filterByType(SPECIAL_ENERGY)})
           }
-        };
+        }
       case FAIRY_CHARM_G_174:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nPrevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's [G] Pokémon-GX and [G] Pokémon-EX.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4112,7 +4112,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case FAIRY_CHARM_P_175:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nPrevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's [P] Pokémon-GX and [P] Pokémon-EX.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4134,7 +4134,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case FAIRY_CHARM_F_176:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nPrevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's [F] Pokémon-GX and [F] Pokémon-EX.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4156,7 +4156,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case FAIRY_CHARM_N_177:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nPrevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's [N] Pokémon-GX and [N] Pokémon-EX.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4178,7 +4178,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case HEAT_FACTORY_PRISM_STAR_178:
         return stadium (this) {
           text "Once during each player's turn, that player may discard a [R] Energy from their hand. If they do, that player draws 3 cards.\nWhenever a player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -4197,7 +4197,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case KAHILI_179:
         return supporter(this) {
           text "Draw 2 cards. Then, flip a coin. If heads, if you played this Kahili from your hand, put this card into your hand instead of the discard pile. If you have no cards in your deck, you can't play this card.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4219,7 +4219,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement {
             assert my.deck
           }
-        };
+        }
       case LIFE_FOREST_PRISM_STAR_180:
         return stadium(this) {
           text "Once during each player's turn, that player may heal 60 damage and remove all Special Conditions from 1 of their [G] Pokémon.\nWhenever a player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -4240,7 +4240,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case LOST_BLENDER_181:
         return itemCard (this) {
           text "Put 2 cards from your hand in the Lost Zone. If you do, draw a card.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4251,7 +4251,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard).size() >=2 : "There is not enough cards in your hand"
           }
-        };
+        }
       case LUSAMINE_PRISM_STAR_182:
         return supporter(this) {
           text "You can play this card only if your opponent has exactly 3 Prize cards remaining.\nPrevent all damage done to your Ultra Beasts by attacks during your opponent's next turn.\nYou may play only 1 Supporter card during your turn (before your attack).\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -4272,7 +4272,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert opp.prizeCardSet.size() == 3 : "Your opponent has not 3 Prize cards remaining."
           }
-        };
+        }
       case MINA_183:
         return supporter(this) {
           text "Search your deck for a [Y] Energy card and attach it to 1 of your Pokémon. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4283,7 +4283,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case MIXED_HERBS_184:
         return itemCard (this) {
           text "You may play 2 Mixed Herbs cards at once. " +
@@ -4297,7 +4297,7 @@ public enum LostThunder implements LogicCardInfo {
               heal 90, my.active
               clearSpecialCondition(my.active)
             } else if (my.active.specialConditions.size()) {
-              SpecialConditionType spc = choose(my.active.specialConditions.asList(), "Which special condition you want to remove");
+              SpecialConditionType spc = choose(my.active.specialConditions.asList(), "Which special condition you want to remove")
               clearSpecialCondition(my.active, TRAINER_CARD, [spc])
             } else {
               assert false : "Your Pokemon is fine"
@@ -4310,7 +4310,7 @@ public enum LostThunder implements LogicCardInfo {
               assert my.active.specialConditions : "Your Pokemon is fine"
             }
           }
-        };
+        }
       case MOOMOO_MILK_185:
         return itemCard (this) {
           text "Choose 1 of your Pokémon, and then flip 2 coins. For each heads, heal 30 damage from that Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4324,7 +4324,7 @@ public enum LostThunder implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MORTY_186:
         return supporter(this) {
           text "You can play this card only if 1 of your [P] Pokémon was Knocked Out during your opponent's last turn.\nYour opponent reveals their hand. Choose 2 cards you find there. Your opponent shuffles those cards into their deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4338,7 +4338,7 @@ public enum LostThunder implements LogicCardInfo {
             assert my.knockoutTypesPerTurn.get(bg.turnCount - 1)?.contains(P) : "The Pokémon Knocked Out was not Psychic"
             assert opp.hand : "Your opponent has no cards in their hand"
           }
-        };
+        }
       case NET_BALL_187:
         return itemCard (this) {
           text "Search your deck for a Basic [G] Pokémon or a [G] Energy card, reveal it, and put it into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4348,7 +4348,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case PROFESSOR_ELM_S_LECTURE_188:
         return supporter(this) {
           text "Search your deck for up to 3 Pokémon with 60 HP or less, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4358,7 +4358,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case SIGHTSEER_189:
         return supporter(this) {
           text "You may discard any number of card from your hand. Then, draw cards until you have 5 cards in your hand. If you can't draw any cards in this way, you can't play this card.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4374,7 +4374,7 @@ public enum LostThunder implements LogicCardInfo {
               assert confirm ("You MUST discard at least $min cards from your hand to use this card. Are you sure you want to use it?")
             }
           }
-        };
+        }
       case SPELL_TAG_190:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nWhen the [P] Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, put 4 damage counters on your opponent's Pokémon in any way you like.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4394,7 +4394,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case THUNDER_MOUNTAIN_PRISM_STAR_191:
         return stadium(this) {
           text "The attacks of [L] Pokémon (both yours and your opponent's) cost [L] less.\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -4415,7 +4415,7 @@ public enum LostThunder implements LogicCardInfo {
           onRemoveFromPlay{
             eff2.unregister()
           }
-        };
+        }
       case WAIT_AND_SEE_HAMMER_192:
         return itemCard (this) {
           text "You can use this card only if you go second, and only on your first turn.\nDiscard an Energy from 1 of your opponent's Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -4427,7 +4427,7 @@ public enum LostThunder implements LogicCardInfo {
             assert bg.turnCount == 2 : "This card is now useless"
             assert opp.all.findAll {it.cards.energyCount(C)} : "There are no energy cards attached to your opponent's Pokémon."
           }
-        };
+        }
       case WHITNEY_193:
         return supporter(this) {
           text "Draw a card. Then, draw 2 cards for each other Whitney in your discard pile.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -4440,7 +4440,7 @@ public enum LostThunder implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There is no more card in your deck"
           }
-        };
+        }
       case MEMORY_ENERGY_194:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\n The Pokémon this card is attached to can use any attack from its previous Evolutions (You still need the necessary Energy to use the attack)"
@@ -4458,7 +4458,7 @@ public enum LostThunder implements LogicCardInfo {
             eff.unregister()
           }
 
-        };
+        }
       case SHUCKLE_GX_195:
         return copy(SHUCKLE_GX_17,this)
       case SCEPTILE_GX_196:
@@ -4543,7 +4543,7 @@ public enum LostThunder implements LogicCardInfo {
         return copy(SPELL_TAG_190,this)
 
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShiningLegends.groovy
@@ -7,23 +7,23 @@ import tcgwars.logic.impl.gen5.DarkExplorers
 import tcgwars.logic.impl.gen5.EmergingPowers
 import tcgwars.logic.impl.gen6.KalosStarterSet
 import tcgwars.logic.impl.gen6.PrimalClash
-import tcgwars.logic.impl.gen6.Xy;
+import tcgwars.logic.impl.gen6.Xy
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -109,53 +109,53 @@ public enum ShiningLegends implements LogicCardInfo {
   ZOROARK_GX_77 ("Zoroark-GX", "77", Rarity.SECRET, [STAGE1, EVOLUTION, POKEMON, POKEMON_GX, _DARKNESS_]),
   MEWTWO_GX_78 ("Mewtwo-GX", "78", Rarity.SECRET, [BASIC, POKEMON, POKEMON_GX, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ShiningLegends(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SHINING_LEGENDS;
+    return tcgwars.logic.card.Collection.SHINING_LEGENDS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -172,7 +172,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case IVYSAUR_2:
         return evolution (this, from:"Bulbasaur", hp:HP100, type:GRASS, retreatCost:4) {
           weakness FIRE
@@ -195,7 +195,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENUSAUR_3:
         return evolution (this, from:"Ivysaur", hp:HP160, type:GRASS, retreatCost:4) {
           weakness FIRE
@@ -217,7 +217,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHROOMISH_4:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -230,7 +230,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRELOOM_5:
         return evolution (this, from:"Shroomish", hp:HP110, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -248,7 +248,7 @@ public enum ShiningLegends implements LogicCardInfo {
                 before ASLEEP_SPC, null, null, BEGIN_TURN, {
                   if(ef.target == defending){ //MARK parentEvent
                     flip "Asleep (Hibernation Spore)", 2, {}, {}, [2:{
-                      ef.unregisterItself(bg.em());
+                      ef.unregisterItself(bg.em())
                     },1:{
                       bc "$self is still asleep."
                     },0:{
@@ -268,7 +268,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARNIVINE_6:
         return basic (this, hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -292,7 +292,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHAYMIN_7:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -313,7 +313,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIRIZION_8:
         return basic (this, hp:HP110, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -336,7 +336,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_GENESECT_9:
         return basic (this, hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -358,7 +358,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ENTEI_GX_10:
         return basic (this, hp:HP180, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -390,7 +390,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORKOAL_11:
         return basic (this, hp:HP110, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -413,7 +413,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LARVESTA_12:
         return basic (this, hp:HP080, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -425,7 +425,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLCARONA_13:
         return evolution (this, from:"Larvesta", hp:HP120, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -446,7 +446,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RESHIRAM_14:
         return basic (this, hp:HP130, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -466,7 +466,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LITTEN_15:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -478,7 +478,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORRACAT_16:
         return evolution (this, from:"Litten", hp:HP090, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -497,7 +497,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INCINEROAR_17:
         return evolution (this, from:"Torracat", hp:HP170, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -520,7 +520,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOTODILE_18:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -539,7 +539,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROCONAW_19:
         return evolution (this, from:"Totodile", hp:HP090, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -563,7 +563,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FERALIGATR_20:
         return evolution (this, from:"Croconaw", hp:HP160, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -583,7 +583,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QWILFISH_21:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -603,7 +603,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUIZEL_22:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -622,7 +622,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOATZEL_23:
         return evolution (this, from:"Buizel", hp:HP100, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -642,7 +642,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_24:
         return basic (this, hp:HP130, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -662,7 +662,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANAPHY_25:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -684,7 +684,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KELDEO_26:
         return basic (this, hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -706,7 +706,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_VOLCANION_27:
         return basic (this, hp:HP130, type:WATER, retreatCost:3) {
           weakness LIGHTNING
@@ -725,7 +725,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_28:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -738,7 +738,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_GX_29:
         return evolution (this, from:"Pikachu", hp:HP210, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -773,7 +773,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_30:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -786,7 +786,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_31:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -799,7 +799,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAIKOU_32:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -822,7 +822,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PLUSLE_33:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -836,7 +836,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MINUN_34:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -859,7 +859,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZEKROM_35:
         return basic (this, hp:HP130, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -882,7 +882,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EKANS_36:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -895,7 +895,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARBOK_37:
         return evolution (this, from:"Ekans", hp:HP120, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -921,7 +921,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JYNX_38:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -941,7 +941,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEWTWO_GX_39:
         return basic (this, hp:HP190, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -972,7 +972,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_MEW_40:
         return basic (this, hp:HP030, type:PSYCHIC, retreatCost:0) {
           weakness PSYCHIC
@@ -997,7 +997,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LATIOS_41:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1018,7 +1018,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_JIRACHI_42:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1034,7 +1034,7 @@ public enum ShiningLegends implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOLETT_43:
         return basic (this, hp:HP090, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -1046,7 +1046,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLURK_44:
         return evolution (this, from:"Golett", hp:HP140, type:PSYCHIC, retreatCost:4) {
           weakness DARKNESS
@@ -1067,7 +1067,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARSHADOW_45:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1095,7 +1095,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNFISK_46:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1115,7 +1115,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPIRITOMB_47:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:2) {
           bwAbility "Cursed Whirlpool", {
@@ -1139,7 +1139,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PURRLOIN_48:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1159,7 +1159,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LIEPARD_49:
         return evolution (this, from:"Purrloin", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1182,7 +1182,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCRAGGY_50:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1209,7 +1209,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCRAFTY_51:
         return evolution (this, from:"Scraggy", hp:HP110, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1230,7 +1230,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZORUA_52:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1250,7 +1250,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZOROARK_GX_53:
         return evolution (this, from:"Zorua", hp:HP210, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1283,7 +1283,7 @@ public enum ShiningLegends implements LogicCardInfo {
               def moveList = []
               def labelList = []
               opp.all.each {pcs->
-                moveList.addAll(pcs.topPokemonCard.moves);
+                moveList.addAll(pcs.topPokemonCard.moves)
                 labelList.addAll(pcs.topPokemonCard.moves.collect{pcs.name+"-"+it.name})
               }
               def move=choose(moveList, labelList)
@@ -1294,7 +1294,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YVELTAL_54:
         return basic (this, hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness LIGHTNING
@@ -1316,7 +1316,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOOPA_55:
         return basic (this, hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1333,7 +1333,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_RAYQUAZA_56:
         return basic (this, hp:HP120, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -1358,7 +1358,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINING_ARCEUS_57:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1383,7 +1383,7 @@ public enum ShiningLegends implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DAMAGE_MOVER_58:
         return itemCard (this) {
           text "Move 3 damage counters from 1 of your Pokémon to another of your Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -1398,9 +1398,9 @@ public enum ShiningLegends implements LogicCardInfo {
           playRequirement{
             assert my.all.size() >= 2 && my.all.findAll {it.numberOfDamageCounters}
           }
-        };
+        }
       case ENERGY_RETRIEVAL_59:
-        return copy(PrimalClash.ENERGY_RETRIEVAL_126, this);
+        return copy(PrimalClash.ENERGY_RETRIEVAL_126, this)
       case GREAT_BALL_60:
         return copy(EmergingPowers.GREAT_BALL_93, this)
       case HAU_61:
@@ -1417,13 +1417,13 @@ public enum ShiningLegends implements LogicCardInfo {
           playRequirement{
             assert my.deck || my.active.numberOfDamageCounters
           }
-        };
+        }
       case POKEMON_CATCHER_64:
         return copy (KalosStarterSet.POKEMON_CATCHER_36, this)
       case SOPHOCLES_65:
         return copy (BurningShadows.SOPHOCLES_123, this)
       case SUPER_SCOOP_UP_66:
-        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this);
+        return copy(FireRedLeafGreen.SUPER_SCOOP_UP_99, this)
       case SWITCH_67:
         return copy (BlackWhite.SWITCH_104, this)
       case ULTRA_BALL_68:
@@ -1449,7 +1449,7 @@ public enum ShiningLegends implements LogicCardInfo {
       case MEWTWO_GX_78:
         return copy (MEWTWO_GX_39, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/ShinyVault.groovy
+++ b/src/tcgwars/logic/impl/gen7/ShinyVault.groovy
@@ -1,49 +1,49 @@
-package tcgwars.logic.impl.gen7;
+package tcgwars.logic.impl.gen7
 
-import tcgwars.logic.impl.gen6.Breakthrough;
+import tcgwars.logic.impl.gen6.Breakthrough
 
-import tcgwars.logic.impl.gen7.CelestialStorm;
-import tcgwars.logic.impl.gen7.DragonMajesty;
-import tcgwars.logic.impl.gen7.ForbiddenLight;
-import tcgwars.logic.impl.gen7.BurningShadows;
-import tcgwars.logic.impl.gen7.SunMoon;
-import tcgwars.logic.impl.gen7.GuardiansRising;
-import tcgwars.logic.impl.gen7.UltraPrism;
-import tcgwars.logic.impl.gen7.ShiningLegends;
-import tcgwars.logic.impl.gen7.CrimsonInvasion;
-import tcgwars.logic.impl.gen7.TeamUp;
-import tcgwars.logic.impl.gen7.LostThunder;
-import tcgwars.logic.impl.gen7.SunMoonPromos;
+import tcgwars.logic.impl.gen7.CelestialStorm
+import tcgwars.logic.impl.gen7.DragonMajesty
+import tcgwars.logic.impl.gen7.ForbiddenLight
+import tcgwars.logic.impl.gen7.BurningShadows
+import tcgwars.logic.impl.gen7.SunMoon
+import tcgwars.logic.impl.gen7.GuardiansRising
+import tcgwars.logic.impl.gen7.UltraPrism
+import tcgwars.logic.impl.gen7.ShiningLegends
+import tcgwars.logic.impl.gen7.CrimsonInvasion
+import tcgwars.logic.impl.gen7.TeamUp
+import tcgwars.logic.impl.gen7.LostThunder
+import tcgwars.logic.impl.gen7.SunMoonPromos
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author thezipcompany@gmail.com
@@ -145,248 +145,248 @@ public enum ShinyVault implements LogicCardInfo {
   TAPU_KOKO_GX_SV93 ("Tapu Koko-GX", "SV93", Rarity.SECRET, [POKEMON, BASIC, POKEMON_GX, _LIGHTNING_]),
   TAPU_LELE_GX_SV94 ("Tapu Lele-GX", "SV94", Rarity.SECRET, [POKEMON, BASIC, POKEMON_GX, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ShinyVault(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SHINY_VAULT;
+    return tcgwars.logic.card.Collection.SHINY_VAULT
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case SCYTHER_SV1:
-      return copy(CelestialStorm.SCYTHER_4, this);
+      return copy(CelestialStorm.SCYTHER_4, this)
       case ROWLET_SV2:
-      return copy(SunMoon.ROWLET_9, this);
+      return copy(SunMoon.ROWLET_9, this)
       case DARTRIX_SV3:
-      return copy(SunMoon.DARTRIX_10, this);
+      return copy(SunMoon.DARTRIX_10, this)
       case WIMPOD_SV4:
-      return copy(BurningShadows.WIMPOD_16, this);
+      return copy(BurningShadows.WIMPOD_16, this)
       case PHEROMOSA_SV5:
-      return copy(ForbiddenLight.PHEROMOSA_11, this);
+      return copy(ForbiddenLight.PHEROMOSA_11, this)
       case CHARMANDER_SV6:
-      return copy(DragonMajesty.CHARMANDER_1, this);
+      return copy(DragonMajesty.CHARMANDER_1, this)
       case CHARMELEON_SV7:
-      return copy(DragonMajesty.CHARMELEON_2, this);
+      return copy(DragonMajesty.CHARMELEON_2, this)
       case ALOLAN_VULPIX_SV8:
-      return copy(GuardiansRising.ALOLAN_VULPIX_21, this);
+      return copy(GuardiansRising.ALOLAN_VULPIX_21, this)
       case WOOPER_SV9:
-      return copy(DragonMajesty.WOOPER_25, this);
+      return copy(DragonMajesty.WOOPER_25, this)
       case QUAGSIRE_SV10:
-      return copy(DragonMajesty.QUAGSIRE_26, this);
+      return copy(DragonMajesty.QUAGSIRE_26, this)
       case FROAKIE_SV11:
-      return copy(ForbiddenLight.FROAKIE_21, this);
+      return copy(ForbiddenLight.FROAKIE_21, this)
       case FROGADIER_SV12:
-      return copy(ForbiddenLight.FROGADIER_23, this);
+      return copy(ForbiddenLight.FROGADIER_23, this)
       case VOLTORB_SV13:
-      return copy(CelestialStorm.VOLTORB_47, this);
+      return copy(CelestialStorm.VOLTORB_47, this)
       case XURKITREE_SV14:
-      return copy(ForbiddenLight.XURKITREE_39, this);
+      return copy(ForbiddenLight.XURKITREE_39, this)
       case SEVIPER_SV15:
       return copy (SunMoonPromos.SEVIPER_SM46, this)
       case SHUPPET_SV16:
-      return copy(CelestialStorm.SHUPPET_63, this);
+      return copy(CelestialStorm.SHUPPET_63, this)
       case INKAY_SV17:
-      return copy(ForbiddenLight.INKAY_50, this);
+      return copy(ForbiddenLight.INKAY_50, this)
       case MALAMAR_SV18:
-      return copy(ForbiddenLight.MALAMAR_51, this);
+      return copy(ForbiddenLight.MALAMAR_51, this)
       case POIPOLE_SV19:
-      return copy(ForbiddenLight.POIPOLE_55, this);
+      return copy(ForbiddenLight.POIPOLE_55, this)
       case SUDOWOODO_SV20:
-      return copy(GuardiansRising.SUDOWOODO_66, this);
+      return copy(GuardiansRising.SUDOWOODO_66, this)
       case RIOLU_SV21:
-      return copy(UltraPrism.RIOLU_66, this);
+      return copy(UltraPrism.RIOLU_66, this)
       case LUCARIO_SV22:
-      return copy(UltraPrism.LUCARIO_67, this);
+      return copy(UltraPrism.LUCARIO_67, this)
       case ROCKRUFF_SV23:
-      return copy(ForbiddenLight.ROCKRUFF_75, this);
+      return copy(ForbiddenLight.ROCKRUFF_75, this)
       case BUZZWOLE_SV24:
-      return copy(ForbiddenLight.BUZZWOLE_77, this);
+      return copy(ForbiddenLight.BUZZWOLE_77, this)
       case ZORUA_SV25:
-      return copy(ShiningLegends.ZORUA_52, this);
+      return copy(ShiningLegends.ZORUA_52, this)
       case GUZZLORD_SV26:
-      return copy(ForbiddenLight.GUZZLORD_80, this);
+      return copy(ForbiddenLight.GUZZLORD_80, this)
       case MAGNEMITE_SV27:
-      return copy(UltraPrism.MAGNEMITE_80, this);
+      return copy(UltraPrism.MAGNEMITE_80, this)
       case MAGNETON_SV28:
-      return copy(UltraPrism.MAGNETON_82, this);
+      return copy(UltraPrism.MAGNETON_82, this)
       case MAGNEZONE_SV29:
-      return copy(UltraPrism.MAGNEZONE_83, this);
+      return copy(UltraPrism.MAGNEZONE_83, this)
       case BELDUM_SV30:
-      return copy(GuardiansRising.BELDUM_83, this);
+      return copy(GuardiansRising.BELDUM_83, this)
       case METANG_SV31:
-      return copy(GuardiansRising.METANG_84, this);
+      return copy(GuardiansRising.METANG_84, this)
       case CELESTEELA_SV32:
-      return copy(CelestialStorm.CELESTEELA_100, this);
+      return copy(CelestialStorm.CELESTEELA_100, this)
       case KARTANA_SV33:
-      return copy(CelestialStorm.KARTANA_101, this);
+      return copy(CelestialStorm.KARTANA_101, this)
       case RALTS_SV34:
-      return copy(BurningShadows.RALTS_91, this);
+      return copy(BurningShadows.RALTS_91, this)
       case KIRLIA_SV35:
-      return copy(BurningShadows.KIRLIA_92, this);
+      return copy(BurningShadows.KIRLIA_92, this)
       case DIANCIE_SV36:
-      return copy(BurningShadows.DIANCIE_94, this);
+      return copy(BurningShadows.DIANCIE_94, this)
       case ALTARIA_SV37:
-      return copy(DragonMajesty.ALTARIA_40, this);
+      return copy(DragonMajesty.ALTARIA_40, this)
       case GIBLE_SV38:
-      return copy(UltraPrism.GIBLE_96, this);
+      return copy(UltraPrism.GIBLE_96, this)
       case GABITE_SV39:
-      return copy(UltraPrism.GABITE_98, this);
+      return copy(UltraPrism.GABITE_98, this)
       case GARCHOMP_SV40:
-      return copy(UltraPrism.GARCHOMP_99, this);
+      return copy(UltraPrism.GARCHOMP_99, this)
       case EEVEE_SV41:
-      return copy(SunMoon.EEVEE_101, this);
+      return copy(SunMoon.EEVEE_101, this)
       case SWABLU_SV42:
-      return copy(DragonMajesty.SWABLU_56, this);
+      return copy(DragonMajesty.SWABLU_56, this)
       case NOIBAT_SV43:
-      return copy(BurningShadows.NOIBAT_109, this);
+      return copy(BurningShadows.NOIBAT_109, this)
       case ORANGURU_SV44:
-      return copy(SunMoon.ORANGURU_113, this);
+      return copy(SunMoon.ORANGURU_113, this)
       case TYPE_NULL_SV45:
-      return copy(CrimsonInvasion.TYPE__NULL_89, this);
+      return copy(CrimsonInvasion.TYPE__NULL_89, this)
       case LEAFEON_GX_SV46:
-      return copy(UltraPrism.LEAFEON_GX_13, this);
+      return copy(UltraPrism.LEAFEON_GX_13, this)
       case DECIDUEYE_GX_SV47:
-      return copy(SunMoon.DECIDUEYE_GX_12, this);
+      return copy(SunMoon.DECIDUEYE_GX_12, this)
       case GOLISOPOD_GX_SV48:
-      return copy(BurningShadows.GOLISOPOD_GX_17, this);
+      return copy(BurningShadows.GOLISOPOD_GX_17, this)
       case CHARIZARD_GX_SV49:
-      return copy(BurningShadows.CHARIZARD_GX_20, this);
+      return copy(BurningShadows.CHARIZARD_GX_20, this)
       case HO_OH_GX_SV50:
-      return copy(BurningShadows.HO_OH_GX_21, this);
+      return copy(BurningShadows.HO_OH_GX_21, this)
       case RESHIRAM_GX_SV51:
-      return copy(DragonMajesty.RESHIRAM_GX_11, this);
+      return copy(DragonMajesty.RESHIRAM_GX_11, this)
       case TURTONATOR_GX_SV52:
-      return copy(GuardiansRising.TURTONATOR_GX_18, this);
+      return copy(GuardiansRising.TURTONATOR_GX_18, this)
       case ALOLAN_NINETALES_GX_SV53:
-      return copy(GuardiansRising.ALOLAN_NINETALES_GX_22, this);
+      return copy(GuardiansRising.ALOLAN_NINETALES_GX_22, this)
       case ARTICUNO_GX_SV54:
-      return copy(CelestialStorm.ARTICUNO_GX_31, this);
+      return copy(CelestialStorm.ARTICUNO_GX_31, this)
       case GLACEON_GX_SV55:
-      return copy(UltraPrism.GLACEON_GX_39, this);
+      return copy(UltraPrism.GLACEON_GX_39, this)
       case GRENINJA_GX_SV56:
-      return copy(ForbiddenLight.GRENINJA_GX_24, this);
+      return copy(ForbiddenLight.GRENINJA_GX_24, this)
       case ELECTRODE_GX_SV57:
-      return copy(CelestialStorm.ELECTRODE_GX_48, this);
+      return copy(CelestialStorm.ELECTRODE_GX_48, this)
       case XURKITREE_GX_SV58:
-      return copy(UltraPrism.XURKITREE_GX_142, this);
+      return copy(UltraPrism.XURKITREE_GX_142, this)
       case MEWTWO_GX_SV59:
-      return copy(ShiningLegends.MEWTWO_GX_39, this);
+      return copy(ShiningLegends.MEWTWO_GX_39, this)
       case ESPEON_GX_SV60:
-      return copy(SunMoon.ESPEON_GX_61, this);
+      return copy(SunMoon.ESPEON_GX_61, this)
       case BANETTE_GX_SV61:
-      return copy(CelestialStorm.BANETTE_GX_66, this);
+      return copy(CelestialStorm.BANETTE_GX_66, this)
       case NIHILEGO_GX_SV62:
-      return copy(CrimsonInvasion.NIHILEGO_GX_49, this);
+      return copy(CrimsonInvasion.NIHILEGO_GX_49, this)
       case NAGANADEL_GX_SV63:
-      return copy(ForbiddenLight.NAGANADEL_GX_56, this);
+      return copy(ForbiddenLight.NAGANADEL_GX_56, this)
       case LUCARIO_GX_SV64:
-      return copy(ForbiddenLight.LUCARIO_GX_122, this);
+      return copy(ForbiddenLight.LUCARIO_GX_122, this)
       case ZYGARDE_GX_SV65:
-      return copy(ForbiddenLight.ZYGARDE_GX_73, this);
+      return copy(ForbiddenLight.ZYGARDE_GX_73, this)
       case LYCANROC_GX_SV66:
-      return copy(GuardiansRising.LYCANROC_GX_74, this);
+      return copy(GuardiansRising.LYCANROC_GX_74, this)
       case LYCANROC_GX_SV67:
-      return copy(TeamUp.LYCANROC_GX_82, this);
+      return copy(TeamUp.LYCANROC_GX_82, this)
       case BUZZWOLE_GX_SV68:
-      return copy(CrimsonInvasion.BUZZWOLE_GX_57, this);
+      return copy(CrimsonInvasion.BUZZWOLE_GX_57, this)
       case UMBREON_GX_SV69:
-      return copy(SunMoon.UMBREON_GX_80, this);
+      return copy(SunMoon.UMBREON_GX_80, this)
       case DARKRAI_GX_SV70:
-      return copy(BurningShadows.DARKRAI_GX_88, this);
+      return copy(BurningShadows.DARKRAI_GX_88, this)
       case GUZZLORD_GX_SV71:
-      return copy(CrimsonInvasion.GUZZLORD_GX_63, this);
+      return copy(CrimsonInvasion.GUZZLORD_GX_63, this)
       case SCIZOR_GX_SV72:
-      return copy(CelestialStorm.SCIZOR_GX_90, this);
+      return copy(CelestialStorm.SCIZOR_GX_90, this)
       case KARTANA_GX_SV73:
-      return copy(CrimsonInvasion.KARTANA_GX_70, this);
+      return copy(CrimsonInvasion.KARTANA_GX_70, this)
       case STAKATAKA_GX_SV74:
-      return copy(CelestialStorm.STAKATAKA_GX_102, this);
+      return copy(CelestialStorm.STAKATAKA_GX_102, this)
       case GARDEVOIR_GX_SV75:
-      return copy(BurningShadows.GARDEVOIR_GX_93, this);
+      return copy(BurningShadows.GARDEVOIR_GX_93, this)
       case SYLVEON_GX_SV76:
-      return copy(GuardiansRising.SYLVEON_GX_92, this);
+      return copy(GuardiansRising.SYLVEON_GX_92, this)
       case ALTARIA_GX_SV77:
-      return copy(DragonMajesty.ALTARIA_GX_41, this);
+      return copy(DragonMajesty.ALTARIA_GX_41, this)
       case NOIVERN_GX_SV78:
-      return copy(BurningShadows.NOIVERN_GX_99, this);
+      return copy(BurningShadows.NOIVERN_GX_99, this)
       case SILVALLY_GX_SV79:
-      return copy(CrimsonInvasion.SILVALLY_GX_90, this);
+      return copy(CrimsonInvasion.SILVALLY_GX_90, this)
       case DRAMPA_GX_SV80:
-      return copy(GuardiansRising.DRAMPA_GX_115, this);
+      return copy(GuardiansRising.DRAMPA_GX_115, this)
       case AETHER_FOUNDATION_EMPLOYEE_SV81:
-      return copy(LostThunder.AETHER_FOUNDATION_EMPLOYEE_168, this);
+      return copy(LostThunder.AETHER_FOUNDATION_EMPLOYEE_168, this)
       case CYNTHIA_SV82:
-      return copy(UltraPrism.CYNTHIA_119, this);
+      return copy(UltraPrism.CYNTHIA_119, this)
       case FISHERMAN_SV83:
-      return copy(Breakthrough.FISHERMAN_136, this);
+      return copy(Breakthrough.FISHERMAN_136, this)
       case GUZMA_SV84:
-      return copy(BurningShadows.GUZMA_115, this);
+      return copy(BurningShadows.GUZMA_115, this)
       case HIKER_SV85:
-      return copy(CelestialStorm.HIKER_133, this);
+      return copy(CelestialStorm.HIKER_133, this)
       case LADY_SV86:
-      return copy(ForbiddenLight.LADY_109, this);
+      return copy(ForbiddenLight.LADY_109, this)
       case AETHER_PARADISE_CONSERVATION_AREA_SV87:
-      return copy(GuardiansRising.AETHER_PARADISE_CONSERVATION_AREA_116, this);
+      return copy(GuardiansRising.AETHER_PARADISE_CONSERVATION_AREA_116, this)
       case BROOKLET_HILL_SV88:
-      return copy(GuardiansRising.BROOKLET_HILL_120, this);
+      return copy(GuardiansRising.BROOKLET_HILL_120, this)
       case MT_CORONET_SV89:
-      return copy(UltraPrism.MT__CORONET_130, this);
+      return copy(UltraPrism.MT__CORONET_130, this)
       case SHRINE_OF_PUNISHMENT_SV90:
-      return copy(CelestialStorm.SHRINE_OF_PUNISHMENT_143, this);
+      return copy(CelestialStorm.SHRINE_OF_PUNISHMENT_143, this)
       case TAPU_BULU_GX_SV91:
-      return copy(BurningShadows.TAPU_BULU_GX_130, this);
+      return copy(BurningShadows.TAPU_BULU_GX_130, this)
       case TAPU_FINI_GX_SV92:
-      return copy(BurningShadows.TAPU_FINI_GX_39, this);
+      return copy(BurningShadows.TAPU_FINI_GX_39, this)
       case TAPU_KOKO_GX_SV93:
-      return copy(GuardiansRising.TAPU_KOKO_GX_47, this);
+      return copy(GuardiansRising.TAPU_KOKO_GX_47, this)
       case TAPU_LELE_GX_SV94:
-      return copy(GuardiansRising.TAPU_LELE_GX_60, this);
+      return copy(GuardiansRising.TAPU_LELE_GX_60, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen7/SunMoon.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoon.groovy
@@ -7,26 +7,26 @@ import tcgwars.logic.impl.gen5.NextDestinies
 import tcgwars.logic.impl.gen6.KalosStarterSet
 import tcgwars.logic.impl.gen6.Xy
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -252,7 +252,7 @@ public enum SunMoon implements LogicCardInfo {
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -2714,9 +2714,9 @@ public enum SunMoon implements LogicCardInfo {
       case ENERGY_SWITCH_117:
         return copy(BlackWhite.ENERGY_SWITCH_94, this)
       case EXP__SHARE_118:
-        return copy(NextDestinies.EXP__SHARE_87, this);
+        return copy(NextDestinies.EXP__SHARE_87, this)
       case GREAT_BALL_119:
-        return copy(EmergingPowers.GREAT_BALL_93, this);
+        return copy(EmergingPowers.GREAT_BALL_93, this)
       case HAU_120:
         return supporter (this) {
           text "Draw 3 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2858,7 +2858,7 @@ public enum SunMoon implements LogicCardInfo {
       case DOUBLE_COLORLESS_ENERGY_136:
         return copy(Xy.DOUBLE_COLORLESS_ENERGY_130, this)
       case RAINBOW_ENERGY_137:
-        return copy(CelestialStorm.RAINBOW_ENERGY_151,this);
+        return copy(CelestialStorm.RAINBOW_ENERGY_151,this)
       case LURANTIS_GX_138:
         return copy (LURANTIS_GX_15, this)
       case LAPRAS_GX_139:

--- a/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
+++ b/src/tcgwars/logic/impl/gen7/SunMoonPromos.groovy
@@ -1,12 +1,12 @@
 package tcgwars.logic.impl.gen7
 
 
-import tcgwars.logic.impl.gen5.BlackWhitePromos;
+import tcgwars.logic.impl.gen5.BlackWhitePromos
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
 import static tcgwars.logic.effect.EffectType.*
@@ -15,12 +15,12 @@ import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.card.pokemon.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -273,53 +273,53 @@ public enum SunMoonPromos implements LogicCardInfo {
   AIPOM_SM244 ("Aipom", "SM244", Rarity.PROMO, [POKEMON, BASIC, _COLORLESS_]),
   SABRINA_BRYCEN_SM246 ("Sabrina & Brycen", "SM246", Rarity.PROMO, [TRAINER, SUPPORTER, TAG_TEAM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SunMoonPromos(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SUN_MOON_PROMOS;
+    return tcgwars.logic.card.Collection.SUN_MOON_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -335,7 +335,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 3,{damage 10}
             }
           }
-        };
+        }
       case LITTEN_SM02:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -346,7 +346,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case POPPLIO_SM03:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -357,7 +357,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case PIKACHU_SM04:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -376,7 +376,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case SNORLAX_GX_SM05:
         return basic (this, hp:HP190, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -418,7 +418,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               afterDamage{apply ASLEEP,self}
             }
           }
-        };
+        }
       case ROCKRUFF_SM06:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -436,7 +436,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PIKIPEK_SM07:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -449,7 +449,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20,self
             }
           }
-        };
+        }
       case LITTEN_SM08:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -467,7 +467,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TOGEDEMARU_SM09:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -486,7 +486,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30*discardAllSelfEnergy(L).size()
             }
           }
-        };
+        }
       case SHIINOTIC_SM10:
         return evolution (this, from:"Morelull", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -508,7 +508,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case BRUXISH_SM11:
         return basic (this, hp:HP110, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -527,7 +527,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               shredDamage 90
             }
           }
-        };
+        }
       case PASSIMIAN_SM12:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -548,7 +548,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 10+30*my.bench.findAll{it.name=='Passimian'}.size()
             }
           }
-        };
+        }
       case ORANGURU_SM13:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -569,9 +569,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 60+20*defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case LYCANROC_GX_SM14:
-        return copy (BurningShadows.LYCANROC_GX_136, this);
+        return copy (BurningShadows.LYCANROC_GX_136, this)
       case ZYGARDE_SM15:
         return basic (this, hp:HP130, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -589,7 +589,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 130
             }
           }
-        };
+        }
       case SOLGALEO_GX_SM16:
         return copy (SunMoon.SOLGALEO_GX_89, this)
       case LUNALA_GX_SM17:
@@ -633,7 +633,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case TSAREENA_SM26:
         return copy (SunMoon.TSAREENA_20, this)
       case TURTONATOR_SM27:
@@ -656,7 +656,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case VIKAVOLT_SM28:
         return copy (SunMoon.VIKAVOLT_52, this)
       case MIMIKYU_SM29:
@@ -675,7 +675,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               astonish()
             }
           }
-        };
+        }
       case TAPU_KOKO_SM30:
         return basic (this, hp:HP110, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -694,13 +694,13 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case TAPU_KOKO_SM31:
-        return copy (TAPU_KOKO_SM30, this);
+        return copy (TAPU_KOKO_SM30, this)
       case TAPU_BULU_GX_SM32:
-        return copy (BurningShadows.TAPU_BULU_GX_130, this);
+        return copy (BurningShadows.TAPU_BULU_GX_130, this)
       case TAPU_KOKO_GX_SM33:
-        return copy (GuardiansRising.TAPU_KOKO_GX_47, this);
+        return copy (GuardiansRising.TAPU_KOKO_GX_47, this)
       case BEWEAR_GX_SM34:
         return evolution (this, from:"Stufful", hp:HP210, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -733,7 +733,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ESPEON_GX_SM35:
         return copy (SunMoon.ESPEON_GX_61, this)
       case UMBREON_GX_SM36:
@@ -761,7 +761,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case KOMALA_SM41:
         return copy (GuardiansRising.KOMALA_114, this)
       case COSMOG_SM42:
@@ -784,7 +784,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case TOGEDEMARU_SM44:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -803,7 +803,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case TAPU_LELE_SM45:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -830,13 +830,13 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
               while(1){
                 def pl=(opp.all.findAll {it.numberOfDamageCounters})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("Source for damage counter (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def tar = opp.all
                 tar.remove(src)
                 tar = tar.select("Target for damage counter (cancel to stop)", false)
-                if(!tar) break;
+                if(!tar) break
 
                 src.damage-=hp(10)
                 directDamage 10, tar
@@ -845,7 +845,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               checkFaint()
             }
           }
-        };
+        }
       case SEVIPER_SM46:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -865,7 +865,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               applyAfterDamage POISONED
             }
           }
-        };
+        }
       case CRABOMINABLE_SM47:
         return evolution (this, from:"Crabrawler", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness PSYCHIC
@@ -885,7 +885,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 2, {damage 40}
             }
           }
-        };
+        }
       case ZYGARDE_SM48:
         return basic (this, hp:HP150, type:DRAGON, retreatCost:4) {
           weakness FAIRY
@@ -906,7 +906,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BEWEAR_SM49:
         return evolution (this, from:"Stufful", hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -930,7 +930,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TAPU_KOKO_GX_SM50:
         return copy (GuardiansRising.TAPU_KOKO_GX_47, this)
       case ALOLAN_MEOWTH_SM51:
@@ -956,7 +956,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case GOLISOPOD_SM52:
         return 	evolution (this, from:"Wimpod", hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -981,7 +981,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               if(defending.pokemonGX || defending.pokemonEX) damage 70
             }
           }
-        };
+        }
       case DHELMISE_SM53:
         return basic (this, hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1001,9 +1001,9 @@ public enum SunMoonPromos implements LogicCardInfo {
             text "70 damage. The Defending Pokémon can't retreat during your opponent's next turn."
             energyCost P,C,C
           }
-        };
+        }
       case LUCARIO_SM54:
-        return copy(BurningShadows.LUCARIO_71, this);
+        return copy(BurningShadows.LUCARIO_71, this)
       case DECIDUEYE_SM55:
         return 	evolution (this, from:"Dartrix", hp:HP140, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1015,7 +1015,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             text "120 damage. This Pokémon does 20 damage to itself."
             energyCost G,C,C
           }
-        };
+        }
       case TSAREENA_GX_SM56:
         return evolution (this, from:"Steenee", hp:HP230, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1055,15 +1055,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HO_OH_GX_SM57:
-        return copy (BurningShadows.HO_OH_GX_21, this);
+        return copy (BurningShadows.HO_OH_GX_21, this)
       case NECROZMA_GX_SM58:
-        return copy (BurningShadows.NECROZMA_GX_63, this);
+        return copy (BurningShadows.NECROZMA_GX_63, this)
       case MARSHADOW_GX_SM59:
-        return copy (BurningShadows.MARSHADOW_GX_80, this);
+        return copy (BurningShadows.MARSHADOW_GX_80, this)
       case CHARIZARD_GX_SM60:
-        return copy (BurningShadows.CHARIZARD_GX_20, this);
+        return copy (BurningShadows.CHARIZARD_GX_20, this)
       case TAPU_BULU_SM61:
         return basic (this, hp:HP130, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -1083,11 +1083,11 @@ public enum SunMoonPromos implements LogicCardInfo {
               if(isGxPerformed()) damage 60
             }
           }
-        };
+        }
       case GOLISOPOD_GX_SM62:
-        return copy (BurningShadows.GOLISOPOD_GX_17, this);
+        return copy (BurningShadows.GOLISOPOD_GX_17, this)
       case SALAZZLE_GX_SM63:
-        return copy (BurningShadows.SALAZZLE_GX_25, this);
+        return copy (BurningShadows.SALAZZLE_GX_25, this)
       case SILVALLY_SM64:
         return 	evolution (this, from:"Type: Null", hp:HP130, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -1109,7 +1109,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip {damage 30}
             }
           }
-        };
+        }
       case ALOLAN_RAICHU_SM65:
         return 	evolution (this, from:"Pikachu", hp:HP110, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1129,15 +1129,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case PHEROMOSA_GX_SM66:
-        return copy (UltraPrism.PHEROMOSA_GX_140, this);
+        return copy (UltraPrism.PHEROMOSA_GX_140, this)
       case CELESTEELA_GX_SM67:
-        return copy (UltraPrism.CELESTEELA_GX_144, this);
+        return copy (UltraPrism.CELESTEELA_GX_144, this)
       case XURKITREE_GX_SM68:
-        return copy (UltraPrism.XURKITREE_GX_142, this);
+        return copy (UltraPrism.XURKITREE_GX_142, this)
       case BUZZWOLE_GX_SM69:
-        return copy (CrimsonInvasion.BUZZWOLE_GX_57, this);
+        return copy (CrimsonInvasion.BUZZWOLE_GX_57, this)
       case SHINING_HO_OH_SM70:
         return basic (this, hp:HP130, type:FIRE, retreatCost:2) {
           weakness LIGHTNING
@@ -1168,17 +1168,17 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KOMMO_O_GX_SM71:
         return copy (GuardiansRising.KOMMO_O_GX_100, this)
       case ALOLAN_RAICHU_SM72:
-        return copy (CrimsonInvasion.ALOLAN_RAICHU_31, this);
+        return copy (CrimsonInvasion.ALOLAN_RAICHU_31, this)
       case SALAZZLE_SM73:
-        return copy (CrimsonInvasion.SALAZZLE_47, this);
+        return copy (CrimsonInvasion.SALAZZLE_47, this)
       case REGIROCK_SM74:
-        return copy (CrimsonInvasion.REGIROCK_53, this);
+        return copy (CrimsonInvasion.REGIROCK_53, this)
       case REGISTEEL_SM75:
-        return copy (CrimsonInvasion.REGISTEEL_68, this);
+        return copy (CrimsonInvasion.REGISTEEL_68, this)
       case PIKACHU_SM76:
         return copy (PIKACHU_SM04, this)
       case MEWTWO_SM77:
@@ -1204,7 +1204,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case CHAMPIONS_FESTIVAL_SM78:
         return copy(BlackWhitePromos.CHAMPIONS_FESTIVAL_BW95, this)
       case SHINING_CELEBI_SM79:
@@ -1229,7 +1229,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case HO_OH_GX_SM80:
         return copy (BurningShadows.HO_OH_GX_21, this)
       case PIKACHU_SM81:
@@ -1256,9 +1256,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZORUA_SM83:
-        return copy (ShiningLegends.ZORUA_52, this);
+        return copy (ShiningLegends.ZORUA_52, this)
       case ZOROARK_GX_SM84:
         return copy (ShiningLegends.ZOROARK_GX_53, this)
       case MARSHADOW_SM85:
@@ -1282,7 +1282,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               if(opp.bench) damage 10, opp.bench.select()
             }
           }
-        };
+        }
       case LATIAS_SM87:
         return basic (this, hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1304,7 +1304,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIOS_SM88:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1323,7 +1323,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case ZOROARK_SM89:
         return 	evolution (this, from:"Zorua", hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1348,11 +1348,11 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAICHU_GX_SM90:
         return copy (ShiningLegends.RAICHU_GX_29, this)
       case SILVALLY_GX_SM91:
-        return copy (CrimsonInvasion.SILVALLY_GX_90, this);
+        return copy (CrimsonInvasion.SILVALLY_GX_90, this)
       case TAPU_FINI_SM92:
         return basic (this, hp:HP120, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -1381,7 +1381,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               if(keyStore('Shining_Current',self,null)==bg.turnCount) damage 60
             }
           }
-        };
+        }
       case MARSHADOW_SM93:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           weakness DARKNESS
@@ -1412,25 +1412,25 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 1,{damage 40},{bc "Surprise Attack failed"}
             }
           }
-        };
+        }
       case WASH_ROTOM_SM94:
-        return copy (UltraPrism.WASH_ROTOM_40, this);
+        return copy (UltraPrism.WASH_ROTOM_40, this)
       case LUCARIO_SM95:
-        return copy (UltraPrism.LUCARIO_67, this);
+        return copy (UltraPrism.LUCARIO_67, this)
       case HEATRAN_SM96:
-        return copy (UltraPrism.HEATRAN_88, this);
+        return copy (UltraPrism.HEATRAN_88, this)
       case GUMSHOOS_SM97:
-        return copy (UltraPrism.GUMSHOOS_113, this);
+        return copy (UltraPrism.GUMSHOOS_113, this)
       case PIKACHU_SM98:
-        return copy (BurningShadows.PIKACHU_40, this);
+        return copy (BurningShadows.PIKACHU_40, this)
       case MIMIKYU_SM99:
-        return copy (GuardiansRising.MIMIKYU_58, this);
+        return copy (GuardiansRising.MIMIKYU_58, this)
       case LUCARIO_GX_SM100:
-        return copy (ForbiddenLight.LUCARIO_GX_122, this);
+        return copy (ForbiddenLight.LUCARIO_GX_122, this)
       case DAWN_WINGS_NECROZMA_GX_SM101:
-        return copy (UltraPrism.DAWN_WINGS_NECROZMA_GX_63, this);
+        return copy (UltraPrism.DAWN_WINGS_NECROZMA_GX_63, this)
       case DUSK_MANE_NECROZMA_GX_SM102:
-        return copy (UltraPrism.DUSK_MANE_NECROZMA_GX_90, this);
+        return copy (UltraPrism.DUSK_MANE_NECROZMA_GX_90, this)
       case LUNALA_GX_SM103:
         return 	evolution (this, from:"Cosmoem", hp:HP230, type:PSYCHIC, retreatCost:0) {
           weakness DARKNESS
@@ -1463,7 +1463,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 250
             }
           }
-        };
+        }
       case SOLGALEO_GX_SM104:
         return 	evolution (this, from:"Cosmoem", hp:HP250, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -1502,7 +1502,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               my.all.each {heal it.damage.value, it}
             }
           }
-        };
+        }
       case LYCANROC_SM105:
         return 	evolution (this, from:"Rockruff", hp:HP120, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1521,7 +1521,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip {damage 30}
             }
           }
-        };
+        }
       case DAWN_WINGS_NECROZMA_SM106:
         return basic (this, hp:HP130, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1544,7 +1544,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUSK_MANE_NECROZMA_SM107:
         return basic (this, hp:HP130, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -1568,7 +1568,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               if (opp.prizeCardSet.size() == 1) damage 100
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM108:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1593,7 +1593,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM109:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1613,7 +1613,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 1,{},{damage 20, self}
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM110:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1633,7 +1633,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 1,{},{damage 20, self}
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM111:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1654,7 +1654,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM112:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1674,7 +1674,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM113:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1693,7 +1693,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ASH_S_PIKACHU_SM114:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1715,15 +1715,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PHEROMOSA_SM115:
-        return copy (ForbiddenLight.PHEROMOSA_11, this);
+        return copy (ForbiddenLight.PHEROMOSA_11, this)
       case XURKITREE_SM116:
-        return copy (ForbiddenLight.XURKITREE_39, this);
+        return copy (ForbiddenLight.XURKITREE_39, this)
       case MALAMAR_SM117:
-        return copy (ForbiddenLight.MALAMAR_51, this);
+        return copy (ForbiddenLight.MALAMAR_51, this)
       case LYCANROC_SM118:
-        return copy (ForbiddenLight.LYCANROC_76, this);
+        return copy (ForbiddenLight.LYCANROC_76, this)
       case EXEGGCUTE_SM119:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1735,7 +1735,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case ROCKRUFF_SM120:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1746,7 +1746,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case RAIKOU_GX_SM121:
         return basic (this, hp:HP170, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1781,7 +1781,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZYGARDE_GX_SM122:
         return basic (this, hp:HP180, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1816,15 +1816,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DAWN_WINGS_NECROZMA_SM123:
-        return copy (DAWN_WINGS_NECROZMA_SM106, this);
+        return copy (DAWN_WINGS_NECROZMA_SM106, this)
       case DUSK_MANE_NECROZMA_SM124:
-        return copy (DUSK_MANE_NECROZMA_SM107, this);
+        return copy (DUSK_MANE_NECROZMA_SM107, this)
       case NAGANADEL_GX_SM125:
-        return copy (ForbiddenLight.NAGANADEL_GX_56, this);
+        return copy (ForbiddenLight.NAGANADEL_GX_56, this)
       case ULTRA_NECROZMA_GX_SM126:
-        return copy (ForbiddenLight.ULTRA_NECROZMA_GX_95, this);
+        return copy (ForbiddenLight.ULTRA_NECROZMA_GX_95, this)
       case ALOLAN_SANDSLASH_SM127:
         return 	evolution (this, from:"Alolan Sandshrew", hp:HP120, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -1844,7 +1844,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip{damage 40}
             }
           }
-        };
+        }
       case ALOLAN_NINETALES_SM128:
         return 	evolution (this, from:"Vulpix", hp:HP110, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -1864,15 +1864,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case KYOGRE_SM129:
-        return copy (CelestialStorm.KYOGRE_46, this);
+        return copy (CelestialStorm.KYOGRE_46, this)
       case MANECTRIC_SM130:
-        return copy (CelestialStorm.MANECTRIC_52, this);
+        return copy (CelestialStorm.MANECTRIC_52, this)
       case CELESTEELA_SM131:
-        return copy (CelestialStorm.CELESTEELA_100, this);
+        return copy (CelestialStorm.CELESTEELA_100, this)
       case DELCATTY_SM132:
-        return copy (CelestialStorm.DELCATTY_121, this);
+        return copy (CelestialStorm.DELCATTY_121, this)
       case THUNDURUS_GX_SM133:
         return basic (this, hp:HP180, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1906,7 +1906,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 4,{damage 100}
             }
           }
-        };
+        }
       case TORNADUS_GX_SM134:
         return basic (this, hp:HP180, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -1940,7 +1940,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIAS_SM135:
         return basic (this, hp:HP110, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -1962,7 +1962,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIOS_SM136:
         return basic (this, hp:HP120, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -1988,9 +1988,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RESHIRAM_GX_SM137:
-        return copy(DragonMajesty.RESHIRAM_GX_11, this);
+        return copy(DragonMajesty.RESHIRAM_GX_11, this)
       case ZEKROM_GX_SM138:
         return basic (this, hp:HP180, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -2023,15 +2023,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               shredDamage 200
             }
           }
-        };
+        }
       case SALAMENCE_GX_SM139:
-        return copy(DragonMajesty.SALAMENCE_GX_44, this);
+        return copy(DragonMajesty.SALAMENCE_GX_44, this)
       case SALAMENCE_SM140:
-        return copy(CelestialStorm.SALAMENCE_106, this);
+        return copy(CelestialStorm.SALAMENCE_106, this)
       case WHITE_KYUREM_GX_SM141:
-        return copy(DragonMajesty.WHITE_KYUREM_GX_48, this);
+        return copy(DragonMajesty.WHITE_KYUREM_GX_48, this)
       case KYUREM_SM142:
-        return copy(DragonMajesty.KYUREM_47, this);
+        return copy(DragonMajesty.KYUREM_47, this)
       case MOLTRES_SM143:
         return basic (this, hp:HP120, type:FIRE, retreatCost:1) {
           weakness LIGHTNING
@@ -2050,7 +2050,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip 1,{damage 150},{bc "Sky Attack failed"}
             }
           }
-        };
+        }
       case ARTICUNO_SM144:
         return basic (this, hp:HP120, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -2072,7 +2072,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZAPDOS_SM146:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness LIGHTNING
@@ -2092,21 +2092,21 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case LEAFEON_GX_SM145:
-        return copy (UltraPrism.LEAFEON_GX_13, this);
+        return copy (UltraPrism.LEAFEON_GX_13, this)
       case GLACEON_GX_SM147:
-        return copy (UltraPrism.GLACEON_GX_39, this);
+        return copy (UltraPrism.GLACEON_GX_39, this)
       case CHAMPIONS_FESTIVAL_SM148:
-        return copy (CHAMPIONS_FESTIVAL_SM78, this);
+        return copy (CHAMPIONS_FESTIVAL_SM78, this)
       case SUICUNE_SM149:
-        return copy (LostThunder.SUICUNE_59, this);
+        return copy (LostThunder.SUICUNE_59, this)
       case RAIKOU_SM150:
-        return copy (LostThunder.RAIKOU_79, this);
+        return copy (LostThunder.RAIKOU_79, this)
       case GIRATINA_SM151:
-        return copy (LostThunder.GIRATINA_97, this);
+        return copy (LostThunder.GIRATINA_97, this)
       case TAPU_LELE_SM152:
-        return copy (LostThunder.TAPU_LELE_150, this);
+        return copy (LostThunder.TAPU_LELE_150, this)
       case ROWLET_SM153:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -2118,7 +2118,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip{damage 20}
             }
           }
-        };
+        }
       case SALANDIT_SM154:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -2139,11 +2139,11 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KINGDRA_GX_SM155:
-        return copy(DragonMajesty.KINGDRA_GX_18, this);
+        return copy(DragonMajesty.KINGDRA_GX_18, this)
       case DRAGONITE_GX_SM156:
-        return copy(DragonMajesty.DRAGONITE_GX_37, this);
+        return copy(DragonMajesty.DRAGONITE_GX_37, this)
       case PIKACHU_SM157:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2166,15 +2166,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CHARIZARD_SM158:
-        return copy(TeamUp.CHARIZARD_14, this);
+        return copy(TeamUp.CHARIZARD_14, this)
       case ZAPDOS_SM159:
-        return copy(TeamUp.ZAPDOS_40, this);
+        return copy(TeamUp.ZAPDOS_40, this)
       case NIDOQUEEN_SM160:
-        return copy(TeamUp.NIDOQUEEN_56, this);
+        return copy(TeamUp.NIDOQUEEN_56, this)
       case JIRACHI_SM161:
-        return copy(TeamUp.JIRACHI_99, this);
+        return copy(TeamUp.JIRACHI_99, this)
       case PIKACHU_SM162:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -2194,7 +2194,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case MIMIKYU_SM163:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:1) {
           move "Mimic" , {
@@ -2217,7 +2217,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip {damage 20}
             }
           }
-        };
+        }
       case DEOXYS_SM164:
         return basic (this, hp:HP110, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -2237,7 +2237,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               afterDamage{decreasedBaseDamageNextTurn(self,"Psycho Boost",hp(50))}
             }
           }
-        };
+        }
       case ULTRA_NECROZMA_SM165:
         return basic (this, hp:HP130, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2254,17 +2254,17 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGIKARP_WAILORD_GX_SM166:
-        return copy(TeamUp.MAGIKARP_WAILORD_GX_160, this);
+        return copy(TeamUp.MAGIKARP_WAILORD_GX_160, this)
       case CELEBI_VENUSAUR_GX_SM167:
-        return copy(TeamUp.CELEBI_VENUSAUR_GX_1, this);
+        return copy(TeamUp.CELEBI_VENUSAUR_GX_1, this)
       case PIKACHU_ZEKROM_GX_SM168:
-        return copy(TeamUp.PIKACHU_ZEKROM_GX_33, this);
+        return copy(TeamUp.PIKACHU_ZEKROM_GX_33, this)
       case EEVEE_SNORLAX_GX_SM169:
-        return copy(TeamUp.EEVEE_SNORLAX_GX_120, this);
+        return copy(TeamUp.EEVEE_SNORLAX_GX_120, this)
       case DETECTIVE_PIKACHU_SM170:
-        return copy(DetectivePikachu.DETECTIVE_PIKACHU_10, this);
+        return copy(DetectivePikachu.DETECTIVE_PIKACHU_10, this)
       case FLAREON_GX_SM171:
         return 	evolution (this, from:"Eevee", hp:HP210, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2304,7 +2304,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20*my.discard.filterByType(ENERGY).filterByEnergyType(R).size()
             }
           }
-        };
+        }
       case VAPOREON_GX_SM172:
         return 	evolution (this, from:"Eevee", hp:HP210, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -2339,7 +2339,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case JOLTEON_GX_SM173:
         return 	evolution (this, from:"Eevee", hp:HP200, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -2373,7 +2373,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               preventAllEffectsNextTurn()
             }
           }
-        };
+        }
       case EEVEE_GX_SM174:
         return basic (this, hp:HP160, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2409,11 +2409,11 @@ public enum SunMoonPromos implements LogicCardInfo {
               my.discard.select(max:3,"select the card you want to put in your hand.").moveTo(my.hand)
             }
           }
-        };
+        }
       case EEVEE_GX_SM175:
-        return copy(EEVEE_GX_SM174, this);
+        return copy(EEVEE_GX_SM174, this)
       case EEVEE_GX_SM176:
-        return copy(EEVEE_GX_SM174, this);
+        return copy(EEVEE_GX_SM174, this)
       case MELTAN_SM177:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2430,7 +2430,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MELMETAL_SM178:
         return evolution (this,from : "Meltan", hp:HP220, type:METAL, retreatCost:4) {
           weakness FIRE
@@ -2470,7 +2470,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VOLCANION_SM179:
         return copy(UnbrokenBonds.VOLCANION_25, this)
       case STAKATAKA_SM180:
@@ -2491,7 +2491,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case EEVEE_SM184:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2515,7 +2515,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TYPHLOSION_SM185:
         return evolution (this,from : "Quilava", hp:HP150, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2541,7 +2541,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FLAREON_SM186:
         return evolution (this,from : "Eevee", hp:HP110, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -2562,7 +2562,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_MAROWAK_GX_SM187:
         return evolution (this, from:"Cubone", hp:HP200, type:R, retreatCost:2) {
           weakness W
@@ -2610,7 +2610,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KANGASKHAN_GX_SM188:
         return basic (this, hp:HP180, type:C, retreatCost:3) {
           weakness FIGHTING
@@ -2642,9 +2642,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               draw 5
             }
           }
-        };
+        }
       case BLASTOISE_GX_SM189:
-        return copy(UnbrokenBonds.BLASTOISE_GX_35, this);
+        return copy(UnbrokenBonds.BLASTOISE_GX_35, this)
       case DETECTIVE_PIKACHU_SM190:
         return basic (this, hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -2663,13 +2663,13 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MEWTWO_MEW_GX_SM191:
-        return copy(UnifiedMinds.MEWTWO_MEW_GX_71, this);
+        return copy(UnifiedMinds.MEWTWO_MEW_GX_71, this)
       case LUCARIO_MELMETAL_GX_SM192:
-        return copy(UnbrokenBonds.LUCARIO_MELMETAL_GX_120, this);
+        return copy(UnbrokenBonds.LUCARIO_MELMETAL_GX_120, this)
       case GARCHOMP_GIRATINA_GX_SM193:
-        return copy(UnifiedMinds.GARCHOMP_GIRATINA_GX_146, this);
+        return copy(UnifiedMinds.GARCHOMP_GIRATINA_GX_146, this)
       case DETECTIVE_PIKACHU_SM194:
         return basic (this, hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -2686,7 +2686,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             shuffleDeck()
             }
           }
-        };
+        }
       case CHARIZARD_GX_SM195:
         return evolution (this, from:"Charmeleon", hp:HP250, type:R, retreatCost:4) {
           weakness W
@@ -2731,7 +2731,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEWTWO_GX_SM196:
         return basic (this, hp:HP190, type:P, retreatCost:2) {
         weakness P
@@ -2762,7 +2762,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             preventAllEffectsNextTurn()
             }
           }
-        };
+        }
       case GRENINJA_GX_SM197:
         return evolution (this, from:"Frogadier", hp:HP230, type:W, retreatCost:1) {
         weakness G
@@ -2801,7 +2801,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             scoopUpPokemon(pcs, delegate)
             }
           }
-        };
+        }
       case BULBASAUR_SM198:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -2819,7 +2819,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case PSYDUCK_SM199:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness GRASS
@@ -2830,7 +2830,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SNUBBULL_SM200:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2849,17 +2849,17 @@ public enum SunMoonPromos implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case RESHIRAM_CHARIZARD_GX_SM201:
-        return copy(UnbrokenBonds.RESHIRAM_CHARIZARD_GX_20, this);
+        return copy(UnbrokenBonds.RESHIRAM_CHARIZARD_GX_20, this)
       case AMOONGUSS_SM202:
-        return copy(UnifiedMinds.AMOONGUSS_14, this);
+        return copy(UnifiedMinds.AMOONGUSS_14, this)
       case TAPU_FINI_SM203:
-        return copy(UnifiedMinds.TAPU_FINI_53, this);
+        return copy(UnifiedMinds.TAPU_FINI_53, this)
       case NECROZMA_SM204:
-        return copy(UnifiedMinds.NECROZMA_101, this);
+        return copy(UnifiedMinds.NECROZMA_101, this)
       case TERRAKION_SM205:
-        return copy(UnifiedMinds.TERRAKION_122, this);
+        return copy(UnifiedMinds.TERRAKION_122, this)
       case PIKACHU_SM206:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -2874,7 +2874,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SUDOWOODO_SM207:
         return basic (this, hp:HP110, type:F, retreatCost:2) {
           weakness W
@@ -2894,23 +2894,23 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VIKAVOLT_SM208:
-        return copy(UnbrokenBonds.VIKAVOLT_59, this);
+        return copy(UnbrokenBonds.VIKAVOLT_59, this)
       case STAKATAKA_SM209:
-        return copy(UnbrokenBonds.STAKATAKA_106, this);
+        return copy(UnbrokenBonds.STAKATAKA_106, this)
       case MOLTRES_ZAPDOS_ARTICUNO_GX_SM210:
-        return copy(HiddenFates.MOLTRES_ZAPDOS_ARTICUNO_GX_44, this);
+        return copy(HiddenFates.MOLTRES_ZAPDOS_ARTICUNO_GX_44, this)
       case CHARIZARD_GX_SM211:
-        return copy(HiddenFates.CHARIZARD_GX_9, this);
+        return copy(HiddenFates.CHARIZARD_GX_9, this)
       case GYARADOS_GX_SM212:
-        return copy(HiddenFates.GYARADOS_GX_16, this);
+        return copy(HiddenFates.GYARADOS_GX_16, this)
       case RAICHU_GX_SM213:
-        return copy(HiddenFates.RAICHU_GX_20, this);
+        return copy(HiddenFates.RAICHU_GX_20, this)
       case MEWTWO_SM214:
-        return copy(UnbrokenBonds.MEWTWO_75, this);
+        return copy(UnbrokenBonds.MEWTWO_75, this)
       case MEW_SM215:
-        return copy(UnbrokenBonds.MEW_76, this);
+        return copy(UnbrokenBonds.MEW_76, this)
       case PORYGON_Z_GX_SM216:
         return evolution (this, from:"Porygon2", hp:HP240, type:C, retreatCost:2) {
           weakness F
@@ -2947,7 +2947,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case TREVENANT_DUSKNOIR_GX_SM217:
         return basic (this, hp:HP270, type:P, retreatCost:3) {
           weakness D
@@ -2996,15 +2996,15 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BUZZWOLE_SM218:
-        return copy(CosmicEclipse.BUZZWOLE_21, this);
+        return copy(CosmicEclipse.BUZZWOLE_21, this)
       case ENTEI_SM219:
-        return copy(CosmicEclipse.ENTEI_28, this);
+        return copy(CosmicEclipse.ENTEI_28, this)
       case PHIONE_SM220:
-        return copy(CosmicEclipse.PHIONE_57, this);
+        return copy(CosmicEclipse.PHIONE_57, this)
       case BLACEPHALON_SM221:
-        return copy(CosmicEclipse.BLACEPHALON_104, this);
+        return copy(CosmicEclipse.BLACEPHALON_104, this)
       case MISMAGIUS_SM222:
       return evolution (this, from:"Misdreavus", hp:HP110, type:P, retreatCost:1) {
         weakness D
@@ -3024,9 +3024,9 @@ public enum SunMoonPromos implements LogicCardInfo {
             astonish()
           }
         }
-      };
+      }
       case TERRAKION_SM223:
-        return copy(UnifiedMinds.TERRAKION_122, this);
+        return copy(UnifiedMinds.TERRAKION_122, this)
       case CELEBI_SM224:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -3065,11 +3065,11 @@ public enum SunMoonPromos implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case VICTINI_SM225:
-        return copy(UnifiedMinds.VICTINI_26, this);
+        return copy(UnifiedMinds.VICTINI_26, this)
       case CHARIZARD_SM226:
-        return copy(TeamUp.CHARIZARD_14, this);
+        return copy(TeamUp.CHARIZARD_14, this)
       case PIKACHU_SM227:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -3090,7 +3090,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               discardAllSelfEnergy(null)
               }
             }
-          };
+          }
       case ARMORED_MEWTWO_SM228:
         return basic (this, hp:HP120, type:P, retreatCost:3) {
           weakness P
@@ -3102,11 +3102,11 @@ public enum SunMoonPromos implements LogicCardInfo {
               cantAttackNextTurn(self)
             }
           }
-        };
+        }
       case VENUSAUR_SNIVY_GX_SM229:
-        return copy(CosmicEclipse.VENUSAUR_SNIVY_GX_1, this);
+        return copy(CosmicEclipse.VENUSAUR_SNIVY_GX_1, this)
       case CHARIZARD_BRAIXEN_GX_SM230:
-        return copy(CosmicEclipse.CHARIZARD_BRAIXEN_GX_22, this);
+        return copy(CosmicEclipse.CHARIZARD_BRAIXEN_GX_22, this)
       case CHAMPIONS_FESTIVAL_SM231:
         return copy(BlackWhitePromos.CHAMPIONS_FESTIVAL_BW95, this)
       case PIKACHU_GX_SM232:
@@ -3141,9 +3141,9 @@ public enum SunMoonPromos implements LogicCardInfo {
               apply PARALYZED
             }
           }
-        };
+        }
       case EEVEE_GX_SM233:
-        return copy(EEVEE_GX_SM174, this);
+        return copy(EEVEE_GX_SM174, this)
       case PIKACHU_SM234:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -3166,7 +3166,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case EEVEE_SM235:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -3177,7 +3177,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flipUntilTails { damage 30 }
             }
           }
-        };
+        }
       case ALOLAN_SANDSLASH_GX_SM236:
         return evolution (this, from:"Alolan Sandshrew", hp:HP200, type:W, retreatCost:2) {
         weakness M
@@ -3208,7 +3208,7 @@ public enum SunMoonPromos implements LogicCardInfo {
             }
           }
         }
-        };
+        }
       case LEAFEON_SM237:
         return evolution (this, from:"Eevee", hp:HP110, type:G, retreatCost:2) {
           weakness R
@@ -3234,7 +3234,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip { damage 40 }
             }
           }
-        };
+        }
       case GLACEON_SM238:
         return evolution (this, from:"Eevee", hp:HP110, type:W, retreatCost:2) {
           weakness M
@@ -3257,7 +3257,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CARRACOSTA_GX_SM239:
         return evolution (this, from:"Tirtouga", hp:HP250, type:F, retreatCost:4) {
           weakness G
@@ -3302,13 +3302,13 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ESPEON_DEOXYS_GX_SM240:
-        return copy(UnifiedMinds.ESPEON_DEOXYS_GX_72, this);
+        return copy(UnifiedMinds.ESPEON_DEOXYS_GX_72, this)
       case UMBREON_DARKRAI_GX_SM241:
-        return copy(UnifiedMinds.UMBREON_DARKRAI_GX_125, this);
+        return copy(UnifiedMinds.UMBREON_DARKRAI_GX_125, this)
       case EEVEE_GX_SM242:
-        return copy(EEVEE_GX_SM174, this);
+        return copy(EEVEE_GX_SM174, this)
       case REGIGIGAS_SM243:
         return basic (this, hp:HP150, type:C, retreatCost:4) {
           weakness F
@@ -3329,7 +3329,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case AIPOM_SM244:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -3350,7 +3350,7 @@ public enum SunMoonPromos implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case SABRINA_BRYCEN_SM246:
         return supporter(this) {
           text "Search your deck for up to 2 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck." +
@@ -3388,7 +3388,7 @@ public enum SunMoonPromos implements LogicCardInfo {
           }
         }
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen7/TeamUp.groovy
+++ b/src/tcgwars/logic/impl/gen7/TeamUp.groovy
@@ -5,24 +5,24 @@ import tcgwars.logic.effect.special.Poisoned
 import tcgwars.logic.groovy.TcgStatics
 import tcgwars.logic.impl.gen5.BlackWhite
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
 import tcgwars.logic.effect.gm.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 public enum TeamUp implements LogicCardInfo {
   CELEBI_VENUSAUR_GX_1("Celebi & Venusaur-GX", "1", Rarity.ULTRARARE, [TAG_TEAM,POKEMON_GX,POKEMON,_GRASS_,BASIC]),
@@ -232,53 +232,53 @@ public enum TeamUp implements LogicCardInfo {
   METAL_ENERGY_204 ("Metal Energy", "204", Rarity.COMMON, [BASIC_ENERGY, ENERGY]),
   FAIRY_ENERGY_205 ("Fairy Energy", "205", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   TeamUp(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.TEAM_UP;
+    return tcgwars.logic.card.Collection.TEAM_UP
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -325,7 +325,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WEEDLE_2:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -346,7 +346,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case WEEDLE_3:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -358,7 +358,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case KAKUNA_4:
         return evolution (this, from:"Weedle", hp:HP080, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -384,7 +384,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BEEDRILL_5:
         return evolution (this, from:"Kakuna", hp:HP130, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -409,7 +409,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10,self
             }
           }
-        };
+        }
       case PARAS_6:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -427,7 +427,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PARASECT_7:
         return evolution (this, from:"Paras", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -450,7 +450,7 @@ public enum TeamUp implements LogicCardInfo {
               flipThenApplySC CONFUSED
             }
           }
-        };
+        }
       case EXEGGCUTE_8:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -461,7 +461,7 @@ public enum TeamUp implements LogicCardInfo {
               flip 4, {damage 10}
             }
           }
-        };
+        }
       case PINSIR_9:
         return basic (this, hp:HP120, type:GRASS, retreatCost:3) {
           weakness FIRE
@@ -481,7 +481,7 @@ public enum TeamUp implements LogicCardInfo {
             onAttack{
               flip 2,{},{},[2:{
                 targeted (defending) {
-                  bc "$defending is Knocked Out.";
+                  bc "$defending is Knocked Out."
                   new Knockout(defending).run(bg)
                 }
               },1:{
@@ -491,7 +491,7 @@ public enum TeamUp implements LogicCardInfo {
               }]
             }
           }
-        };
+        }
       case SHAYMIN_PRISM_STAR_10:
         return basic (this, hp:HP080, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -504,7 +504,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARMANDER_11:
         return basic (this, hp:HP050, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -522,7 +522,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case CHARMANDER_12:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -536,7 +536,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARMELEON_13:
         return evolution (this, from:"Charmander", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -550,7 +550,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CHARIZARD_14:
         return evolution (this, from:"Charmeleon", hp:HP150, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -584,7 +584,7 @@ public enum TeamUp implements LogicCardInfo {
 
             }
           }
-        };
+        }
       case VULPIX_15:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -597,7 +597,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NINETALES_16:
         return evolution (this, from:"Vulpix", hp:HP100, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -619,7 +619,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case PONYTA_17:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -638,7 +638,7 @@ public enum TeamUp implements LogicCardInfo {
               flip{damage 30}
             }
           }
-        };
+        }
       case RAPIDASH_18:
         return evolution (this, from:"Ponyta", hp:HP100, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -658,7 +658,7 @@ public enum TeamUp implements LogicCardInfo {
               flip{preventAllEffectsNextTurn()}
             }
           }
-        };
+        }
       case MOLTRES_19:
         return basic (this, hp:HP120, type:FIRE, retreatCost:2) {
           weakness LIGHTNING
@@ -683,7 +683,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LITTEN_20:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -695,7 +695,7 @@ public enum TeamUp implements LogicCardInfo {
               flip {damage 10}
             }
           }
-        };
+        }
       case TORRACAT_21:
         return evolution (this, from:"Litten", hp:HP090, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -716,7 +716,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case SQUIRTLE_22:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -735,7 +735,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SQUIRTLE_23:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -753,7 +753,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case WARTORTLE_24:
         return evolution (this, from:"Squirtle", hp:HP090, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -771,7 +771,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case BLASTOISE_25:
         return evolution (this, from:"Wartortle", hp:HP160, type:WATER, retreatCost:3) {
           weakness GRASS
@@ -799,7 +799,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case PSYDUCK_26:
         return basic (this, hp:HP060, type:WATER, retreatCost:2) {
           weakness GRASS
@@ -828,7 +828,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOLDUCK_27:
         return evolution (this, from:"Psyduck", hp:HP110, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -858,7 +858,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARYU_28:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -870,7 +870,7 @@ public enum TeamUp implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case MAGIKARP_29:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -887,7 +887,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GYARADOS_30:
         return evolution (this, from:"Magikarp", hp:HP150, type:WATER, retreatCost:4) {
           weakness LIGHTNING
@@ -919,7 +919,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LAPRAS_31:
         return basic (this, hp:HP130, type:WATER, retreatCost:3) {
           weakness METAL
@@ -937,7 +937,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10 + 30* self.cards.energyCount(W)
             }
           }
-        };
+        }
       case ARTICUNO_32:
         return basic (this, hp:HP110, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -978,7 +978,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_ZEKROM_GX_33:
         return basic (this, hp:HP240, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -1012,7 +1012,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_GEODUDE_34:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1025,7 +1025,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 60, self
             }
           }
-        };
+        }
       case ALOLAN_GEODUDE_35:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -1045,7 +1045,7 @@ public enum TeamUp implements LogicCardInfo {
               flip 1,{damage 50},{bc "$thisMove missed."}
             }
           }
-        };
+        }
       case ALOLAN_GRAVELER_36:
         return evolution (this, from:"Alolan Geodude", hp:HP100, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1063,7 +1063,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case ALOLAN_GOLEM_37:
         return evolution (this, from:"Alolan Graveler", hp:HP180, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1077,9 +1077,9 @@ public enum TeamUp implements LogicCardInfo {
               def dmgCount = 0
               while(1){
                 def pl=(my.all.findAll {it.cards.filterByEnergyType(L) && it!=self})
-                if(!pl) break;
+                if(!pl) break
                 def src=pl.select("Source for [L] energy (cancel to stop moving)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.filterByEnergyType(L).select("Card to move").first()
                 energySwitch(src, self, card)
                 dmgCount += 20
@@ -1097,7 +1097,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VOLTORB_38:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1109,7 +1109,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ELECTRODE_39:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1121,13 +1121,13 @@ public enum TeamUp implements LogicCardInfo {
                 powerUsed()
                 while(1){
                   def pl=(my.all.findAll {it.cards.energyCount(L)})
-                  if(!pl) break;
+                  if(!pl) break
                   def src =pl.select("source for energy (cancel to stop)", false)
-                  if(!src) break;
+                  if(!src) break
                   def card=src.cards.filterByEnergyType(L).select("Card to move").first()
 
                   def tar=my.all.select("Target for energy (cancel to stop)", false)
-                  if(!tar) break;
+                  if(!tar) break
                   energySwitch(src, tar, card)
                 }
               }
@@ -1140,7 +1140,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ZAPDOS_40:
         return basic (this, hp:HP110, type:LIGHTNING, retreatCost:2) {
           weakness LIGHTNING
@@ -1154,7 +1154,7 @@ public enum TeamUp implements LogicCardInfo {
                 noWeaknessDamage(70,defending)
             }
           }
-        };
+        }
       case MAREEP_41:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness LIGHTNING
@@ -1169,7 +1169,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FLAAFFY_42:
         return evolution (this, from:"Mareep", hp:HP090, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1191,7 +1191,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case AMPHAROS_GX_43:
         return evolution (this, from:"Flaaffy", hp:HP240, type:LIGHTNING, retreatCost:3) {
           weakness FIGHTING
@@ -1226,7 +1226,7 @@ public enum TeamUp implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case BLITZLE_44:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1248,7 +1248,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ZEBSTRIKA_45:
         return evolution (this, from:"Blitzle", hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1270,7 +1270,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case EMOLGA_46:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:0) {
           weakness LIGHTNING
@@ -1292,7 +1292,7 @@ public enum TeamUp implements LogicCardInfo {
               flip{apply PARALYZED}
             }
           }
-        };
+        }
       case JOLTIK_47:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1305,7 +1305,7 @@ public enum TeamUp implements LogicCardInfo {
               removeDamageCounterEqualToDamageDone()
             }
           }
-        };
+        }
       case GALVANTULA_48:
         return evolution (this, from:"Joltik", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1333,7 +1333,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HELIOPTILE_49:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1352,7 +1352,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case HELIOLISK_50:
         return evolution (this, from:"Helioptile", hp:HP100, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1374,7 +1374,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TAPU_KOKO_PRISM_STAR_51:
         return basic (this, hp:HP130, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1401,7 +1401,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case ZERAORA_52:
         return basic (this, hp:HP120, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1421,7 +1421,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case GENGAR_MIMIKYU_GX_53:
         return basic (this, hp:HP240, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1478,7 +1478,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NIDORAN_FEMALE_54:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1494,7 +1494,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case NIDORINA_55:
         return evolution (this, from:"Nidoran♀", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1516,7 +1516,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case NIDOQUEEN_56:
         return evolution (this, from:"Nidorina", hp:HP160, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1542,7 +1542,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case NIDORAN_MALE_57:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1560,7 +1560,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case NIDORINO_58:
         return evolution (this, from:"Nidoran♂", hp:HP090, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1579,7 +1579,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case NIDOKING_59:
         return evolution (this, from:"Nidorino", hp:HP160, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1607,7 +1607,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TENTACOOL_60:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1619,7 +1619,7 @@ public enum TeamUp implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case TENTACRUEL_61:
         return evolution (this, from:"Tentacool", hp:HP100, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1648,7 +1648,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GRIMER_62:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1659,7 +1659,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case MUK_63:
         return evolution (this, from:"Grimer", hp:HP130, type:PSYCHIC, retreatCost:4) {
           weakness PSYCHIC
@@ -1685,7 +1685,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_MAROWAK_64:
         return evolution (this, from:"Cubone", hp:HP120, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1709,7 +1709,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case STARMIE_65:
         return evolution (this, from:"Staryu", hp:HP080, type:PSYCHIC, retreatCost:0) {
           weakness PSYCHIC
@@ -1730,7 +1730,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MR_MIME_66:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1755,7 +1755,7 @@ public enum TeamUp implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case MR_MIME_GX_67:
         return basic (this, hp:HP150, type:PSYCHIC, retreatCost:2) {
           bwAbility "Magic Odds" , {
@@ -1789,7 +1789,7 @@ public enum TeamUp implements LogicCardInfo {
               heal self.numberOfDamageCounters*10, self
             }
           }
-        };
+        }
       case JYNX_68:
         return basic (this, hp:HP090, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1812,7 +1812,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case COSMOG_69:
         return basic (this, hp:HP050, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1836,7 +1836,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case COSMOEM_70:
         return evolution (this, from:"Cosmog", hp:HP100, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1847,7 +1847,7 @@ public enum TeamUp implements LogicCardInfo {
               heal 20, self
             }
           }
-        };
+        }
       case MANKEY_71:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1866,7 +1866,7 @@ public enum TeamUp implements LogicCardInfo {
             energyCost F,C
             onAttack{damage 30}
           }
-        };
+        }
       case PRIMEAPE_72:
         return evolution (this, from:"Mankey", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1890,7 +1890,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HITMONLEE_73:
         return basic (this, hp:HP100, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1912,7 +1912,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case HITMONCHAN_74:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1936,7 +1936,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case OMANYTE_75:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1948,7 +1948,7 @@ public enum TeamUp implements LogicCardInfo {
               flipThenApplySC PARALYZED
             }
           }
-        };
+        }
       case OMASTAR_76:
         return evolution (this, from:"Omanyte", hp:HP130, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1970,7 +1970,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case KABUTO_77:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -1982,7 +1982,7 @@ public enum TeamUp implements LogicCardInfo {
               reduceDamageNextTurn(hp(20),thisMove)
             }
           }
-        };
+        }
       case KABUTOPS_78:
         return evolution (this, from:"Kabuto", hp:HP140, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -2005,7 +2005,7 @@ public enum TeamUp implements LogicCardInfo {
               multiDamage(opp.bench,2,20)
             }
           }
-        };
+        }
       case LARVITAR_79:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -2016,7 +2016,7 @@ public enum TeamUp implements LogicCardInfo {
               shredDamage 30
             }
           }
-        };
+        }
       case PUPITAR_80:
         return evolution (this, from:"Larvitar", hp:HP080, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -2030,7 +2030,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PANCHAM_81:
         return basic (this, hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -2048,7 +2048,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LYCANROC_GX_82:
         return evolution (this, from:"Rockruff", hp:HP200, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -2084,7 +2084,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30*opp.discard.filterByType(ENERGY).size()
             }
           }
-        };
+        }
       case ALOLAN_GRIMER_83:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2096,7 +2096,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20+50*defending.specialConditions.size()
             }
           }
-        };
+        }
       case ALOLAN_MUK_84:
         return evolution (this, from:"Alolan Grimer", hp:HP120, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2125,7 +2125,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TYRANITAR_85:
         return evolution (this, from:"Pupitar", hp:HP170, type:DARKNESS, retreatCost:4) {
           weakness FIGHTING
@@ -2149,7 +2149,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case POOCHYENA_86:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2169,7 +2169,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case MIGHTYENA_87:
         return evolution (this, from:"Poochyena", hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2189,7 +2189,7 @@ public enum TeamUp implements LogicCardInfo {
               discardRandomCardFromOpponentsHand()
             }
           }
-        };
+        }
       case ABSOL_88:
         return basic (this, hp:HP100, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2209,7 +2209,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30 + 30*defending.retreatCost
             }
           }
-        };
+        }
       case SPIRITOMB_89:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           move "Spirit Compressor" , {
@@ -2230,7 +2230,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ZORUA_90:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -2245,7 +2245,7 @@ public enum TeamUp implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case ZOROARK_91:
         return evolution (this, from:"Zorua", hp:HP110, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -2267,7 +2267,7 @@ public enum TeamUp implements LogicCardInfo {
               damage Math.min(20*my.discard.filterByType(POKEMON).size(),200)
             }
           }
-        };
+        }
       case VULLABY_92:
         return basic (this, hp:HP060, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2286,7 +2286,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case MANDIBUZZ_93:
         return evolution (this, from:"Vullaby", hp:HP120, type:DARKNESS, retreatCost:2) {
           weakness LIGHTNING
@@ -2310,7 +2310,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case PANGORO_94:
         return evolution (this, from:"Pancham", hp:HP140, type:DARKNESS, retreatCost:4) {
           weakness FIGHTING
@@ -2338,7 +2338,7 @@ public enum TeamUp implements LogicCardInfo {
               afterDamage{apply CONFUSED, self}
             }
           }
-        };
+        }
       case YVELTAL_95:
         return basic (this, hp:HP110, type:DARKNESS, retreatCost:0) {
           weakness LIGHTNING
@@ -2359,7 +2359,7 @@ public enum TeamUp implements LogicCardInfo {
               cantRetreat(defending)
             }
           }
-        };
+        }
       case HOOPA_GX_96:
         return basic (this, hp:HP190, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2398,7 +2398,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case INCINEROAR_GX_97:
         return evolution (this, from:"Torracat", hp:HP250, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -2442,7 +2442,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10+50*self.numberOfDamageCounters
             }
           }
-        };
+        }
       case SKARMORY_98:
         return basic (this, hp:HP110, type:METAL, retreatCost:1) {
           weakness LIGHTNING
@@ -2463,7 +2463,7 @@ public enum TeamUp implements LogicCardInfo {
               reduceDamageNextTurn(hp(30),thisMove)
             }
           }
-        };
+        }
       case JIRACHI_99:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2487,7 +2487,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case BRONZOR_100:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2510,7 +2510,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BRONZONG_101:
         return evolution (this, from:"Bronzor", hp:HP130, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2538,7 +2538,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FERROSEED_102:
         return basic (this, hp:HP060, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2550,7 +2550,7 @@ public enum TeamUp implements LogicCardInfo {
               flipUntilTails {damage 20}
             }
           }
-        };
+        }
       case FERROTHORN_103:
         return evolution (this, from:"Ferroseed", hp:HP120, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2574,7 +2574,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PAWNIARD_104:
         return basic (this, hp:HP070, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2593,7 +2593,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BISHARP_105:
         return evolution (this, from:"Pawniard", hp:HP110, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2613,7 +2613,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case COBALION_GX_106:
         return basic (this, hp:HP170, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2674,7 +2674,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HONEDGE_107:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2686,7 +2686,7 @@ public enum TeamUp implements LogicCardInfo {
               flip{discardDefendingEnergy()}
             }
           }
-        };
+        }
       case DOUBLADE_108:
         return evolution (this, from:"Honedge", hp:HP090, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2700,7 +2700,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30*count
             }
           }
-        };
+        }
       case AEGISLASH_109:
         return evolution (this, from:"Doublade", hp:HP140, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2725,7 +2725,7 @@ public enum TeamUp implements LogicCardInfo {
               shredDamage 100
             }
           }
-        };
+        }
       case KLEFKI_110:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2752,7 +2752,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case ALOLAN_NINETALES_111:
         return evolution (this, from:"Alolan Vulpix", hp:HP110, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2767,7 +2767,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case MIMIKYU_112:
         return basic (this, hp:HP070, type:FAIRY, retreatCost:1) {
           initHook {Card thisCard->
@@ -2811,7 +2811,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LATIAS_LATIOS_GX_113:
         return basic (this, hp:HP250, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2841,7 +2841,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_EXEGGUTOR_114:
         return evolution (this, from:"Exeggcute", hp:HP160, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2860,7 +2860,7 @@ public enum TeamUp implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_EXEGGUTOR_115:
         return evolution (this, from:"Exeggcute", hp:HP160, type:DRAGON, retreatCost:4) {
           weakness FAIRY
@@ -2884,7 +2884,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 60*tar.select(max:tar.size(),"Choose the Exeggcute to discard").discard().size()
             }
           }
-        };
+        }
       case DRATINI_116:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2895,7 +2895,7 @@ public enum TeamUp implements LogicCardInfo {
               flip 2,{},{},[2:{damage 60},1:{bc "$thisMove failed"},0:{bc "$thisMove failed"}]
             }
           }
-        };
+        }
       case DRATINI_117:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2920,7 +2920,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case DRAGONAIR_118:
         return evolution (this, from:"Dratini", hp:HP090, type:DRAGON, retreatCost:2) {
           weakness FAIRY
@@ -2938,7 +2938,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAGONITE_119:
         return evolution (this, from:"Dragonair", hp:HP160, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2958,7 +2958,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case EEVEE_SNORLAX_GX_120:
         return basic (this, hp:HP270, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -2997,7 +2997,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIDGEY_121:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3016,7 +3016,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PIDGEY_122:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3029,7 +3029,7 @@ public enum TeamUp implements LogicCardInfo {
               flip {damage 10}
             }
           }
-        };
+        }
       case PIDGEOTTO_123:
         return evolution (this, from:"Pidgey", hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3052,7 +3052,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case PIDGEOT_124:
         return evolution (this, from:"Pidgeotto", hp:HP130, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -3074,7 +3074,7 @@ public enum TeamUp implements LogicCardInfo {
               scoopUpPokemon(defending, delegate)
             }
           }
-        };
+        }
       case MEOWTH_125:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3092,7 +3092,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PERSIAN_126:
         return evolution (this, from:"Meowth", hp:HP100, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3121,7 +3121,7 @@ public enum TeamUp implements LogicCardInfo {
               flip {damage 60}
             }
           }
-        };
+        }
       case FARFETCHD_127:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3146,7 +3146,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case KANGASKHAN_128:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -3167,7 +3167,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case TAUROS_129:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -3183,7 +3183,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case AERODACTYL_130:
         return evolution (this, from:"Unidentified Fossil", hp:HP130, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -3205,7 +3205,7 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LUGIA_131:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:2) {
           weakness LIGHTNING
@@ -3226,7 +3226,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case ZANGOOSE_132:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -3254,7 +3254,7 @@ public enum TeamUp implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case BILLS_ANALYSIS_133:
         return supporter(this) {
           text "Look at the top 7 cards of your deck. You may reveal up to 2 Trainer cards you find there and put them into your hand. Shuffle the other cards back into your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3265,7 +3265,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There is no more card in your deck"
           }
-        };
+        }
       case BLACK_MARKET_PRISM_STAR_134:
         return stadium(this) {
           text "Whenever any player's [D] Pokémon with any [D] Energy attached to it is Knocked Out by damage from an opponent's attack, that opponent takes 1 less Prize card.\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -3290,7 +3290,7 @@ public enum TeamUp implements LogicCardInfo {
             eff2.unregister()
           }
 
-        };
+        }
       case BROCKS_GRIT_135:
         return supporter(this) {
           text "Shuffle 6 in any combination of Pokémon and basic Energy cards from your discard pile into your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3303,7 +3303,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.discard.findAll{it.cardTypes.is(BASIC_ENERGY) || it.cardTypes.is(POKEMON)} : "There are no basic Pokémon or basic Energy cards in your discard"
           }
-        };
+        }
       case BUFF_PADDING_136:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nIf the Retreat Cost of the Pokémon this card is attached to is 4, that Pokémon gets +50 HP.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3318,7 +3318,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case DANA_137:
         return supporter(this) {
           text "You can play this card only if your opponent's Active Pokémon is a Stage 2 Pokémon. Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3330,7 +3330,7 @@ public enum TeamUp implements LogicCardInfo {
             assert opp.active.stage2 : "The opponent's Active Pokémon is not a Stage 2 Pokémon"
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case DANGEROUS_DRILL_138:
         return itemCard (this) {
           text "You can play this card only if you discard a [D] Pokémon from your hand.\nDiscard a Pokémon Tool or Special Energy card from 1 of your opponent's Pokémon, or discard any Stadium card in play.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3360,7 +3360,7 @@ public enum TeamUp implements LogicCardInfo {
             assert my.hand.filterByType(POKEMON).findAll{it.asPokemonCard().types.contains(D)}: "There is no [D] pokémon in your hand"
             assert opp.all.findAll{it.cards.filterByType(POKEMON_TOOL, SPECIAL_ENERGY)} || ( bg.stadiumInfoStruct ) : "There is no cards to discard"
           }
-        };
+        }
       case ELECTROCHARGER_139:
         return itemCard (this) {
           text "Flip 2 coins. For each heads, shuffle an Electropower from your discard pile into your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3368,14 +3368,14 @@ public enum TeamUp implements LogicCardInfo {
             int cnt=0
             flip 2, {cnt++}
             if(cnt){
-              my.discard.findAll{it.name == "Electropower"}.select(max: cnt).moveTo(my.deck);
+              my.discard.findAll{it.name == "Electropower"}.select(max: cnt).moveTo(my.deck)
               shuffleDeck()
             }
           }
           playRequirement{
             assert my.discard.find{it.name == "Electropower"} : "There is no Electropower in your discard"
           }
-        };
+        }
       case ERIKAS_HOSPITALITY_140:
         return supporter(this) {
           text "You can play this card only if you have 4 or fewer other cards in your hand.\nDraw a card for each of your opponent's Pokémon in play.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3385,7 +3385,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.hand.getExcludedList(thisCard).size()<=4 : "You don't have 4 or fewer other cards in your hand."
           }
-        };
+        }
       case EVELYN_141:
         return supporter(this) {
           text "You can play this card only if your opponent's Active Pokémon is a Stage 1 Pokémon.\nDraw 4 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3396,7 +3396,7 @@ public enum TeamUp implements LogicCardInfo {
             assert opp.active.stage1 : "Your opponent's Active Pokémon is not a Stage 1 Pokémon"
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case FAIRY_CHARM_UB_142:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nPrevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's Ultra Beast Pokémon-GX and Ultra Beast Pokémon-EX.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3418,7 +3418,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case GRASS_MEMORY_143:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a [G] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3435,7 +3435,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case INGO_EMMET_144:
         return supporter(this) {
           text "Look at the top card of your deck, and then choose 1:Discard your hand and draw 5 cards.\nDiscard your hand and draw 5 cards from the bottom of your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3460,7 +3460,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case JASMINE_145:
         return supporter(this) {
           text "Search your deck for a [M] Pokémon, reveal it, and put it into your hand. If you go second and it's your first turn, search for 5 [M] Pokémon instead of 1. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3471,7 +3471,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case JUDGE_WHISTLE_146:
         return itemCard (this) {
           text "Choose 1:Draw a card.\nPut a Judge card from your discard pile into your hand.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3495,7 +3495,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.deck || my.discard.findAll{it.name == "Judge"}
           }
-        };
+        }
       case LAVENDER_TOWN_147:
         return stadium(this) {
           text "Once during each player's turn, that player may look at their opponent's hand."
@@ -3512,7 +3512,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case METAL_GOGGLES_148:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe [M] Pokémon this card is attached to takes 30 less damage from your opponent's attacks (after applying Weakness and Resistance), and your opponent's attacks and Abilities can't put damage counters on it.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3544,7 +3544,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case MORGAN_149:
         return supporter(this) {
           text "You can play this card only if you discard Dana, Evelyn, and Nita from your hand.\nLook at the top 12 cards of your deck and attach any number of Energy cards you find there to your Pokémon in any way you like. Shuffle the other cards back into your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3568,7 +3568,7 @@ public enum TeamUp implements LogicCardInfo {
             assert my.hand.find{it.name == "Nita"} : "You don't have Nita in your hand"
             assert my.deck : "There are no more cards in your deck."
           }
-        };
+        }
       case NANU_150:
         return supporter(this) {
           text "Choose a Basic [D] Pokémon in your discard pile. Switch it with 1 of your Pokémon in play. Any attached cards, damage counters, Special Conditions, turns in play, and any other effects remain of the new Pokémon.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3582,7 +3582,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC).findAll{it.asPokemonCard().types.contains(D)} : "There are no more cards in your deck."
           }
-        };
+        }
       case NITA_151:
         return supporter(this) {
           text "You can play this card only if your opponent's Active Pokémon is a Basic Pokémon.\nPut an Energy from your opponent's Active Pokémon on top of their deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3595,7 +3595,7 @@ public enum TeamUp implements LogicCardInfo {
             assert opp.active.basic : "Your opponent's Active Pokémon is not a Basic Pokémon"
             assert opp.active.cards.filterByType(ENERGY) : "There is no energy attached to your opponent's Active Pokémon"
           }
-        };
+        }
       case POKEMON_COMMUNICATION_152:
         return copy(BlackWhite.POKEMON_COMMUNICATION_99, this)
 //        return itemCard (this) {
@@ -3617,7 +3617,7 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert opp.discard : "There is no card in your opponent's discard"
           }
-        };
+        }
       case SABRINAS_SUGGESTION_154:
         return supporter(this) {
           text "Your opponent reveals their hand. You may choose a Supporter card you find there and use the effect of that card as the effect of this card.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3636,9 +3636,9 @@ public enum TeamUp implements LogicCardInfo {
           playRequirement{
             assert opp.hand : "There is no card in your opponent's hand"
           }
-        };
+        }
       case UNIDENTIFIED_FOSSIL_155:
-        return copy (UltraPrism.UNIDENTIFIED_FOSSIL_134, this);
+        return copy (UltraPrism.UNIDENTIFIED_FOSSIL_134, this)
       case VIRIDIAN_FOREST_156:
         return stadium(this) {
           text "Once during each player's turn, that player may discard a card from their hand. If they do, that player searches their deck for a basic Energy card, reveals it, and puts it into their hand. Then, that player shuffles their deck\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card."
@@ -3659,7 +3659,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case WATER_MEMORY_157:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a [W] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3676,7 +3676,7 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case WONDROUS_LABYRINTH_PRISM_STAR_158:
         return stadium(this) {
           text "The attacks of non-[Y] Pokémon (both yours and your opponent's) cost [C] more.\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.\nPrism Star Rule: You can't have more than 1 Prism Star card with the same name in your deck. If a Prism Star card would go to the discard pile, put it in the Lost Zone instead."
@@ -3697,9 +3697,9 @@ public enum TeamUp implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case CELEBI_VENUSAUR_GX_159:
-        return copy (CELEBI_VENUSAUR_GX_1, this);
+        return copy (CELEBI_VENUSAUR_GX_1, this)
       case MAGIKARP_WAILORD_GX_160:
         return basic (this, hp:HP300, type:WATER, retreatCost:4) {
           weakness GRASS
@@ -3724,136 +3724,136 @@ public enum TeamUp implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGIKARP_WAILORD_GX_161:
-        return copy (MAGIKARP_WAILORD_GX_160, this);
+        return copy (MAGIKARP_WAILORD_GX_160, this)
 
       case PIKACHU_ZEKROM_GX_162:
-        return copy (PIKACHU_ZEKROM_GX_33, this);
+        return copy (PIKACHU_ZEKROM_GX_33, this)
 
       case AMPHAROS_GX_163:
-        return copy (AMPHAROS_GX_43, this);
+        return copy (AMPHAROS_GX_43, this)
 
       case GENGAR_MIMIKYU_GX_164:
-        return copy (GENGAR_MIMIKYU_GX_53, this);
+        return copy (GENGAR_MIMIKYU_GX_53, this)
 
       case GENGAR_MIMIKYU_GX_165:
-        return copy (GENGAR_MIMIKYU_GX_53, this);
+        return copy (GENGAR_MIMIKYU_GX_53, this)
 
       case HOOPA_GX_166:
-        return copy (HOOPA_GX_96, this);
+        return copy (HOOPA_GX_96, this)
 
       case INCINEROAR_GX_167:
-        return copy (INCINEROAR_GX_97, this);
+        return copy (INCINEROAR_GX_97, this)
 
       case COBALION_GX_168:
-        return copy (COBALION_GX_106, this);
+        return copy (COBALION_GX_106, this)
 
       case LATIAS_LATIOS_GX_169:
-        return copy (LATIAS_LATIOS_GX_113, this);
+        return copy (LATIAS_LATIOS_GX_113, this)
 
       case LATIAS_LATIOS_GX_170:
-        return copy (LATIAS_LATIOS_GX_113, this);
+        return copy (LATIAS_LATIOS_GX_113, this)
 
       case EEVEE_SNORLAX_GX_171:
-        return copy (EEVEE_SNORLAX_GX_120, this);
+        return copy (EEVEE_SNORLAX_GX_120, this)
 
       case BROCKS_GRIT_172:
-        return copy (BROCKS_GRIT_135, this);
+        return copy (BROCKS_GRIT_135, this)
 
       case DANA_173:
-        return copy (DANA_137, this);
+        return copy (DANA_137, this)
 
       case ERIKAS_HOSPITALITY_174:
-        return copy (ERIKAS_HOSPITALITY_140, this);
+        return copy (ERIKAS_HOSPITALITY_140, this)
 
       case EVELYN_175:
-        return copy (EVELYN_141, this);
+        return copy (EVELYN_141, this)
 
       case INGO_EMMET_176:
-        return copy (INGO_EMMET_144, this);
+        return copy (INGO_EMMET_144, this)
 
       case JASMINE_177:
-        return copy (JASMINE_145, this);
+        return copy (JASMINE_145, this)
 
       case MORGAN_178:
-        return copy (MORGAN_149, this);
+        return copy (MORGAN_149, this)
 
       case NANU_179:
-        return copy (NANU_150, this);
+        return copy (NANU_150, this)
 
       case NITA_180:
-        return copy (NITA_151, this);
+        return copy (NITA_151, this)
 
       case SABRINAS_SUGGESTION_181:
-        return copy (SABRINAS_SUGGESTION_154, this);
+        return copy (SABRINAS_SUGGESTION_154, this)
 
       case CELEBI_VENUSAUR_GX_182:
-        return copy (CELEBI_VENUSAUR_GX_1, this);
+        return copy (CELEBI_VENUSAUR_GX_1, this)
 
       case MAGIKARP_WAILORD_GX_183:
-        return copy (MAGIKARP_WAILORD_GX_160, this);
+        return copy (MAGIKARP_WAILORD_GX_160, this)
 
       case PIKACHU_ZEKROM_GX_184:
-        return copy (PIKACHU_ZEKROM_GX_33, this);
+        return copy (PIKACHU_ZEKROM_GX_33, this)
 
       case AMPHAROS_GX_185:
-        return copy (AMPHAROS_GX_43, this);
+        return copy (AMPHAROS_GX_43, this)
 
       case GENGAR_MIMIKYU_GX_186:
-        return copy (GENGAR_MIMIKYU_GX_53, this);
+        return copy (GENGAR_MIMIKYU_GX_53, this)
 
       case HOOPA_GX_187:
-        return copy (HOOPA_GX_96, this);
+        return copy (HOOPA_GX_96, this)
 
       case INCINEROAR_GX_188:
-        return copy (INCINEROAR_GX_97, this);
+        return copy (INCINEROAR_GX_97, this)
 
       case COBALION_GX_189:
-        return copy (COBALION_GX_106, this);
+        return copy (COBALION_GX_106, this)
 
       case LATIAS_LATIOS_GX_190:
-        return copy (LATIAS_LATIOS_GX_113, this);
+        return copy (LATIAS_LATIOS_GX_113, this)
 
       case EEVEE_SNORLAX_GX_191:
-        return copy (EEVEE_SNORLAX_GX_120, this);
+        return copy (EEVEE_SNORLAX_GX_120, this)
 
       case DANGEROUS_DRILL_192:
-        return copy (DANGEROUS_DRILL_138, this);
+        return copy (DANGEROUS_DRILL_138, this)
 
       case ELECTROCHARGER_193:
-        return copy (ELECTROCHARGER_139, this);
+        return copy (ELECTROCHARGER_139, this)
 
       case JUDGE_WHISTLE_194:
-        return copy (JUDGE_WHISTLE_146, this);
+        return copy (JUDGE_WHISTLE_146, this)
 
       case METAL_GOGGLES_195:
-        return copy (METAL_GOGGLES_148, this);
+        return copy (METAL_GOGGLES_148, this)
 
       case POKEMON_COMMUNICATION_196:
         return copy(BlackWhite.POKEMON_COMMUNICATION_99, this)
 //          return copy (POKEMON_COMMUNICATION_152, this);
 
       case GRASS_ENERGY_197:
-        return basicEnergy (this, G);
+        return basicEnergy (this, G)
       case FIRE_ENERGY_198:
-        return basicEnergy (this, R);
+        return basicEnergy (this, R)
       case WATER_ENERGY_199:
-        return basicEnergy (this, W);
+        return basicEnergy (this, W)
       case LIGHTNING_ENERGY_200:
-        return basicEnergy (this, L);
+        return basicEnergy (this, L)
       case PSYCHIC_ENERGY_201:
-        return basicEnergy (this, P);
+        return basicEnergy (this, P)
       case FIGHTING_ENERGY_202:
-        return basicEnergy (this, F);
+        return basicEnergy (this, F)
       case DARKNESS_ENERGY_203:
-        return basicEnergy (this, D);
+        return basicEnergy (this, D)
       case METAL_ENERGY_204:
-        return basicEnergy (this, M);
+        return basicEnergy (this, M)
       case FAIRY_ENERGY_205:
-        return basicEnergy (this, Y);
+        return basicEnergy (this, Y)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
+++ b/src/tcgwars/logic/impl/gen7/UltraPrism.groovy
@@ -3,23 +3,23 @@ package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.impl.gen6.Flashfire
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author itrezad@gmail.com
@@ -202,53 +202,53 @@ public enum UltraPrism implements LogicCardInfo {
   LUNALA_GX_172 ("Lunala-GX", "172", Rarity.SECRET, [STAGE2, EVOLUTION, POKEMON, POKEMON_GX, _PSYCHIC_]),
   SOLGALEO_GX_173 ("Solgaleo-GX", "173", Rarity.SECRET, [STAGE2, EVOLUTION, POKEMON, POKEMON_GX, _METAL_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   UltraPrism(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.ULTRA_PRISM;
+    return tcgwars.logic.card.Collection.ULTRA_PRISM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -265,7 +265,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMA_2:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -279,7 +279,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YANMEGA_3:
         return evolution (this, from:"Yanma", hp:HP120, type:GRASS, retreatCost:1) {
           weakness LIGHTNING
@@ -302,7 +302,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSELIA_4:
         return basic (this, hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -315,7 +315,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROSERADE_5:
         return evolution (this, from:"Roselia", hp:HP100, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -337,17 +337,17 @@ public enum UltraPrism implements LogicCardInfo {
               damage 100
               while(1){
                 def pl=(my.all.findAll {it.cards.energyCount(G)})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("Source for energy (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
                 def tar=my.all.select("Target for energy (cancel to stop)", false)
-                if(!tar) break;
+                if(!tar) break
                 energySwitch(src, tar, card)
               }
             }
           }
-        };
+        }
       case TURTWIG_6:
         return basic (this, hp:HP070, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -370,7 +370,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTWIG_7:
         return basic (this, hp:HP080, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -389,7 +389,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROTLE_8:
         return evolution (this, from:"Turtwig", hp:HP110, type:GRASS, retreatCost:4) {
           weakness FIRE
@@ -409,7 +409,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORTERRA_9:
         return evolution (this, from:"Grotle", hp:HP180, type:GRASS, retreatCost:4) {
           weakness FIRE
@@ -430,7 +430,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERUBI_10:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -442,7 +442,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHERRIM_11:
         return evolution (this, from:"Cherubi", hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -462,7 +462,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARNIVINE_12:
         return basic (this, hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -482,7 +482,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LEAFEON_GX_13:
         return evolution (this, from:"Eevee", hp:HP200, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -531,7 +531,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOW_ROTOM_14:
         return basic (this, hp:HP090, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -559,7 +559,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHAYMIN_15:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -595,7 +595,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWPIDER_16:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -608,7 +608,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARAQUANID_17:
         return evolution (this, from:"Dewpider", hp:HP100, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -633,7 +633,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_18:
         return basic (this, hp:HP080, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -658,7 +658,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMORTAR_19:
         return evolution (this, from:"Magmar", hp:HP130, type:FIRE, retreatCost:3) {
           weakness WATER
@@ -681,7 +681,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMCHAR_20:
         return basic (this, hp:HP040, type:FIRE, retreatCost:0) {
           weakness WATER
@@ -693,7 +693,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHIMCHAR_21:
         return basic (this, hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -705,7 +705,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MONFERNO_22:
         return evolution (this, from:"Chimchar", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -718,7 +718,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INFERNAPE_23:
         return evolution (this, from:"Monferno", hp:HP130, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -740,7 +740,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEAT_ROTOM_24:
         return basic (this, hp:HP090, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -767,7 +767,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALANDIT_25:
         return basic (this, hp:HP070, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -786,7 +786,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAZZLE_26:
         return evolution (this, from:"Salandit", hp:HP110, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -812,7 +812,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TURTONATOR_27:
         return basic (this, hp:HP130, type:FIRE, retreatCost:4) {
           weakness WATER
@@ -832,7 +832,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_SANDSHREW_28:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness METAL
@@ -843,7 +843,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_SANDSLASH_29:
         return evolution (this, from:"Alolan Sandshrew", hp:HP120, type:WATER, retreatCost:1) {
           weakness METAL
@@ -865,7 +865,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_VULPIX_30:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness METAL
@@ -883,7 +883,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIPLUP_31:
         return basic (this, hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -895,7 +895,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIPLUP_32:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -914,7 +914,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRINPLUP_33:
         return evolution (this, from:"Piplup", hp:HP090, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -934,7 +934,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EMPOLEON_34:
         return evolution (this, from:"Prinplup", hp:HP160, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -954,7 +954,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUIZEL_35:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -966,7 +966,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLOATZEL_36:
         return evolution (this, from:"Buizel", hp:HP100, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -989,7 +989,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNOVER_37:
         return basic (this, hp:HP080, type:WATER, retreatCost:3) {
           weakness METAL
@@ -1002,7 +1002,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABOMASNOW_38:
         return evolution (this, from:"Snover", hp:HP130, type:WATER, retreatCost:3) {
           weakness METAL
@@ -1024,7 +1024,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLACEON_GX_39:
         return evolution (this, from:"Eevee", hp:HP200, type:WATER, retreatCost:2) {
           weakness METAL
@@ -1066,7 +1066,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WASH_ROTOM_40:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1096,7 +1096,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROST_ROTOM_41:
         return basic (this, hp:HP090, type:WATER, retreatCost:1) {
           weakness METAL
@@ -1125,7 +1125,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANAPHY_42:
         return basic (this, hp:HP070, type:WATER, retreatCost:1) {
           weakness GRASS
@@ -1149,7 +1149,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTABUZZ_43:
         return basic (this, hp:HP080, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -1170,7 +1170,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTIVIRE_44:
         return evolution (this, from:"Electabuzz", hp:HP140, type:LIGHTNING, retreatCost:4) {
           weakness FIGHTING
@@ -1191,7 +1191,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_45:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1215,7 +1215,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHINX_46:
         return basic (this, hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1232,7 +1232,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXIO_47:
         return evolution (this, from:"Shinx", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1254,7 +1254,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUXRAY_48:
         return evolution (this, from:"Luxio", hp:HP150, type:LIGHTNING, retreatCost:0) {
           weakness FIGHTING
@@ -1279,7 +1279,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PACHIRISU_49:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1310,7 +1310,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ROTOM_50:
         return basic (this, hp:HP070, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1339,7 +1339,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFLOON_51:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness LIGHTNING
@@ -1359,7 +1359,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFBLIM_52:
         return evolution (this, from:"Drifloon", hp:HP110, type:PSYCHIC, retreatCost:1) {
           weakness LIGHTNING
@@ -1386,7 +1386,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPIRITOMB_53:
         return basic (this, hp:HP070, type:PSYCHIC, retreatCost:1) {
           move "Lightless World", {
@@ -1408,7 +1408,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKORUPI_54:
         return basic (this, hp:HP080, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1427,7 +1427,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAPION_55:
         return evolution (this, from:"Skorupi", hp:HP130, type:PSYCHIC, retreatCost:3) {
           weakness PSYCHIC
@@ -1443,7 +1443,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROAGUNK_56:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1456,7 +1456,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOXICROAK_57:
         return evolution (this, from:"Croagunk", hp:HP100, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -1477,7 +1477,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIRATINA_PRISM_STAR_58:
         return basic (this, hp:HP160, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1503,7 +1503,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRESSELIA_59:
         return basic (this, hp:HP120, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1528,7 +1528,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COSMOG_60:
         return basic (this, hp:HP060, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -1540,9 +1540,9 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COSMOEM_61:
-        return copy (SunMoon.COSMOEM_65, this);
+        return copy (SunMoon.COSMOEM_65, this)
       case LUNALA_PRISM_STAR_62:
         return basic (this, hp:HP160, type:PSYCHIC, retreatCost:3) {
           weakness DARKNESS
@@ -1568,7 +1568,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DAWN_WINGS_NECROZMA_GX_63:
         return basic (this, hp:HP180, type:PSYCHIC, retreatCost:2) {
           weakness DARKNESS
@@ -1604,7 +1604,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRANIDOS_64:
         return evolution (this, from:"Unidentified Fossil", hp:HP090, type:FIGHTING, retreatCost:1) {
           //TODO: Does the evolution from unidentified fossil take extra checks?
@@ -1624,7 +1624,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAMPARDOS_65:
         return evolution (this, from:"Cranidos", hp:HP150, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -1649,7 +1649,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIOLU_66:
         return basic (this, hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1668,7 +1668,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_67:
         return evolution (this, from:"Riolu", hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1692,7 +1692,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOPOTAS_68:
         return basic (this, hp:HP090, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -1706,7 +1706,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HIPPOWDON_69:
         return evolution (this, from:"Hippopotas", hp:HP140, type:FIGHTING, retreatCost:4) {
           weakness GRASS
@@ -1726,7 +1726,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PASSIMIAN_70:
         return basic (this, hp:HP110, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -1752,7 +1752,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_71:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1766,7 +1766,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_72:
         return evolution (this, from:"Murkrow", hp:HP110, type:DARKNESS, retreatCost:1) {
           weakness LIGHTNING
@@ -1787,7 +1787,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNEASEL_73:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1817,7 +1817,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEAVILE_74:
         return evolution (this, from:"Sneasel", hp:HP090, type:DARKNESS, retreatCost:1) {
           weakness FIGHTING
@@ -1838,7 +1838,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNKY_75:
         return basic (this, hp:HP070, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1853,7 +1853,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SKUNTANK_76:
         return evolution (this, from:"Stunky", hp:HP120, type:DARKNESS, retreatCost:3) {
           weakness FIGHTING
@@ -1875,7 +1875,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARKRAI_PRISM_STAR_77:
         return basic (this, hp:HP160, type:DARKNESS, retreatCost:2) {
           weakness FIGHTING
@@ -1909,7 +1909,7 @@ public enum UltraPrism implements LogicCardInfo {
                   before ASLEEP_SPC, null, null, BEGIN_TURN, {
                     if(ef.target == self.owner.opposite.pbg.active){ //MARK parentEvent
                       flip "Asleep (Abyssal Sleep)", 2, {}, {}, [2:{
-                        ef.unregisterItself(bg.em());
+                        ef.unregisterItself(bg.em())
                       },1:{
                         bc "$self is still asleep."
                       },0:{
@@ -1923,7 +1923,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_DIGLETT_78:
         return basic (this, hp:HP050, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1935,7 +1935,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_DUGTRIO_79:
         return evolution (this, from:"Alolan Diglett", hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1950,7 +1950,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_80:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1973,7 +1973,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEMITE_81:
         return basic (this, hp:HP060, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -1999,7 +1999,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_82:
         return evolution (this, from:"Magnemite", hp:HP090, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2020,7 +2020,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNEZONE_83:
         return evolution (this, from:"Magneton", hp:HP150, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2044,7 +2044,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIELDON_84:
         return evolution (this, from:"Unidentified Fossil", hp:HP100, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2065,7 +2065,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BASTIODON_85:
         return evolution (this, from:"Shieldon", hp:HP160, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2092,7 +2092,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZOR_86:
         return basic (this, hp:HP060, type:METAL, retreatCost:2) {
           weakness FIRE
@@ -2112,7 +2112,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BRONZONG_87:
         return evolution (this, from:"Bronzor", hp:HP110, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2135,7 +2135,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HEATRAN_88:
         return basic (this, hp:HP130, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2159,7 +2159,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SOLGALEO_PRISM_STAR_89:
         return basic (this, hp:HP160, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2187,7 +2187,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSK_MANE_NECROZMA_GX_90:
         return basic (this, hp:HP190, type:METAL, retreatCost:3) {
           weakness FIRE
@@ -2223,7 +2223,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGEARNA_91:
         return basic (this, hp:HP090, type:METAL, retreatCost:1) {
           weakness FIRE
@@ -2249,7 +2249,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MORELULL_92:
         return basic (this, hp:HP060, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2269,7 +2269,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHIINOTIC_93:
         return evolution (this, from:"Morelull", hp:HP100, type:FAIRY, retreatCost:2) {
           weakness METAL
@@ -2293,7 +2293,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAPU_LELE_94:
         return basic (this, hp:HP110, type:FAIRY, retreatCost:1) {
           weakness METAL
@@ -2320,13 +2320,13 @@ public enum UltraPrism implements LogicCardInfo {
               }
               while(1){
                 def pl=(opp.all.findAll {it.numberOfDamageCounters})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("Source for damage counter (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def tar = opp.all
                 tar.remove(src)
                 tar = tar.select("Target for damage counter (cancel to stop)", false)
-                if(!tar) break;
+                if(!tar) break
 
                 src.damage-=hp(10)
                 directDamage 10, tar
@@ -2336,7 +2336,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_EXEGGUTOR_95:
         return evolution (this, from:"Exeggcute", hp:HP130, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2364,7 +2364,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GIBLE_96:
         return basic (this, hp:HP050, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2374,7 +2374,7 @@ public enum UltraPrism implements LogicCardInfo {
             ascension delegate
           }
 
-        };
+        }
       case GIBLE_97:
         return basic (this, hp:HP060, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2394,7 +2394,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GABITE_98:
         return evolution (this, from:"Gible", hp:HP080, type:DRAGON, retreatCost:1) {
           weakness FAIRY
@@ -2411,7 +2411,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARCHOMP_99:
         return evolution (this, from:"Gabite", hp:HP150, type:DRAGON, retreatCost:0) {
           weakness FAIRY
@@ -2434,7 +2434,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIALGA_GX_100:
         return basic (this, hp:HP180, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2491,7 +2491,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PALKIA_GX_101:
         return basic (this, hp:HP180, type:DRAGON, retreatCost:3) {
           weakness FAIRY
@@ -2501,9 +2501,9 @@ public enum UltraPrism implements LogicCardInfo {
             onAttack {
               while(1){
                 def pl=(my.bench.findAll {it.cards.energyCount(C)})
-                if(!pl) break;
+                if(!pl) break
                 def src =pl.select("source for energy (cancel to stop)", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
                 energySwitch(src, self, card)
               }
@@ -2533,7 +2533,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_102:
         return basic (this, hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2552,7 +2552,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKILICKY_103:
         return evolution (this, from:"Lickitung", hp:HP130, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -2577,7 +2577,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_104:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2589,7 +2589,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_105:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2608,7 +2608,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUNEARY_106:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2627,7 +2627,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LOPUNNY_107:
         return evolution (this, from:"Buneary", hp:HP090, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2653,7 +2653,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLAMEOW_108:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2666,7 +2666,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PURUGLY_109:
         return evolution (this, from:"Glameow", hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2691,7 +2691,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FAN_ROTOM_110:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -2719,7 +2719,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHAYMIN_111:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness LIGHTNING
@@ -2748,7 +2748,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case YUNGOOS_112:
         return basic (this, hp:HP070, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -2771,7 +2771,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GUMSHOOS_113:
         return evolution (this, from:"Yungoos", hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2794,7 +2794,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ORANGURU_114:
         return basic (this, hp:HP120, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2819,7 +2819,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYPE__NULL_115:
         return basic (this, hp:HP110, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -2840,9 +2840,9 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SILVALLY_GX_116:
-        return copy (CrimsonInvasion.SILVALLY_GX_90, this);
+        return copy (CrimsonInvasion.SILVALLY_GX_90, this)
 
       case DRAMPA_117:
         return basic (this, hp:HP130, type:COLORLESS, retreatCost:3) {
@@ -2863,7 +2863,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ANCIENT_CRYSTAL_118:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nThe Regirock, Regice, Registeel, or Regigigas this card is attached to takes 30 less damage from your opponent’s attacks (after applying Weakness and Resistance).\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2883,7 +2883,7 @@ public enum UltraPrism implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case CYNTHIA_119:
         return supporter (this) {
           text "Shuffle your hand into your deck. Then, draw 6 cards.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2896,7 +2896,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty || (my.hand.getExcludedList(thisCard).size() != 0)
           }
-        };
+        }
       case CYRUS_PRISM_STAR_120:
         return supporter (this) {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\nYou can play this card only if your Active Pokémon is a [W] or [M] Pokémon.\nYour opponent chooses 2 Benched Pokémon and shuffles the others, and all cards attached to them, into their deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2913,7 +2913,7 @@ public enum UltraPrism implements LogicCardInfo {
             assert my.active.types.contains(W) || my.active.types.contains(M) : "Your Active Pokémon needs to be [W] or [M]. (The card text was officially changed)"
             assert opp.bench.size() > 2 : "Opponent needs to have more than 2 benched Pokémon"
           }
-        };
+        }
       case ELECTRIC_MEMORY_121:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a Lightning Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2931,7 +2931,7 @@ public enum UltraPrism implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case ESCAPE_BOARD_122:
         return pokemonTool (this) {
           text "The Retreat Cost of the Pokémon this card is attached to is [C] less, and it can retreat even if it’s Asleep or Paralyzed.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2950,7 +2950,7 @@ public enum UltraPrism implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case FIRE_MEMORY_123:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it.\nThe Silvally-GX this card is attached to is a [R] Pokémon.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -2967,7 +2967,7 @@ public enum UltraPrism implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case GARDENIA_124:
         return supporter (this) {
           text "Heal 80 damage from 1 of your Pokémon that has any [G] Energy attached to it.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2979,9 +2979,9 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.all.any {it.cards.energyCount(G) && it.numberOfDamageCounters }
           }
-        };
+        }
       case LILLIE_125:
-        return copy(SunMoon.LILLIE_122,this);
+        return copy(SunMoon.LILLIE_122,this)
       case LOOKER_126:
         return supporter (this) {
           text "Draw 3 cards from the bottom of your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -2992,7 +2992,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case LOOKER_WHISTLE_127:
         return itemCard (this) {
           text "Search your deck for up to 2 cards named Looker, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3003,7 +3003,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case MARS_128:
         return supporter (this) {
           text "Draw 2 cards. If you do, discard a random card from your opponent’s hand.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3014,7 +3014,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case MISSING_CLOVER_129:
         return itemCard (this) {
           text "You may play 4 Missing Clover cards at once. \n-If you played 1 card, look at the top card of your deck \n if you played 4 cards, take a prize card \nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3031,7 +3031,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert (my.hand.count{it.name=="Missing Clover"} >= 4 || my.deck) : "You have no cards in your deck"
           }
-        };
+        }
       case MT__CORONET_130:
         return stadium (this) {
           text "Once during each player’s turn, that player may put 2 [M] Energy cards from their discard pile into their hand.\nThis card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -3049,7 +3049,7 @@ public enum UltraPrism implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case ORDER_PAD_131:
         return itemCard (this) {
           text "Flip a coin. If heads, search your deck for an Item card, reveal it, and put it into your hand. Then, shuffle your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3062,7 +3062,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty
           }
-        };
+        }
       case PAL_PAD_132:
         return itemCard (this) {
           text "Shuffle 2 Supporter cards from your discard pile into your deck.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3073,9 +3073,9 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(SUPPORTER) : "No supporter in discard"
           }
-        };
+        }
       case POKEMON_FAN_CLUB_133:
-        return copy(Flashfire.POKEMON_FAN_CLUB_94,this);
+        return copy(Flashfire.POKEMON_FAN_CLUB_94,this)
       case UNIDENTIFIED_FOSSIL_134:
         return itemCard (this) {
           text "Play this card as if it were a 60-HP [C] Basic Pokémon. At any time during your turn (before your attack), you may discard this card from play.\nThis card can’t retreat.\nYou may play as many Item cards as you like during your turn (before your attack)."
@@ -3127,7 +3127,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert bench.notFull
           }
-        };
+        }
       case VOLKNER_135:
         return supporter (this) {
           text "Search your deck for an Item card and a [L] Energy card, reveal them, and put them into your hand. Then, shuffle your deck.\nYou may play only 1 Supporter card during your turn (before your attack)."
@@ -3139,7 +3139,7 @@ public enum UltraPrism implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty
           }
-        };
+        }
       case SUPER_BOOST_ENERGY_PRISM_STAR_136:
         return specialEnergy (this, [[C]]) {
           text "♢ (Prism Star) Rule: You can’t have more than 1 ♢ card with the same name in your deck. If a ♢ card would go to the discard pile, put it in the Lost Zone instead.\n" +
@@ -3163,7 +3163,7 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case UNIT_ENERGY_GRW_137:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\n While this card is attached to a Pokémon, it provides [G], [W], and [R] Energy but provides only 1 Energy at a time."
@@ -3173,7 +3173,7 @@ public enum UltraPrism implements LogicCardInfo {
           getEnergyTypesOverride {
             self != null ? [[G,R,W] as Set] : [[C] as Set]
           }
-        };
+        }
       case UNIT_ENERGY_LPM_138:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy.\n While this card is attached to a Pokémon, it provides [L], [P], and [M] Energy but provides only 1 Energy at a time."
@@ -3183,9 +3183,9 @@ public enum UltraPrism implements LogicCardInfo {
           getEnergyTypesOverride {
             self != null ? [[L,P,M] as Set] : [[C] as Set]
           }
-        };
+        }
       case LEAFEON_GX_139:
-        return copy (LEAFEON_GX_13, this);
+        return copy (LEAFEON_GX_13, this)
       case PHEROMOSA_GX_140:
         return basic (this, hp:HP170, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -3218,9 +3218,9 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLACEON_GX_141:
-        return copy (GLACEON_GX_39, this);
+        return copy (GLACEON_GX_39, this)
       case XURKITREE_GX_142:
         return basic (this, hp:HP180, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -3264,9 +3264,9 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DAWN_WINGS_NECROZMA_GX_143:
-        return copy (DAWN_WINGS_NECROZMA_GX_63, this);
+        return copy (DAWN_WINGS_NECROZMA_GX_63, this)
       case CELESTEELA_GX_144:
         return basic (this, hp:HP200, type:METAL, retreatCost:4) {
           weakness LIGHTNING
@@ -3300,67 +3300,67 @@ public enum UltraPrism implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUSK_MANE_NECROZMA_GX_145:
-        return copy (DUSK_MANE_NECROZMA_GX_90, this);
+        return copy (DUSK_MANE_NECROZMA_GX_90, this)
       case DIALGA_GX_146:
-        return copy (DIALGA_GX_100, this);
+        return copy (DIALGA_GX_100, this)
       case PALKIA_GX_147:
-        return copy (PALKIA_GX_101, this);
+        return copy (PALKIA_GX_101, this)
       case CYNTHIA_148:
-        return copy (CYNTHIA_119, this);
+        return copy (CYNTHIA_119, this)
       case GARDENIA_149:
-        return copy (GARDENIA_124, this);
+        return copy (GARDENIA_124, this)
       case LANA_150:
-        return copy (BurningShadows.LANA_117,this);
+        return copy (BurningShadows.LANA_117,this)
       case LILLIE_151:
-        return copy (LILLIE_125, this);
+        return copy (LILLIE_125, this)
       case LOOKER_152:
-        return copy (LOOKER_126, this);
+        return copy (LOOKER_126, this)
       case LUSAMINE_153:
-        return copy (CrimsonInvasion.LUSAMINE_96,this);
+        return copy (CrimsonInvasion.LUSAMINE_96,this)
       case MARS_154:
-        return copy (MARS_128, this);
+        return copy (MARS_128, this)
       case POKEMON_FAN_CLUB_155:
-        return copy (POKEMON_FAN_CLUB_133, this);
+        return copy (POKEMON_FAN_CLUB_133, this)
       case VOLKNER_156:
-        return copy (VOLKNER_135, this);
+        return copy (VOLKNER_135, this)
       case LEAFEON_GX_157:
-        return copy (LEAFEON_GX_13, this);
+        return copy (LEAFEON_GX_13, this)
       case PHEROMOSA_GX_158:
-        return copy (PHEROMOSA_GX_140, this);
+        return copy (PHEROMOSA_GX_140, this)
       case GLACEON_GX_159:
-        return copy (GLACEON_GX_39, this);
+        return copy (GLACEON_GX_39, this)
       case XURKITREE_GX_160:
-        return copy (XURKITREE_GX_142, this);
+        return copy (XURKITREE_GX_142, this)
       case DAWN_WINGS_NECROZMA_GX_161:
         return copy (DAWN_WINGS_NECROZMA_GX_63, this)
       case CELESTEELA_GX_162:
-        return copy (CELESTEELA_GX_144, this);
+        return copy (CELESTEELA_GX_144, this)
       case DUSK_MANE_NECROZMA_GX_163:
-        return copy (DUSK_MANE_NECROZMA_GX_90, this);
+        return copy (DUSK_MANE_NECROZMA_GX_90, this)
       case DIALGA_GX_164:
-        return copy (DIALGA_GX_100, this);
+        return copy (DIALGA_GX_100, this)
       case PALKIA_GX_165:
-        return copy (PALKIA_GX_101, this);
+        return copy (PALKIA_GX_101, this)
       case CRUSHING_HAMMER_166:
-        return copy (SunMoon.CRUSHING_HAMMER_115, this);
+        return copy (SunMoon.CRUSHING_HAMMER_115, this)
       case ESCAPE_BOARD_167:
-        return copy (ESCAPE_BOARD_122, this);
+        return copy (ESCAPE_BOARD_122, this)
       case MISSING_CLOVER_168:
-        return copy (MISSING_CLOVER_129, this);
+        return copy (MISSING_CLOVER_129, this)
       case PEEKING_RED_CARD_169:
-        return copy (CrimsonInvasion.PEEKING_RED_CARD_97,this);
+        return copy (CrimsonInvasion.PEEKING_RED_CARD_97,this)
       case UNIT_ENERGY_GRW_170:
-        return copy (UNIT_ENERGY_GRW_137, this);
+        return copy (UNIT_ENERGY_GRW_137, this)
       case UNIT_ENERGY_LPM_171:
-        return copy (UNIT_ENERGY_LPM_138, this);
+        return copy (UNIT_ENERGY_LPM_138, this)
       case LUNALA_GX_172:
-        return copy (SunMoonPromos.LUNALA_GX_SM17, this);
+        return copy (SunMoonPromos.LUNALA_GX_SM17, this)
       case SOLGALEO_GX_173:
-        return copy (SunMoonPromos.SOLGALEO_GX_SM16, this);
+        return copy (SunMoonPromos.SOLGALEO_GX_SM16, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnbrokenBonds.groovy
@@ -1,29 +1,29 @@
 package tcgwars.logic.impl.gen7
 
 import tcgwars.logic.effect.getter.GetterEffect
-import tcgwars.logic.groovy.TcgStatics;
+import tcgwars.logic.groovy.TcgStatics
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
+import tcgwars.logic.*
+import tcgwars.logic.card.*
 import tcgwars.logic.card.energy.*
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -265,53 +265,53 @@ public enum UnbrokenBonds implements LogicCardInfo {
   POKEGEAR_3_0_233 ("Pokégear 3.0", "233", Rarity.SECRET, [TRAINER, ITEM]),
   TRIPLE_ACCELERATION_ENERGY_234 ("Triple Acceleration Energy", "234", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   UnbrokenBonds(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.UNBROKEN_BONDS;
+    return tcgwars.logic.card.Collection.UNBROKEN_BONDS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -368,7 +368,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CATERPIE_2:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R
@@ -392,7 +392,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case METAPOD_3:
         return evolution (this, from:"Caterpie", hp:HP070, type:G, retreatCost:3) {
           weakness R
@@ -416,7 +416,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BUTTERFREE_4:
         return evolution (this, from:"Metapod", hp:HP130, type:G, retreatCost:1) {
           weakness R
@@ -441,7 +441,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH_5:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -460,7 +460,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH_6:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -472,7 +472,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLOOM_7:
         return evolution (this, from:"Oddish", hp:HP080, type:G, retreatCost:2) {
           weakness R
@@ -501,7 +501,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_8:
         return evolution (this, from:"Gloom", hp:HP140, type:G, retreatCost:3) {
           weakness R
@@ -524,7 +524,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENONAT_9:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -547,7 +547,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENONAT_10:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -560,7 +560,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_11:
         return evolution (this, from:"Venonat", hp:HP090, type:G, retreatCost:0) {
           weakness R
@@ -584,7 +584,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_GX_12:
         return evolution (this, from:"Venonat", hp:HP200, type:G, retreatCost:1) {
           weakness R
@@ -619,7 +619,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELLSPROUT_13:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -631,7 +631,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEPINBELL_14:
         return evolution (this, from:"Bellsprout", hp:HP080, type:G, retreatCost:2) {
           weakness R
@@ -651,7 +651,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VICTREEBEL_15:
         return evolution (this, from:"Weepinbell", hp:HP140, type:G, retreatCost:2) {
           weakness R
@@ -687,7 +687,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGELA_16:
         return basic (this, hp:HP080, type:G, retreatCost:2) {
           weakness R
@@ -709,7 +709,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TANGROWTH_17:
         return evolution (this, from:"Tangela", hp:HP130, type:G, retreatCost:3) {
           weakness R
@@ -732,7 +732,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRUBBIN_18:
         return basic (this, hp:HP060, type:G, retreatCost:2) {
           weakness R
@@ -755,7 +755,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KARTANA_19:
         return basic (this, hp:HP070, type:G, retreatCost:0) {
           weakness R
@@ -779,7 +779,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RESHIRAM_CHARIZARD_GX_20:
         return basic (this, hp:HP270, type:R, retreatCost:3) {
           weakness W
@@ -812,7 +812,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GROWLITHE_21:
         return basic (this, hp:HP080, type:R, retreatCost:2) {
           weakness W
@@ -831,7 +831,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARCANINE_22:
         return evolution (this, from:"Growlithe", hp:HP140, type:R, retreatCost:4) {
           weakness W
@@ -858,7 +858,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARUMAKA_23:
         return basic (this, hp:HP080, type:R, retreatCost:2) {
           weakness W
@@ -881,7 +881,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARMANITAN_24:
         return evolution (this, from:"Darumaka", hp:HP130, type:R, retreatCost:3) {
           weakness W
@@ -905,7 +905,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLCANION_25:
         return basic (this, hp:HP120, type:R, retreatCost:2) {
           weakness W
@@ -935,7 +935,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LITTEN_26:
         return basic (this, hp:HP050, type:R, retreatCost:1) {
           weakness W
@@ -947,7 +947,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LITTEN_27:
         return basic (this, hp:HP060, type:R, retreatCost:1) {
           weakness W
@@ -971,7 +971,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TORRACAT_28:
         return evolution (this, from:"Litten", hp:HP080, type:R, retreatCost:1) {
           weakness W
@@ -984,7 +984,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INCINEROAR_29:
         return evolution (this, from:"Torracat", hp:HP160, type:R, retreatCost:2) {
           weakness W
@@ -1013,7 +1013,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALANDIT_30:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W
@@ -1032,7 +1032,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SALAZZLE_31:
         return evolution (this, from:"Salandit", hp:HP100, type:R, retreatCost:1) {
           weakness W
@@ -1054,7 +1054,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLACEPHALON_32:
         return basic (this, hp:HP120, type:R, retreatCost:2) {
           weakness W
@@ -1082,7 +1082,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SQUIRTLE_33:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1095,7 +1095,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WARTORTLE_34:
         return evolution (this, from:"Squirtle", hp:HP070, type:W, retreatCost:2) {
           weakness G
@@ -1119,7 +1119,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BLASTOISE_GX_35:
         return evolution (this, from:"Wartortle", hp:HP240, type:W, retreatCost:3) {
           weakness G
@@ -1171,7 +1171,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWAG_36:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness G
@@ -1192,7 +1192,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWAG_37:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1202,7 +1202,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             callForFamily(basic:true,1,delegate)
           }
 
-        };
+        }
       case POLIWHIRL_38:
         return evolution (this, from:"Poliwag", hp:HP090, type:W, retreatCost:2) {
           weakness G
@@ -1222,7 +1222,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POLIWRATH_39:
         return evolution (this, from:"Poliwhirl", hp:HP150, type:W, retreatCost:3) {
           weakness G
@@ -1244,7 +1244,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACOOL_40:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1259,7 +1259,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACRUEL_41:
         return evolution (this, from:"Tentacool", hp:HP100, type:W, retreatCost:1) {
           weakness G
@@ -1271,7 +1271,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               assertOppAll(info: "with Energy attached to them", {it.cards.filterByType(ENERGY)})
             }
             onAttack {
-              def bothAll = new PcsList();
+              def bothAll = new PcsList()
               opp.all.each{
                 bothAll.add(it)
               }
@@ -1290,7 +1290,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_42:
         return basic (this, hp:HP070, type:W, retreatCost:2) {
           weakness G
@@ -1309,7 +1309,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_43:
         return evolution (this, from:"Slowpoke", hp:HP120, type:W, retreatCost:2) {
           weakness G
@@ -1328,7 +1328,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEEL_44:
         return basic (this, hp:HP080, type:W, retreatCost:2) {
           weakness G
@@ -1340,7 +1340,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEWGONG_45:
         return evolution (this, from:"Seel", hp:HP120, type:W, retreatCost:2) {
           weakness M
@@ -1360,7 +1360,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRABBY_46:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness G
@@ -1379,7 +1379,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGLER_47:
         return evolution (this, from:"Krabby", hp:HP130, type:W, retreatCost:4) {
           weakness G
@@ -1399,7 +1399,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDEEN_48:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1412,7 +1412,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEAKING_49:
         return evolution (this, from:"Goldeen", hp:HP100, type:W, retreatCost:1) {
           weakness G
@@ -1424,7 +1424,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KYUREM_50:
         return basic (this, hp:HP130, type:W, retreatCost:2) {
           weakness M
@@ -1449,7 +1449,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROAKIE_51:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1462,7 +1462,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FROGADIER_52:
         return evolution (this, from:"Froakie", hp:HP080, type:W, retreatCost:1) {
           weakness G
@@ -1491,7 +1491,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PYUKUMUKU_53:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness G
@@ -1509,7 +1509,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_54:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           weakness F
@@ -1522,7 +1522,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RAICHU_55:
         return evolution (this, from:"Pikachu", hp:HP120, type:L, retreatCost:2) {
           weakness F
@@ -1549,7 +1549,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STUNFISK_56:
         return basic (this, hp:HP110, type:L, retreatCost:3) {
           weakness F
@@ -1572,7 +1572,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DEDENNE_GX_57:
         return basic (this, hp:HP160, type:L, retreatCost:1) {
           weakness F
@@ -1609,7 +1609,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHARJABUG_58:
         return evolution (this, from:"Grubbin", hp:HP080, type:L, retreatCost:3) {
           weakness F
@@ -1650,7 +1650,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VIKAVOLT_59:
         return evolution (this, from:"Charjabug", hp:HP150, type:L, retreatCost:2) {
           weakness F
@@ -1674,7 +1674,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZERAORA_60:
         return basic (this, hp:HP120, type:L, retreatCost:1) {
           weakness F
@@ -1695,7 +1695,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUK_ALOLAN_MUK_GX_61:
         return basic (this, hp:HP270, type:P, retreatCost:4) {
           weakness P
@@ -1728,7 +1728,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EKANS_62:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness P
@@ -1749,7 +1749,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARBOK_63:
         return evolution (this, from:"Ekans", hp:HP120, type:P, retreatCost:2) {
           weakness P
@@ -1772,7 +1772,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_64:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness L
@@ -1793,7 +1793,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT_65:
         return evolution (this, from:"Zubat", hp:HP080, type:P, retreatCost:1) {
           weakness L
@@ -1814,7 +1814,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CROBAT_66:
         return evolution (this, from:"Golbat", hp:HP130, type:P, retreatCost:0) {
           weakness L
@@ -1840,7 +1840,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_67:
         return basic (this, hp:HP040, type:P, retreatCost:1) {
           weakness D
@@ -1854,7 +1854,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
                   tryWithDeterministicCurrentThreadPlayerType(self.owner) {
                     def count = Math.min(my.bench.freeBenchCount, 2)
                     my.deck.search(max:count, "When this Pokémon is Knocked Out, search your deck for up to 2 Haunter and put them onto your Bench. Then, shuffle your deck.", {it.name=="Haunter"}).each {
-                      my.deck.remove(it);
+                      my.deck.remove(it)
                       benchPCS(it)
                     }
                     shuffleDeck()
@@ -1871,7 +1871,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_68:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness D
@@ -1884,7 +1884,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_69:
         return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
           weakness D
@@ -1898,7 +1898,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENGAR_70:
         return evolution (this, from:"Haunter", hp:HP130, type:P, retreatCost:0) {
           weakness D
@@ -1927,7 +1927,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DROWZEE_71:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness P
@@ -1946,7 +1946,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYPNO_72:
         return evolution (this, from:"Drowzee", hp:HP110, type:P, retreatCost:2) {
           weakness P
@@ -1972,7 +1972,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_73:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness P
@@ -1985,7 +1985,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING_74:
         return evolution (this, from:"Koffing", hp:HP120, type:P, retreatCost:3) {
           weakness P
@@ -2014,7 +2014,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEWTWO_75:
         return basic (this, hp:HP120, type:P, retreatCost:2) {
           weakness P
@@ -2035,7 +2035,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEW_76:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2058,7 +2058,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISDREAVUS_77:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness D
@@ -2071,7 +2071,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MISMAGIUS_78:
         return evolution (this, from:"Misdreavus", hp:HP110, type:P, retreatCost:1) {
           weakness D
@@ -2096,7 +2096,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ESPURR_79:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2123,7 +2123,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWSTIC_80:
         return evolution (this, from:"Espurr", hp:HP090, type:P, retreatCost:1) {
           weakness P
@@ -2166,7 +2166,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARSHADOW_81:
         return basic (this, hp:HP080, type:P, retreatCost:1) {
           weakness D
@@ -2192,7 +2192,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MARSHADOW_MACHAMP_GX_82:
         return basic (this, hp:HP270, type:F, retreatCost:3) {
           weakness P
@@ -2236,7 +2236,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSHREW_83:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness G
@@ -2255,7 +2255,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSLASH_84:
         return evolution (this, from:"Sandshrew", hp:HP110, type:F, retreatCost:1) {
           weakness G
@@ -2275,7 +2275,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DIGLETT_85:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness G
@@ -2291,7 +2291,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DUGTRIO_86:
         return evolution (this, from:"Diglett", hp:HP090, type:F, retreatCost:1) {
           weakness G
@@ -2306,7 +2306,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GEODUDE_87:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness G
@@ -2325,7 +2325,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRAVELER_88:
         return evolution (this, from:"Geodude", hp:HP110, type:F, retreatCost:4) {
           weakness G
@@ -2345,7 +2345,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM_89:
         return evolution (this, from:"Graveler", hp:HP180, type:F, retreatCost:4) {
           weakness G
@@ -2365,7 +2365,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CUBONE_90:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness G
@@ -2384,7 +2384,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAROWAK_91:
         return evolution (this, from:"Cubone", hp:HP110, type:F, retreatCost:2) {
           weakness G
@@ -2404,7 +2404,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_92:
         return basic (this, hp:HP080, type:F, retreatCost:2) {
           weakness G
@@ -2417,7 +2417,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_93:
         return basic (this, hp:HP090, type:F, retreatCost:4) {
           weakness G
@@ -2436,7 +2436,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON_94:
         return evolution (this, from:"Rhyhorn", hp:HP110, type:F, retreatCost:4) {
           weakness G
@@ -2462,7 +2462,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYPERIOR_95:
         return evolution (this, from:"Rhydon", hp:HP170, type:F, retreatCost:4) {
           weakness G
@@ -2485,7 +2485,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WOOPER_96:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness G
@@ -2497,7 +2497,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case QUAGSIRE_97:
         return evolution (this, from:"Wooper", hp:HP120, type:F, retreatCost:2) {
           weakness G
@@ -2516,7 +2516,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLIGAR_98:
         return basic (this, hp:HP060, type:F, retreatCost:2) {
           weakness G
@@ -2538,7 +2538,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLISCOR_99:
         return evolution (this, from:"Gligar", hp:HP110, type:F, retreatCost:1) {
           weakness G
@@ -2561,7 +2561,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TYROGUE_100:
         return basic (this, hp:HP060, type:F, retreatCost:0) {
           bwAbility "Bratty Kick", {
@@ -2576,7 +2576,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONTOP_101:
         return basic (this, hp:HP090, type:F, retreatCost:1) {
           weakness P
@@ -2598,7 +2598,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RIOLU_102:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness P
@@ -2611,7 +2611,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LANDORUS_103:
         return basic (this, hp:HP120, type:F, retreatCost:1) {
           weakness G
@@ -2633,7 +2633,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRABRAWLER_104:
         return basic (this, hp:HP080, type:F, retreatCost:2) {
           weakness P
@@ -2653,7 +2653,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CRABOMINABLE_105:
         return evolution (this, from:"Crabrawler", hp:HP140, type:F, retreatCost:4) {
           weakness P
@@ -2674,7 +2674,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case STAKATAKA_106:
         return basic (this, hp:HP120, type:F, retreatCost:4) {
           weakness G
@@ -2693,7 +2693,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRENINJA_ZOROARK_GX_107:
         return basic (this, hp:HP250, type:D, retreatCost:2) {
           weakness F
@@ -2729,7 +2729,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MURKROW_108:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness L
@@ -2742,7 +2742,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HONCHKROW_GX_109:
         return evolution (this, from:"Murkrow", hp:HP210, type:D, retreatCost:2) {
           weakness L
@@ -2785,7 +2785,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CARVANHA_110:
         return basic (this, hp:HP060, type:D, retreatCost:1) {
           weakness F
@@ -2798,7 +2798,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHARPEDO_111:
         return evolution (this, from:"Carvanha", hp:HP110, type:D, retreatCost:1) {
           weakness F
@@ -2825,7 +2825,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPIRITOMB_112:
         return basic (this, hp:HP060, type:D, retreatCost:1) {
           bwAbility "Building Spite", {
@@ -2844,7 +2844,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDILE_113:
         return basic (this, hp:HP060, type:D, retreatCost:2) {
           weakness F
@@ -2868,7 +2868,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDILE_114:
         return basic (this, hp:HP070, type:D, retreatCost:2) {
           weakness F
@@ -2889,7 +2889,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KROKOROK_115:
         return evolution (this, from:"Sandile", hp:HP090, type:D, retreatCost:2) {
           weakness F
@@ -2910,7 +2910,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KROOKODILE_116:
         return evolution (this, from:"Krokorok", hp:HP150, type:D, retreatCost:3) {
           weakness F
@@ -2931,7 +2931,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRENINJA_117:
         return evolution (this, from:"Frogadier", hp:HP130, type:D, retreatCost:0) {
           weakness F
@@ -2949,7 +2949,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case INKAY_118:
         return basic (this, hp:HP060, type:D, retreatCost:1) {
           weakness F
@@ -2962,7 +2962,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MALAMAR_119:
         return evolution (this, from:"Inkay", hp:HP100, type:D, retreatCost:1) {
           weakness F
@@ -3005,7 +3005,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_MELMETAL_GX_120:
         return basic (this, hp:HP260, type:M, retreatCost:3) {
           weakness R
@@ -3049,7 +3049,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_DIGLETT_121:
         return basic (this, hp:HP050, type:M, retreatCost:1) {
           weakness R
@@ -3061,7 +3061,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ALOLAN_DUGTRIO_122:
         return evolution (this, from:"Alolan Diglett", hp:HP080, type:M, retreatCost:1) {
           weakness R
@@ -3087,7 +3087,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARON_123:
         return basic (this, hp:HP060, type:M, retreatCost:1) {
           weakness R
@@ -3107,7 +3107,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAIRON_124:
         return evolution (this, from:"Aron", hp:HP090, type:M, retreatCost:3) {
           weakness R
@@ -3127,7 +3127,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AGGRON_125:
         return evolution (this, from:"Lairon", hp:HP170, type:M, retreatCost:4) {
           weakness R
@@ -3152,7 +3152,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LUCARIO_126:
         return evolution (this, from:"Riolu", hp:HP130, type:M, retreatCost:2) {
           weakness R
@@ -3173,7 +3173,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GENESECT_127:
         return basic (this, hp:HP130, type:M, retreatCost:2) {
           weakness R
@@ -3193,7 +3193,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MELTAN_128:
         return basic (this, hp:HP070, type:M, retreatCost:1) {
           weakness R
@@ -3207,7 +3207,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MELMETAL_129:
         return evolution (this, from:"Meltan", hp:HP150, type:M, retreatCost:4) {
           weakness R
@@ -3230,7 +3230,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GARDEVOIR_SYLVEON_GX_130:
         return basic (this, hp:HP260, type:Y, retreatCost:2) {
           weakness M
@@ -3257,13 +3257,13 @@ public enum UnbrokenBonds implements LogicCardInfo {
               afterDamage {
                 while(1){
                   def pl=(my.all.findAll {it.cards.energyCount(C)})
-                  if(!pl) break;
+                  if(!pl) break
                   def src =pl.select("source for energy (cancel to stop)", false)
-                  if(!src) break;
+                  if(!src) break
                   def card=src.cards.select("Card to move",cardTypeFilter(ENERGY)).first()
 
                   def tar=my.all.select("Target for energy (cancel to stop)", false)
-                  if(!tar) break;
+                  if(!tar) break
                   energySwitch(src, tar, card)
                 }
               }
@@ -3285,7 +3285,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFFA_131:
         return basic (this, hp:HP060, type:Y, retreatCost:0) {
           bwAbility "Excitable Draw", {
@@ -3302,7 +3302,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFAIRY_132:
         return basic (this, hp:HP060, type:Y, retreatCost:1) {
           weakness M
@@ -3315,7 +3315,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLEFABLE_133:
         return evolution (this, from:"Clefairy", hp:HP110, type:Y, retreatCost:1) {
           weakness M
@@ -3328,7 +3328,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_134:
         return basic (this, hp:HP070, type:Y, retreatCost:2) {
           weakness M
@@ -3341,7 +3341,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WIGGLYTUFF_135:
         return evolution (this, from:"Jigglypuff", hp:HP110, type:Y, retreatCost:1) {
           weakness M
@@ -3365,7 +3365,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEPI_136:
         return basic (this, hp:HP050, type:Y, retreatCost:1) {
           weakness M
@@ -3379,7 +3379,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGETIC_137:
         return evolution (this, from:"Togepi", hp:HP080, type:Y, retreatCost:1) {
           weakness M
@@ -3403,7 +3403,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TOGEKISS_138:
         return evolution (this, from:"Togetic", hp:HP140, type:Y, retreatCost:1) {
           weakness M
@@ -3424,7 +3424,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COTTONEE_139:
         return basic (this, hp:HP050, type:Y, retreatCost:1) {
           weakness M
@@ -3438,7 +3438,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WHIMSICOTT_GX_140:
         return evolution (this, from:"Cottonee", hp:HP190, type:Y, retreatCost:1) {
           weakness M
@@ -3476,7 +3476,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPRITZEE_141:
         return basic (this, hp:HP060, type:Y, retreatCost:1) {
           weakness M
@@ -3499,7 +3499,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AROMATISSE_142:
         return evolution (this, from:"Spritzee", hp:HP090, type:Y, retreatCost:1) {
           weakness M
@@ -3532,7 +3532,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATTATA_143:
         return basic (this, hp:HP030, type:C, retreatCost:1) {
           weakness F
@@ -3544,7 +3544,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RATICATE_144:
         return evolution (this, from:"Rattata", hp:HP070, type:C, retreatCost:1) {
           weakness F
@@ -3559,7 +3559,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SPEAROW_145:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -3579,7 +3579,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FEAROW_146:
         return evolution (this, from:"Spearow", hp:HP100, type:C, retreatCost:1) {
           weakness L
@@ -3593,7 +3593,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH_147:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -3616,7 +3616,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_148:
         return evolution (this, from:"Meowth", hp:HP100, type:C, retreatCost:0) {
           weakness F
@@ -3643,7 +3643,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_GX_149:
         return evolution (this, from:"Meowth", hp:HP200, type:C, retreatCost:2) {
           weakness F
@@ -3681,7 +3681,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODUO_150:
         return basic (this, hp:HP070, type:C, retreatCost:1) {
           weakness L
@@ -3701,7 +3701,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO_151:
         return evolution (this, from:"Doduo", hp:HP100, type:C, retreatCost:0) {
           weakness L
@@ -3722,7 +3722,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKITUNG_152:
         return basic (this, hp:HP090, type:C, retreatCost:2) {
           weakness F
@@ -3735,7 +3735,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LICKILICKY_153:
         return evolution (this, from:"Lickitung", hp:HP130, type:C, retreatCost:4) {
           weakness F
@@ -3760,7 +3760,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_154:
         return basic (this, hp:HP050, type:C, retreatCost:1) {
           weakness F
@@ -3783,7 +3783,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_155:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -3802,7 +3802,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON2_156:
         return evolution (this, from:"Porygon", hp:HP080, type:C, retreatCost:2) {
           weakness F
@@ -3821,7 +3821,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_Z_157:
         return evolution (this, from:"Porygon2", hp:HP130, type:C, retreatCost:2) {
           weakness F
@@ -3844,7 +3844,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SNORLAX_158:
         return basic (this, hp:HP150, type:C, retreatCost:4) {
           weakness F
@@ -3870,7 +3870,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLAMEOW_159:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness F
@@ -3893,7 +3893,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PURUGLY_160:
         return evolution (this, from:"Glameow", hp:HP120, type:C, retreatCost:3) {
           weakness F
@@ -3914,7 +3914,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAPPINY_161:
         return basic (this, hp:HP060, type:C, retreatCost:0) {
           bwAbility "Playhouse Heal", {
@@ -3930,7 +3930,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHATOT_162:
         return basic (this, hp:HP070, type:C, retreatCost:1) {
           weakness L
@@ -3953,7 +3953,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CELESTEELA_GX_163:
         return basic (this, hp:HP200, type:C, retreatCost:4) {
           weakness L
@@ -4005,7 +4005,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BEAST_BRINGER_164:
         return pokemonTool (this) {
           text "If you have exactly 6 Prize cards remaining, and if your opponent's Active Pokémon-GX or Pokémon-EX is Knocked Out by damage from an attack of the Ultra Beast this card is attached to, take 1 more Prize card."
@@ -4029,7 +4029,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case CHIP_CHIP_ICE_AXE_165:
         return itemCard (this) {
           text "Look at the top 3 cards of your opponent's deck and choose 1 of them. Your opponent shuffles the other cards back into their deck. Then, put the card you chose on top of their deck."
@@ -4042,7 +4042,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert opp.deck
           }
-        };
+        }
         case DEVOLUTION_SPRAY_Z_166:
         return itemCard (this) {
           text "Devolve 1 of your evolved Pokémon by shuffling any number of Evolution cards on it into your deck. (That Pokémon can't evolve this turn.)"
@@ -4059,7 +4059,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assertMyAll(isStage: EVOLVED)
           }
-        };
+        }
       case DUSK_STONE_167:
         return itemCard (this) {
           text "Search your deck for a Mismagius, Honchkrow, Chandelure, or Aegislash, including Pokémon-GX, that evolves from 1 of your Pokémon in play, and put it onto that Pokémon to evolve it. Then, shuffle your deck. You can use this card during your first turn or on a Pokémon that was put into play this turn."
@@ -4076,7 +4076,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
               ['Misdreavus', 'Murkrow', 'Lampent', 'Doublade'].contains(it.name)
             })
           }
-        };
+        }
       case DUST_ISLAND_168:
         return stadium (this) {
           text "Whenever either player switches their Poisoned Active Pokémon with 1 of their Benched Pokémon with the effect of a Trainer card, the new Active Pokémon is now affected by that Special Condition."
@@ -4100,7 +4100,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case ELECTROMAGNETIC_RADAR_169:
         return itemCard (this) {
           text "You can play this card only if you discard 2 other cards from your hand." +
@@ -4114,7 +4114,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2
             assert deck
           }
-        };
+        }
       case ENERGY_SPINNER_170:
         return itemCard (this) {
           text "Search your deck for a basic Energy card, reveal it, and put it into your hand. If you go second and it's your first turn, search for up to 3 basic Energy cards instead of 1. Then, shuffle your deck."
@@ -4125,7 +4125,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case FAIRY_CHARM_ABILITY_171:
         return pokemonTool (this) {
           text "Prevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's Pokémon-GX and Pokémon-EX that have Abilities."
@@ -4145,7 +4145,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case FAIRY_CHARM_LIGHTNING_172:
         return pokemonTool (this) {
           text "Prevent all damage done to the [Y] Pokémon this card is attached to by attacks from your opponent's [L] Pokémon-GX and [L] Pokémon-EX."
@@ -4165,7 +4165,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case FIRE_CRYSTAL_173:
         return itemCard (this) {
           text "Put 3 [R] Energy cards from your discard pile into your hand."
@@ -4175,7 +4175,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByEnergyType(R)
           }
-        };
+        }
       case GIOVANNI_S_EXILE_174:
         return supporter (this) {
           text "Discard up to 2 of your Benched Pokémon that have no damage counters on them and all cards attached to them."
@@ -4202,7 +4202,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert list() : "You got no benched pokemon with no damage counters"
           }
-        };
+        }
       case GREEN_S_EXPLORATION_175:
         return supporter (this) {
           text "You can play this card only if you have no Pokémon with Abilities in play." +
@@ -4214,7 +4214,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert !my.all.find{it.hasModernAbility()}
           }
-        };
+        }
       case JANINE_176:
         return supporter (this) {
           text "Look at the top 4 cards of your deck and put 2 of them into your hand. Shuffle the other cards back into your deck."
@@ -4226,7 +4226,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
       case KOGA_S_TRAP_177:
         return supporter (this) {
           text "Your opponent's Active Pokémon is now Confused and Poisoned."
@@ -4247,7 +4247,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             }
             assert !defendingConfused || !defendingPoisoned || extraPoisonCount : "Your opponent's Active Pokémon is already Confused and Poisoned"
           }
-        };
+        }
       case LT_SURGE_S_STRATEGY_178:
         return supporter (this) {
           text "You can play this card only if you have more Prize cards remaining than your opponent." +
@@ -4269,7 +4269,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert my.prizeCardSet.size()>opp.prizeCardSet.size()
           }
-        };
+        }
       case MARTIAL_ARTS_DOJO_179:
         return stadium (this) {
           text "The attacks of non-Ultra Beast Pokémon that have any basic [F] Energy attached to them (both yours and your opponent's) do 10 more damage to the opponent's Active Pokémon (before applying Weakness and Resistance). If the attacking player has more Prize cards remaining than their opponent, those attacks do 40 more damage instead."
@@ -4290,7 +4290,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case METAL_CORE_BARRIER_180:
         return pokemonTool (this) {
           text "If this card is attached to 1 of your Pokémon, discard it at the end of your opponent's turn." +
@@ -4321,7 +4321,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             eff1.unregister()
             eff2.unregister()
           }
-        };
+        }
       case MOLAYNE_181:
         return supporter (this) {
           text "You can play this card only if you discard 2 [M] Energy cards from your hand." +
@@ -4335,7 +4335,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             assert my.hand.filterByEnergyType(M).size()>=2:"Not enough [M] energy in hand"
             assert my.discard.filterByType(TRAINER):"No Trainer in discard"
           }
-        };
+        }
       case POKEGEAR_3_0_182:
         return itemCard (this) {
           text "Look at the top 7 cards of your deck. You may reveal a Supporter card you find there and put it into your hand. Shuffle the other cards back into your deck."
@@ -4346,7 +4346,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert deck
           }
-        };
+        }
       case POWER_PLANT_183:
         return stadium (this) {
           text "Pokémon-GX and Pokémon-EX in play (both yours and your opponent's) have no Abilities."
@@ -4370,7 +4370,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             effect2.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case RED_S_CHALLENGE_184:
         return supporter (this) {
           text "You can play this card only if you discard 2 other cards from your hand." +
@@ -4384,7 +4384,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             assert my.hand.getExcludedList(thisCard).size() >= 2 : "Not enough cards in hand"
             assert deck : "Empty deck"
           }
-        };
+        }
       case SAMSON_OAK_185:
         return supporter (this) {
           text "Draw 2 cards. If both Active Pokémon are the same type, draw 2 more cards."
@@ -4395,7 +4395,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert deck
           }
-        };
+        }
       case STEALTHY_HOOD_186:
         return pokemonTool (this) {
           text "Prevent all effects of your opponent's Abilities done to the Pokémon this card is attached to. Remove any such existing effects."
@@ -4418,7 +4418,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
             eff.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case SURPRISE_BOX_187:
         return itemCard (this) {
           text "Put a card from your opponent’s discard pile into their hand."
@@ -4428,7 +4428,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert opp.discard : "No cards in opponent discard"
           }
-        };
+        }
       case ULTRA_FOREST_KARTENVOY_188:
         return supporter (this) {
           text "During this turn, damage from your Ultra Beasts' attacks isn't affected by any effects on your opponent's Active Pokémon."
@@ -4452,7 +4452,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case WELDER_189:
         return supporter (this) {
           text "Attach up to 2 [R] Energy cards from your hand to 1 of your Pokémon. If you do, draw 3 cards."
@@ -4465,7 +4465,7 @@ public enum UnbrokenBonds implements LogicCardInfo {
           playRequirement{
             assert my.hand.filterByEnergyType(R)
           }
-        };
+        }
       case TRIPLE_ACCELERATION_ENERGY_190:
         return specialEnergy (this, [[]]) {
           text "This card can only be attached to Evolution Pokémon. If this card is attached to 1 of your Pokémon, discard it at the end of the turn." +
@@ -4506,97 +4506,97 @@ public enum UnbrokenBonds implements LogicCardInfo {
               return [[] as Set]
             }
           }
-        };
+        }
       case PHEROMOSA_BUZZWOLE_GX_191:
-        return copy (PHEROMOSA_BUZZWOLE_GX_1, this);
+        return copy (PHEROMOSA_BUZZWOLE_GX_1, this)
       case PHEROMOSA_BUZZWOLE_GX_192:
-        return copy (PHEROMOSA_BUZZWOLE_GX_1, this);
+        return copy (PHEROMOSA_BUZZWOLE_GX_1, this)
       case VENOMOTH_GX_193:
-        return copy (VENOMOTH_GX_12, this);
+        return copy (VENOMOTH_GX_12, this)
       case RESHIRAM_CHARIZARD_GX_194:
-        return copy (RESHIRAM_CHARIZARD_GX_20, this);
+        return copy (RESHIRAM_CHARIZARD_GX_20, this)
       case DEDENNE_GX_195:
-        return copy (DEDENNE_GX_57, this);
+        return copy (DEDENNE_GX_57, this)
       case MUK_ALOLAN_MUK_GX_196:
-        return copy (MUK_ALOLAN_MUK_GX_61, this);
+        return copy (MUK_ALOLAN_MUK_GX_61, this)
       case MUK_ALOLAN_MUK_GX_197:
-        return copy (MUK_ALOLAN_MUK_GX_61, this);
+        return copy (MUK_ALOLAN_MUK_GX_61, this)
       case MARSHADOW_MACHAMP_GX_198:
-        return copy (MARSHADOW_MACHAMP_GX_82, this);
+        return copy (MARSHADOW_MACHAMP_GX_82, this)
       case MARSHADOW_MACHAMP_GX_199:
-        return copy (MARSHADOW_MACHAMP_GX_82, this);
+        return copy (MARSHADOW_MACHAMP_GX_82, this)
       case GRENINJA_ZOROARK_GX_200:
-        return copy (GRENINJA_ZOROARK_GX_107, this);
+        return copy (GRENINJA_ZOROARK_GX_107, this)
       case GRENINJA_ZOROARK_GX_201:
-        return copy (GRENINJA_ZOROARK_GX_107, this);
+        return copy (GRENINJA_ZOROARK_GX_107, this)
       case HONCHKROW_GX_202:
-        return copy (HONCHKROW_GX_109, this);
+        return copy (HONCHKROW_GX_109, this)
       case LUCARIO_MELMETAL_GX_203:
-        return copy (LUCARIO_MELMETAL_GX_120, this);
+        return copy (LUCARIO_MELMETAL_GX_120, this)
       case GARDEVOIR_SYLVEON_GX_204:
-        return copy (GARDEVOIR_SYLVEON_GX_130, this);
+        return copy (GARDEVOIR_SYLVEON_GX_130, this)
       case GARDEVOIR_SYLVEON_GX_205:
-        return copy (GARDEVOIR_SYLVEON_GX_130, this);
+        return copy (GARDEVOIR_SYLVEON_GX_130, this)
       case WHIMSICOTT_GX_206:
-        return copy (WHIMSICOTT_GX_140, this);
+        return copy (WHIMSICOTT_GX_140, this)
       case PERSIAN_GX_207:
-        return copy (PERSIAN_GX_149, this);
+        return copy (PERSIAN_GX_149, this)
       case CELESTEELA_GX_208:
-        return copy (CELESTEELA_GX_163, this);
+        return copy (CELESTEELA_GX_163, this)
       case GREEN_S_EXPLORATION_209:
-        return copy (GREEN_S_EXPLORATION_175, this);
+        return copy (GREEN_S_EXPLORATION_175, this)
       case JANINE_210:
-        return copy (JANINE_176, this);
+        return copy (JANINE_176, this)
       case KOGA_S_TRAP_211:
-        return copy (KOGA_S_TRAP_177, this);
+        return copy (KOGA_S_TRAP_177, this)
       case MOLAYNE_212:
-        return copy (MOLAYNE_181, this);
+        return copy (MOLAYNE_181, this)
       case RED_S_CHALLENGE_213:
-        return copy (RED_S_CHALLENGE_184, this);
+        return copy (RED_S_CHALLENGE_184, this)
       case WELDER_214:
-        return copy (WELDER_189, this);
+        return copy (WELDER_189, this)
       case PHEROMOSA_BUZZWOLE_GX_215:
-        return copy (PHEROMOSA_BUZZWOLE_GX_1, this);
+        return copy (PHEROMOSA_BUZZWOLE_GX_1, this)
       case VENOMOTH_GX_216:
-        return copy (VENOMOTH_GX_12, this);
+        return copy (VENOMOTH_GX_12, this)
       case RESHIRAM_CHARIZARD_GX_217:
-        return copy (RESHIRAM_CHARIZARD_GX_20, this);
+        return copy (RESHIRAM_CHARIZARD_GX_20, this)
       case BLASTOISE_GX_218:
-        return copy (BLASTOISE_GX_35, this);
+        return copy (BLASTOISE_GX_35, this)
       case DEDENNE_GX_219:
-        return copy (DEDENNE_GX_57, this);
+        return copy (DEDENNE_GX_57, this)
       case MUK_ALOLAN_MUK_GX_220:
-        return copy (MUK_ALOLAN_MUK_GX_61, this);
+        return copy (MUK_ALOLAN_MUK_GX_61, this)
       case MARSHADOW_MACHAMP_GX_221:
-        return copy (MARSHADOW_MACHAMP_GX_82, this);
+        return copy (MARSHADOW_MACHAMP_GX_82, this)
       case GRENINJA_ZOROARK_GX_222:
-        return copy (GRENINJA_ZOROARK_GX_107, this);
+        return copy (GRENINJA_ZOROARK_GX_107, this)
       case HONCHKROW_GX_223:
-        return copy (HONCHKROW_GX_109, this);
+        return copy (HONCHKROW_GX_109, this)
       case LUCARIO_MELMETAL_GX_224:
-        return copy (LUCARIO_MELMETAL_GX_120, this);
+        return copy (LUCARIO_MELMETAL_GX_120, this)
       case GARDEVOIR_SYLVEON_GX_225:
-        return copy (GARDEVOIR_SYLVEON_GX_130, this);
+        return copy (GARDEVOIR_SYLVEON_GX_130, this)
       case WHIMSICOTT_GX_226:
-        return copy (WHIMSICOTT_GX_140, this);
+        return copy (WHIMSICOTT_GX_140, this)
       case PERSIAN_GX_227:
-        return copy (PERSIAN_GX_149, this);
+        return copy (PERSIAN_GX_149, this)
       case CELESTEELA_GX_228:
-        return copy (CELESTEELA_GX_163, this);
+        return copy (CELESTEELA_GX_163, this)
       case BEAST_BRINGER_229:
-        return copy (BEAST_BRINGER_164, this);
+        return copy (BEAST_BRINGER_164, this)
       case ELECTROMAGNETIC_RADAR_230:
-        return copy (ELECTROMAGNETIC_RADAR_169, this);
+        return copy (ELECTROMAGNETIC_RADAR_169, this)
       case FIRE_CRYSTAL_231:
-        return copy (FIRE_CRYSTAL_173, this);
+        return copy (FIRE_CRYSTAL_173, this)
       case METAL_CORE_BARRIER_232:
-        return copy (METAL_CORE_BARRIER_180, this);
+        return copy (METAL_CORE_BARRIER_180, this)
       case POKEGEAR_3_0_233:
-        return copy (POKEGEAR_3_0_182, this);
+        return copy (POKEGEAR_3_0_182, this)
       case TRIPLE_ACCELERATION_ENERGY_234:
-        return copy (TRIPLE_ACCELERATION_ENERGY_190, this);
+        return copy (TRIPLE_ACCELERATION_ENERGY_190, this)
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
+++ b/src/tcgwars/logic/impl/gen7/UnifiedMinds.groovy
@@ -1,22 +1,22 @@
-package tcgwars.logic.impl.gen7;
+package tcgwars.logic.impl.gen7
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
 import tcgwars.logic.effect.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author Thomas Luong
@@ -285,53 +285,53 @@ public enum UnifiedMinds implements LogicCardInfo {
   RECYCLE_ENERGY_257 ("Recycle Energy", "257", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY]),
   WEAKNESS_GUARD_ENERGY_258 ("Weakness Guard Energy", "258", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   UnifiedMinds(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.UNIFIED_MINDS;
+    return tcgwars.logic.card.Collection.UNIFIED_MINDS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -387,7 +387,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case YANMA_2:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
           weakness R
@@ -405,7 +405,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case YANMEGA_3:
         return evolution (this, from:"Yanma", hp:HP120, type:G, retreatCost:1) {
           weakness R
@@ -424,7 +424,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case CELEBI_4:
         return basic (this, hp:HP080, type:G, retreatCost:1) {
           weakness R
@@ -450,7 +450,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case SHROOMISH_5:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -461,7 +461,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               apply POISONED
             }
           }
-        };
+        }
       case SEWADDLE_6:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -483,7 +483,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case SEWADDLE_7:
         return basic (this, hp:HP050, type:G, retreatCost:1) {
           weakness R
@@ -507,7 +507,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case SWADLOON_8:
         return evolution (this, from:"Sewaddle", hp:HP070, type:G, retreatCost:2) {
           weakness R
@@ -531,7 +531,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LEAVANNY_9:
         return evolution (this, from:"Swadloon", hp:HP120, type:G, retreatCost:1) {
           weakness R
@@ -558,7 +558,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case DWEBBLE_10:
         return basic (this, hp:HP070, type:G, retreatCost:2) {
           weakness R
@@ -569,7 +569,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CRUSTLE_11:
         return evolution (this, from:"Dwebble", hp:HP120, type:G, retreatCost:3) {
           weakness R
@@ -594,7 +594,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip 3,{},{}, [ 1:{damage 40}, 2:{damage 80}, 3:{damage 150} ]
             }
           }
-        };
+        }
       case KARRABLAST_12:
         return basic (this, hp:HP070, type:G, retreatCost:2) {
           weakness R
@@ -606,7 +606,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case FOONGUS_13:
         return basic (this, hp:HP040, type:G, retreatCost:1) {
           weakness R
@@ -617,7 +617,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               apply ASLEEP
             }
           }
-        };
+        }
       case AMOONGUSS_14:
         return evolution (this, from:"Foongus", hp:HP100, type:G, retreatCost:2) {
           weakness R
@@ -648,7 +648,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (defending.isSPC(POISONED)) damage 70
             }
           }
-        };
+        }
       case FOMANTIS_15:
         return basic (this, hp:HP070, type:G, retreatCost:1) {
           weakness R
@@ -669,7 +669,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LURANTIS_16:
         return evolution (this, from:"Fomantis", hp:HP110, type:G, retreatCost:1) {
           weakness R
@@ -688,7 +688,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (self.cards.energyCount(R)) damage 50
             }
           }
-        };
+        }
       case BOUNSWEET_17:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness R
@@ -706,7 +706,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case STEENEE_18:
         return evolution (this, from:"Bounsweet", hp:HP090, type:G, retreatCost:2) {
           weakness R
@@ -724,7 +724,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case TSAREENA_19:
         return evolution (this, from:"Steenee", hp:HP140, type:G, retreatCost:2) {
           weakness R
@@ -744,7 +744,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case DHELMISE_20:
         return basic (this, hp:HP100, type:G, retreatCost:1) {
           weakness R
@@ -760,7 +760,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case MAGMAR_21:
         return basic (this, hp:HP080, type:R, retreatCost:2) {
           weakness W
@@ -772,7 +772,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case MAGMORTAR_22:
         return evolution (this, from:"Magmar", hp:HP130, type:R, retreatCost:3) {
           weakness W
@@ -792,7 +792,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case NUMEL_23:
         return basic (this, hp:HP090, type:R, retreatCost:4) {
           weakness W
@@ -811,7 +811,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case CAMERUPT_24:
         return evolution (this, from:"Numel", hp:HP140, type:R, retreatCost:4) {
           weakness W
@@ -830,7 +830,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C, C
             }
           }
-        };
+        }
       case HEATRAN_GX_25:
         return basic (this, hp:HP190, type:R, retreatCost:3) {
           weakness W
@@ -843,9 +843,9 @@ public enum UnifiedMinds implements LogicCardInfo {
                   powerUsed()
                   while(1){
                     def pl=(my.all.findAll {it.cards.filterByEnergyType(R) && it!=self})
-                    if(!pl) break;
+                    if(!pl) break
                     def src=pl.select("Source for [R] Energy (cancel to stop moving).", false)
-                    if(!src) break;
+                    if(!src) break
                     def card=src.cards.filterByEnergyType(R).select("Select a [R] Energy to move to Heatran-GX.").first()
                     energySwitch(src, self, card)
                   }
@@ -871,7 +871,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50*self.cards.energyCount(R)
             }
           }
-        };
+        }
       case VICTINI_26:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W
@@ -905,7 +905,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LITWICK_27:
         return basic (this, hp:HP060, type:R, retreatCost:1) {
           weakness W
@@ -920,9 +920,9 @@ public enum UnifiedMinds implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case LITWICK_28:
-        return copy (LITWICK_27, this);
+        return copy (LITWICK_27, this)
       case LAMPENT_29:
         return evolution (this, from:"Litwick", hp:HP080, type:R, retreatCost:1) {
           weakness W
@@ -935,7 +935,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CHANDELURE_30:
         return evolution (this, from:"Lampent", hp:HP140, type:R, retreatCost:2) {
           weakness W
@@ -958,13 +958,13 @@ public enum UnifiedMinds implements LogicCardInfo {
               afterDamage{
                 if (firePokemon && my.bench.freeBenchCount) {
                   firePokemon.select(max: my.bench.freeBenchCount, min: 0).each {
-                    benchPCS(it);
+                    benchPCS(it)
                   }
                 }
               }
             }
           }
-        };
+        }
       case FLETCHINDER_31:
         return evolution (this, from:"Fletchling", hp:HP080, type:R, retreatCost:1) {
           weakness W
@@ -979,7 +979,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TALONFLAME_32:
         return evolution (this, from:"Fletchinder", hp:HP130, type:R, retreatCost:0) {
           weakness W
@@ -1004,7 +1004,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SALANDIT_33:
         return basic (this, hp:HP070, type:R, retreatCost:1) {
           weakness W
@@ -1015,7 +1015,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case SALAZZLE_34:
         return evolution (this, from:"Salandit", hp:HP100, type:R, retreatCost:1) {
           weakness W
@@ -1026,7 +1026,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SLOWPOKE_PSYDUCK_GX_35:
         return basic (this, hp:HP250, type:W, retreatCost:2) {
           weakness G
@@ -1055,7 +1055,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LAPRAS_36:
         return basic (this, hp:HP110, type:W, retreatCost:1) {
           weakness G
@@ -1077,7 +1077,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case SNORUNT_37:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness M
@@ -1088,7 +1088,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case FROSLASS_38:
         return evolution (this, from:"Snorunt", hp:HP080, type:W, retreatCost:1) {
           weakness M
@@ -1111,7 +1111,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case FINNEON_39:
         return basic (this, hp:HP050, type:W, retreatCost:1) {
           weakness G
@@ -1122,7 +1122,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LUMINEON_40:
         return evolution (this, from:"Finneon", hp:HP090, type:W, retreatCost:0) {
           weakness G
@@ -1136,7 +1136,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SNOVER_41:
         return basic (this, hp:HP090, type:W, retreatCost:4) {
           weakness M
@@ -1148,7 +1148,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case ABOMASNOW_42:
         return evolution (this, from:"Snover", hp:HP140, type:W, retreatCost:4) {
           weakness M
@@ -1168,7 +1168,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case BASCULIN_43:
         return basic (this, hp:HP080, type:W, retreatCost:1) {
           weakness G
@@ -1191,7 +1191,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TIRTOUGA_44:
         return evolution (this, from:"Unidentified Fossil", hp:HP100, type:W, retreatCost:3) {
           weakness G
@@ -1209,7 +1209,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case CARRACOSTA_45:
         return evolution (this, from:"Tirtouga", hp:HP160, type:W, retreatCost:3) {
           weakness G
@@ -1271,7 +1271,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20*opp.active.retreatCost
             }
           }
-        };
+        }
       case CRYOGONAL_46:
         return basic (this, hp:HP090, type:W, retreatCost:1) {
           weakness M
@@ -1291,7 +1291,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KELDEO_GX_47:
         return basic (this, hp:HP170, type:W, retreatCost:2) {
           weakness G
@@ -1315,7 +1315,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50*opp.bench.size()
             }
           }
-        };
+        }
       case DEWPIDER_48:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness G
@@ -1333,7 +1333,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case ARAQUANID_49:
         return evolution (this, from:"Dewpider", hp:HP100, type:W, retreatCost:1) {
           weakness G
@@ -1358,7 +1358,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case WIMPOD_50:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness G
@@ -1370,7 +1370,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               sandAttack(thisMove)
             }
           }
-        };
+        }
       case GOLISOPOD_51:
         return evolution (this, from:"Wimpod", hp:HP140, type:W, retreatCost:4) {
           weakness G
@@ -1392,7 +1392,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PYUKUMUKU_52:
         return basic (this, hp:HP080, type:W, retreatCost:1) {
           weakness G
@@ -1410,7 +1410,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case TAPU_FINI_53:
         return basic (this, hp:HP120, type:W, retreatCost:1) {
           weakness G
@@ -1432,7 +1432,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case RAICHU_ALOLAN_RAICHU_GX_54:
         return basic (this, hp:HP260, type:L, retreatCost:2) {
           weakness F
@@ -1461,7 +1461,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIKACHU_55:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -1480,7 +1480,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PIKACHU_56:
         return basic (this, hp:HP070, type:L, retreatCost:1) {
           weakness F
@@ -1499,7 +1499,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ALOLAN_RAICHU_57:
         return evolution (this, from:"Pikachu", hp:HP110, type:L, retreatCost:1) {
           weakness F
@@ -1529,7 +1529,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case MAGNEMITE_58:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness F
@@ -1543,7 +1543,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAGNETON_59:
         return evolution (this, from:"Magnemite", hp:HP090, type:L, retreatCost:2) {
           weakness F
@@ -1562,7 +1562,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip 3, { damage 40 }
             }
           }
-        };
+        }
       case MAGNEZONE_60:
         return evolution (this, from:"Magneton", hp:HP160, type:L, retreatCost:3) {
           weakness F
@@ -1581,7 +1581,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               my.discard.filterByType(TRAINER).select().moveTo(my.hand)
             }
           }
-        };
+        }
       case JOLTIK_61:
         return basic (this, hp:HP040, type:L, retreatCost:1) {
           weakness F
@@ -1593,7 +1593,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { apply PARALYZED }
             }
           }
-        };
+        }
       case GALVANTULA_62:
         return evolution (this, from:"Joltik", hp:HP090, type:L, retreatCost:1) {
           weakness F
@@ -1612,7 +1612,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               bg.em().run(new DirectDamage(damage, pcs))
             }
           }
-        };
+        }
       case TYNAMO_63:
         return basic (this, hp:HP030, type:L, retreatCost:1) {
           weakness F
@@ -1627,7 +1627,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case TYNAMO_64:
         return basic (this, hp:HP040, type:L, retreatCost:1) {
           weakness F
@@ -1640,7 +1640,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case EELEKTRIK_65:
         return evolution (this, from:"Tynamo", hp:HP090, type:L, retreatCost:2) {
           weakness F
@@ -1652,7 +1652,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30*discardAllSelfEnergy(L).size()
             }
           }
-        };
+        }
       case EELEKTROSS_66:
         return evolution (this, from:"Eelektrik", hp:HP150, type:L, retreatCost:3) {
           weakness F
@@ -1675,9 +1675,9 @@ public enum UnifiedMinds implements LogicCardInfo {
               assert pcs : "Benching was unsuccessful."
               while(1){
                 def pl=(my.all.findAll {it.cards.filterByEnergyType(L) && it!=pcs})
-                if(!pl) break;
+                if(!pl) break
                 def src=pl.select("Source for [L] Energy (cancel to stop).", false)
-                if(!src) break;
+                if(!src) break
                 def card=src.cards.filterByEnergyType(L).select("Select a [L] Energy to move to Eelektross.").first()
                 energySwitch(src, pcs, card)
               }
@@ -1694,7 +1694,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case STUNFISK_67:
         return basic (this, hp:HP090, type:L, retreatCost:1) {
           weakness F
@@ -1707,7 +1707,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (defending.getRemainingHP() > self.getRemainingHP()) damage 30
             }
           }
-        };
+        }
       case THUNDURUS_68:
         return basic (this, hp:HP120, type:L, retreatCost:1) {
           weakness F
@@ -1730,7 +1730,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TAPU_KOKO_69:
         return basic (this, hp:HP120, type:L, retreatCost:1) {
           weakness F
@@ -1753,7 +1753,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case XURKITREE_70:
         return basic (this, hp:HP120, type:L, retreatCost:2) {
           weakness F
@@ -1775,7 +1775,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEWTWO_MEW_GX_71:
         return basic (this, hp:HP270, type:P, retreatCost:2) {
           weakness P
@@ -1796,7 +1796,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ESPEON_DEOXYS_GX_72:
         return basic (this, hp:HP260, type:P, retreatCost:2) {
           weakness P
@@ -1820,7 +1820,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               putDamageCountersOnOpponentsPokemon(counters)
             }
           }
-        };
+        }
       case EXEGGCUTE_73:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness P
@@ -1832,7 +1832,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case EXEGGUTOR_74:
         return evolution (this, from:"Exeggcute", hp:HP140, type:P, retreatCost:3) {
           weakness P
@@ -1852,7 +1852,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               afterDamage{my.hand.discard()}
             }
           }
-        };
+        }
       case ALOLAN_MAROWAK_75:
         return evolution (this, from:"Cubone", hp:HP120, type:P, retreatCost:2) {
           weakness D
@@ -1877,7 +1877,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case JYNX_76:
         return basic (this, hp:HP080, type:P, retreatCost:1) {
           weakness P
@@ -1906,7 +1906,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { applyAfterDamage PARALYZED }
             }
           }
-        };
+        }
       case WYNAUT_77:
         return basic (this, hp:HP060, type:P, retreatCost:0) {
           bwAbility "Peppy Pick", {
@@ -1916,7 +1916,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               bg.gm().betweenTurns()
             }
           }
-        };
+        }
       case LATIOS_GX_78:
         return basic (this, hp:HP170, type:P, retreatCost:0) {
           weakness P
@@ -1969,7 +1969,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case JIRACHI_GX_79A:
       case JIRACHI_GX_79:
         return basic (this, hp:HP160, type:P, retreatCost:1) {
@@ -1999,7 +1999,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               preventAllEffectsNextTurn()
             }
           }
-        };
+        }
       case DRIFLOON_80:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness D
@@ -2012,7 +2012,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRIFBLIM_81:
         return evolution (this, from:"Drifloon", hp:HP100, type:P, retreatCost:1) {
           weakness D
@@ -2034,7 +2034,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SKORUPI_82:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness P
@@ -2052,7 +2052,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case UXIE_83:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P
@@ -2076,7 +2076,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MESPRIT_84:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2098,7 +2098,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case AZELF_85:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P
@@ -2109,7 +2109,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               putDamageCountersOnOpponentsPokemon(3)
             }
           }
-        };
+        }
       case GIRATINA_86:
         return basic (this, hp:HP130, type:P, retreatCost:1) {
           weakness D
@@ -2133,7 +2133,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage CONFUSED
             }
           }
-        };
+        }
       case CRESSELIA_87:
         return basic (this, hp:HP130, type:P, retreatCost:2) {
           weakness P
@@ -2155,7 +2155,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MUNNA_88:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2164,7 +2164,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             energyCost C
             foresight(4, delegate)
           }
-        };
+        }
       case MUSHARNA_89:
         return evolution (this, from:"Munna", hp:HP100, type:P, retreatCost:2) {
           weakness P
@@ -2184,7 +2184,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case ELGYEM_90:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness P
@@ -2196,7 +2196,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage(CONFUSED)
             }
           }
-        };
+        }
       case BEHEEYEM_91:
         return evolution (this, from:"Elgyem", hp:HP080, type:P, retreatCost:1) {
           weakness P
@@ -2228,7 +2228,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HONEDGE_92:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness D
@@ -2251,7 +2251,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HONEDGE_93:
         return basic (this, hp:HP070, type:P, retreatCost:3) {
           weakness D
@@ -2263,7 +2263,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               noWrDamage 10, defending
             }
           }
-        };
+        }
       case DOUBLADE_94:
         return evolution (this, from:"Honedge", hp:HP090, type:P, retreatCost:3) {
           weakness D
@@ -2275,7 +2275,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               noWrDamage 30, defending
             }
           }
-        };
+        }
       case AEGISLASH_95:
         return evolution (this, from:"Doublade", hp:HP130, type:P, retreatCost:3) {
           weakness D
@@ -2304,7 +2304,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage Math.min(10*my.discard.filterByType(ITEM).size(), 130)
             }
           }
-        };
+        }
       case MAREANIE_96:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness P
@@ -2315,7 +2315,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case TOXAPEX_97:
         return evolution (this, from:"Mareanie", hp:HP110, type:P, retreatCost:2) {
           weakness P
@@ -2326,7 +2326,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SALANDIT_98:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P
@@ -2344,7 +2344,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case SALAZZLE_99:
         return evolution (this, from:"Salandit", hp:HP110, type:P, retreatCost:1) {
           weakness P
@@ -2363,7 +2363,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case COSMOG_100:
         return basic (this, hp:HP040, type:P, retreatCost:0) {
           weakness P
@@ -2374,7 +2374,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case NECROZMA_101:
         return basic (this, hp:HP130, type:P, retreatCost:2) {
           weakness P
@@ -2394,7 +2394,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (self.cards.filterByType(SPECIAL_ENERGY)) damage 60
             }
           }
-        };
+        }
       case POIPOLE_102:
         return basic (this, hp:HP070, type:P, retreatCost:1) {
           weakness P
@@ -2415,7 +2415,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ONIX_103:
         return basic (this, hp:HP110, type:F, retreatCost:4) {
           weakness G
@@ -2427,7 +2427,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               reduceDamageNextTurn(hp(20), thisMove)
             }
           }
-        };
+        }
       case STEELIX_104:
         return evolution (this, from:"Onix", hp:HP170, type:F, retreatCost:4) {
           weakness G
@@ -2462,7 +2462,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CUBONE_105:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness G
@@ -2480,7 +2480,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case AERODACTYL_GX_106:
         return evolution (this, from:"Unidentified Fossil", hp:HP210, type:F, retreatCost:0) {
           weakness G
@@ -2517,7 +2517,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERACROSS_107:
         return basic (this, hp:HP100, type:F, retreatCost:1) {
           weakness P
@@ -2541,7 +2541,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case BRELOOM_108:
         return evolution (this, from:"Shroomish", hp:HP120, type:F, retreatCost:2) {
           weakness P
@@ -2560,7 +2560,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (defending.isSPC(ASLEEP)) damage 90
             }
           }
-        };
+        }
       case MEDITITE_109:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness P
@@ -2573,7 +2573,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEDICHAM_110:
         return evolution (this, from:"Meditite", hp:HP110, type:F, retreatCost:1) {
           weakness P
@@ -2592,7 +2592,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               if (self.cards.findAll { it.name=="Karate Belt" }) damage 60
             }
           }
-        };
+        }
       case RELICANTH_111:
         return basic (this, hp:HP090, type:F, retreatCost:1) {
           weakness G
@@ -2613,7 +2613,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               applyAfterDamage ASLEEP
             }
           }
-        };
+        }
       case GIBLE_112:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness G
@@ -2631,7 +2631,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GABITE_113:
         return evolution (this, from:"Gible", hp:HP090, type:F, retreatCost:1) {
           weakness G
@@ -2649,7 +2649,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case GARCHOMP_114:
         return evolution (this, from:"Gabite", hp:HP150, type:F, retreatCost:0) {
           weakness G
@@ -2679,7 +2679,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RIOLU_115:
         return basic (this, hp:HP060, type:F, retreatCost:1) {
           weakness P
@@ -2690,9 +2690,9 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case RIOLU_116:
-        return copy (RIOLU_115, this);
+        return copy (RIOLU_115, this)
       case LUCARIO_117:
         return evolution (this, from:"Riolu", hp:HP120, type:F, retreatCost:2) {
           weakness P
@@ -2716,7 +2716,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case DRILBUR_118:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness G
@@ -2727,7 +2727,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case EXCADRILL_119:
         return evolution (this, from:"Drilbur", hp:HP120, type:F, retreatCost:2) {
           weakness G
@@ -2749,7 +2749,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case ARCHEN_120:
         return evolution (this, from:"Unidentified Fossil", hp:HP080, type:F, retreatCost:1) {
           weakness L
@@ -2762,7 +2762,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case ARCHEOPS_121:
         return evolution (this, from:"Archen", hp:HP130, type:F, retreatCost:1) {
           weakness L
@@ -2783,7 +2783,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardDefendingEnergy()
             }
           }
-        };
+        }
       case TERRAKION_122:
         return basic (this, hp:HP140, type:F, retreatCost:4) {
           weakness G
@@ -2805,7 +2805,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case MELOETTA_123:
         return basic (this, hp:HP090, type:F, retreatCost:1) {
           weakness P
@@ -2826,7 +2826,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flipUntilTails { damage 30 }
             }
           }
-        };
+        }
       case ZYGARDE_124:
         return basic (this, hp:HP090, type:F, retreatCost:1) {
           weakness G
@@ -2856,7 +2856,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case UMBREON_DARKRAI_GX_125:
         return basic (this, hp:HP270, type:D, retreatCost:2) {
           weakness F
@@ -2899,7 +2899,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MEGA_SABLEYE_TYRANITAR_GX_126:
         return basic (this, hp:HP280, type:D, retreatCost:4) {
           weakness F
@@ -2944,7 +2944,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ALOLAN_GRIMER_127:
         return basic (this, hp:HP080, type:D, retreatCost:2) {
           weakness F
@@ -2962,7 +2962,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case MURKROW_128:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness L
@@ -2977,7 +2977,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               astonish()
             }
           }
-        };
+        }
       case MURKROW_129:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness L
@@ -2989,7 +2989,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case HONCHKROW_130:
         return evolution (this, from:"Murkrow", hp:HP110, type:D, retreatCost:1) {
           weakness L
@@ -3008,7 +3008,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case SNEASEL_131:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness F
@@ -3020,7 +3020,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case WEAVILE_GX_132:
         return evolution (this, from:"Sneasel", hp:HP200, type:D, retreatCost:1) {
           weakness F
@@ -3057,7 +3057,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case SABLEYE_133:
         return basic (this, hp:HP080, type:D, retreatCost:1) {
           move "Mirror Gem", {
@@ -3071,7 +3071,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAPION_134:
         return evolution (this, from:"Skorupi", hp:HP140, type:D, retreatCost:4) {
           weakness F
@@ -3104,7 +3104,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case PURRLOIN_135:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness F
@@ -3120,7 +3120,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               target.cards.filterByType(POKEMON_TOOL).select("Choose a Pokémon Tool to discard.").discard()
             }
           }
-        };
+        }
       case LIEPARD_136:
         return evolution (this, from:"Purrloin", hp:HP100, type:D, retreatCost:1) {
           weakness F
@@ -3142,7 +3142,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SCRAGGY_137:
         return basic (this, hp:HP070, type:D, retreatCost:2) {
           weakness F
@@ -3161,7 +3161,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case SCRAFTY_138:
         return evolution (this, from:"Scraggy", hp:HP110, type:D, retreatCost:2) {
           weakness F
@@ -3181,7 +3181,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case YVELTAL_139:
         return basic (this, hp:HP130, type:D, retreatCost:2) {
           weakness L
@@ -3203,7 +3203,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HOOPA_140:
         return basic (this, hp:HP130, type:D, retreatCost:2) {
           weakness F
@@ -3223,7 +3223,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               noWrDamage 80, defending
             }
           }
-        };
+        }
       case MAWILE_GX_141:
         return basic (this, hp:HP170, type:M, retreatCost:1) {
           weakness R
@@ -3263,7 +3263,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               opp.hand.filterByType(SUPPORTER).showToOpponent("Your opponent used Big Eater GX: These Supporter cards will now be discarded.").discard()
             }
           }
-        };
+        }
       case ESCAVALIER_142:
         return evolution (this, from:"Karrablast", hp:HP130, type:M, retreatCost:3) {
           weakness R
@@ -3285,7 +3285,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case COTTONEE_143:
         return basic (this, hp:HP060, type:Y, retreatCost:1) {
           weakness M
@@ -3297,7 +3297,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               draw 1
             }
           }
-        };
+        }
       case WHIMSICOTT_144:
         return evolution (this, from:"Cottonee", hp:HP080, type:Y, retreatCost:0) {
           weakness M
@@ -3319,7 +3319,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case DEDENNE_145:
         return basic (this, hp:HP070, type:Y, retreatCost:1) {
           weakness M
@@ -3336,7 +3336,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GARCHOMP_GIRATINA_GX_146:
         return basic (this, hp:HP270, type:N, retreatCost:3) {
           weakness Y
@@ -3372,7 +3372,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRATINI_147:
         return basic (this, hp:HP060, type:N, retreatCost:2) {
           weakness Y
@@ -3385,7 +3385,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRATINI_148:
         return basic (this, hp:HP060, type:N, retreatCost:2) {
           weakness Y
@@ -3406,7 +3406,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGONAIR_149:
         return evolution (this, from:"Dratini", hp:HP090, type:N, retreatCost:2) {
           weakness Y
@@ -3424,7 +3424,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRAGONAIR_150:
         return evolution (this, from:"Dratini", hp:HP100, type:N, retreatCost:2) {
           weakness Y
@@ -3443,7 +3443,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardDefendingEnergy()
             }
           }
-        };
+        }
       case DRAGONITE_151:
         return evolution (this, from:"Dragonair", hp:HP160, type:N, retreatCost:2) {
           weakness Y
@@ -3470,7 +3470,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRAGONITE_GX_152:
         return evolution (this, from:"Dragonair", hp:HP250, type:N, retreatCost:2) {
           weakness Y
@@ -3506,7 +3506,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               draw 10 - my.hand.size()
             }
           }
-        };
+        }
       case LATIAS_153:
         return basic (this, hp:HP120, type:N, retreatCost:1) {
           weakness Y
@@ -3525,7 +3525,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 100
             }
           }
-        };
+        }
       case AXEW_154:
         return basic (this, hp:HP060, type:N, retreatCost:1) {
           weakness Y
@@ -3547,7 +3547,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case FRAXURE_155:
         return evolution (this, from:"Axew", hp:HP090, type:N, retreatCost:2) {
           weakness Y
@@ -3567,7 +3567,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAXORUS_156:
         return evolution (this, from:"Fraxure", hp:HP150, type:N, retreatCost:3) {
           weakness Y
@@ -3596,7 +3596,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DRUDDIGON_157:
         return basic (this, hp:HP120, type:N, retreatCost:2) {
           weakness Y
@@ -3619,7 +3619,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { damage 100 }
             }
           }
-        };
+        }
       case NOIBAT_158:
         return basic (this, hp:HP060, type:N, retreatCost:1) {
           weakness Y
@@ -3631,7 +3631,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case NOIVERN_159:
         return evolution (this, from:"Noibat", hp:HP120, type:N, retreatCost:0) {
           weakness Y
@@ -3650,7 +3650,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               my.deck.subList(0,1).discard()
             }
           }
-        };
+        }
       case NAGANADEL_GX_160:
         return evolution (this, from:"Poipole", hp:HP210, type:N, retreatCost:1) {
           weakness Y
@@ -3689,7 +3689,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               bc "Injection GX added 1 card to prizes and shuffled them."
             }
           }
-        };
+        }
       case LICKITUNG_161:
         return basic (this, hp:HP100, type:C, retreatCost:4) {
           weakness F
@@ -3708,7 +3708,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 40
             }
           }
-        };
+        }
       case LICKILICKY_162:
         return evolution (this, from:"Lickitung", hp:HP130, type:C, retreatCost:4) {
           weakness F
@@ -3730,7 +3730,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KANGASKHAN_163:
         return basic (this, hp:HP130, type:C, retreatCost:2) {
           weakness F
@@ -3749,7 +3749,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 50*tagTeams.size()
             }
           }
-        };
+        }
       case TAUROS_164:
         return basic (this, hp:HP110, type:C, retreatCost:1) {
           weakness F
@@ -3766,7 +3766,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10, self
             }
           }
-        };
+        }
       case HOOTHOOT_165:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -3779,7 +3779,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case NOCTOWL_166:
         return evolution (this, from:"Hoothoot", hp:HP090, type:C, retreatCost:1) {
           weakness L
@@ -3798,7 +3798,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case SLAKOTH_167:
         return basic (this, hp:HP050, type:C, retreatCost:2) {
           weakness F
@@ -3831,7 +3831,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SLAKOTH_168:
         return basic (this, hp:HP070, type:C, retreatCost:3) {
           weakness F
@@ -3850,7 +3850,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case VIGOROTH_169:
         return evolution (this, from:"Slakoth", hp:HP090, type:C, retreatCost:1) {
           weakness F
@@ -3868,7 +3868,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case SLAKING_170:
         return evolution (this, from:"Vigoroth", hp:HP180, type:C, retreatCost:4) {
           weakness F
@@ -3904,7 +3904,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BIDOOF_171:
         return basic (this, hp:HP070, type:C, retreatCost:2) {
           weakness F
@@ -3922,7 +3922,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { damage 60 }
             }
           }
-        };
+        }
       case BIBAREL_172:
         return evolution (this, from:"Bidoof", hp:HP120, type:C, retreatCost:2) {
           weakness F
@@ -3946,7 +3946,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               amnesia delegate
             }
           }
-        };
+        }
       case MUNCHLAX_173:
         return basic (this, hp:HP060, type:C, retreatCost:0) {
           bwAbility "Snack Search", {
@@ -3963,7 +3963,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case PIDOVE_174:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -3982,7 +3982,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case TRANQUILL_175:
         return evolution (this, from:"Pidove", hp:HP080, type:C, retreatCost:1) {
           weakness L
@@ -4002,7 +4002,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case UNFEZANT_176:
         return evolution (this, from:"Tranquill", hp:HP140, type:C, retreatCost:1) {
           weakness L
@@ -4029,7 +4029,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case AUDINO_177:
         return basic (this, hp:HP090, type:C, retreatCost:1) {
           weakness F
@@ -4050,7 +4050,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case TORNADUS_178:
         return basic (this, hp:HP120, type:C, retreatCost:1) {
           weakness L
@@ -4072,7 +4072,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FLETCHLING_179:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness L
@@ -4084,7 +4084,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case YUNGOOS_180:
         return basic (this, hp:HP070, type:C, retreatCost:1) {
           weakness F
@@ -4095,7 +4095,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GUMSHOOS_181:
         return evolution (this, from:"Yungoos", hp:HP100, type:C, retreatCost:1) {
           weakness F
@@ -4110,7 +4110,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ORANGURU_182:
         return basic (this, hp:HP120, type:C, retreatCost:3) {
           weakness F
@@ -4135,7 +4135,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case TYPE_NULL_183:
         return basic (this, hp:HP100, type:C, retreatCost:1) {
           weakness F
@@ -4154,7 +4154,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case SILVALLY_184:
         return evolution (this, from:"Type: Null", hp:HP130, type:C, retreatCost:2) {
           weakness F
@@ -4174,7 +4174,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               discardSelfEnergy C
             }
           }
-        };
+        }
       case KOMALA_185:
         return basic (this, hp:HP090, type:C, retreatCost:1) {
           weakness F
@@ -4196,7 +4196,7 @@ public enum UnifiedMinds implements LogicCardInfo {
               apply ASLEEP, self
             }
           }
-        };
+        }
       case BLAINE_S_QUIZ_SHOW_186:
         return supporter (this) {
           text "Put a Pokémon from your hand face down in front of you and tell your opponent the name of an attack it has. Your opponent guesses the name of that Pokémon, and then you reveal it. If your opponent guessed right, they draw 4 cards. If they guessed wrong, you draw 4 cards. Return the Pokémon to your hand."
@@ -4205,7 +4205,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case BLIZZARD_TOWN_187:
         return stadium (this) {
           text "Pokémon with 40 HP or less remaining (both yours and your opponent’s) can’t attack."
@@ -4223,7 +4223,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case BLUE_S_TACTICS_188:
         return supporter (this) {
           text "At the end of this turn, draw cards until you have 8 cards in your hand."
@@ -4241,7 +4241,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case BUG_CATCHER_189:
         return supporter (this) {
           text "Draw 2 cards. Flip a coin. If heads, draw 2 more cards."
@@ -4252,7 +4252,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case CHANNELER_190:
         return supporter (this) {
           text "Remove all effects of attacks on you and each of your Pokémon."
@@ -4261,7 +4261,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case CHERISH_BALL_191:
         return itemCard (this) {
           text "Search your deck for a Pokémon-GX, reveal it, and put it into your hand. Then, shuffle your deck."
@@ -4272,7 +4272,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case COACH_TRAINER_192:
         return supporter (this) {
           text "Draw 2 cards. If your Active Pokémon is a TAG TEAM Pokémon, draw 2 more cards."
@@ -4285,7 +4285,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case DARK_CITY_193:
         return stadium (this) {
           text "Basic [D] Pokémon in play (both your and your opponent’s) have no Retreat Cost."
@@ -4301,7 +4301,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay{
             eff.unregister()
           }
-        };
+        }
       case EAR_RINGING_BELL_194:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack (even if that Pokémon is Knocked Out), the Attacking Pokémon is now Confused."
@@ -4309,7 +4309,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             bc "Ear-Ringing Bell activates."
             apply CONFUSED, ef.attacker, TRAINER_CARD
           }
-        };
+        }
       case FLYINIUM_Z_AIR_SLASH_195:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to has the Air Slash attack, it can use the GX attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -4337,7 +4337,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case GIANT_BOMB_196:
         return pokemonTool (this) {
           text "If this card is attached to 1 of your Pokémon, discard it at the end of your opponent’s turn." +
@@ -4368,7 +4368,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case GIANT_HEARTH_197:
         return stadium(this) {
           text "Once during each player’s turn, that player may discard a card from their hand. If they do, that player searches their deck for up to 2 [R] Energy cards, reveals them, and puts them into their hand. Then, that player shuffles their deck."
@@ -4389,7 +4389,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case GREAT_POTION_198:
         return itemCard (this) {
           text "Heal 50 damage from your Active Pokémon-GX."
@@ -4400,7 +4400,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             assert my.active.pokemonGX : "Your Active Pokémon is not a Pokémon-GX."
             assert my.active.numberOfDamageCounters : "Your Active Pokémon-GX has no damage."
           }
-        };
+        }
       case GRIMSLEY_199:
         return supporter (this) {
           text "Move up to 3 damage counters from 1 of your opponent’s Pokémon to another of their Pokémon."
@@ -4426,7 +4426,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             assert opp.all.size() > 1 : "Your opponent only has one Pokémon in play"
             assertOppAll(overrideText: true, info: "There are no damage counters to move", {it.numberOfDamageCounters})
           }
-        };
+        }
       case HAPU_200:
         return supporter (this) {
           text "Look at the top 6 cards of your deck and put 2 of them into your hand. Discard the other cards."
@@ -4439,7 +4439,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case KARATE_BELT_201:
         return pokemonTool (this) {
           text "If you have more Prize cards remaining than your opponent, the attacks of the Pokémon this card is attached to cost [F] less."
@@ -4460,7 +4460,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff1.unregister()
           }
-        };
+        }
       case MISTY_S_FAVOR_202:
         return supporter (this) {
           text "Search your deck for up to 3 Supporter cards, reveal them, and put them into your hand. Then, shuffle your deck."
@@ -4471,7 +4471,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case NORMALIUM_Z_TACKLE_203:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to has the Tackle attack, it can use the GX attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -4499,7 +4499,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case POKE_MANIAC_204:
         return supporter (this) {
           text "Search your deck for up to 3 Pokémon that have a Retreat Cost of exactly 4, reveal them, and put them into your hand. Then, shuffle your deck."
@@ -4510,7 +4510,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case POKEMON_RESEARCH_LAB_205:
         return stadium (this) {
           text "Once during each player’s turn, that player may search their deck for up to 2 Pokémon that evolve from Unidentified Fossil, put those Pokémon onto their Bench, and shuffle their deck. If a player searches their deck in this way, their turn ends."
@@ -4537,7 +4537,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay{
             actions.each { bg().gm().unregisterAction(it) }
           }
-        };
+        }
       case RESET_STAMP_206:
         return itemCard (this) {
           text "Your opponent shuffles their hand into their deck and draws a card for each of their remaining Prize cards."
@@ -4548,7 +4548,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           }
           playRequirement{
           }
-        };
+        }
       case SLUMBERING_FOREST_207:
         return stadium (this) {
           text "If a Pokémon is Asleep, its owner flips 2 coins instead of 1 for that Special Condition between turns. If either of them is tails, that Pokémon is still Asleep."
@@ -4557,7 +4557,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             eff = delayed {
               before ASLEEP_SPC, null, null, BEGIN_TURN, {
                 flip "Asleep (Slumbering Forest)", 2, {}, {}, [2:{
-                  ef.unregisterItself(bg.em());
+                  ef.unregisterItself(bg.em())
                 },1:{
                   bc "$ef.target is still asleep."
                 },0:{
@@ -4570,7 +4570,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case STADIUM_NAV_208:
         return itemCard (this) {
           text "Flip 2 coins. For each heads, search your deck for a Stadium card, reveal it, and put it into your hand. Then, shuffle your deck."
@@ -4581,7 +4581,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           playRequirement{
             assert my.deck : "Your deck is empty."
           }
-        };
+        }
       case TAG_SWITCH_209:
         return itemCard (this) {
           text "Move up to 2 Energy from 1 of your TAG TEAM Pokémon to another of your Pokémon."
@@ -4594,9 +4594,9 @@ public enum UnifiedMinds implements LogicCardInfo {
             assert my.all.size() > 1 : "You only have one Pokémon in play"
             assertMyAll(hasVariants: TAG_TEAM, info: "with Energy attached to them", {it.cards.filterByType(ENERGY)})
           }
-        };
+        }
       case UNIDENTIFIED_FOSSIL_210:
-        return copy(UltraPrism.UNIDENTIFIED_FOSSIL_134, this);
+        return copy(UltraPrism.UNIDENTIFIED_FOSSIL_134, this)
       case U_TURN_BOARD_211:
         return pokemonTool (this) {
           text "The Retreat Cost of the Pokémon this card is attached to is [C] less." +
@@ -4625,7 +4625,7 @@ public enum UnifiedMinds implements LogicCardInfo {
             eff.unregister()
             eff2.unregister()
           }
-        };
+        }
       case RECYCLE_ENERGY_212:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy." +
@@ -4649,7 +4649,7 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case WEAKNESS_GUARD_ENERGY_213:
         return specialEnergy (this, [[C]]) {
           text "This card provides [C] Energy." +
@@ -4663,99 +4663,99 @@ public enum UnifiedMinds implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case ROWLET_ALOLAN_EXEGGUTOR_GX_214:
-        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this);
+        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this)
       case ROWLET_ALOLAN_EXEGGUTOR_GX_215:
-        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this);
+        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this)
       case HEATRAN_GX_216:
-        return copy (HEATRAN_GX_25, this);
+        return copy (HEATRAN_GX_25, this)
       case SLOWPOKE_PSYDUCK_GX_217:
-        return copy (SLOWPOKE_PSYDUCK_GX_35, this);
+        return copy (SLOWPOKE_PSYDUCK_GX_35, this)
       case SLOWPOKE_PSYDUCK_GX_218:
-        return copy (SLOWPOKE_PSYDUCK_GX_35, this);
+        return copy (SLOWPOKE_PSYDUCK_GX_35, this)
       case KELDEO_GX_219:
-        return copy (KELDEO_GX_47, this);
+        return copy (KELDEO_GX_47, this)
       case RAICHU_ALOLAN_RAICHU_GX_220:
-        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this);
+        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this)
       case RAICHU_ALOLAN_RAICHU_GX_221:
-        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this);
+        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this)
       case MEWTWO_MEW_GX_222:
-        return copy (MEWTWO_MEW_GX_71, this);
+        return copy (MEWTWO_MEW_GX_71, this)
       case LATIOS_GX_223:
-        return copy (LATIOS_GX_78, this);
+        return copy (LATIOS_GX_78, this)
       case AERODACTYL_GX_224:
-        return copy (AERODACTYL_GX_106, this);
+        return copy (AERODACTYL_GX_106, this)
       case MEGA_SABLEYE_TYRANITAR_GX_225:
-        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this);
+        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this)
       case MEGA_SABLEYE_TYRANITAR_GX_226:
-        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this);
+        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this)
       case MAWILE_GX_227:
-        return copy (MAWILE_GX_141, this);
+        return copy (MAWILE_GX_141, this)
       case GARCHOMP_GIRATINA_GX_228:
-        return copy (GARCHOMP_GIRATINA_GX_146, this);
+        return copy (GARCHOMP_GIRATINA_GX_146, this)
       case DRAGONITE_GX_229:
-        return copy (DRAGONITE_GX_152, this);
+        return copy (DRAGONITE_GX_152, this)
       case NAGANADEL_GX_230:
-        return copy (NAGANADEL_GX_160, this);
+        return copy (NAGANADEL_GX_160, this)
       case BLUE_S_TACTICS_231:
-        return copy (BLUE_S_TACTICS_188, this);
+        return copy (BLUE_S_TACTICS_188, this)
       case CHANNELER_232:
-        return copy (CHANNELER_190, this);
+        return copy (CHANNELER_190, this)
       case COACH_TRAINER_233:
-        return copy (COACH_TRAINER_192, this);
+        return copy (COACH_TRAINER_192, this)
       case GRIMSLEY_234:
-        return copy (GRIMSLEY_199, this);
+        return copy (GRIMSLEY_199, this)
       case MISTY_S_FAVOR_235:
-        return copy (MISTY_S_FAVOR_202, this);
+        return copy (MISTY_S_FAVOR_202, this)
       case POKE_MANIAC_236:
-        return copy (POKE_MANIAC_204, this);
+        return copy (POKE_MANIAC_204, this)
       case ROWLET_ALOLAN_EXEGGUTOR_GX_237:
-        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this);
+        return copy (ROWLET_ALOLAN_EXEGGUTOR_GX_1, this)
       case HEATRAN_GX_238:
-        return copy (HEATRAN_GX_25, this);
+        return copy (HEATRAN_GX_25, this)
       case SLOWPOKE_PSYDUCK_GX_239:
-        return copy (SLOWPOKE_PSYDUCK_GX_35, this);
+        return copy (SLOWPOKE_PSYDUCK_GX_35, this)
       case KELDEO_GX_240:
-        return copy (KELDEO_GX_47, this);
+        return copy (KELDEO_GX_47, this)
       case RAICHU_ALOLAN_RAICHU_GX_241:
-        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this);
+        return copy (RAICHU_ALOLAN_RAICHU_GX_54, this)
       case MEWTWO_MEW_GX_242:
-        return copy (MEWTWO_MEW_GX_71, this);
+        return copy (MEWTWO_MEW_GX_71, this)
       case LATIOS_GX_243:
-        return copy (LATIOS_GX_78, this);
+        return copy (LATIOS_GX_78, this)
       case AERODACTYL_GX_244:
-        return copy (AERODACTYL_GX_106, this);
+        return copy (AERODACTYL_GX_106, this)
       case MEGA_SABLEYE_TYRANITAR_GX_245:
-        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this);
+        return copy (MEGA_SABLEYE_TYRANITAR_GX_126, this)
       case MAWILE_GX_246:
-        return copy (MAWILE_GX_141, this);
+        return copy (MAWILE_GX_141, this)
       case GARCHOMP_GIRATINA_GX_247:
-        return copy (GARCHOMP_GIRATINA_GX_146, this);
+        return copy (GARCHOMP_GIRATINA_GX_146, this)
       case DRAGONITE_GX_248:
-        return copy (DRAGONITE_GX_152, this);
+        return copy (DRAGONITE_GX_152, this)
       case NAGANADEL_GX_249:
-        return copy (NAGANADEL_GX_160, this);
+        return copy (NAGANADEL_GX_160, this)
       case CHERISH_BALL_250:
-        return copy (CHERISH_BALL_191, this);
+        return copy (CHERISH_BALL_191, this)
       case GIANT_BOMB_251:
-        return copy (GIANT_BOMB_196, this);
+        return copy (GIANT_BOMB_196, this)
       case KARATE_BELT_252:
-        return copy (KARATE_BELT_201, this);
+        return copy (KARATE_BELT_201, this)
       case RESET_STAMP_253:
-        return copy (RESET_STAMP_206, this);
+        return copy (RESET_STAMP_206, this)
       case TAG_SWITCH_254:
-        return copy (TAG_SWITCH_209, this);
+        return copy (TAG_SWITCH_209, this)
       case U_TURN_BOARD_255:
-        return copy (U_TURN_BOARD_211, this);
+        return copy (U_TURN_BOARD_211, this)
       case VIRIDIAN_FOREST_256:
         return copy(TeamUp.VIRIDIAN_FOREST_156, this)
       case RECYCLE_ENERGY_257:
-        return copy (RECYCLE_ENERGY_212, this);
+        return copy (RECYCLE_ENERGY_212, this)
       case WEAKNESS_GUARD_ENERGY_258:
-        return copy (WEAKNESS_GUARD_ENERGY_213, this);
+        return copy (WEAKNESS_GUARD_ENERGY_213, this)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
+++ b/src/tcgwars/logic/impl/gen8/AmazingVoltTackle.groovy
@@ -1,37 +1,37 @@
 package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.effect.gm.PlayCard
-import tcgwars.logic.effect.gm.PlayTrainer;
+import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -160,53 +160,53 @@ public enum AmazingVoltTackle implements LogicCardInfo {
   TELEPHOTO_SCOPE_120 ("Telephoto Scope", "120", Rarity.UNCOMMON, [POKEMON_TOOL, TRAINER, ITEM]),
   MEMORY_CAPSULE_121 ("Memory Capsule", "121", Rarity.UNCOMMON, [POKEMON_TOOL, TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   AmazingVoltTackle(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.AMAZING_VOLT_TACKLE;
+    return tcgwars.logic.card.Collection.AMAZING_VOLT_TACKLE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -222,7 +222,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NUZLEAF_2:
       return evolution (this, from:"Seedot", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -233,7 +233,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHIFTRY_3:
       return evolution (this, from:"Nuzleaf", hp:HP150, type:G, retreatCost:3) {
         weakness R
@@ -284,7 +284,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             whirlwind()
           }
         }
-      };
+      }
       case NINCADA_4:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -296,7 +296,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             heal 10, self
           }
         }
-      };
+      }
       case NINJASK_5:
       return evolution (this, from:"Nincada", hp:HP060, type:G, retreatCost:0) {
         weakness R
@@ -318,7 +318,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case SKIDDO_6:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -340,7 +340,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GOGOAT_7:
       return evolution (this, from:"Skiddo", hp:HP130, type:G, retreatCost:2) {
         weakness R
@@ -359,7 +359,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case ORBEETLE_V_8:
       return basic (this, hp:HP180, type:G, retreatCost:1) {
         weakness R
@@ -379,7 +379,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30 * defending.getEnergyCount(bg)
           }
         }
-      };
+      }
       case ORBEETLE_VMAX_9:
       return evolution (this, from:"Orbeetle V", hp:HP310, type:G, retreatCost:1) {
         weakness R
@@ -400,7 +400,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 50 * defending.getEnergyCount(bg)
           }
         }
-      };
+      }
       case CHARMANDER_10:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -421,7 +421,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHARMELEON_11:
       return evolution (this, from:"Charmander", hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -440,7 +440,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             if (my.deck) my.deck.subList(0, 3).discard()
           }
         }
-      };
+      }
       case CHARIZARD_12:
       return evolution (this, from:"Charmeleon", hp:HP170, type:R, retreatCost:3) {
         weakness W
@@ -464,7 +464,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 50 * my.discard.findAll { it.name == "Leon" }.size()
           }
         }
-      };
+      }
       case FLAREON_13:
       return evolution (this, from:"Eevee", hp:HP110, type:R, retreatCost:2) {
         weakness W
@@ -498,7 +498,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SLUGMA_14:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -519,7 +519,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGCARGO_15:
       return evolution (this, from:"Slugma", hp:HP130, type:R, retreatCost:3) {
         weakness W
@@ -538,7 +538,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             discardSelfEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case TALONFLAME_V_16:
       return basic (this, hp:HP190, type:R, retreatCost:0) {
         weakness L
@@ -562,7 +562,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             discardSelfEnergyAfterDamage C
           }
         }
-      };
+      }
       case VAPOREON_17:
       return evolution (this, from:"Eevee", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -596,7 +596,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case WAILMER_18:
       return basic (this, hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -608,7 +608,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20 * self.cards.filterByEnergyType(W).size()
           }
         }
-      };
+      }
       case WAILORD_19:
       return evolution (this, from:"Wailmer", hp:HP200, type:W, retreatCost:4) {
         weakness L
@@ -631,7 +631,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 40 * self.cards.filterByEnergyType(W).size()
           }
         }
-      };
+      }
       case OSHAWOTT_20:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -649,7 +649,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DEWOTT_21:
       return evolution (this, from:"Oshawott", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -671,7 +671,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             if (selectedEnergy) selectedEnergy.moveTo opp.hand
           }
         }
-      };
+      }
       case SAMUROTT_22:
       return evolution (this, from:"Dewott", hp:HP160, type:W, retreatCost:2) {
         weakness L
@@ -690,7 +690,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             if (selectedEnergy) selectedEnergy.moveTo opp.hand
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_V_23:
       return basic (this, hp:HP220, type:W, retreatCost:2) {
         weakness M
@@ -710,7 +710,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_VMAX_24:
       return evolution (this, from:"Galarian Darmanitan V", hp:HP320, type:W, retreatCost:3) {
         weakness M
@@ -722,7 +722,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             opp.bench.each { damage 30, it }
           }
         }
-      };
+      }
       case CHEWTLE_25:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -734,7 +734,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case DREDNAW_26:
       return evolution (this, from:"Chewtle", hp:HP140, type:W, retreatCost:4) {
         weakness L
@@ -754,7 +754,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case CRAMORANT_27:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -782,7 +782,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 60 * count
           }
         }
-      };
+      }
       case ARROKUDA_28:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -805,7 +805,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BARRASKEWDA_29:
       return evolution (this, from:"Arrokuda", hp:HP120, type:W, retreatCost:1) {
         weakness L
@@ -828,7 +828,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case PIKACHU_V_30:
       return basic (this, hp:HP190, type:L, retreatCost:1) {
         weakness F
@@ -853,7 +853,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             discardAllSelfEnergy()
           }
         }
-      };
+      }
       case PIKACHU_VMAX_31:
       return evolution (this, from:"Pikachu V", hp:HP310, type:L, retreatCost:2) {
         weakness F
@@ -868,7 +868,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VOLTORB_32:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -879,7 +879,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ELECTRODE_33:
       return evolution (this, from:"Voltorb", hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -906,7 +906,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case JOLTEON_34:
       return evolution (this, from:"Eevee", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -940,7 +940,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case ZAPDOS_35:
       return basic (this, hp:HP110, type:L, retreatCost:1) {
         weakness L
@@ -975,7 +975,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BLITZLE_36:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -986,7 +986,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ZEBSTRIKA_37:
       return evolution (this, from:"Blitzle", hp:HP110, type:L, retreatCost:1) {
         weakness F
@@ -1004,7 +1004,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case TYNAMO_38:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1021,7 +1021,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EELEKTRIK_39:
       return evolution (this, from:"Tynamo", hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -1045,7 +1045,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case EELEKTROSS_40:
       return evolution (this, from:"Eelektrik", hp:HP160, type:L, retreatCost:3) {
         weakness F
@@ -1087,7 +1087,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30, pokes
           }
         }
-      };
+      }
       case ALAKAZAM_V_41:
       return basic (this, hp:HP190, type:P, retreatCost:1) {
         weakness D
@@ -1109,7 +1109,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30 * opp.hand.size()
           }
         }
-      };
+      }
       case SHEDINJA_42:
       return basic (this, hp:HP030, type:P, retreatCost:1) {
         globalAbility {
@@ -1136,7 +1136,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             directDamage defending.remainingHP.value - 10, defending
           }
         }
-      };
+      }
       case DUSKULL_43:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1146,7 +1146,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           energyCost C
           foresight 4, delegate
         }
-      };
+      }
       case DUSCLOPS_44:
       return evolution (this, from:"Duskull", hp:HP090, type:P, retreatCost:2) {
         weakness D
@@ -1168,7 +1168,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case DUSKNOIR_45:
       return evolution (this, from:"Dusclops", hp:HP150, type:P, retreatCost:2) {
         weakness D
@@ -1193,7 +1193,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case CHIMECHO_46:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1221,7 +1221,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             applyAfterDamage ASLEEP
           }
         }
-      };
+      }
       case WOOBAT_47:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness L
@@ -1236,7 +1236,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             opp.all.each { damage 30, it }
           }
         }
-      };
+      }
       case SWOOBAT_48:
       return evolution (this, from:"Woobat", hp:HP100, type:P, retreatCost:1) {
         weakness L
@@ -1259,7 +1259,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case COTTONEE_49:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
@@ -1270,7 +1270,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WHIMSICOTT_50:
       return evolution (this, from:"Cottonee", hp:HP090, type:P, retreatCost:0) {
         weakness M
@@ -1291,7 +1291,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             additionalDamageByDiscardingCardTypeFromPokemon 10, 40, POKEMON_TOOL
           }
         }
-      };
+      }
       case MILCERY_51:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness M
@@ -1312,7 +1312,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ALCREMIE_52:
       return evolution (this, from:"Milcery", hp:HP090, type:P, retreatCost:1) {
         weakness M
@@ -1333,7 +1333,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case MACHOP_53:
       return copy(ChampionsPath.MACHOP_24, this)
       case MACHOKE_54:
@@ -1360,7 +1360,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30 * self.numberOfDamageCounters
           }
         }
-      };
+      }
       case DONPHAN_57:
       return evolution (this, from:"Phanpy", hp:HP150, type:F, retreatCost:4) {
         weakness G
@@ -1379,7 +1379,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case HITMONTOP_58:
       return basic (this, hp:HP090, type:F, retreatCost:1) {
         weakness P
@@ -1403,7 +1403,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case DRILBUR_59:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -1421,7 +1421,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             flip { damage 50 }
           }
         }
-      };
+      }
       case TERRAKION_60:
       return basic (this, hp:HP140, type:F, retreatCost:4) {
         weakness G
@@ -1443,7 +1443,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MUDBRAY_61:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -1461,7 +1461,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MUDSDALE_62:
       return evolution (this, from:"Mudbray", hp:HP140, type:F, retreatCost:3) {
         weakness G
@@ -1479,7 +1479,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 180 - (defending.retreatCost * 30)
           }
         }
-      };
+      }
       case CLOBBOPUS_63:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness P
@@ -1497,7 +1497,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GRAPPLOCT_64:
       return evolution (this, from:"Clobbopus", hp:HP130, type:F, retreatCost:2) {
         weakness P
@@ -1520,7 +1520,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_SIRFETCH_D_V_65:
       return copy(SwordShieldPromos.GALARIAN_SIRFETCH_D_V_SWSH43, this)
       case POOCHYENA_66:
@@ -1540,7 +1540,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MIGHTYENA_67:
       return evolution (this, from:"Poochyena", hp:HP110, type:D, retreatCost:1) {
         weakness G
@@ -1559,7 +1559,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SABLEYE_68:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -1581,7 +1581,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             amnesia delegate
           }
         }
-      };
+      }
       case DRAPION_V_69:
       return basic (this, hp:HP210, type:D, retreatCost:3) {
         weakness F
@@ -1602,7 +1602,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case SANDILE_70:
       return basic (this, hp:HP070, type:D, retreatCost:2) {
         weakness G
@@ -1616,7 +1616,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             opp.deck.subList(0, 3).discard()
           }
         }
-      };
+      }
       case KROKOROK_71:
       return evolution (this, from:"Sandile", hp:HP090, type:D, retreatCost:2) {
         weakness G
@@ -1637,7 +1637,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             opp.deck.subList(0, 3).discard()
           }
         }
-      };
+      }
       case KROOKODILE_72:
       return evolution (this, from:"Krokorok", hp:HP150, type:D, retreatCost:3) {
         weakness G
@@ -1659,7 +1659,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             apply CONFUSED, self
           }
         }
-      };
+      }
       case TRUBBISH_73:
       return basic (this, hp:HP070, type:D, retreatCost:2) {
         weakness F
@@ -1682,7 +1682,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GARBODOR_74:
       return evolution (this, from:"Trubbish", hp:HP120, type:D, retreatCost:3) {
         weakness F
@@ -1707,7 +1707,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case GALARIAN_MEOWTH_75:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -1726,7 +1726,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             flip 3, { damage 20 }
           }
         }
-      };
+      }
       case GALARIAN_PERRSERKER_76:
       return evolution (this, from:"Galarian Meowth", hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -1753,7 +1753,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case EXCADRILL_77:
       return evolution (this, from:"Drilbur", hp:HP130, type:M, retreatCost:3) {
         weakness R
@@ -1773,7 +1773,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case FERROSEED_78:
       return basic (this, hp:HP060, type:M, retreatCost:3) {
         weakness R
@@ -1786,7 +1786,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case FERROTHORN_79:
       return evolution (this, from:"Ferroseed", hp:HP110, type:M, retreatCost:3) {
         weakness R
@@ -1802,7 +1802,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case AEGISLASH_V_80:
       return basic (this, hp:HP210, type:M, retreatCost:3) {
         weakness R
@@ -1821,7 +1821,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             shredDamage 130
           }
         }
-      };
+      }
       case AEGISLASH_VMAX_81:
       return evolution (this, from:"Aegislash V", hp:HP320, type:M, retreatCost:3) {
         weakness R
@@ -1834,7 +1834,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 30 * my.prizeCardSet.takenCount
           }
         }
-      };
+      }
       case DURALUDON_82:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -1855,7 +1855,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             discardSelfEnergyAfterDamage C
           }
         }
-      };
+      }
       case EEVEE_83:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1873,7 +1873,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNORLAX_84:
       return basic (this, hp:HP130, type:C, retreatCost:3) {
         weakness F
@@ -1896,7 +1896,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case TAILLOW_85:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -1908,7 +1908,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case SWELLOW_86:
       return evolution (this, from:"Taillow", hp:HP090, type:C, retreatCost:0) {
         weakness L
@@ -1931,7 +1931,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WHISMUR_87:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1942,7 +1942,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             flipUntilTails { damage 40 }
           }
         }
-      };
+      }
       case LOUDRED_88:
       return evolution (this, from:"Whismur", hp:HP100, type:C, retreatCost:2) {
         weakness F
@@ -1960,7 +1960,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case EXPLOUD_89:
       return evolution (this, from:"Loudred", hp:HP160, type:C, retreatCost:3) {
         weakness F
@@ -1978,7 +1978,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case DRONE_ROTOM_90:
       return itemCard (this) {
         text "Your opponent reveals their hand. Then" +
@@ -1990,7 +1990,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         playRequirement{
           assert opp.hand : "Opponent's hand is empty"
         }
-      };
+      }
       case TELEPHOTO_SCOPE_91:
       return pokemonTool (this) {
         text "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Benched Pokémon V or Benched Pokémon-GX (before applying Weakness and Resistance)."
@@ -2010,7 +2010,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case MEMORY_CAPSULE_92:
       return pokemonTool (this) {
         text "The Pokémon this card is attached to can use any attack from its previous Evolutions. (You still need the necessary Energy to use each attack.)"
@@ -2029,7 +2029,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         onRemoveFromPlay {
           moveListGetter.unregister()
         }
-      };
+      }
       case BEA_93:
       return supporter (this) {
         text "Discard the top 5 cards of your deck. If any of those cards are Energy cards" +
@@ -2045,7 +2045,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           assert my.deck : "Deck is empty"
           assert my.bench.any { it.types.contains F } : "No $F Pokémon on your bench"
         }
-      };
+      }
       case LEON_94:
       return supporter (this) {
         text "During this turn" +
@@ -2063,7 +2063,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             unregisterAfter 1
           }
         }
-      };
+      }
       case LEAGUE_STAFF_95:
       return supporter (this) {
         text "Draw 2 cards. If Wyndon Stadium is in play" +
@@ -2075,7 +2075,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case NESSA_96:
       return supporter (this) {
         text "Put up to 4 in any combination of [W] Pokémon and [W] Energy cards from your discard pile into your hand."
@@ -2091,7 +2091,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
             (it.cardTypes.is(POKEMON) && it.asPokemonCard().types.contains(W))
           } || my.discard.filterByEnergyType(W) : "No $W Pokémon or $W Energy in your discard pile"
         }
-      };
+      }
       case HERO_S_BATH_97:
       return stadium (this) {
         text "Basic Pokémon in play (both yours and your opponent's) take 20 less damage from attacks (after applying Weakness and Resistance)."
@@ -2112,7 +2112,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case WYNDON_STADIUM_98:
       return stadium (this) {
         text "Whenever either player plays a Pokémon VMAX from their hand during their turn to evolve their Pokémon V" +
@@ -2129,7 +2129,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case WASH_W_ENERGY_99:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon" +
@@ -2156,7 +2156,7 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           if (self != null) return [[W] as Set]
           else  return [[] as Set]
         }
-      };
+      }
       case COATING_M_ENERGY_100:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon" +
@@ -2176,51 +2176,51 @@ public enum AmazingVoltTackle implements LogicCardInfo {
           if (self != null) return [[M] as Set]
           else  return [[] as Set]
         }
-      };
+      }
       case ORBEETLE_V_101:
-      return copy (ORBEETLE_V_8, this);
+      return copy (ORBEETLE_V_8, this)
       case TALONFLAME_V_102:
-      return copy (TALONFLAME_V_16, this);
+      return copy (TALONFLAME_V_16, this)
       case GALARIAN_DARMANITAN_V_103:
-      return copy (GALARIAN_DARMANITAN_V_23, this);
+      return copy (GALARIAN_DARMANITAN_V_23, this)
       case PIKACHU_V_104:
-      return copy (PIKACHU_V_30, this);
+      return copy (PIKACHU_V_30, this)
       case ALAKAZAM_V_105:
-      return copy (ALAKAZAM_V_41, this);
+      return copy (ALAKAZAM_V_41, this)
       case GALARIAN_SIRFETCH_D_V_106:
-      return copy (GALARIAN_SIRFETCH_D_V_65, this);
+      return copy (GALARIAN_SIRFETCH_D_V_65, this)
       case DRAPION_V_107:
-      return copy (DRAPION_V_69, this);
+      return copy (DRAPION_V_69, this)
       case AEGISLASH_V_108:
-      return copy (AEGISLASH_V_80, this);
+      return copy (AEGISLASH_V_80, this)
       case BEA_109:
-      return copy (BEA_93, this);
+      return copy (BEA_93, this)
       case LEON_110:
-      return copy (LEON_94, this);
+      return copy (LEON_94, this)
       case NESSA_111:
-      return copy (NESSA_96, this);
+      return copy (NESSA_96, this)
       case ORBEETLE_VMAX_112:
-      return copy (ORBEETLE_VMAX_9, this);
+      return copy (ORBEETLE_VMAX_9, this)
       case GALARIAN_DARMANITAN_VMAX_113:
-      return copy (GALARIAN_DARMANITAN_VMAX_24, this);
+      return copy (GALARIAN_DARMANITAN_VMAX_24, this)
       case PIKACHU_VMAX_114:
-      return copy (PIKACHU_VMAX_31, this);
+      return copy (PIKACHU_VMAX_31, this)
       case AEGISLASH_VMAX_115:
-      return copy (AEGISLASH_VMAX_81, this);
+      return copy (AEGISLASH_VMAX_81, this)
       case BEA_116:
-      return copy (BEA_93, this);
+      return copy (BEA_93, this)
       case LEON_117:
-      return copy (LEON_94, this);
+      return copy (LEON_94, this)
       case NESSA_118:
-      return copy (NESSA_96, this);
+      return copy (NESSA_96, this)
       case GALARIAN_OBSTAGOON_119:
       return copy (SwordShield.GALARIAN_OBSTAGOON_119, this)
       case TELEPHOTO_SCOPE_120:
-      return copy (TELEPHOTO_SCOPE_91, this);
+      return copy (TELEPHOTO_SCOPE_91, this)
       case MEMORY_CAPSULE_121:
-      return copy (MEMORY_CAPSULE_92, this);
+      return copy (MEMORY_CAPSULE_92, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/BattleStyles.groovy
+++ b/src/tcgwars/logic/impl/gen8/BattleStyles.groovy
@@ -3,37 +3,37 @@ package tcgwars.logic.impl.gen8
 import tcgwars.logic.impl.gen5.NextDestinies
 import tcgwars.logic.impl.gen5.PlasmaStorm
 import tcgwars.logic.impl.gen6.AncientOrigins
-import tcgwars.logic.impl.gen7.GuardiansRising;
+import tcgwars.logic.impl.gen7.GuardiansRising
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author
@@ -224,53 +224,53 @@ public enum BattleStyles implements LogicCardInfo {
   RAPID_STRIKE_ENERGY_182 ("Rapid Strike Energy", "182", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY, RAPID_STRIKE]),
   SINGLE_STRIKE_ENERGY_183 ("Single Strike Energy", "183", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY, SINGLE_STRIKE]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   BattleStyles(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.BATTLE_STYLES;
+    return tcgwars.logic.card.Collection.BATTLE_STYLES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -287,7 +287,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (defending.isSPC(POISONED)) damage 40
           }
         }
-      };
+      }
       case WEEPINBELL_2:
       return evolution (this, from:"Bellsprout", hp:HP080, type:G, retreatCost:2) {
         weakness FIRE
@@ -308,7 +308,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VICTREEBEL_3:
       return evolution (this, from:"Weepinbell", hp:HP150, type:G, retreatCost:3) {
         weakness FIRE
@@ -330,7 +330,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case CACNEA_4:
       return basic (this, hp:HP070, type:G, retreatCost:2) {
         weakness FIRE
@@ -348,7 +348,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CACTURNE_5:
       return evolution (this, from:"Cacnea", hp:HP120, type:G, retreatCost:2) {
         weakness FIRE
@@ -370,7 +370,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (self.cards.energyCount(D)) damage 70
           }
         }
-      };
+      }
       case KRICKETUNE_V_6:
       return basic (this, hp:HP180, type:G, retreatCost:1) {
         weakness FIRE
@@ -399,7 +399,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { damage 80 }
           }
         }
-      };
+      }
       case CHERUBI_7:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness FIRE
@@ -410,7 +410,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHERRIM_8:
       return evolution (this, from:"Cherubi", hp:HP080, type:G, retreatCost:2) {
         weakness FIRE
@@ -433,7 +433,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case CARNIVINE_9:
       return basic (this, hp:HP110, type:G, retreatCost:2) {
         weakness FIRE
@@ -452,7 +452,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip 3, { damage 60 }
           }
         }
-      };
+      }
       case DURANT_10:
       return basic (this, hp:HP090, type:G, retreatCost:1) {
         weakness FIRE
@@ -475,7 +475,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SCATTERBUG_11:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness FIRE
@@ -488,7 +488,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SPEWPA_12:
       return evolution (this, from:"Scatterbug", hp:HP080, type:G, retreatCost:3) {
         weakness FIRE
@@ -506,7 +506,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VIVILLON_13:
       return evolution (this, from:"Spewpa", hp:HP120, type:G, retreatCost:1) {
         weakness FIRE
@@ -528,7 +528,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case FOMANTIS_14:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness FIRE
@@ -539,7 +539,7 @@ public enum BattleStyles implements LogicCardInfo {
             flipUntilTails { damage 20 }
           }
         }
-      };
+      }
       case LURANTIS_15:
       return evolution (this, from:"Fomantis", hp:HP120, type:G, retreatCost:2) {
         weakness FIRE
@@ -558,7 +558,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case TAPU_BULU_16:
       return basic (this, hp:HP130, type:G, retreatCost:2) {
         weakness FIRE
@@ -583,7 +583,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BLIPBUG_17:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness FIRE
@@ -594,7 +594,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FLAPPLE_V_18:
       return basic (this, hp:HP190, type:G, retreatCost:1) {
         weakness FIRE
@@ -615,7 +615,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case FLAPPLE_VMAX_19:
       return evolution (this, from:"Flapple V", hp:HP320, type:G, retreatCost:3) {
         weakness FIRE
@@ -626,7 +626,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 250 - (10*self.numberOfDamageCounters)
           }
         }
-      };
+      }
       case ENTEI_20:
       return basic (this, hp:HP130, type:R, retreatCost:2) {
         weakness WATER
@@ -648,7 +648,7 @@ public enum BattleStyles implements LogicCardInfo {
             applyAfterDamage BURNED
           }
         }
-      };
+      }
       case VICTINI_V_21:
       return basic (this, hp:HP190, type:R, retreatCost:1) {
         weakness WATER
@@ -672,7 +672,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VICTINI_VMAX_22:
       return evolution (this, from:"Victini V", hp:HP310, type:R, retreatCost:2) {
         weakness WATER
@@ -696,7 +696,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TEPIG_23:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness WATER
@@ -714,7 +714,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PIGNITE_24:
       return evolution (this, from:"Tepig", hp:HP100, type:R, retreatCost:3) {
         weakness WATER
@@ -732,7 +732,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case EMBOAR_25:
       return evolution (this, from:"Pignite", hp:HP180, type:R, retreatCost:4) {
         weakness WATER
@@ -759,7 +759,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case HEATMOR_26:
       return basic (this, hp:HP120, type:R, retreatCost:2) {
         weakness WATER
@@ -781,7 +781,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (list) discardDefendingEnergyAfterDamage (*list)
           }
         }
-      };
+      }
       case SALANDIT_27:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness WATER
@@ -798,7 +798,7 @@ public enum BattleStyles implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case SALAZZLE_28:
       return evolution (this, from:"Salandit", hp:HP090, type:R, retreatCost:1) {
         weakness WATER
@@ -816,7 +816,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 90 * defending.specialConditions.size()
           }
         }
-      };
+      }
       case SIZZLIPEDE_29:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness WATER
@@ -828,7 +828,7 @@ public enum BattleStyles implements LogicCardInfo {
             applyAfterDamage(BURNED)
           }
         }
-      };
+      }
       case CENTISKORCH_30:
       return evolution (this, from:"Sizzlipede", hp:HP130, type:R, retreatCost:2) {
         weakness WATER
@@ -857,7 +857,7 @@ public enum BattleStyles implements LogicCardInfo {
             applyAfterDamage(BURNED)
           }
         }
-      };
+      }
       case HORSEA_31:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness LIGHTNING
@@ -869,7 +869,7 @@ public enum BattleStyles implements LogicCardInfo {
             sandAttack thisMove
           }
         }
-      };
+      }
       case SEADRA_32:
       return evolution (this, from:"Horsea", hp:HP090, type:W, retreatCost:1) {
         weakness LIGHTNING
@@ -880,7 +880,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KINGDRA_33:
       return evolution (this, from:"Seadra", hp:HP150, type:W, retreatCost:1) {
         weakness LIGHTNING
@@ -906,7 +906,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 40 * self.cards.energyCount(W)
           }
         }
-      };
+      }
       case GALARIAN_MR_MIME_34:
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness METAL
@@ -929,7 +929,7 @@ public enum BattleStyles implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case GALARIAN_MR_RIME_35:
       return evolution (this, from:"Galarian Mr. Mime", hp:HP110, type:W, retreatCost:2) {
         weakness METAL
@@ -960,7 +960,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case REMORAID_36:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness LIGHTNING
@@ -978,7 +978,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case OCTILLERY_37:
       return evolution (this, from:"Remoraid", hp:HP110, type:W, retreatCost:2) {
         weakness LIGHTNING
@@ -1001,7 +1001,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CORPHISH_38:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness LIGHTNING
@@ -1013,7 +1013,7 @@ public enum BattleStyles implements LogicCardInfo {
             flipThenApplySC PARALYZED
           }
         }
-      };
+      }
       case CRAWDAUNT_39:
       return evolution (this, from:"Corphish", hp:HP130, type:W, retreatCost:3) {
         weakness LIGHTNING
@@ -1034,7 +1034,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case EMPOLEON_V_40:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness LIGHTNING
@@ -1073,7 +1073,7 @@ public enum BattleStyles implements LogicCardInfo {
             afterDamage { moveEnergy(self, my.bench) }
           }
         }
-      };
+      }
       case FRILLISH_41:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness LIGHTNING
@@ -1092,7 +1092,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case JELLICENT_42:
       return evolution (this, from:"Frillish", hp:HP120, type:W, retreatCost:3) {
         weakness LIGHTNING
@@ -1103,7 +1103,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10 * my.discard.filterByType(ENERGY).filterByEnergyType(W).size()
           }
         }
-      };
+      }
       case BRUXISH_43:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness LIGHTNING
@@ -1121,7 +1121,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case ELECTABUZZ_44:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         weakness FIGHTING
@@ -1133,7 +1133,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case ELECTIVIRE_45:
       return evolution (this, from:"Electabuzz", hp:HP140, type:L, retreatCost:3) {
         weakness FIGHTING
@@ -1153,7 +1153,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case SHINX_46:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1164,7 +1164,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LUXIO_47:
       return evolution (this, from:"Shinx", hp:HP080, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1182,7 +1182,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LUXRAY_48:
       return evolution (this, from:"Luxio", hp:HP150, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1202,7 +1202,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (defending.numberOfDamageCounters) damage 100
           }
         }
-      };
+      }
       case PACHIRISU_49:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1224,7 +1224,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TAPU_KOKO_V_50:
       return basic (this, hp:HP210, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1246,7 +1246,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20 + 40 * addDmg
           }
         }
-      };
+      }
       case TAPU_KOKO_VMAX_51:
       return evolution (this, from:"Tapu Koko V", hp:HP320, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1260,7 +1260,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case YAMPER_52:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1287,7 +1287,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BOLTUND_53:
       return evolution (this, from:"Yamper", hp:HP130, type:L, retreatCost:1) {
         weakness FIGHTING
@@ -1312,7 +1312,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case GALARIAN_SLOWPOKE_54:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness DARKNESS
@@ -1327,7 +1327,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { switchYourOpponentsBenchedWithActive() }
           }
         }
-      };
+      }
       case SPOINK_55:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1346,7 +1346,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRUMPIG_56:
       return evolution (this, from:"Spoink", hp:HP130, type:P, retreatCost:3) {
         weakness DARKNESS
@@ -1366,7 +1366,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case BALTOY_57:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1379,7 +1379,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 60, self
           }
         }
-      };
+      }
       case CLAYDOL_58:
       return evolution (this, from:"Baltoy", hp:HP120, type:P, retreatCost:2) {
         weakness DARKNESS
@@ -1405,7 +1405,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case CHIMECHO_59:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1429,7 +1429,7 @@ public enum BattleStyles implements LogicCardInfo {
             applyAfterDamage(ASLEEP)
           }
         }
-      };
+      }
       case ESPURR_60:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1442,7 +1442,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case MEOWSTIC_61:
       return evolution (this, from:"Espurr", hp:HP090, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1467,7 +1467,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MIMIKYU_V_62:
       return basic (this, hp:HP160, type:P, retreatCost:2) {
         weakness DARKNESS
@@ -1499,7 +1499,7 @@ public enum BattleStyles implements LogicCardInfo {
             directDamage 30 * opp.prizeCardSet.takenCount, defending
           }
         }
-      };
+      }
       case NECROZMA_V_63:
       return basic (this, hp:HP220, type:P, retreatCost:3) {
         weakness DARKNESS
@@ -1520,7 +1520,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (self.cards.filterByType(SPECIAL_ENERGY)) damage 120
           }
         }
-      };
+      }
       case DOTTLER_64:
       return evolution (this, from:"Blipbug", hp:HP070, type:P, retreatCost:2) {
         weakness DARKNESS
@@ -1543,7 +1543,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ORBEETLE_65:
       return evolution (this, from:"Dottler", hp:HP110, type:P, retreatCost:1) {
         weakness DARKNESS
@@ -1573,7 +1573,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case MANKEY_66:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness PSYCHIC
@@ -1584,7 +1584,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { damage 50 }
           }
         }
-      };
+      }
       case PRIMEAPE_67:
       return evolution (this, from:"Mankey", hp:HP120, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -1608,7 +1608,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50 * count
           }
         }
-      };
+      }
       case ONIX_68:
       return basic (this, hp:HP110, type:F, retreatCost:4) {
         weakness GRASS
@@ -1627,7 +1627,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 60, self
           }
         }
-      };
+      }
       case CUBONE_69:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness GRASS
@@ -1645,7 +1645,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAROWAK_70:
       return evolution (this, from:"Cubone", hp:HP110, type:F, retreatCost:2) {
         weakness GRASS
@@ -1669,7 +1669,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip 2, { damage 90 }
           }
         }
-      };
+      }
       case GLIGAR_71:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness GRASS
@@ -1680,7 +1680,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GLISCOR_72:
       return evolution (this, from:"Gligar", hp:HP120, type:F, retreatCost:1) {
         weakness GRASS
@@ -1699,7 +1699,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case TIMBURR_73:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -1710,7 +1710,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GURDURR_74:
       return evolution (this, from:"Timburr", hp:HP100, type:F, retreatCost:3) {
         weakness PSYCHIC
@@ -1728,7 +1728,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CONKELDURR_75:
       return evolution (this, from:"Gurdurr", hp:HP160, type:F, retreatCost:3) {
         weakness PSYCHIC
@@ -1747,7 +1747,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 150
           }
         }
-      };
+      }
       case MIENFOO_76:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness PSYCHIC
@@ -1758,7 +1758,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip 2, { damage 30 }
           }
         }
-      };
+      }
       case MIENSHAO_77:
       return evolution (this, from:"Mienfoo", hp:HP090, type:F, retreatCost:1) {
         weakness PSYCHIC
@@ -1783,7 +1783,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ROLYCOLY_78:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness GRASS
@@ -1795,7 +1795,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case CARKOL_79:
       return evolution (this, from:"Rolycoly", hp:HP100, type:F, retreatCost:3) {
         weakness GRASS
@@ -1814,7 +1814,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case COALOSSAL_80:
       return evolution (this, from:"Carkol", hp:HP180, type:F, retreatCost:4) {
         weakness GRASS
@@ -1833,7 +1833,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50, self
           }
         }
-      };
+      }
       case SILICOBRA_81:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness GRASS
@@ -1851,7 +1851,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SANDACONDA_82:
       return evolution (this, from:"Silicobra", hp:HP130, type:F, retreatCost:3) {
         weakness GRASS
@@ -1878,7 +1878,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case FALINKS_83:
       return basic (this, hp:HP110, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -1891,7 +1891,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STONJOURNER_84:
       return basic (this, hp:HP130, type:F, retreatCost:3) {
         weakness GRASS
@@ -1913,7 +1913,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case SINGLE_STRIKE_URSHIFU_V_85:
       return basic (this, hp:HP220, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -1936,7 +1936,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case SINGLE_STRIKE_URSHIFU_VMAX_86:
       return evolution (this, from:"Single Strike Urshifu V", hp:HP330, type:F, retreatCost:3) {
         weakness PSYCHIC
@@ -1957,7 +1957,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAPID_STRIKE_URSHIFU_V_87:
       return basic (this, hp:HP220, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -1976,7 +1976,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 150
           }
         }
-      };
+      }
       case RAPID_STRIKE_URSHIFU_VMAX_88:
       return evolution (this, from:"Rapid Strike Urshifu V", hp:HP330, type:F, retreatCost:2) {
         weakness PSYCHIC
@@ -2000,7 +2000,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZUBAT_89:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness FIGHTING
@@ -2018,7 +2018,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLBAT_90:
       return evolution (this, from:"Zubat", hp:HP080, type:D, retreatCost:1) {
         weakness FIGHTING
@@ -2039,7 +2039,7 @@ public enum BattleStyles implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C)
           }
         }
-      };
+      }
       case CROBAT_91:
       return evolution (this, from:"Golbat", hp:HP130, type:D, retreatCost:0) {
         weakness FIGHTING
@@ -2059,7 +2059,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case GALARIAN_SLOWBRO_92:
       return evolution (this, from:"GalarianSlowpoke", hp:HP130, type:D, retreatCost:3) {
         weakness FIGHTING
@@ -2079,7 +2079,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (self.specialConditions) damage 120
           }
         }
-      };
+      }
       case MURKROW_93:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness LIGHTNING
@@ -2101,7 +2101,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HONCHKROW_94:
       return evolution (this, from:"Murkrow", hp:HP130, type:D, retreatCost:2) {
         weakness LIGHTNING
@@ -2128,7 +2128,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (defending.cards.filterByType(SPECIAL_ENERGY)) damage 80
           }
         }
-      };
+      }
       case HOUNDOUR_95:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness GRASS
@@ -2139,7 +2139,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOOM_96:
       return evolution (this, from:"Houndour", hp:HP130, type:D, retreatCost:2) {
         weakness GRASS
@@ -2168,7 +2168,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TYRANITAR_V_97:
       return basic (this, hp:HP230, type:D, retreatCost:3) {
         weakness GRASS
@@ -2192,7 +2192,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MORPEKO_98:
       return basic (this, hp:HP080, type:D, retreatCost:1) {
         weakness GRASS
@@ -2216,7 +2216,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STEELIX_99:
       return evolution (this, from:"Onix", hp:HP190, type:M, retreatCost:4) {
         weakness FIRE
@@ -2235,7 +2235,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 200
           }
         }
-      };
+      }
       case MAWILE_100:
       return basic (this, hp:HP090, type:M, retreatCost:1) {
         weakness FIRE
@@ -2255,7 +2255,7 @@ public enum BattleStyles implements LogicCardInfo {
             swiftDamage(100, defending)
           }
         }
-      };
+      }
       case BRONZOR_101:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness FIRE
@@ -2267,7 +2267,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BRONZONG_102:
       return evolution (this, from:"Bronzor", hp:HP110, type:M, retreatCost:3) {
         weakness FIRE
@@ -2295,7 +2295,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case PAWNIARD_103:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness FIRE
@@ -2314,7 +2314,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BISHARP_104:
       return evolution (this, from:"Pawniard", hp:HP110, type:M, retreatCost:1) {
         weakness FIRE
@@ -2334,7 +2334,7 @@ public enum BattleStyles implements LogicCardInfo {
             if (defending.types.contains(M)) damage 90
           }
         }
-      };
+      }
       case HONEDGE_105:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness FIRE
@@ -2347,7 +2347,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case DOUBLADE_106:
       return evolution (this, from:"Honedge", hp:HP080, type:M, retreatCost:2) {
         weakness FIRE
@@ -2360,7 +2360,7 @@ public enum BattleStyles implements LogicCardInfo {
             flip { discardDefendingEnergyAfterDamage() }
           }
         }
-      };
+      }
       case AEGISLASH_107:
       return evolution (this, from:"Doublade", hp:HP150, type:M, retreatCost:3) {
         weakness FIRE
@@ -2391,7 +2391,7 @@ public enum BattleStyles implements LogicCardInfo {
             discardSelfEnergyAfterDamage(M, M)
           }
         }
-      };
+      }
       case AEGISLASH_108:
       return evolution (this, from:"Doublade", hp:HP150, type:M, retreatCost:3) {
         weakness FIRE
@@ -2422,7 +2422,7 @@ public enum BattleStyles implements LogicCardInfo {
             preventAllDamageFromCustomPokemonNextTurn thisMove, self, { it.pokemonVMAX }
           }
         }
-      };
+      }
       case CORVIKNIGHT_V_109:
       return basic (this, hp:HP210, type:M, retreatCost:1) {
         weakness FIRE
@@ -2443,7 +2443,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case CORVIKNIGHT_VMAX_110:
       return evolution (this, from:"Corviknight V", hp:HP320, type:M, retreatCost:0) {
         weakness FIRE
@@ -2467,7 +2467,7 @@ public enum BattleStyles implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case SPEAROW_111:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness LIGHTNING
@@ -2479,7 +2479,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FEAROW_112:
       return evolution (this, from:"Spearow", hp:HP090, type:C, retreatCost:0) {
         weakness LIGHTNING
@@ -2491,7 +2491,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case LICKITUNG_113:
       return basic (this, hp:HP110, type:C, retreatCost:4) {
         weakness FIGHTING
@@ -2509,7 +2509,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case LICKILICKY_114:
       return evolution (this, from:"Lickitung", hp:HP140, type:C, retreatCost:4) {
         weakness FIGHTING
@@ -2543,7 +2543,7 @@ public enum BattleStyles implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GLAMEOW_115:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness FIGHTING
@@ -2561,7 +2561,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PURUGLY_116:
       return evolution (this, from:"Glameow", hp:HP120, type:C, retreatCost:3) {
         weakness FIGHTING
@@ -2583,7 +2583,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case STOUTLAND_V_117:
       return basic (this, hp:HP210, type:C, retreatCost:3) {
         weakness FIGHTING
@@ -2621,7 +2621,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case BOUFFALANT_118:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness FIGHTING
@@ -2646,7 +2646,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case DRAMPA_119:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness FIGHTING
@@ -2663,7 +2663,7 @@ public enum BattleStyles implements LogicCardInfo {
             flipUntilTails { damage 30 }
           }
         }
-      };
+      }
       case INDEEDEE_120:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness FIGHTING
@@ -2681,7 +2681,7 @@ public enum BattleStyles implements LogicCardInfo {
             damage 10 * my.hand.size()
           }
         }
-      };
+      }
       case BRUNO_121:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, draw 4 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 7 cards instead."
@@ -2707,7 +2707,7 @@ public enum BattleStyles implements LogicCardInfo {
         playRequirement{
           assert my.hand.getExcludedList(thisCard) || my.deck : "Both Hand and Deck are empty"
         }
-      };
+      }
       case CAMPING_GEAR_122:
       return itemCard (this) {
         text "Search your deck for a card and put it into your hand. Then, shuffle your deck. Your turn ends."
@@ -2719,7 +2719,7 @@ public enum BattleStyles implements LogicCardInfo {
         playRequirement {
           assert my.deck : "Your Deck is empty"
         }
-      };
+      }
       case CHERYL_123:
       return supporter (this) {
         text "Heal all damage from each of your Evolution Pokémon. If you do, discard all Energy from the Pokémon that were healed in this way."
@@ -2738,7 +2738,7 @@ public enum BattleStyles implements LogicCardInfo {
         playRequirement{
           assert my.all.findAll {it.realEvolution && it.numberOfDamageCounters > 0 }
         }
-      };
+      }
       case ENERGY_RECYCLER_124:
         return itemCard (this) {
           text "Shuffle up to 5 basic Energy cards from your discard pile into your deck. You may play any number of Item cards during your turn."
@@ -2749,7 +2749,7 @@ public enum BattleStyles implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC_ENERGY)
           }
-        };
+        }
       case ESCAPE_ROPE_125:
         return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case EXP_SHARE_126:
@@ -2765,7 +2765,7 @@ public enum BattleStyles implements LogicCardInfo {
         playRequirement{
           assert opp.all.find { it.cards.filterByType(SPECIAL_ENERGY) } : "Your opponent has no Special Energy cards attached"
         }
-      };
+      }
       case KORRINA_S_FOCUS_128:
       return supporter (this) {
         text "Draw cards until you have 6 cards in your hand."
@@ -2776,7 +2776,7 @@ public enum BattleStyles implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard).size() < 6 : "You have 6 or more cards in your hand"
           assert my.deck : "Your deck is empty"
         }
-      };
+      }
       case LEVEL_BALL_129:
         return copy(AncientOrigins.LEVEL_BALL_76, this)
       case PHOEBE_130:
@@ -2800,7 +2800,7 @@ public enum BattleStyles implements LogicCardInfo {
             unregisterAfter 1
           }
         }
-      };
+      }
       case RAPID_STRIKE_SCROLL_OF_SWIRLS_131:
       return pokemonTool (this) {
         text "The Rapid Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -2834,7 +2834,7 @@ public enum BattleStyles implements LogicCardInfo {
         onRemoveFromPlay {
           newMove.unregister()
         }
-      };
+      }
       case RAPID_STRIKE_STYLE_MUSTARD_132:
       return supporter (this) {
         text "You can play this card only when it is the last card in your hand." +
@@ -2851,7 +2851,7 @@ public enum BattleStyles implements LogicCardInfo {
           assert discardPile.findAll {it.cardTypes.is(POKEMON) && it.cardTypes.is(RAPID_STRIKE)} : "No Rapid Strike Pokémon in discard pile"
           assert bench.notFull : "Bench is full"
         }
-      };
+      }
       case SINGLE_STRIKE_SCROLL_OF_SCORN_133:
       return pokemonTool (this) {
         text "The Single Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -2886,7 +2886,7 @@ public enum BattleStyles implements LogicCardInfo {
         onRemoveFromPlay {
           newMove.unregister()
         }
-      };
+      }
       case SINGLE_STRIKE_STYLE_MUSTARD_134:
       return supporter (this) {
         text "You can play this card only when it is the last card in your hand." +
@@ -2904,7 +2904,7 @@ public enum BattleStyles implements LogicCardInfo {
           assert hand.size() == 1 : "You can play this card only when it is the last card in your hand"
           assert bench.notFull : "Bench is full"
         }
-      };
+      }
       case SORDWARD_SHIELBERT_135:
       return supporter (this) {
         text "Choose a Trainer card from your discard pile. Then, ask your opponent if you may put it into your hand. If yes, put that card into your hand. If no, draw 3 cards."
@@ -2922,7 +2922,7 @@ public enum BattleStyles implements LogicCardInfo {
         playRequirement {
           assert my.discard.hasType(TRAINER) : "There are no Trainer cards in your discard pile."
         }
-      };
+      }
       case TOOL_JAMMER_136:
       return pokemonTool (this) {
         text "As long as the Pokémon this card is attached to is in the Active Spot, Pokémon Tools attached to your opponent's Active Pokémon have no effect, except for Tool Jammer."
@@ -3006,7 +3006,7 @@ public enum BattleStyles implements LogicCardInfo {
           deactivateEffect()
           eff.unregister()
         }
-      };
+      }
       case TOWER_OF_DARKNESS_137:
       return stadium (this) {
         text "Once during each player's turn, that player may draw 2 cards. In order to use this effect, that player must discard a Single Strike card from their hand."
@@ -3026,7 +3026,7 @@ public enum BattleStyles implements LogicCardInfo {
         onRemoveFromPlay {
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case TOWER_OF_WATERS_138:
       return stadium (this) {
         text "The Retreat Cost of each Rapid Strike Pokémon in play (both yours and your opponent's) is [C][C] less."
@@ -3041,7 +3041,7 @@ public enum BattleStyles implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case URN_OF_VITALITY_139:
       return itemCard (this) {
         text "Shuffle up to 2 Single Strike Energy cards from your discard pile into your deck."
@@ -3053,7 +3053,7 @@ public enum BattleStyles implements LogicCardInfo {
 
           assert my.discard.any { it.name == "Single Strike Energy" } : "No Single Strike Energy"
         }
-      };
+      }
       case RAPID_STRIKE_ENERGY_140:
       return specialEnergy (this, [[C]]) {
         text "This card can only be attached to a Rapid Strike Pokémon. If this card is attached to anything other than a Rapid Strike Pokémon, discard this card." +
@@ -3082,7 +3082,7 @@ public enum BattleStyles implements LogicCardInfo {
         getEnergyTypesOverride {
           self != null ? [[W, F] as Set, [W, F] as Set] : [[] as Set]
         }
-      };
+      }
       case SINGLE_STRIKE_ENERGY_141:
       return specialEnergy (this, [[C]]) {
         text "This card can only be attached to a Single Strike Pokémon. If this card is attached to anything other than a Single Strike Pokémon, discard this card." +
@@ -3121,93 +3121,93 @@ public enum BattleStyles implements LogicCardInfo {
         getEnergyTypesOverride {
           self != null ? [[F, D] as Set] : [[] as Set]
         }
-      };
+      }
       case KRICKETUNE_V_142:
-      return copy (KRICKETUNE_V_6, this);
+      return copy (KRICKETUNE_V_6, this)
       case FLAPPLE_V_143:
-      return copy (FLAPPLE_V_18, this);
+      return copy (FLAPPLE_V_18, this)
       case VICTINI_V_144:
-      return copy (VICTINI_V_21, this);
+      return copy (VICTINI_V_21, this)
       case EMPOLEON_V_145:
-      return copy (EMPOLEON_V_40, this);
+      return copy (EMPOLEON_V_40, this)
       case EMPOLEON_V_146:
-      return copy (EMPOLEON_V_40, this);
+      return copy (EMPOLEON_V_40, this)
       case TAPU_KOKO_V_147:
-      return copy (TAPU_KOKO_V_50, this);
+      return copy (TAPU_KOKO_V_50, this)
       case MIMIKYU_V_148:
-      return copy (MIMIKYU_V_62, this);
+      return copy (MIMIKYU_V_62, this)
       case NECROZMA_V_149:
-      return copy (NECROZMA_V_63, this);
+      return copy (NECROZMA_V_63, this)
       case SINGLE_STRIKE_URSHIFU_V_150:
-      return copy (SINGLE_STRIKE_URSHIFU_V_85, this);
+      return copy (SINGLE_STRIKE_URSHIFU_V_85, this)
       case SINGLE_STRIKE_URSHIFU_V_151:
-      return copy (SINGLE_STRIKE_URSHIFU_V_85, this);
+      return copy (SINGLE_STRIKE_URSHIFU_V_85, this)
       case RAPID_STRIKE_URSHIFU_V_152:
-      return copy (RAPID_STRIKE_URSHIFU_V_87, this);
+      return copy (RAPID_STRIKE_URSHIFU_V_87, this)
       case RAPID_STRIKE_URSHIFU_V_153:
-      return copy (RAPID_STRIKE_URSHIFU_V_87, this);
+      return copy (RAPID_STRIKE_URSHIFU_V_87, this)
       case TYRANITAR_V_154:
-      return copy (TYRANITAR_V_97, this);
+      return copy (TYRANITAR_V_97, this)
       case TYRANITAR_V_155:
-      return copy (TYRANITAR_V_97, this);
+      return copy (TYRANITAR_V_97, this)
       case CORVIKNIGHT_V_156:
-      return copy (CORVIKNIGHT_V_109, this);
+      return copy (CORVIKNIGHT_V_109, this)
       case STOUTLAND_V_157:
-      return copy (STOUTLAND_V_117, this);
+      return copy (STOUTLAND_V_117, this)
       case BRUNO_158:
-      return copy (BRUNO_121, this);
+      return copy (BRUNO_121, this)
       case CHERYL_159:
-      return copy (CHERYL_123, this);
+      return copy (CHERYL_123, this)
       case KORRINA_S_FOCUS_160:
-      return copy (KORRINA_S_FOCUS_128, this);
+      return copy (KORRINA_S_FOCUS_128, this)
       case PHOEBE_161:
-      return copy (PHOEBE_130, this);
+      return copy (PHOEBE_130, this)
       case RAPID_STRIKE_STYLE_MUSTARD_162:
-      return copy (RAPID_STRIKE_STYLE_MUSTARD_132, this);
+      return copy (RAPID_STRIKE_STYLE_MUSTARD_132, this)
       case SINGLE_STRIKE_STYLE_MUSTARD_163:
-      return copy (SINGLE_STRIKE_STYLE_MUSTARD_134, this);
+      return copy (SINGLE_STRIKE_STYLE_MUSTARD_134, this)
       case FLAPPLE_VMAX_164:
-      return copy (FLAPPLE_VMAX_19, this);
+      return copy (FLAPPLE_VMAX_19, this)
       case VICTINI_VMAX_165:
-      return copy (VICTINI_VMAX_22, this);
+      return copy (VICTINI_VMAX_22, this)
       case TAPU_KOKO_VMAX_166:
-      return copy (TAPU_KOKO_VMAX_51, this);
+      return copy (TAPU_KOKO_VMAX_51, this)
       case SINGLE_STRIKE_URSHIFU_VMAX_167:
-      return copy (SINGLE_STRIKE_URSHIFU_VMAX_86, this);
+      return copy (SINGLE_STRIKE_URSHIFU_VMAX_86, this)
       case SINGLE_STRIKE_URSHIFU_VMAX_168:
-      return copy (SINGLE_STRIKE_URSHIFU_VMAX_86, this);
+      return copy (SINGLE_STRIKE_URSHIFU_VMAX_86, this)
       case RAPID_STRIKE_URSHIFU_VMAX_169:
-      return copy (RAPID_STRIKE_URSHIFU_VMAX_88, this);
+      return copy (RAPID_STRIKE_URSHIFU_VMAX_88, this)
       case RAPID_STRIKE_URSHIFU_VMAX_170:
-      return copy (RAPID_STRIKE_URSHIFU_VMAX_88, this);
+      return copy (RAPID_STRIKE_URSHIFU_VMAX_88, this)
       case CORVIKNIGHT_VMAX_171:
-      return copy (CORVIKNIGHT_VMAX_110, this);
+      return copy (CORVIKNIGHT_VMAX_110, this)
       case BRUNO_172:
-      return copy (BRUNO_121, this);
+      return copy (BRUNO_121, this)
       case CHERYL_173:
-      return copy (CHERYL_123, this);
+      return copy (CHERYL_123, this)
       case KORRINA_S_FOCUS_174:
-      return copy (KORRINA_S_FOCUS_128, this);
+      return copy (KORRINA_S_FOCUS_128, this)
       case PHOEBE_175:
-      return copy (PHOEBE_130, this);
+      return copy (PHOEBE_130, this)
       case RAPID_STRIKE_STYLE_MUSTARD_176:
-      return copy (RAPID_STRIKE_STYLE_MUSTARD_132, this);
+      return copy (RAPID_STRIKE_STYLE_MUSTARD_132, this)
       case SINGLE_STRIKE_STYLE_MUSTARD_177:
-      return copy (SINGLE_STRIKE_STYLE_MUSTARD_134, this);
+      return copy (SINGLE_STRIKE_STYLE_MUSTARD_134, this)
       case OCTILLERY_178:
-      return copy (OCTILLERY_37, this);
+      return copy (OCTILLERY_37, this)
       case HOUNDOOM_179:
-      return copy (HOUNDOOM_96, this);
+      return copy (HOUNDOOM_96, this)
       case EXP_SHARE_180:
-      return copy (EXP_SHARE_126, this);
+      return copy (EXP_SHARE_126, this)
       case LEVEL_BALL_181:
-      return copy (LEVEL_BALL_129, this);
+      return copy (LEVEL_BALL_129, this)
       case RAPID_STRIKE_ENERGY_182:
-      return copy (RAPID_STRIKE_ENERGY_140, this);
+      return copy (RAPID_STRIKE_ENERGY_140, this)
       case SINGLE_STRIKE_ENERGY_183:
-      return copy (SINGLE_STRIKE_ENERGY_141, this);
+      return copy (SINGLE_STRIKE_ENERGY_141, this)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/BlueSkyStream.groovy
+++ b/src/tcgwars/logic/impl/gen8/BlueSkyStream.groovy
@@ -2,37 +2,37 @@ package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.impl.gen5.BlackWhite
 import tcgwars.logic.impl.gen5.EmergingPowers
-import tcgwars.logic.impl.gen6.Xy;
+import tcgwars.logic.impl.gen6.Xy
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -130,53 +130,53 @@ public enum BlueSkyStream implements LogicCardInfo {
   STORMY_MOUNTAIN_RANGE_89 ("Stormy Mountain Range", "89", Rarity.UNCOMMON, [TRAINER, STADIUM]),
   LIGHTNING_ENERGY_90 ("Lightning Energy", "90", Rarity.COMMON, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   BlueSkyStream(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.BLUE_SKY_STREAM;
+    return tcgwars.logic.card.Collection.BLUE_SKY_STREAM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -194,7 +194,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SKIPLOOM_2:
       return evolution (this, from:"Hoppip", hp:HP060, type:G, retreatCost:0) {
         weakness R
@@ -225,7 +225,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case JUMPLUFF_3:
       return evolution (this, from:"Skiploom", hp:HP090, type:G, retreatCost:0) {
         weakness R
@@ -240,7 +240,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case TROPIUS_4:
       return basic (this, hp:HP110, type:G, retreatCost:1) {
         weakness R
@@ -260,7 +260,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case PANSAGE_5:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -271,7 +271,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SIMISAGE_6:
       return evolution (this, from:"Pansage", hp:HP100, type:G, retreatCost:1) {
         weakness R
@@ -294,7 +294,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case TREVENANT_V_7:
       return basic (this, hp:HP210, type:G, retreatCost:2) {
         weakness R
@@ -316,7 +316,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TREVENANT_VMAX_8:
       return evolution (this, from:"Trevenant V", hp:HP320, type:G, retreatCost:3) {
         weakness R
@@ -337,7 +337,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case APPLIN_9:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -348,7 +348,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VULPIX_10:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -359,7 +359,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NINETALES_11:
       return evolution (this, from:"Vulpix", hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -378,7 +378,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case VICTINI_12:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -394,7 +394,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PANSEAR_13:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -407,7 +407,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SIMISEAR_14:
       return evolution (this, from:"Pansear", hp:HP100, type:R, retreatCost:1) {
         weakness W
@@ -432,7 +432,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VOLCARONA_V_15:
       return basic (this, hp:HP210, type:R, retreatCost:2) {
         weakness W
@@ -458,7 +458,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             discardSelfEnergyAfterDamage()
           }
         }
-      };
+      }
       case SIZZLIPEDE_16:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -473,7 +473,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case CENTISKORCH_17:
       return evolution (this, from:"Sizzlipede", hp:HP130, type:R, retreatCost:2) {
         weakness W
@@ -492,7 +492,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case SHELLDER_18:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness L
@@ -510,7 +510,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLOYSTER_19:
       return evolution (this, from:"Shellder", hp:HP130, type:W, retreatCost:2) {
         weakness L
@@ -526,7 +526,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             multiDamage opp.bench, 2, 30, text
           }
         }
-      };
+      }
       case GYARADOS_V_20:
       return basic (this, hp:HP220, type:W, retreatCost:3) {
         weakness L
@@ -547,7 +547,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case GYARADOS_VMAX_21:
       return evolution (this, from:"Gyarados V", hp:HP330, type:W, retreatCost:4) {
         weakness L
@@ -566,7 +566,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 240
           }
         }
-      };
+      }
       case GALARIAN_DARUMAKA_22:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -578,7 +578,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             flipTails { damage 10, self }
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_23:
       return evolution (this, from:"Galarian Darumaka", hp:HP130, type:W, retreatCost:2) {
         weakness M
@@ -603,7 +603,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case CRYOGONAL_24:
       return basic (this, hp:HP090, type:W, retreatCost:1) {
         weakness M
@@ -630,7 +630,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WISHIWASHI_25:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -650,7 +650,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30 * self.cards.basicEnergyCardCount()
           }
         }
-      };
+      }
       case MAREEP_26:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -668,7 +668,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FLAAFFY_27:
       return evolution (this, from:"Mareep", hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -689,7 +689,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case AMPHAROS_28:
       return evolution (this, from:"Flaaffy", hp:HP150, type:L, retreatCost:2) {
         weakness F
@@ -714,7 +714,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PLUSLE_29:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -739,7 +739,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MINUN_30:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -755,7 +755,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOXEL_31:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -766,7 +766,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOXTRICITY_32:
       return evolution (this, from:"Toxel", hp:HP130, type:L, retreatCost:2) {
         weakness F
@@ -781,7 +781,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case REGIELEKI_33:
       return basic (this, hp:HP120, type:L, retreatCost:2) {
         weakness F
@@ -804,7 +804,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SANDSHREW_34:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -832,7 +832,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20 * my.bench.findAll { it.getTopPokemonCard().moves.any { it.name == "Everyone Rollout" } }.size()
           }
         }
-      };
+      }
       case SANDSLASH_35:
       return evolution (this, from:"Sandshrew", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -848,7 +848,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEDICHAM_V_36:
       return basic (this, hp:HP210, type:F, retreatCost:2) {
         weakness P
@@ -885,7 +885,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             noResistanceDamage 100, defending
           }
         }
-      };
+      }
       case BALTOY_37:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -896,7 +896,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAYDOL_38:
       return evolution (this, from:"Baltoy", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -920,7 +920,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             directDamage defending.remainingHP.value - 60, defending
           }
         }
-      };
+      }
       case LANDORUS_39:
       return basic (this, hp:HP120, type:F, retreatCost:1) {
         weakness G
@@ -946,7 +946,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STUFFUL_40:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness P
@@ -964,7 +964,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BEWEAR_41:
       return evolution (this, from:"Stufful", hp:HP130, type:F, retreatCost:3) {
         weakness P
@@ -983,7 +983,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case DRAGONITE_V_42:
       return basic (this, hp:HP230, type:N, retreatCost:3) {
         move "Shred", {
@@ -1003,7 +1003,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BAGON_43:
       return basic (this, hp:HP070, type:N, retreatCost:2) {
         move "Gnaw", {
@@ -1020,7 +1020,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SHELGON_44:
       return evolution (this, from:"Bagon", hp:HP090, type:N, retreatCost:3) {
         move "Hard Roll", {
@@ -1033,7 +1033,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SALAMENCE_45:
       return evolution (this, from:"Shelgon", hp:HP170, type:N, retreatCost:2) {
         bwAbility "Intimidating Roar", {
@@ -1053,7 +1053,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             if (defending.numberOfDamageCounters) damage 120
           }
         }
-      };
+      }
       case RAYQUAZA_V_46:
       return basic (this, hp:HP210, type:N, retreatCost:2) {
         move "Dragon Pulse", {
@@ -1089,7 +1089,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAYQUAZA_VMAX_47:
       return evolution (this, from:"Rayquaza V", hp:HP320, type:N, retreatCost:2) {
         bwAbility "Blue Sky Wave", {
@@ -1128,7 +1128,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZYGARDE_48:
       return basic (this, hp:HP130, type:N, retreatCost:2) {
         move "Bite", {
@@ -1149,7 +1149,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 40 * opp.prizeCardSet.takenCount, tar
           }
         }
-      };
+      }
       case TURTONATOR_49:
       return basic (this, hp:HP130, type:N, retreatCost:3) {
         move "Shell Trap", {
@@ -1170,7 +1170,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case FLAPPLE_50:
       return evolution (this, from:"Applin", hp:HP080, type:N, retreatCost:1) {
         move "Acidic Mucus", {
@@ -1193,7 +1193,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             if (defending.pokemonV) damage 80
           }
         }
-      };
+      }
       case APPLETUN_51:
       return evolution (this, from:"Applin", hp:HP090, type:N, retreatCost:3) {
         move "Sticky Mucus", {
@@ -1215,7 +1215,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             if (defending.pokemonV) damage 80
           }
         }
-      };
+      }
       case REGIDRAGO_52:
       return basic (this, hp:HP130, type:N, retreatCost:3) {
         move "Hammer In", {
@@ -1232,7 +1232,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 240 - 20 * self.numberOfDamageCounters
           }
         }
-      };
+      }
       case CHANSEY_53:
       return basic (this, hp:HP110, type:C, retreatCost:2) {
         weakness F
@@ -1251,7 +1251,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case BLISSEY_54:
       return evolution (this, from:"Chansey", hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -1282,7 +1282,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 20 * my.bench.findAll { it.getTopPokemonCard().moves.any { it.name == "Everyone Rollout" } }.size()
           }
         }
-      };
+      }
       case STANTLER_55:
       return basic (this, hp:HP110, type:C, retreatCost:1) {
         weakness F
@@ -1303,7 +1303,7 @@ public enum BlueSkyStream implements LogicCardInfo {
             damage 30 * defending.energyCards.size()
           }
         }
-      };
+      }
       case LUCKY_ICE_POP_56:
       return itemCard (this) {
         text "Heal 20 damage from your Active Pokémon. Then" +
@@ -1327,9 +1327,9 @@ public enum BlueSkyStream implements LogicCardInfo {
         playRequirement {
           assert my.active.numberOfDamageCounters : "Active Pokémon has no damage counters on it"
         }
-      };
+      }
       case GREAT_BALL_57:
-        return copy (EmergingPowers.GREAT_BALL_93, this);
+        return copy (EmergingPowers.GREAT_BALL_93, this)
       case TOY_CATCHER_58:
       return itemCard (this) {
         text "Choose 1 of your opponent's Benched Pokémon with 50 HP or less and switch it with their Active Pokémon."
@@ -1339,7 +1339,7 @@ public enum BlueSkyStream implements LogicCardInfo {
         playRequirement {
           assert opp.bench.any { it.remainingHP.value <= 50 } : "Opponent has no Benched Pokémon with 50 HP or less remaining"
         }
-      };
+      }
       case SWITCH_59:
         return copy(BlackWhite.SWITCH_104, this)
       case RUBBERY_GLOVES_60:
@@ -1361,7 +1361,7 @@ public enum BlueSkyStream implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case NETHER_MASK_61:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if it is Knocked Out)" +
@@ -1383,7 +1383,7 @@ public enum BlueSkyStream implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case RAPID_STRIKE_SCROLL_OF_THE_FLYING_DRAGON_62:
       return pokemonTool (this) {
         text "The Rapid Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)"
@@ -1417,7 +1417,7 @@ public enum BlueSkyStream implements LogicCardInfo {
         onRemoveFromPlay {
           newMove.unregister()
         }
-      };
+      }
       case SHAUNA_63:
         return copy(Xy.SHAUNA_127, this)
       case SCHOOLBOY_64:
@@ -1435,7 +1435,7 @@ public enum BlueSkyStream implements LogicCardInfo {
         playRequirement {
           assert deck : "Deck is empty"
         }
-      };
+      }
       case ZINNIA_S_RESOLVE_65:
       return supporter (this) {
         text "You can play this card only if you discard 2 other cards from your hand. Draw a card for each of your opponent's Pokémon in play."
@@ -1447,7 +1447,7 @@ public enum BlueSkyStream implements LogicCardInfo {
           assert hand.getExcludedList(thisCard).size() >= 2 : "You do not have 2 other cards to discard from your hand"
           assert deck : "Your deck is empty"
         }
-      };
+      }
       case STORMY_MOUNTAIN_RANGE_66:
       return stadium (this) {
         text "Once during each player's turn" +
@@ -1474,57 +1474,57 @@ public enum BlueSkyStream implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg.gm().unregisterAction it }
         }
-      };
+      }
       case AURORA_ENERGY_67:
-      return copy (SwordShield.AURORA_ENERGY_186, this);
+      return copy (SwordShield.AURORA_ENERGY_186, this)
       case TREVENANT_V_68:
-      return copy (TREVENANT_V_7, this);
+      return copy (TREVENANT_V_7, this)
       case VOLCARONA_V_69:
-      return copy (VOLCARONA_V_15, this);
+      return copy (VOLCARONA_V_15, this)
       case GYARADOS_V_70:
-      return copy (GYARADOS_V_20, this);
+      return copy (GYARADOS_V_20, this)
       case MEDICHAM_V_71:
-      return copy (MEDICHAM_V_36, this);
+      return copy (MEDICHAM_V_36, this)
       case MEDICHAM_V_72:
-      return copy (MEDICHAM_V_36, this);
+      return copy (MEDICHAM_V_36, this)
       case DRAGONITE_V_73:
-      return copy (DRAGONITE_V_42, this);
+      return copy (DRAGONITE_V_42, this)
       case DRAGONITE_V_74:
-      return copy (DRAGONITE_V_42, this);
+      return copy (DRAGONITE_V_42, this)
       case RAYQUAZA_V_75:
-      return copy (RAYQUAZA_V_46, this);
+      return copy (RAYQUAZA_V_46, this)
       case RAYQUAZA_V_76:
-      return copy (RAYQUAZA_V_46, this);
+      return copy (RAYQUAZA_V_46, this)
       case SHAUNA_77:
-      return copy (SHAUNA_63, this);
+      return copy (SHAUNA_63, this)
       case SCHOOLBOY_78:
-      return copy (SCHOOLBOY_64, this);
+      return copy (SCHOOLBOY_64, this)
       case ZINNIA_S_RESOLVE_79:
-      return copy (ZINNIA_S_RESOLVE_65, this);
+      return copy (ZINNIA_S_RESOLVE_65, this)
       case TREVENANT_VMAX_80:
-      return copy (TREVENANT_VMAX_8, this);
+      return copy (TREVENANT_VMAX_8, this)
       case GYARADOS_VMAX_81:
-      return copy (GYARADOS_VMAX_21, this);
+      return copy (GYARADOS_VMAX_21, this)
       case RAYQUAZA_VMAX_82:
-      return copy (RAYQUAZA_VMAX_47, this);
+      return copy (RAYQUAZA_VMAX_47, this)
       case RAYQUAZA_VMAX_83:
-      return copy (RAYQUAZA_VMAX_47, this);
+      return copy (RAYQUAZA_VMAX_47, this)
       case SHAUNA_84:
-      return copy (SHAUNA_63, this);
+      return copy (SHAUNA_63, this)
       case SCHOOLBOY_85:
-      return copy (SCHOOLBOY_64, this);
+      return copy (SCHOOLBOY_64, this)
       case ZINNIA_S_RESOLVE_86:
-      return copy (ZINNIA_S_RESOLVE_65, this);
+      return copy (ZINNIA_S_RESOLVE_65, this)
       case FROSLASS_87:
-      return copy (ChillingReign.FROSLASS_36, this);
+      return copy (ChillingReign.FROSLASS_36, this)
       case TOY_CATCHER_88:
-      return copy (TOY_CATCHER_58, this);
+      return copy (TOY_CATCHER_58, this)
       case STORMY_MOUNTAIN_RANGE_89:
-      return copy (STORMY_MOUNTAIN_RANGE_66, this);
+      return copy (STORMY_MOUNTAIN_RANGE_66, this)
       case LIGHTNING_ENERGY_90:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChampionsPath.groovy
@@ -1,15 +1,15 @@
 package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
-import tcgwars.logic.impl.gen5.EmergingPowers;
+import tcgwars.logic.impl.gen5.EmergingPowers
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
@@ -103,53 +103,53 @@ public enum ChampionsPath implements LogicCardInfo {
   CHARIZARD_V_79 ("Charizard V", 79, Rarity.SECRET, [POKEMON, BASIC, POKEMON_V, _FIRE_]),
   STRANGE_CANNED_FOOD_80 ("Strange Canned Food", 80, Rarity.SECRET, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected int collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected int collectionLineNo
 
   ChampionsPath(String name, int collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CHAMPIONS_PATH;
+    return tcgwars.logic.card.Collection.CHAMPIONS_PATH
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -179,7 +179,7 @@ public enum ChampionsPath implements LogicCardInfo {
             cantUseAttack thisMove, self
           }
         }
-      };
+      }
       case WEEDLE_2:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -188,7 +188,7 @@ public enum ChampionsPath implements LogicCardInfo {
           energyCost C
           callForFamily basic:true, 1, delegate
         }
-      };
+      }
       case KAKUNA_3:
       return evolution (this, from:"Weedle", hp:HP080, type:G, retreatCost:3) {
         weakness R
@@ -199,7 +199,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BEEDRILL_4:
       return evolution (this, from:"Kakuna", hp:HP140, type:G, retreatCost:1) {
         weakness R
@@ -211,9 +211,9 @@ public enum ChampionsPath implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case ELDEGOSS_V_5:
-      return copy (RebelClash.ELDEGOSS_V_19, this);
+      return copy (RebelClash.ELDEGOSS_V_19, this)
       case VULPIX_6:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -234,7 +234,7 @@ public enum ChampionsPath implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case VICTINI_7:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -255,7 +255,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case INCINEROAR_V:
       return basic (this, hp:HP220, type:R, retreatCost:3) {
         weakness W
@@ -278,7 +278,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case SIZZLIPEDE_9:
       return copy(SwordShield.SIZZLIPEDE_37, this)
       case CENTISKORCH_10:
@@ -299,7 +299,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case CARVANHA_11:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -310,7 +310,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHARPEDO_12:
       return evolution (this, from:"Carvanha", hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -324,7 +324,7 @@ public enum ChampionsPath implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WAILORD_V_13:
       return basic (this, hp:HP280, type:W, retreatCost:4) {
         weakness L
@@ -345,7 +345,7 @@ public enum ChampionsPath implements LogicCardInfo {
             flip 3, { damage 120 }
           }
         }
-      };
+      }
       case DREDNAW_V_14:
       return basic (this, hp:HP210, type:W, retreatCost:4) {
         weakness L
@@ -371,7 +371,7 @@ public enum ChampionsPath implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case DREDNAW_VMAX_15:
       return evolution (this, from:"Drednaw V", hp:HP320, type:W, retreatCost:4) {
         weakness L
@@ -397,7 +397,7 @@ public enum ChampionsPath implements LogicCardInfo {
             flip { damage 80 }
           }
         }
-      };
+      }
       case GARDEVOIR_V_16:
       return basic (this, hp:HP210, type:P, retreatCost:2) {
         weakness M
@@ -416,7 +416,7 @@ public enum ChampionsPath implements LogicCardInfo {
             if(self.lastHealedTurn == bg.turnCount) damage 80
           }
         }
-      };
+      }
       case GARDEVOIR_VMAX_17:
       return evolution (this, from:"Gardevoir V", hp:HP320, type:P, retreatCost:2) {
         weakness M
@@ -428,7 +428,7 @@ public enum ChampionsPath implements LogicCardInfo {
             heal 50, self
           }
         }
-      };
+      }
       case HATENNA_18:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -447,7 +447,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HATTREM_19:
       return evolution (this, from:"Hatenna", hp:HP090, type:P, retreatCost:2) {
         weakness D
@@ -466,7 +466,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HATTERENE_20:
       return evolution (this, from:"Hattrem", hp:HP150, type:P, retreatCost:2) {
         weakness D
@@ -486,7 +486,7 @@ public enum ChampionsPath implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case GALARIAN_CURSOLA_V_21:
       return basic (this, hp:HP190, type:P, retreatCost:2) {
         weakness D
@@ -510,7 +510,7 @@ public enum ChampionsPath implements LogicCardInfo {
             putDamageCountersOnOpponentsPokemon(3, opp.bench)
           }
         }
-      };
+      }
       case ALCREMIE_V_22:
       return basic (this, hp:HP170, type:P, retreatCost:2) {
         weakness M
@@ -532,7 +532,7 @@ public enum ChampionsPath implements LogicCardInfo {
             if (defending.basic) cantAttackNextTurn(defending)
           }
         }
-      };
+      }
       case ALCREMIE_VMAX_23:
       return evolution (this, from:"Alcremie V", hp:HP310, type:P, retreatCost:3) {
         weakness M
@@ -558,7 +558,7 @@ public enum ChampionsPath implements LogicCardInfo {
             additionalDamageByDiscardingCardTypeFromPokemon 60, ENERGY
           }
         }
-      };
+      }
       case MACHOP_24:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness P
@@ -577,7 +577,7 @@ public enum ChampionsPath implements LogicCardInfo {
             flip { damage 40 }
           }
         }
-      };
+      }
       case MACHOKE_25:
       return evolution (this, from:"Machop", hp:HP110, type:F, retreatCost:3) {
         weakness P
@@ -596,7 +596,7 @@ public enum ChampionsPath implements LogicCardInfo {
             flip { damage 70 }
           }
         }
-      };
+      }
       case MACHAMP_26:
       return evolution (this, from:"Machoke", hp:HP170, type:F, retreatCost:3) {
         weakness P
@@ -620,7 +620,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 50, self
           }
         }
-      };
+      }
       case LUCARIO_V_27:
       return basic (this, hp:HP210, type:F, retreatCost:2) {
         weakness P
@@ -640,7 +640,7 @@ public enum ChampionsPath implements LogicCardInfo {
             cantUseAttack thisMove, self
           }
         }
-      };
+      }
       case ZYGARDE_28:
       return basic (this, hp:HP140, type:F, retreatCost:3) {
         weakness G
@@ -659,7 +659,7 @@ public enum ChampionsPath implements LogicCardInfo {
             discardSelfEnergyAfterDamage F
           }
         }
-      };
+      }
       case ROCKRUFF_29:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -680,7 +680,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LYCANROC_30:
       return evolution (this, from:"Rockruff", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -700,7 +700,7 @@ public enum ChampionsPath implements LogicCardInfo {
             cantUseAttack thisMove, self
           }
         }
-      };
+      }
       case ROLYCOLY_31:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -711,7 +711,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRAPPLOCT_V_32:
       return basic (this, hp:HP210, type:F, retreatCost:2) {
         weakness P
@@ -733,7 +733,7 @@ public enum ChampionsPath implements LogicCardInfo {
             flip { damage 100 }
           }
         }
-      };
+      }
       case EKANS_33:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -751,7 +751,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARBOK_34:
       return evolution (this, from:"Ekans", hp:HP120, type:D, retreatCost:1) {
         weakness F
@@ -769,7 +769,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case GALARIAN_ZIGZAGOON_35:
       return basic (this, hp:HP070, type:D, retreatCost:2) {
         weakness G
@@ -782,7 +782,7 @@ public enum ChampionsPath implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_LINOONE_36:
       return evolution (this, from:"Galarian Zigzagoon", hp:HP100, type:D, retreatCost:2) {
         weakness G
@@ -794,7 +794,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case GALARIAN_OBSTAGOON_37:
       return evolution (this, from:"Galarian Linoone", hp:HP170, type:D, retreatCost:2) {
         weakness G
@@ -816,7 +816,7 @@ public enum ChampionsPath implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case ABSOL_38:
       return basic (this, hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -827,11 +827,11 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case PURRLION_39:
       return copy (DarknessAblaze.PURRLOIN_106, this)
       case LIEPARD_40:
-      return copy (DarknessAblaze.LIEPARD_107, this);
+      return copy (DarknessAblaze.LIEPARD_107, this)
       case SCRAGGY_41:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -849,7 +849,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SCRAFTY_42:
       return evolution (this, from:"Scraggy", hp:HP120, type:D, retreatCost:2) {
         weakness G
@@ -871,9 +871,9 @@ public enum ChampionsPath implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TRUBBISH_43:
-      return copy (RebelClash.TRUBBISH_117, this);
+      return copy (RebelClash.TRUBBISH_117, this)
       case INKAY_44:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness G
@@ -894,7 +894,7 @@ public enum ChampionsPath implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MALAMAR_45:
       return evolution (this, from:"Inkay", hp:HP120, type:D, retreatCost:3) {
         weakness G
@@ -918,7 +918,7 @@ public enum ChampionsPath implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NICKIT_46:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -939,7 +939,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DURALUDON_V_47:
       return basic (this, hp:HP220, type:M, retreatCost:3) {
         weakness R
@@ -965,7 +965,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 40 * self.cards.energyCount(M)
           }
         }
-      };
+      }
       case SWABLU_48:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -977,7 +977,7 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ALTARIA_49:
       return evolution (this, from:"Swablu", hp:HP110, type:C, retreatCost:1) {
         weakness L
@@ -1007,35 +1007,35 @@ public enum ChampionsPath implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BEDE_50:
-      return copy (SwordShield.BEDE_157, this);
+      return copy (SwordShield.BEDE_157, this)
       case FULL_HEAL_51:
-      return copy (RebelClash.FULL_HEAL_159, this);
+      return copy (RebelClash.FULL_HEAL_159, this)
       case GREAT_BALL_52:
-      return copy (EmergingPowers.GREAT_BALL_93, this);
+      return copy (EmergingPowers.GREAT_BALL_93, this)
       case HOP_53:
-      return copy (SwordShield.HOP_165, this);
+      return copy (SwordShield.HOP_165, this)
       case HYPER_POTION_54:
-      return copy (SwordShield.HYPER_POTION_166, this);
+      return copy (SwordShield.HYPER_POTION_166, this)
       case KABU_55:
-      return copy (DarknessAblaze.KABU_163, this);
+      return copy (DarknessAblaze.KABU_163, this)
       case MARNIE_56:
-      return copy (SwordShield.MARNIE_169, this);
+      return copy (SwordShield.MARNIE_169, this)
       case MILO_57:
-      return copy (RebelClash.MILO_161, this);
+      return copy (RebelClash.MILO_161, this)
       case PIERS_58:
-      return copy (DarknessAblaze.PIERS_165, this);
+      return copy (DarknessAblaze.PIERS_165, this)
       case POKE_BALL_59:
-      return copy(FireRedLeafGreen.POKE_BALL_95, this);
+      return copy(FireRedLeafGreen.POKE_BALL_95, this)
       case POKEMON_CENTER_LADY_60:
-      return copy(SwordShield.POKEMON_CENTER_LADY_176, this);
+      return copy(SwordShield.POKEMON_CENTER_LADY_176, this)
       case POTION_61:
-      return copy (SwordShield.POTION_177, this);
+      return copy (SwordShield.POTION_177, this)
       case PROFESSOR_S_RESEARCH_62:
-      return copy (SwordShield.PROFESSOR_S_RESEARCH_178, this);
+      return copy (SwordShield.PROFESSOR_S_RESEARCH_178, this)
       case ROTOM_BIKE_63:
-      return copy (SwordShield.ROTOM_BIKE_181, this);
+      return copy (SwordShield.ROTOM_BIKE_181, this)
       case ROTOM_PHONE_64:
       return itemCard (this) {
         text "Look at the top 5 cards of your deck. Choose a card you find there, shuffle your deck, then put that card on top of your deck."
@@ -1048,9 +1048,9 @@ public enum ChampionsPath implements LogicCardInfo {
         playRequirement{
           assert my.deck.notEmpty : "Your deck is empty!"
         }
-      };
+      }
       case SONIA_65:
-      return copy (RebelClash.SONIA_167, this);
+      return copy (RebelClash.SONIA_167, this)
       case STRANGE_CANNED_FOOD_66:
       return itemCard (this) {
         text "Heal 80 damage from 1 of your Pokémon with a [P] Energy attached to it. Then, discard a [P] Energy from that Pokémon."
@@ -1063,37 +1063,37 @@ public enum ChampionsPath implements LogicCardInfo {
         playRequirement{
           assert my.all.findAll{it.cards.energyCount(P) && it.numberOfDamageCounters} : "You have no damaged Pokémon with [P] Energy attached to them"
         }
-      };
+      }
       case TEAM_YELL_GRUNT_67:
-      return copy (SwordShield.TEAM_YELL_GRUNT_184, this);
+      return copy (SwordShield.TEAM_YELL_GRUNT_184, this)
       case TURRFIELD_68:
-      return copy (RebelClash.TURRFIELD_170, this);
+      return copy (RebelClash.TURRFIELD_170, this)
       case DREDNAW_V_69:
-      return copy (DREDNAW_V_14, this);
+      return copy (DREDNAW_V_14, this)
       case GARDEVOIR_V_70:
-      return copy (GARDEVOIR_V_16, this);
+      return copy (GARDEVOIR_V_16, this)
       case GALARIAN_CURSOLA_V_71:
-      return copy (GALARIAN_CURSOLA_V_21, this);
+      return copy (GALARIAN_CURSOLA_V_21, this)
       case GRAPPLOCT_V_72:
-      return copy (GRAPPLOCT_V_32, this);
+      return copy (GRAPPLOCT_V_32, this)
       case HOP_73:
-      return copy (SwordShield.HOP_165, this);
+      return copy (SwordShield.HOP_165, this)
       case CHARIZARD_VMAX_74:
-      return copy (DarknessAblaze.CHARIZARD_VMAX_20, this);
+      return copy (DarknessAblaze.CHARIZARD_VMAX_20, this)
       case DREDNAW_VMAX_75:
-      return copy (DREDNAW_VMAX_15, this);
+      return copy (DREDNAW_VMAX_15, this)
       case GARDEVOIR_VMAX_76:
-      return copy (GARDEVOIR_VMAX_17, this);
+      return copy (GARDEVOIR_VMAX_17, this)
       case KABU_77:
-      return copy (DarknessAblaze.KABU_163, this);
+      return copy (DarknessAblaze.KABU_163, this)
       case PIERS_78:
-      return copy (DarknessAblaze.PIERS_165, this);
+      return copy (DarknessAblaze.PIERS_165, this)
       case CHARIZARD_V_79:
-      return copy (DarknessAblaze.CHARIZARD_V_19, this);
+      return copy (DarknessAblaze.CHARIZARD_V_19, this)
       case STRANGE_CANNED_FOOD_80:
-      return copy (STRANGE_CANNED_FOOD_66, this);
+      return copy (STRANGE_CANNED_FOOD_66, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/ChillingReign.groovy
+++ b/src/tcgwars/logic/impl/gen8/ChillingReign.groovy
@@ -2,37 +2,37 @@ package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.effect.gm.AttachEnergy
 import tcgwars.logic.groovy.TcgStatics
-import tcgwars.logic.impl.gen5.PlasmaBlast;
+import tcgwars.logic.impl.gen5.PlasmaBlast
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author Lithogenn@gmail.com
@@ -273,53 +273,53 @@ public enum ChillingReign implements LogicCardInfo {
   PSYCHIC_ENERGY_232 ("Psychic Energy", "232", Rarity.UNCOMMON, [ENERGY, BASIC_ENERGY]),
   FIGHTING_ENERGY_233 ("Fighting Energy", "233", Rarity.UNCOMMON, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ChillingReign(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.CHILLING_REIGN;
+    return tcgwars.logic.card.Collection.CHILLING_REIGN
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -336,7 +336,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case KAKUNA_2:
         return evolution (this, from:"Weedle", hp:HP080, type:G, retreatCost:3) {
           weakness FIRE
@@ -348,7 +348,7 @@ public enum ChillingReign implements LogicCardInfo {
               reduceDamageNextTurn(hp(40), thisMove)
             }
           }
-        };
+        }
       case BEEDRILL_3:
         return evolution (this, from:"Kakuna", hp:HP130, type:G, retreatCost:1) {
           weakness FIRE
@@ -373,7 +373,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage C
             }
           }
-        };
+        }
       case LEDYBA_4:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness FIRE
@@ -393,7 +393,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LEDIAN_5:
         return evolution (this, from:"Ledyba", hp:HP090, type:G, retreatCost:1) {
           weakness FIRE
@@ -415,7 +415,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage C
             }
           }
-        };
+        }
       case HERACROSS_6:
         return basic (this, hp:HP120, type:G, retreatCost:2) {
           weakness FIRE
@@ -436,7 +436,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip 2, {}, {}, [2:{ damage 160 }]
             }
           }
-        };
+        }
       case CELEBI_V_7:
         return basic (this, hp:HP190, type:G, retreatCost:1) {
           weakness FIRE
@@ -464,7 +464,7 @@ public enum ChillingReign implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case CELEBI_VMAX_8:
         return evolution (this, from:"Celebi V", hp:HP310, type:G, retreatCost:1) {
           weakness FIRE
@@ -492,7 +492,7 @@ public enum ChillingReign implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case SNOVER_9:
         return basic (this, hp:HP080, type:G, retreatCost:2) {
           weakness FIRE
@@ -504,7 +504,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case ABOMASNOW_10:
         return evolution (this, from:"Snover", hp:HP140, type:G, retreatCost:3) {
           weakness FIRE
@@ -540,7 +540,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case DEERLING_11:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness FIRE
@@ -560,7 +560,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SAWSBUCK_12:
         return evolution (this, from:"Deerling", hp:HP110, type:G, retreatCost:1) {
           weakness FIRE
@@ -583,7 +583,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BOUNSWEET_13:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness FIRE
@@ -595,7 +595,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case STEENEE_14:
         return evolution (this, from:"Bounsweet", hp:HP080, type:G, retreatCost:1) {
           weakness FIRE
@@ -616,7 +616,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case TSAREENA_15:
         return evolution (this, from:"Steenee", hp:HP140, type:G, retreatCost:2) {
           weakness FIRE
@@ -637,7 +637,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case GROOKEY_16:
         return basic (this, hp:HP060, type:G, retreatCost:1) {
           weakness FIRE
@@ -649,7 +649,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip 2, { damage 30 }
             }
           }
-        };
+        }
       case THWACKEY_17:
         return evolution (this, from:"Grookey", hp:HP100, type:G, retreatCost:2) {
           weakness FIRE
@@ -664,7 +664,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RILLABOOM_18:
         return evolution (this, from:"Thwackey", hp:HP180, type:G, retreatCost:3) {
           weakness FIRE
@@ -690,7 +690,7 @@ public enum ChillingReign implements LogicCardInfo {
               additionalDamageByDiscardingCardTypeFromPokemon 30, ENERGY
             }
           }
-        };
+        }
       case ZARUDE_19:
         return basic (this, hp:HP130, type:G, retreatCost:2) {
           weakness FIRE
@@ -717,7 +717,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60 + 20 * self.cards.energyCount(G)
             }
           }
-        };
+        }
       case BLAZIKEN_V_20:
         return basic (this, hp:HP210, type:R, retreatCost:2) {
           weakness WATER
@@ -738,7 +738,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case BLAZIKEN_VMAX_21:
         return evolution (this, from:"Blaziken V", hp:HP320, type:R, retreatCost:2) {
           weakness WATER
@@ -772,7 +772,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASTFORM_SUNNY_FORM_22:
         return basic (this, hp:HP070, type:R, retreatCost:0) {
           weakness WATER
@@ -805,7 +805,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LARVESTA_23:
         return basic (this, hp:HP080, type:R, retreatCost:3) {
           weakness WATER
@@ -821,7 +821,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VOLCARONA_24:
         return evolution (this, from:"Larvesta", hp:HP130, type:R, retreatCost:2) {
           weakness WATER
@@ -842,7 +842,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case VOLCANION_V_25:
         return basic (this, hp:HP220, type:R, retreatCost:3) {
           weakness WATER
@@ -865,7 +865,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SCORBUNNY_26:
         return basic (this, hp:HP060, type:R, retreatCost:1) {
           weakness WATER
@@ -877,7 +877,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case RABOOT_27:
         return evolution (this, from:"Scorbunny", hp:HP090, type:R, retreatCost:1) {
           weakness WATER
@@ -890,7 +890,7 @@ public enum ChillingReign implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case CINDERACE_28:
         return evolution (this, from:"Raboot", hp:HP170, type:R, retreatCost:1) {
           weakness WATER
@@ -919,7 +919,7 @@ public enum ChillingReign implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case LAPRAS_29:
         return basic (this, hp:HP110, type:W, retreatCost:1) {
           weakness METAL
@@ -945,7 +945,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(ASLEEP)
             }
           }
-        };
+        }
       case SNEASEL_30:
         return basic (this, hp:HP070, type:W, retreatCost:1) {
           weakness METAL
@@ -957,7 +957,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip { discardDefendingEnergy() }
             }
           }
-        };
+        }
       case WEAVILE_31:
         return evolution (this, from:"Sneasel", hp:HP110, type:W, retreatCost:1) {
           weakness METAL
@@ -999,7 +999,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DELIBIRD_32:
         return basic (this, hp:HP090, type:W, retreatCost:1) {
           weakness METAL
@@ -1023,7 +1023,7 @@ public enum ChillingReign implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case CASTFORM_RAINY_FORM_33:
         return basic (this, hp:HP070, type:W, retreatCost:0) {
           weakness LIGHTNING
@@ -1051,7 +1051,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASTFORM_SNOWY_FORM_34:
         return basic (this, hp:HP070, type:W, retreatCost:0) {
           weakness METAL
@@ -1078,7 +1078,7 @@ public enum ChillingReign implements LogicCardInfo {
               cantUseAttack(thisMove, self)
             }
           }
-        };
+        }
       case SNORUNT_35:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness METAL
@@ -1090,7 +1090,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case FROSLASS_36:
         return evolution (this, from:"Snorunt", hp:HP090, type:W, retreatCost:1) {
           weakness METAL
@@ -1112,7 +1112,7 @@ public enum ChillingReign implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case SPHEAL_37:
         return basic (this, hp:HP070, type:W, retreatCost:2) {
           weakness METAL
@@ -1124,7 +1124,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case SEALEO_38:
         return evolution (this, from:"Spheal", hp:HP110, type:W, retreatCost:4) {
           weakness METAL
@@ -1144,7 +1144,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case WALREIN_39:
         return evolution (this, from:"Sealeo", hp:HP170, type:W, retreatCost:4) {
           weakness METAL
@@ -1166,7 +1166,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(PARALYZED)
             }
           }
-        };
+        }
       case TAPU_FINI_40:
         return basic (this, hp:HP120, type:W, retreatCost:1) {
           weakness LIGHTNING
@@ -1190,7 +1190,7 @@ public enum ChillingReign implements LogicCardInfo {
               moveSelfEnergyAfterDamage(my.hand)
             }
           }
-        };
+        }
       case SOBBLE_41:
         return basic (this, hp:HP060, type:W, retreatCost:1) {
           weakness LIGHTNING
@@ -1221,7 +1221,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip 2, { damage 20 }
             }
           }
-        };
+        }
       case DRIZZILE_42:
         return evolution (this, from:"Sobble", hp:HP090, type:W, retreatCost:1) {
           weakness LIGHTNING
@@ -1234,7 +1234,7 @@ public enum ChillingReign implements LogicCardInfo {
               switchYourActive()
             }
           }
-        };
+        }
       case INTELEON_43:
         return evolution (this, from:"Drizzile", hp:HP150, type:W, retreatCost:1) {
           weakness LIGHTNING
@@ -1257,7 +1257,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case RAPID_STRIKE_URSHIFU_44:
         return evolution (this, from:"Kubfu", hp:HP140, type:W, retreatCost:2) {
           weakness LIGHTNING
@@ -1277,7 +1277,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30 * my.all.count { it.rapidStrike }
             }
           }
-        };
+        }
       case ICE_RIDER_CALYREX_V_45:
         return basic (this, hp:HP210, type:W, retreatCost:2) {
           weakness METAL
@@ -1298,7 +1298,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case ICE_RIDER_CALYREX_VMAX_46:
         return evolution (this, from:"Ice Rider Calyrex V", hp:HP320, type:W, retreatCost:2) {
           weakness METAL
@@ -1322,7 +1322,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case MAREEP_47:
         return basic (this, hp:HP070, type:L, retreatCost:2) {
           weakness FIGHTING
@@ -1342,7 +1342,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case FLAAFFY_48:
         return evolution (this, from:"Mareep", hp:HP100, type:L, retreatCost:2) {
           weakness FIGHTING
@@ -1354,7 +1354,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case AMPHAROS_49:
         return evolution (this, from:"Flaaffy", hp:HP160, type:L, retreatCost:2) {
           weakness FIGHTING
@@ -1383,7 +1383,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case BLITZLE_50:
         return basic (this, hp:HP060, type:L, retreatCost:1) {
           weakness FIGHTING
@@ -1395,7 +1395,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 10, opp.all.select("Deal damage to?")
             }
           }
-        };
+        }
       case ZEBSTRIKA_51:
         return evolution (this, from:"Blitzle", hp:HP120, type:L, retreatCost:1) {
           weakness FIGHTING
@@ -1430,7 +1430,7 @@ public enum ChillingReign implements LogicCardInfo {
               flipUntilTails { damage 90 }
             }
           }
-        };
+        }
       case THUNDURUS_52:
         return basic (this, hp:HP120, type:L, retreatCost:1) {
           weakness FIGHTING
@@ -1454,7 +1454,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case ZERAORA_V_53:
         return basic (this, hp:HP210, type:L, retreatCost:2) {
           weakness FIGHTING
@@ -1482,7 +1482,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GALARIAN_SLOWPOKE_54:
         return basic (this, hp:HP070, type:P, retreatCost:2) {
           weakness DARKNESS
@@ -1503,7 +1503,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GASTLY_55:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1517,7 +1517,7 @@ public enum ChillingReign implements LogicCardInfo {
               flipThenApplySC(ASLEEP)
             }
           }
-        };
+        }
       case HAUNTER_56:
         return evolution (this, from:"Gastly", hp:HP080, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1530,7 +1530,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GENGAR_57:
         return evolution (this, from:"Haunter", hp:HP130, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1555,7 +1555,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 10 + 40 * defending.numberOfDamageCounters
             }
           }
-        };
+        }
       case GALARIAN_ARTICUNO_V_58:
         return basic (this, hp:HP210, type:P, retreatCost:2) {
           weakness DARKNESS
@@ -1581,7 +1581,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(CONFUSED)
             }
           }
-        };
+        }
       case RALTS_59:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness METAL
@@ -1593,7 +1593,7 @@ public enum ChillingReign implements LogicCardInfo {
               apply(CONFUSED)
             }
           }
-        };
+        }
       case KIRLIA_60:
         return evolution (this, from:"Ralts", hp:HP080, type:P, retreatCost:1) {
           weakness METAL
@@ -1616,7 +1616,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GARDEVOIR_61:
         return evolution (this, from:"Kirlia", hp:HP140, type:P, retreatCost:2) {
           weakness METAL
@@ -1648,7 +1648,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60 + 30 * self.cards.energyCount(P)
             }
           }
-        };
+        }
       case SHUPPET_62:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1661,7 +1661,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BANETTE_63:
         return evolution (this, from:"Shuppet", hp:HP080, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1687,7 +1687,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(CONFUSED)
             }
           }
-        };
+        }
       case CRESSELIA_64:
         return basic (this, hp:HP120, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1723,7 +1723,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GOLETT_65:
         return basic (this, hp:HP090, type:P, retreatCost:3) {
           weakness DARKNESS
@@ -1744,7 +1744,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GOLURK_66:
         return evolution (this, from:"Golett", hp:HP150, type:P, retreatCost:4) {
           weakness DARKNESS
@@ -1769,7 +1769,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case SWIRLIX_67:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness METAL
@@ -1782,7 +1782,7 @@ public enum ChillingReign implements LogicCardInfo {
               heal 10, self
             }
           }
-        };
+        }
       case SLURPUFF_68:
         return evolution (this, from:"Swirlix", hp:HP110, type:P, retreatCost:2) {
           weakness METAL
@@ -1810,7 +1810,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 80
             }
           }
-        };
+        }
       case INKAY_69:
         return basic (this, hp:HP050, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1823,7 +1823,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case MALAMAR_70:
         return evolution (this, from:"Inkay", hp:HP120, type:P, retreatCost:3) {
           weakness DARKNESS
@@ -1846,7 +1846,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case HATENNA_71:
         return basic (this, hp:HP060, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1859,7 +1859,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HATTREM_72:
         return evolution (this, from:"Hatenna", hp:HP080, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1872,7 +1872,7 @@ public enum ChillingReign implements LogicCardInfo {
               heal 30, self
             }
           }
-        };
+        }
       case HATTERENE_73:
         return evolution (this, from:"Hattrem", hp:HP130, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -1900,7 +1900,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30 + 50 * defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case SHADOW_RIDER_CALYREX_V_74:
         return basic (this, hp:HP210, type:P, retreatCost:2) {
           weakness DARKNESS
@@ -1939,7 +1939,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHADOW_RIDER_CALYREX_VMAX_75:
         return evolution (this, from:"Shadow Rider Calyrex V", hp:HP320, type:P, retreatCost:2) {
           weakness DARKNESS
@@ -1963,7 +1963,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 10 + 30 * my.all.sum { it.cards.energyCount(P) }
             }
           }
-        };
+        }
       case DIGLETT_76:
         return basic (this, hp:HP050, type:F, retreatCost:1) {
           weakness GRASS
@@ -1978,7 +1978,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DUGTRIO_77:
         return evolution (this, from:"Diglett", hp:HP090, type:F, retreatCost:1) {
           weakness GRASS
@@ -1997,7 +1997,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GALARIAN_FARFETCH_D_78:
         return basic (this, hp:HP080, type:F, retreatCost:1) {
           weakness PSYCHIC
@@ -2010,7 +2010,7 @@ public enum ChillingReign implements LogicCardInfo {
               dontApplyResistance()
             }
           }
-        };
+        }
       case GALARIAN_SIRFETCH_D_79:
         return evolution (this, from:"Galarian Farfetch'd", hp:HP130, type:F, retreatCost:2) {
           weakness PSYCHIC
@@ -2034,7 +2034,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GALARIAN_ZAPDOS_V_80:
         return basic (this, hp:HP200, type:F, retreatCost:1) {
           weakness PSYCHIC
@@ -2071,7 +2071,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 170
             }
           }
-        };
+        }
       case GALLADE_81:
         return evolution (this, from:"Kirlia", hp:HP170, type:F, retreatCost:2) {
           weakness PSYCHIC
@@ -2094,7 +2094,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60 * opp.all.count { it.pokemonV }
             }
           }
-        };
+        }
       case GALARIAN_YAMASK_82:
         return basic (this, hp:HP060, type:F, retreatCost:2) {
           weakness GRASS
@@ -2107,7 +2107,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case GALARIAN_RUNERIGUS_83:
         return evolution (this, from:"Galarian Yamask", hp:HP120, type:F, retreatCost:2) {
           weakness GRASS
@@ -2141,7 +2141,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60 + 20 * defending.cards.energyCount(C)
             }
           }
-        };
+        }
       case CRABRAWLER_84:
         return basic (this, hp:HP080, type:F, retreatCost:3) {
           weakness PSYCHIC
@@ -2161,7 +2161,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip 2, { damage 40 }
             }
           }
-        };
+        }
       case CRABOMINABLE_85:
         return evolution (this, from:"Crabrawler", hp:HP150, type:F, retreatCost:4) {
           weakness PSYCHIC
@@ -2180,7 +2180,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 130
             }
           }
-        };
+        }
       case ROCKRUFF_86:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness GRASS
@@ -2195,7 +2195,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case LYCANROC_87:
         return evolution (this, from:"Rockruff", hp:HP120, type:F, retreatCost:2) {
           weakness GRASS
@@ -2207,7 +2207,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 80 + 10 * my.discard.count { it.cardTypes.is(POKEMON) && it.cardTypes.is(SINGLE_STRIKE) }
             }
           }
-        };
+        }
       case PASSIMIAN_88:
         return basic (this, hp:HP110, type:F, retreatCost:1) {
           weakness PSYCHIC
@@ -2235,7 +2235,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20, opp.all.select("Deal damage to?")
             }
           }
-        };
+        }
       case SANDACONDA_V_89:
         return basic (this, hp:HP220, type:F, retreatCost:2) {
           weakness GRASS
@@ -2260,7 +2260,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 140
             }
           }
-        };
+        }
       case SANDACONDA_VMAX_90:
         return evolution (this, from:"Sandaconda V", hp:HP320, type:F, retreatCost:3) {
           weakness GRASS
@@ -2285,19 +2285,19 @@ public enum ChillingReign implements LogicCardInfo {
                 if (my.bench && confirm("Do you want to move any amount of Energy from your Pokémon to your other Pokémon in any way you like?"))
                   while (true) {
                     def pl = (my.all.findAll { it.cards.filterByType(ENERGY) })
-                    if (!pl) break;
+                    if (!pl) break
                     def src = pl.select("Source for energy (cancel to stop)", false)
-                    if (!src) break;
+                    if (!src) break
                     def card = src.cards.filterByType(ENERGY).select("Energy to move").first()
 
                     def tar = my.all.findAll{it != src}.select("Target for energy (cancel to stop)", false)
-                    if (!tar) break;
+                    if (!tar) break
                     energySwitch(src, tar, card)
                   }
               }
             }
           }
-        };
+        }
       case CLOBBOPUS_91:
         return basic (this, hp:HP070, type:F, retreatCost:2) {
           weakness PSYCHIC
@@ -2309,7 +2309,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case GRAPPLOCT_92:
         return evolution (this, from:"Clobbopus", hp:HP140, type:F, retreatCost:3) {
           weakness PSYCHIC
@@ -2332,7 +2332,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case KUBFU_93:
         return basic (this, hp:HP070, type:F, retreatCost:1) {
           weakness PSYCHIC
@@ -2353,7 +2353,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case KOFFING_94:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness FIGHTING
@@ -2366,7 +2366,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(POISONED)
             }
           }
-        };
+        }
       case WEEZING_95:
         return evolution (this, from:"Koffing", hp:HP130, type:D, retreatCost:2) {
           weakness FIGHTING
@@ -2388,7 +2388,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20 + 20 * count
             }
           }
-        };
+        }
       case GALARIAN_WEEZING_96:
         return evolution (this, from:"Koffing", hp:HP130, type:D, retreatCost:2) {
           weakness FIGHTING
@@ -2411,7 +2411,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case GALARIAN_MOLTRES_V_97:
         return basic (this, hp:HP220, type:D, retreatCost:2) {
           weakness GRASS
@@ -2436,7 +2436,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case GALARIAN_SLOWKING_98:
         return evolution (this, from:"Galarian Slowpoke", hp:HP120, type:D, retreatCost:3) {
           weakness FIGHTING
@@ -2462,7 +2462,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case GALARIAN_SLOWKING_V_99:
         return basic (this, hp:HP220, type:D, retreatCost:3) {
           weakness FIGHTING
@@ -2500,7 +2500,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GALARIAN_SLOWKING_VMAX_100:
         return evolution (this, from:"Galarian Slowking V", hp:HP320, type:D, retreatCost:3) {
           weakness FIGHTING
@@ -2514,7 +2514,7 @@ public enum ChillingReign implements LogicCardInfo {
               extraPoison(11)
             }
           }
-        };
+        }
       case QWILFISH_101:
         return basic (this, hp:HP090, type:D, retreatCost:1) {
           weakness FIGHTING
@@ -2544,7 +2544,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(POISONED)
             }
           }
-        };
+        }
       case SEVIPER_102:
         return basic (this, hp:HP110, type:D, retreatCost:2) {
           weakness FIGHTING
@@ -2576,7 +2576,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SPIRITOMB_103:
         return basic (this, hp:HP070, type:D, retreatCost:1) {
           weakness GRASS
@@ -2604,7 +2604,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LIEPARD_V_104:
         return basic (this, hp:HP190, type:D, retreatCost:1) {
           weakness GRASS
@@ -2631,7 +2631,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case VENIPEDE_105:
         return basic (this, hp:HP070, type:D, retreatCost:2) {
           weakness FIGHTING
@@ -2644,7 +2644,7 @@ public enum ChillingReign implements LogicCardInfo {
               applyAfterDamage(POISONED)
             }
           }
-        };
+        }
       case WHIRLIPEDE_106:
         return evolution (this, from:"Venipede", hp:HP090, type:D, retreatCost:3) {
           weakness FIGHTING
@@ -2665,7 +2665,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case SCOLIPEDE_107:
         return evolution (this, from:"Whirlipede", hp:HP160, type:D, retreatCost:3) {
           weakness FIGHTING
@@ -2689,7 +2689,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SINGLE_STRIKE_URSHIFU_108:
         return evolution (this, from:"Kubfu", hp:HP140, type:D, retreatCost:2) {
           weakness GRASS
@@ -2717,7 +2717,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARON_109:
         return basic (this, hp:HP070, type:M, retreatCost:2) {
           weakness FIRE
@@ -2738,7 +2738,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case LAIRON_110:
         return evolution (this, from:"Aron", hp:HP100, type:M, retreatCost:3) {
           weakness FIRE
@@ -2759,7 +2759,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case AGGRON_111:
         return evolution (this, from:"Lairon", hp:HP180, type:M, retreatCost:4) {
           weakness FIRE
@@ -2784,7 +2784,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METAGROSS_V_112:
         return basic (this, hp:HP220, type:M, retreatCost:3) {
           weakness FIRE
@@ -2809,7 +2809,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case METAGROSS_VMAX_113:
         return evolution (this, from:"Metagross V", hp:HP330, type:M, retreatCost:3) {
           weakness FIRE
@@ -2833,7 +2833,7 @@ public enum ChillingReign implements LogicCardInfo {
               increasedBaseDamageNextTurn thisMove.name, hp(150)
             }
           }
-        };
+        }
       case COBALION_114:
         return basic (this, hp:HP120, type:M, retreatCost:2) {
           weakness FIRE
@@ -2855,7 +2855,7 @@ public enum ChillingReign implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case TAUROS_115:
         return basic (this, hp:HP130, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -2877,7 +2877,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 30, self
             }
           }
-        };
+        }
       case PORYGON_116:
         return basic (this, hp:HP060, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -2889,7 +2889,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case PORYGON2_117:
         return evolution (this, from:"Porygon", hp:HP090, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -2901,7 +2901,7 @@ public enum ChillingReign implements LogicCardInfo {
               flip 3, { damage 30 }
             }
           }
-        };
+        }
       case PORYGON_Z_118:
         return evolution (this, from:"Porygon2", hp:HP140, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -2924,7 +2924,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage(C, C)
             }
           }
-        };
+        }
       case BLISSEY_V_119:
         return basic (this, hp:HP250, type:C, retreatCost:4) {
           weakness FIGHTING
@@ -2954,7 +2954,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZANGOOSE_120:
         return basic (this, hp:HP110, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -2990,7 +2990,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case CASTFORM_121:
         return basic (this, hp:HP070, type:C, retreatCost:0) {
           weakness FIGHTING
@@ -3017,7 +3017,7 @@ public enum ChillingReign implements LogicCardInfo {
               draw 6 - my.hand.size()
             }
           }
-        };
+        }
       case KECLEON_122:
         return basic (this, hp:HP090, type:C, retreatCost:2) {
           weakness FIGHTING
@@ -3041,7 +3041,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case SHAYMIN_123:
         return basic (this, hp:HP070, type:C, retreatCost:1) {
           weakness LIGHTNING
@@ -3066,7 +3066,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case TORNADUS_V_124:
         return basic (this, hp:HP210, type:C, retreatCost:2) {
           weakness LIGHTNING
@@ -3091,7 +3091,7 @@ public enum ChillingReign implements LogicCardInfo {
               discardSelfEnergyAfterDamage()
             }
           }
-        };
+        }
       case TORNADUS_VMAX_125:
         return evolution (this, from:"Tornadus V", hp:HP320, type:C, retreatCost:2) {
           weakness LIGHTNING
@@ -3118,7 +3118,7 @@ public enum ChillingReign implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case FURFROU_126:
         return basic (this, hp:HP090, type:C, retreatCost:1) {
           weakness FIGHTING
@@ -3142,7 +3142,7 @@ public enum ChillingReign implements LogicCardInfo {
               reduceDamageNextTurn(hp(20), thisMove)
             }
           }
-        };
+        }
       case SKWOVET_127:
         return basic (this, hp:HP060, type:C, retreatCost:1) {
           weakness FIGHTING
@@ -3164,7 +3164,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case GREEDENT_128:
         return evolution (this, from:"Skwovet", hp:HP120, type:C, retreatCost:1) {
           weakness FIGHTING
@@ -3182,7 +3182,7 @@ public enum ChillingReign implements LogicCardInfo {
               damage 90
             }
           }
-        };
+        }
       case AGATHA_129:
         return supporter (this) {
           text "Move up to 3 damage counters from your Active Pokémon to your opponent's Active Pokémon. You may play only 1 Supporter card during your turn."
@@ -3196,7 +3196,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.active.numberOfDamageCounters : "Active Pokémon does not have damage counters"
           }
-        };
+        }
       case AVERY_130:
         return supporter (this) {
           text "Draw 3 cards. If you drew any cards in this way, your opponent discards Pokémon from their Bench until they have 3. You may play only 1 Supporter card during your turn."
@@ -3219,7 +3219,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert (my.deck || opp.bench.size() > 3) : "No cards in deck or opponent's bench is not more than 3"
           }
-        };
+        }
       case BRAWLY_131:
         return supporter (this) {
           text "Search your deck for up to 3 Rapid Strike Basic Pokémon and put them on your Bench. Then, shuffle your deck. You may play only 1 Supporter card during your turn."
@@ -3236,7 +3236,7 @@ public enum ChillingReign implements LogicCardInfo {
             assert my.deck : "No cards in deck"
             assert my.bench.notFull : "No space on bench"
           }
-        };
+        }
       case CAITLIN_132:
         return supporter (this) {
           text "Put any number of cards from your hand on the bottom of your deck in any order. Then, draw that many cards."
@@ -3250,7 +3250,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert hand.getExcludedList(thisCard).size() >= 1 : "Not enough cards in hand to use"
           }
-        };
+        }
       case CRUSHING_GLOVES_133:
         return pokemonTool (this) {
           text "The Pokémon this card is attached to does 30 more damage to your opponent's Active [M] Pokémon."
@@ -3271,7 +3271,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case DOCTOR_134:
         return supporter (this) {
           text "Draw 2 cards. If your opponent's Active Pokémon is a Pokémon VMAX, draw 2 more cards. You may play only 1 Supporter card during your turn."
@@ -3284,7 +3284,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.deck : "Deck is empty"
           }
-        };
+        }
       case DYNA_TREE_HILL_135:
         return stadium (this) {
           text "Pokémon in play (both yours and your opponent's) can't be healed. Note Pokémon uses the word recover when referring to Special Conditions, so although Pokémon in play can't have their HP healed, they can still recover from Special Conditions."
@@ -3300,7 +3300,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case ECHOING_HORN_136:
         return itemCard (this) {
           text "Put a Basic Pokémon from your opponent's discard pile onto their Bench. You may play any number of Item cards during your turn."
@@ -3311,7 +3311,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert opp.bench.notFull && opp.discard.filterByType(BASIC) : "Opponent's discard Pile has no Basic Pokémon or their bench is full"
           }
-        };
+        }
       case EXPEDITION_UNIFORM_137:
         return itemCard (this) {
           text "Look at the bottom 3 cards from your deck and place them on top of your deck in any order. You may play any number of Item cards during your turn."
@@ -3330,7 +3330,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.deck : "Deck is empty"
           }
-        };
+        }
       case FIRE_RESISTANT_GLOVES_138:
         return pokemonTool (this) {
           text "When the Pokémon this card is attached to attacks, damage done to your opponent's Active [R] Pokémon is increased by 30. You may play any number of Item cards during your turn."
@@ -3352,7 +3352,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case FLANNERY_139:
         return supporter (this) {
           text "Choose a Special Energy card attached to 1 of your opponent's Pokémon, and any Stadium card in play, and discard them. You may play only 1 Supporter card during your turn."
@@ -3372,7 +3372,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert bg.stadiumInfoStruct || opp.all.any { it.cards.filterByType(SPECIAL_ENERGY) } : "No Stadium in play or Special Energy attached"
           }
-        };
+        }
       case FOG_CRYSTAL_140:
         return itemCard (this) {
           text "Search your deck for either a Basic [P] Pokémon or [P] Energy, reveal it, and put it into your hand. Then, shuffle your deck. You may play as many Item cards as you like during your turn."
@@ -3385,7 +3385,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.deck : "Deck is empty"
           }
-        };
+        }
       case GALARIAN_CHESTPLATE_141:
         return pokemonTool (this) {
           text "If the Pokémon this card is attached to has 'Galarian' in its name, it takes 30 less damage from attacks from your opponent’s Pokémon (after applying Weakness and Resistance)."
@@ -3405,7 +3405,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case HONEY_142:
         return supporter (this) {
           text "Draw a card for each of your opponent’s Benched Pokémon V."
@@ -3416,7 +3416,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert opp.bench.any { it.pokemonV } : "No Pokémon V on your opponent's bench"
           }
-        };
+        }
       case JUSTIFIED_GLOVES_143:
         return pokemonTool (this) {
           text "When the Pokémon this card is attached to attacks, damage done to your opponent's Active [D] Pokémon is increased by 30. You may play any number of Item cards during your turn."
@@ -3438,7 +3438,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case KAREN_S_CONVICTION_144:
         return supporter (this) {
           text "During this turn, your Single Strike Pokémon's attacks do 20 more damage to your opponent's Active Pokémon for each Prize Card your opponent has already taken. You may play only 1 Supporter card during your turn."
@@ -3456,7 +3456,7 @@ public enum ChillingReign implements LogicCardInfo {
               unregisterAfter 1
             }
           }
-        };
+        }
       case KLARA_145:
         return supporter (this) {
           text "Choose up to 2 Pokémon and up to 2 Basic Energy from your discard pile, show them to your opponent, and put them into your hand. You may play only 1 Supporter card during your turn."
@@ -3472,7 +3472,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.discard.filterByType(BASIC_ENERGY) || my.discard.filterByType(POKEMON) : "No Basic Energies or Pokémon in discard"
           }
-        };
+        }
       case MELONY_146:
         return supporter (this) {
           text "Attach a [W] Energy from your discard pile to 1 of your Pokémon V. Then, draw 3 cards. You may play only 1 Supporter card during your turn."
@@ -3486,7 +3486,7 @@ public enum ChillingReign implements LogicCardInfo {
             assert my.all.any { it.pokemonV } : "No Pokémon V available"
             assert my.discard.filterByType(ENERGY).filterByEnergyType(W) : "No [W] energies in discard"
           }
-        };
+        }
       case OLD_CEMETERY_147:
         return stadium (this) {
           text "Whenever a player attaches an Energy from their hand to 1 of their Pokémon (excluding [P] Pokémon), put 2 damage counters on that Pokémon. This Stadium stays in play when you play it. Discard it if another Stadium comes into play. If a Stadium with the same name is in play, you can't play this card."
@@ -3505,7 +3505,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case PATH_TO_THE_PEAK_148:
         return stadium (this) {
           text "Each player's Pokémon in play with a Rule Box has no Abilities. This Stadium stays in play when you play it. Discard it if another Stadium comes into play. If a Stadium with the same name is in play, you can't play this card."
@@ -3530,7 +3530,7 @@ public enum ChillingReign implements LogicCardInfo {
             effect2.unregister()
             new CheckAbilities().run(bg)
           }
-        };
+        }
       case PEONIA_149:
         return supporter (this) {
           text "Choose up to 3 of your Prize cards and put them into your hand. Then, place the same number of cards from your hand face-down as Prize cards. You may play only 1 Supporter card during your turn."
@@ -3543,7 +3543,7 @@ public enum ChillingReign implements LogicCardInfo {
             def cards = my.hand.getExcludedList(thisCard).select(count: prizes.size(), "Choose cards to put back as prize cards")
             cards.moveTo(hidden:true, my.prizeCardSet)
           }
-        };
+        }
       case PEONY_150:
         return supporter (this) {
           text "Discard your hand and search your deck for up to 2 Trainer cards, reveal them, and put them into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn."
@@ -3559,7 +3559,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.deck : "Deck is empty"
           }
-        };
+        }
       case RAPID_STRIKE_SCROLL_OF_THE_SKIES_151:
         return pokemonTool (this) {
           text "The Rapid Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)" +
@@ -3602,7 +3602,7 @@ public enum ChillingReign implements LogicCardInfo {
               card.moveTo(opponent.hand)
             }
           }
-        };
+        }
       case SIEBOLD_153:
         return supporter (this) {
           text "Choose up to 2 of your Rapid Strike Pokémon in play and heal 60 damage from each of them. You may play only 1 Supporter card during your turn."
@@ -3617,7 +3617,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.all.find { it.rapidStrike } : "Couldn't find any Rapid Strike Pokémon with damage counters"
           }
-        };
+        }
       case SINGLE_STRIKE_SCROLL_OF_PIERCING_154:
         return pokemonTool (this) {
           text "The Single Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.) " +
@@ -3651,7 +3651,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             newMove.unregister()
           }
-        };
+        }
       case WEEDING_GLOVES_155:
         return pokemonTool (this) {
           text "When the Pokémon this card is attached to attacks, damage done to your opponent's Active [G] Pokémon is increased by 30. You may play any number of Item cards during your turn."
@@ -3673,7 +3673,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case WELCOMING_LANTERN_156:
         return itemCard (this) {
           text "Choose a Single Strike Supporter card from your discard pile and put it into your hand. You may play any number of Item cards during your turn."
@@ -3683,7 +3683,7 @@ public enum ChillingReign implements LogicCardInfo {
           playRequirement {
             assert my.discard.any { it.cardTypes.is(SINGLE_STRIKE) && it.cardTypes.is(SUPPORTER) } : "No Single Strike Supporter cards in discard"
           }
-        };
+        }
       case IMPACT_ENERGY_157:
         return specialEnergy (this, [[C]]) {
           text "This card can only be attached to a Single Strike Pokémon. If this card is attached to anything other than a Single Strike Pokémon, discard this card. As long as this card is attached to a Pokémon, this card provides every type of Energy but provides only 1 Energy at a time. If this Pokémon is Poisoned, it is no longer Poisoned and cannot be Poisoned."
@@ -3721,7 +3721,7 @@ public enum ChillingReign implements LogicCardInfo {
           allowAttach { to ->
             to.topPokemonCard.cardTypes.is(SINGLE_STRIKE)
           }
-        };
+        }
       case LUCKY_ENERGY_158:
         return specialEnergy (this, [[C]]) {
           text "This card provides 1 [C] Energy while attached to a Pokémon. If the Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent's attack, draw 1 card."
@@ -3741,7 +3741,7 @@ public enum ChillingReign implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case SPIRAL_ENERGY_159:
         return specialEnergy (this, [[]]) {
           text "This card can only be attached to a Rapid Strike Pokémon. If this card is attached to anything other than a Rapid Strike Pokémon, discard this card. As long as this card is attached to a Pokémon, this card provides every type of Energy but provides only 1 Energy at a time. If this Pokémon is Paralyzed, it is no longer Paralyzed and cannot be Paralyzed."
@@ -3779,21 +3779,21 @@ public enum ChillingReign implements LogicCardInfo {
           allowAttach { to ->
             to.topPokemonCard.cardTypes.is(RAPID_STRIKE)
           }
-        };
+        }
       case CELEBI_V_160:
-        return copy (CELEBI_V_7, this);
+        return copy (CELEBI_V_7, this)
       case BLAZIKEN_V_161:
-        return copy (BLAZIKEN_V_20, this);
+        return copy (BLAZIKEN_V_20, this)
       case VOLCANION_V_162:
-        return copy (VOLCANION_V_25, this);
+        return copy (VOLCANION_V_25, this)
       case ICE_RIDER_CALYREX_V_163:
-        return copy (ICE_RIDER_CALYREX_V_45, this);
+        return copy (ICE_RIDER_CALYREX_V_45, this)
       case ICE_RIDER_CALYREX_V_164:
-        return copy (ICE_RIDER_CALYREX_V_45, this);
+        return copy (ICE_RIDER_CALYREX_V_45, this)
       case ZERAORA_V_165:
-        return copy (ZERAORA_V_53, this);
+        return copy (ZERAORA_V_53, this)
       case ZERAORA_V_166:
-        return copy (ZERAORA_V_53, this);
+        return copy (ZERAORA_V_53, this)
       case GALARIAN_RAPIDASH_V_167:
         return basic (this, hp:HP210, type:P, retreatCost:1) {
           weakness DARKNESS
@@ -3822,141 +3822,141 @@ public enum ChillingReign implements LogicCardInfo {
               directDamage dmg, target
             }
           }
-        };
+        }
       case GALARIAN_RAPIDASH_V_168:
-        return copy (GALARIAN_RAPIDASH_V_167, this);
+        return copy (GALARIAN_RAPIDASH_V_167, this)
       case GALARIAN_ARTICUNO_V_169:
-        return copy (GALARIAN_ARTICUNO_V_58, this);
+        return copy (GALARIAN_ARTICUNO_V_58, this)
       case GALARIAN_ARTICUNO_V_170:
-        return copy (GALARIAN_ARTICUNO_V_58, this);
+        return copy (GALARIAN_ARTICUNO_V_58, this)
       case SHADOW_RIDER_CALYREX_V_171:
-        return copy (SHADOW_RIDER_CALYREX_V_74, this);
+        return copy (SHADOW_RIDER_CALYREX_V_74, this)
       case SHADOW_RIDER_CALYREX_V_172:
-        return copy (SHADOW_RIDER_CALYREX_V_74, this);
+        return copy (SHADOW_RIDER_CALYREX_V_74, this)
       case GALARIAN_ZAPDOS_V_173:
-        return copy (GALARIAN_ZAPDOS_V_80, this);
+        return copy (GALARIAN_ZAPDOS_V_80, this)
       case GALARIAN_ZAPDOS_V_174:
-        return copy (GALARIAN_ZAPDOS_V_80, this);
+        return copy (GALARIAN_ZAPDOS_V_80, this)
       case SANDACONDA_V_175:
-        return copy (SANDACONDA_V_89, this);
+        return copy (SANDACONDA_V_89, this)
       case GALARIAN_MOLTRES_V_176:
-        return copy (GALARIAN_MOLTRES_V_97, this);
+        return copy (GALARIAN_MOLTRES_V_97, this)
       case GALARIAN_MOLTRES_V_177:
-        return copy (GALARIAN_MOLTRES_V_97, this);
+        return copy (GALARIAN_MOLTRES_V_97, this)
       case GALARIAN_SLOWKING_V_178:
-        return copy (GALARIAN_SLOWKING_V_99, this);
+        return copy (GALARIAN_SLOWKING_V_99, this)
       case GALARIAN_SLOWKING_V_179:
-        return copy (GALARIAN_SLOWKING_V_99, this);
+        return copy (GALARIAN_SLOWKING_V_99, this)
       case LIEPARD_V_180:
-        return copy (LIEPARD_V_104, this);
+        return copy (LIEPARD_V_104, this)
       case METAGROSS_V_181:
-        return copy (METAGROSS_V_112, this);
+        return copy (METAGROSS_V_112, this)
       case BLISSEY_V_182:
-        return copy (BLISSEY_V_119, this);
+        return copy (BLISSEY_V_119, this)
       case BLISSEY_V_183:
-        return copy (BLISSEY_V_119, this);
+        return copy (BLISSEY_V_119, this)
       case TORNADUS_V_184:
-        return copy (TORNADUS_V_124, this);
+        return copy (TORNADUS_V_124, this)
       case TORNADUS_V_185:
-        return copy (TORNADUS_V_124, this);
+        return copy (TORNADUS_V_124, this)
       case AGATHA_186:
-        return copy (AGATHA_129, this);
+        return copy (AGATHA_129, this)
       case AVERY_187:
-        return copy (AVERY_130, this);
+        return copy (AVERY_130, this)
       case BRAWLY_188:
-        return copy (BRAWLY_131, this);
+        return copy (BRAWLY_131, this)
       case CAITLIN_189:
-        return copy (CAITLIN_132, this);
+        return copy (CAITLIN_132, this)
       case DOCTOR_190:
-        return copy (DOCTOR_134, this);
+        return copy (DOCTOR_134, this)
       case FLANNERY_191:
-        return copy (FLANNERY_139, this);
+        return copy (FLANNERY_139, this)
       case HONEY_192:
-        return copy (HONEY_142, this);
+        return copy (HONEY_142, this)
       case KAREN_S_CONVICTION_193:
-        return copy (KAREN_S_CONVICTION_144, this);
+        return copy (KAREN_S_CONVICTION_144, this)
       case KLARA_194:
-        return copy (KLARA_145, this);
+        return copy (KLARA_145, this)
       case MELONY_195:
-        return copy (MELONY_146, this);
+        return copy (MELONY_146, this)
       case PEONIA_196:
-        return copy (PEONIA_149, this);
+        return copy (PEONIA_149, this)
       case PEONY_197:
-        return copy (PEONY_150, this);
+        return copy (PEONY_150, this)
       case SIEBOLD_198:
-        return copy (SIEBOLD_153, this);
+        return copy (SIEBOLD_153, this)
       case CELEBI_VMAX_199:
-        return copy (CELEBI_VMAX_8, this);
+        return copy (CELEBI_VMAX_8, this)
       case BLAZIKEN_VMAX_200:
-        return copy (BLAZIKEN_VMAX_21, this);
+        return copy (BLAZIKEN_VMAX_21, this)
       case BLAZIKEN_VMAX_201:
-        return copy (BLAZIKEN_VMAX_21, this);
+        return copy (BLAZIKEN_VMAX_21, this)
       case ICE_RIDER_CALYREX_VMAX_202:
-        return copy (ICE_RIDER_CALYREX_VMAX_46, this);
+        return copy (ICE_RIDER_CALYREX_VMAX_46, this)
       case ICE_RIDER_CALYREX_VMAX_203:
-        return copy (ICE_RIDER_CALYREX_VMAX_46, this);
+        return copy (ICE_RIDER_CALYREX_VMAX_46, this)
       case SHADOW_RIDER_CALYREX_VMAX_204:
-        return copy (SHADOW_RIDER_CALYREX_VMAX_75, this);
+        return copy (SHADOW_RIDER_CALYREX_VMAX_75, this)
       case SHADOW_RIDER_CALYREX_VMAX_205:
-        return copy (SHADOW_RIDER_CALYREX_VMAX_75, this);
+        return copy (SHADOW_RIDER_CALYREX_VMAX_75, this)
       case SANDACONDA_VMAX_206:
-        return copy (SANDACONDA_VMAX_90, this);
+        return copy (SANDACONDA_VMAX_90, this)
       case GALARIAN_SLOWKING_VMAX_207:
-        return copy (GALARIAN_SLOWKING_VMAX_100, this);
+        return copy (GALARIAN_SLOWKING_VMAX_100, this)
       case METAGROSS_VMAX_208:
-        return copy (METAGROSS_VMAX_113, this);
+        return copy (METAGROSS_VMAX_113, this)
       case TORNADUS_VMAX_209:
-        return copy (TORNADUS_VMAX_125, this);
+        return copy (TORNADUS_VMAX_125, this)
       case AGATHA_210:
-        return copy (AGATHA_129, this);
+        return copy (AGATHA_129, this)
       case AVERY_211:
-        return copy (AVERY_130, this);
+        return copy (AVERY_130, this)
       case BRAWLY_212:
-        return copy (BRAWLY_131, this);
+        return copy (BRAWLY_131, this)
       case CAITLIN_213:
-        return copy (CAITLIN_132, this);
+        return copy (CAITLIN_132, this)
       case DOCTOR_214:
-        return copy (DOCTOR_134, this);
+        return copy (DOCTOR_134, this)
       case FLANNERY_215:
-        return copy (FLANNERY_139, this);
+        return copy (FLANNERY_139, this)
       case KAREN_S_CONVICTION_216:
-        return copy (KAREN_S_CONVICTION_144, this);
+        return copy (KAREN_S_CONVICTION_144, this)
       case KLARA_217:
-        return copy (KLARA_145, this);
+        return copy (KLARA_145, this)
       case MELONY_218:
-        return copy (MELONY_146, this);
+        return copy (MELONY_146, this)
       case PEONIA_219:
-        return copy (PEONIA_149, this);
+        return copy (PEONIA_149, this)
       case PEONY_220:
-        return copy (PEONY_150, this);
+        return copy (PEONY_150, this)
       case SIEBOLD_221:
-        return copy (SIEBOLD_153, this);
+        return copy (SIEBOLD_153, this)
       case ELECTRODE_222:
-        return copy (VividVoltage.ELECTRODE_46, this);
+        return copy (VividVoltage.ELECTRODE_46, this)
       case BRONZONG_223:
-        return copy (BattleStyles.BRONZONG_102, this);
+        return copy (BattleStyles.BRONZONG_102, this)
       case SNORLAX_224:
-        return copy (AmazingVoltTackle.SNORLAX_84, this);
+        return copy (AmazingVoltTackle.SNORLAX_84, this)
       case ECHOING_HORN_225:
-        return copy (ECHOING_HORN_136, this);
+        return copy (ECHOING_HORN_136, this)
       case FAN_OF_WAVES_226:
-        return copy (BattleStyles.FAN_OF_WAVES_127, this);
+        return copy (BattleStyles.FAN_OF_WAVES_127, this)
       case FOG_CRYSTAL_227:
-        return copy (FOG_CRYSTAL_140, this);
+        return copy (FOG_CRYSTAL_140, this)
       case RUGGED_HELMET_228:
-        return copy (RUGGED_HELMET_152, this);
+        return copy (RUGGED_HELMET_152, this)
       case URN_OF_VITALITY_229:
-        return copy (BattleStyles.URN_OF_VITALITY_139, this);
+        return copy (BattleStyles.URN_OF_VITALITY_139, this)
       case WELCOMING_LANTERN_230:
-        return copy (WELCOMING_LANTERN_156, this);
+        return copy (WELCOMING_LANTERN_156, this)
       case WATER_ENERGY_231:
-        return basicEnergy (this, WATER);
+        return basicEnergy (this, WATER)
       case PSYCHIC_ENERGY_232:
-        return basicEnergy (this, PSYCHIC);
+        return basicEnergy (this, PSYCHIC)
       case FIGHTING_ENERGY_233:
-        return basicEnergy (this, FIGHTING);
+        return basicEnergy (this, FIGHTING)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3,24 +3,24 @@ package tcgwars.logic.impl.gen8
 import tcgwars.logic.effect.advanced.PutOnBench
 import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.*;
+import tcgwars.logic.*
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -232,53 +232,53 @@ public enum DarknessAblaze implements LogicCardInfo {
   TURBO_PATCH_200 ("Turbo Patch", "200", Rarity.SECRET, [TRAINER, ITEM]),
   CAPTURE_ENERGY_201 ("Capture Energy", "201", Rarity.SECRET, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   DarknessAblaze(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.DARKNESS_ABLAZE;
+    return tcgwars.logic.card.Collection.DARKNESS_ABLAZE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -304,7 +304,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case BUTTERFREE_VMAX_2:
       return evolution (this, from:"Butterfree V", hp:HP300, type:G, retreatCost:0) {
         weakness R
@@ -318,7 +318,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case PARAS_3:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -330,7 +330,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PARASECT_4:
       return evolution (this, from:"Paras", hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -351,7 +351,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case CARNIVINE_5:
       return basic (this, hp:HP090, type:G, retreatCost:1) {
         weakness R
@@ -376,7 +376,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             removeDamageCounterEqualToDamageDone()
           }
         }
-      };
+      }
       case PANSAGE_6:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -396,7 +396,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SIMISAGE_7:
       return evolution (this, from:"Pansage", hp:HP100, type:G, retreatCost:1) {
         weakness R
@@ -417,7 +417,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case KARRABLAST_8:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -429,7 +429,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flipUntilTails {damage 20}
           }
         }
-      };
+      }
       case SHELMET_9:
       return basic (this, hp:HP070, type:G, retreatCost:3) {
         weakness R
@@ -441,7 +441,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ACCELGOR_10:
       return evolution (this, from:"Shelmet", hp:HP090, type:G, retreatCost:0) {
         weakness R
@@ -453,7 +453,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ROWLET_11:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -478,7 +478,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60, opp.bench.select("Select a Pokémon to deal 60 damage to.")
           }
         }
-      };
+      }
       case DARTRIX_12:
       return evolution (this, from:"Rowlet", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -490,7 +490,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DECIDUEYE_13:
       return evolution (this, from:"Dartrix", hp:HP140, type:G, retreatCost:2) {
         weakness R
@@ -527,7 +527,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BOUNSWEET_14:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -549,7 +549,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STEENEE_15:
       return evolution (this, from:"Bounsweet", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -571,7 +571,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TSAREENA_16:
       return evolution (this, from:"Steenee", hp:HP150, type:G, retreatCost:2) {
         weakness R
@@ -601,7 +601,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WIMPOD_17:
       return basic (this, hp:HP070, type:G, retreatCost:3) {
         weakness R
@@ -614,7 +614,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case GOLISOPOD_18:
       return evolution (this, from:"Wimpod", hp:HP130, type:G, retreatCost:2) {
         weakness R
@@ -636,7 +636,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case CHARIZARD_V_19:
       return basic (this, hp:HP220, type:R, retreatCost:3) {
         weakness W
@@ -657,7 +657,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             discardSelfEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case CHARIZARD_VMAX_20:
       return evolution (this, from:"Charizard V", hp:HP330, type:R, retreatCost:3) {
         weakness W
@@ -678,7 +678,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             discardSelfEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case HOUNDOOM_V_21:
       return basic (this, hp:HP210, type:R, retreatCost:1) {
         weakness W
@@ -701,7 +701,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             if (cond) damage 100
           }
         }
-      };
+      }
       case TORCHIC_22:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -718,7 +718,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case COMBUSKEN_23:
       return evolution (this, from:"Torchic", hp:HP090, type:R, retreatCost:1) {
         weakness W
@@ -739,7 +739,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case BLAZIKEN_24:
       return evolution (this, from:"Combusken", hp:HP170, type:R, retreatCost:2) {
         weakness W
@@ -760,7 +760,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HEATRAN_25:
       return basic (this, hp:HP130, type:R, retreatCost:4) {
         weakness W
@@ -781,7 +781,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 80 + 10 * self.numberOfDamageCounters
           }
         }
-      };
+      }
       case PANSEAR_26:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -801,7 +801,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SIMISEAR_27:
       return evolution (this, from:"Pansear", hp:HP100, type:R, retreatCost:1) {
         weakness W
@@ -822,7 +822,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_28:
       return evolution (this, from:"Galarian Darumaka", hp:HP140, type:R, retreatCost:3) {
         weakness W
@@ -849,7 +849,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LARVESTA_29:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -861,7 +861,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case VOLCARONA_30:
       return evolution (this, from:"Larvesta", hp:HP120, type:R, retreatCost:1) {
         weakness W
@@ -883,7 +883,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case FLETCHINDER_31:
       return evolution (this, from:"Fletchling", hp:HP070, type:R, retreatCost:1) {
         weakness L
@@ -897,7 +897,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case TALONFLAME_32:
       return evolution (this, from:"Fletchinder", hp:HP140, type:R, retreatCost:1) {
         weakness L
@@ -918,7 +918,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case CENTISKORCH_V_33:
       return basic (this, hp:HP210, type:R, retreatCost:3) {
         weakness W
@@ -942,7 +942,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case CENTISKORCH_VMAX_34:
       return evolution (this, from:"Centiskorch V", hp:HP320, type:R, retreatCost:3) {
         weakness W
@@ -960,7 +960,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_MR_MIME_35:
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness M
@@ -980,7 +980,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GALARIAN_MR_RIME_36:
       return evolution (this, from:"Galarian Mr. Mime", hp:HP120, type:W, retreatCost:2) {
         weakness M
@@ -1006,7 +1006,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20 * my.discard.findAll{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} }.size()
           }
         }
-      };
+      }
       case SUICUNE_37:
       return basic (this, hp:HP120, type:W, retreatCost:1) {
         weakness L
@@ -1025,7 +1025,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.hand, W, W
           }
         }
-      };
+      }
       case FEEBAS_38:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1039,7 +1039,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             heal 20, self
           }
         }
-      };
+      }
       case MILOTIC_39:
       return evolution (this, from:"Feebas", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -1062,7 +1062,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case RELICANTH_40:
       return basic (this, hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -1089,7 +1089,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PANPOUR_41:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1109,7 +1109,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SIMIPOUR_42:
       return evolution (this, from:"Panpour", hp:HP100, type:W, retreatCost:1) {
         weakness L
@@ -1130,7 +1130,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case GALARIAN_DARUMAKA_43:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness M
@@ -1150,9 +1150,9 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_44:
-      return copy(RebelClash.GALARIAN_DARMANITAN_48, this);
+      return copy(RebelClash.GALARIAN_DARMANITAN_48, this)
       case VANILLITE_45:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness M
@@ -1165,7 +1165,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip {apply PARALYZED}
           }
         }
-      };
+      }
       case VANILLISH_46:
       return evolution (this, from:"Vanillite", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -1178,7 +1178,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip {apply PARALYZED}
           }
         }
-      };
+      }
       case VANILLUXE_47:
       return evolution (this, from:"Vanillish", hp:HP150, type:W, retreatCost:2) {
         weakness M
@@ -1199,7 +1199,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case CUBCHOO_48:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness M
@@ -1219,7 +1219,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BEARTIC_49:
       return evolution (this, from:"Cubchoo", hp:HP140, type:W, retreatCost:3) {
         weakness M
@@ -1240,7 +1240,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 50, self
           }
         }
-      };
+      }
       case WISHIWASHI_50:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1264,7 +1264,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAREANIE_51:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness L
@@ -1287,7 +1287,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case TOXAPEX_52:
       return evolution (this, from:"Mareanie", hp:HP130, type:W, retreatCost:3) {
         weakness L
@@ -1314,7 +1314,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case DRACOVISH_53:
       return evolution (this, from:"Rare Fossil", hp:HP150, type:W, retreatCost:3) {
         weakness L
@@ -1342,7 +1342,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case ARCTOVISH_54:
       return evolution (this, from:"Rare Fossil", hp:HP150, type:W, retreatCost:2) {
         weakness L
@@ -1364,7 +1364,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case MAREEP_55:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1376,7 +1376,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FLAAFFY_56:
       return evolution (this, from:"Mareep", hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -1388,7 +1388,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case AMPHAROS_57:
       return evolution (this, from:"Flaaffy", hp:HP150, type:L, retreatCost:2) {
         weakness F
@@ -1409,7 +1409,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case ELECTRIKE_58:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1424,7 +1424,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MANECTRIC_59:
       return evolution (this, from:"Electrike", hp:HP110, type:L, retreatCost:1) {
         weakness F
@@ -1448,7 +1448,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VIKAVOLT_V_60:
       return basic (this, hp:HP210, type:L, retreatCost:3) {
         weakness F
@@ -1480,7 +1480,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             discardSelfEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case TAPU_KOKO_61:
       return basic (this, hp:HP110, type:L, retreatCost:0) {
         weakness F
@@ -1502,7 +1502,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case TOXEL_62:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -1522,7 +1522,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOXTRICITY_63:
       return evolution (this, from:"Toxel", hp:HP120, type:L, retreatCost:2) {
         weakness F
@@ -1545,7 +1545,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case PINCURCHIN_64:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -1564,7 +1564,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case DRACOZOLT_65:
       return evolution (this, from:"Rare Fossil", hp:HP160, type:L, retreatCost:4) {
         weakness F
@@ -1586,7 +1586,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case ARCTOZOLT_66:
       return evolution (this, from:"Rare Fossil", hp:HP130, type:L, retreatCost:2) {
         weakness F
@@ -1609,7 +1609,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case JIGGLYPUFF_67:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness M
@@ -1629,7 +1629,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WIGGLYTUFF_68:
       return evolution (this, from:"Jigglypuff", hp:HP120, type:P, retreatCost:2) {
         weakness M
@@ -1654,7 +1654,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MEW_V_69:
       return basic (this, hp:HP180, type:P, retreatCost:0) {
         weakness D
@@ -1667,7 +1667,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30 * ( self.cards.energyCount(C) + defending.cards.energyCount(C) )
           }
         }
-      };
+      }
       case SNUBBULL_70:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness M
@@ -1679,7 +1679,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRANBULL_71:
       return evolution (this, from:"Snubbull", hp:HP130, type:P, retreatCost:2) {
         weakness M
@@ -1700,7 +1700,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case LUNATONE_72:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -1718,7 +1718,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20*(1+ defending.cards.energyCount(C))
           }
         }
-      };
+      }
       case GOTHITA_73:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1746,7 +1746,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GOTHORITA_74:
       return evolution (this, from:"Gothita", hp:HP080, type:P, retreatCost:2) {
         weakness D
@@ -1774,7 +1774,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GOTHITELLE_75:
       return evolution (this, from:"Gothorita", hp:HP140, type:P, retreatCost:2) {
         weakness D
@@ -1804,7 +1804,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GOLETT_76:
       return basic (this, hp:HP090, type:P, retreatCost:3) {
         weakness D
@@ -1825,7 +1825,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GOLURK_77:
       return evolution (this, from:"Golett", hp:HP150, type:P, retreatCost:4) {
         weakness D
@@ -1846,7 +1846,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case DEDENNE_78:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness M
@@ -1858,7 +1858,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20 * my.discard.findAll{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} }.size()
           }
         }
-      };
+      }
       case MORELULL_79:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
@@ -1878,7 +1878,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHIINOTIC_80:
       return evolution (this, from:"Morelull", hp:HP110, type:P, retreatCost:2) {
         weakness M
@@ -1904,7 +1904,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MIMIKYU_81:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1928,7 +1928,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SINISTEA_82:
       return basic (this, hp:HP030, type:P, retreatCost:1) {
         weakness D
@@ -1941,7 +1941,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             directDamage 20, defending
           }
         }
-      };
+      }
       case POLTEAGEIST_83:
       return evolution (this, from:"Sinistea", hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1965,7 +1965,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20 * my.discard.findAll{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} }.size()
           }
         }
-      };
+      }
       case DIGLETT_84:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1977,7 +1977,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DUGTRIO_85:
       return evolution (this, from:"Diglett", hp:HP090, type:F, retreatCost:1) {
         weakness G
@@ -2000,7 +2000,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case LARVITAR_86:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2020,7 +2020,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PUPITAR_87:
       return evolution (this, from:"Larvitar", hp:HP080, type:F, retreatCost:3) {
         weakness G
@@ -2049,7 +2049,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TYRANITAR_88:
       return evolution (this, from:"Pupitar", hp:HP180, type:F, retreatCost:4) {
         weakness G
@@ -2079,7 +2079,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TRAPINCH_89:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -2094,7 +2094,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VIBRAVA_90:
       return evolution (this, from:"Trapinch", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -2109,7 +2109,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FLYGON_91:
       return evolution (this, from:"Vibrava", hp:HP150, type:F, retreatCost:1) {
         weakness G
@@ -2138,7 +2138,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SOLROCK_92:
       return basic (this, hp:HP090, type:F, retreatCost:1) {
         weakness G
@@ -2158,7 +2158,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HIPPOPOTAS_93:
       return basic (this, hp:HP100, type:F, retreatCost:4) {
         weakness G
@@ -2181,7 +2181,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HIPPOWDON_94:
       return evolution (this, from:"Hippopotas", hp:HP150, type:F, retreatCost:4) {
         weakness G
@@ -2203,7 +2203,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 150
           }
         }
-      };
+      }
       case RHYPERIOR_V_95:
       return basic (this, hp:HP230, type:F, retreatCost:4) {
         weakness G
@@ -2225,7 +2225,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case DIGGERSBY_96:
       return evolution (this, from:"Bunnelby", hp:HP130, type:F, retreatCost:3) {
         weakness G
@@ -2245,7 +2245,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case PASSIMIAN_97:
       return basic (this, hp:HP110, type:F, retreatCost:1) {
         weakness P
@@ -2263,9 +2263,9 @@ public enum DarknessAblaze implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case GALARIAN_SIRFETCH_D_98:
-      return copy(RebelClash.GALARIAN_SIRFETCH_D_95, this);
+      return copy(RebelClash.GALARIAN_SIRFETCH_D_95, this)
       case GALARIAN_SLOWBRO_V_99:
       return basic (this, hp:HP210, type:D, retreatCost:3) {
         weakness F
@@ -2287,7 +2287,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantRetreat(defending)
           }
         }
-      };
+      }
       case GRIMER_100:
       return basic (this, hp:HP080, type:D, retreatCost:3) {
         weakness F
@@ -2311,7 +2311,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MUK_101:
       return evolution (this, from:"Grimer", hp:HP140, type:D, retreatCost:4) {
         weakness F
@@ -2332,7 +2332,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case SPINARAK_102:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -2352,7 +2352,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ARIADOS_103:
       return evolution (this, from:"Spinarak", hp:HP110, type:D, retreatCost:2) {
         weakness F
@@ -2381,7 +2381,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CROBAT_V_104:
       return basic (this, hp:HP180, type:D, retreatCost:1) {
         weakness F
@@ -2407,7 +2407,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DARKRAI_105:
       return basic (this, hp:HP120, type:D, retreatCost:2) {
         weakness G
@@ -2434,7 +2434,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60 + 20*self.cards.energyCount(D)
           }
         }
-      };
+      }
       case PURRLOIN_106:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -2459,7 +2459,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LIEPARD_107:
       return evolution (this, from:"Purrloin", hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -2485,7 +2485,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case DEINO_108:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness G
@@ -2497,7 +2497,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZWEILOUS_109:
       return evolution (this, from:"Deino", hp:HP100, type:D, retreatCost:2) {
         weakness G
@@ -2517,7 +2517,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case HYDREIGON_110:
       return evolution (this, from:"Zweilous", hp:HP160, type:D, retreatCost:3) {
         weakness G
@@ -2539,7 +2539,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case HOOPA_111:
       return basic (this, hp:HP120, type:D, retreatCost:2) {
         weakness G
@@ -2553,7 +2553,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NICKIT_112:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -2567,7 +2567,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case THIEVUL_113:
       return evolution (this, from:"Nickit", hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -2592,7 +2592,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case GRIMMSNARL_V_114:
       return basic (this, hp:HP220, type:D, retreatCost:2) {
         weakness G
@@ -2613,7 +2613,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.hand, D, D
           }
         }
-      };
+      }
       case GRIMMSNARL_VMAX_115:
       return evolution (this, from:"Grimmsnarl V", hp:HP330, type:D, retreatCost:3) {
         weakness G
@@ -2626,7 +2626,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             extraEnergyDamage(2,hp(50),D,thisMove)
           }
         }
-      };
+      }
       case ETERNATUS_V_116:
       return basic (this, hp:HP220, type:D, retreatCost:2) {
         weakness F
@@ -2659,7 +2659,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ETERNATUS_VMAX_117:
       return evolution (this, from:"Eternatus V", hp:HP340, type:D, retreatCost:3) {
         weakness F
@@ -2786,7 +2786,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30 * my.all.findAll{it.types.contains(D)}.size()
           }
         }
-      };
+      }
       case SCIZOR_V_118:
       return basic (this, hp:HP210, type:M, retreatCost:2) {
         weakness R
@@ -2816,7 +2816,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case SCIZOR_VMAX_119:
       return evolution (this, from:"Scizor V", hp:HP320, type:M, retreatCost:2) {
         weakness R
@@ -2838,7 +2838,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 190
           }
         }
-      };
+      }
       case SKARMORY_120:
       return basic (this, hp:HP120, type:M, retreatCost:1) {
         weakness L
@@ -2860,7 +2860,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case ARON_121:
       return basic (this, hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -2881,7 +2881,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LAIRON_122:
       return evolution (this, from:"Aron", hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -2903,7 +2903,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case AGGRON_123:
       return evolution (this, from:"Lairon", hp:HP160, type:M, retreatCost:3) {
         weakness R
@@ -2934,7 +2934,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 160
           }
         }
-      };
+      }
       case ESCAVALIER_124:
       return evolution (this, from:"Karrablast", hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -2956,7 +2956,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case KLINK_125:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -2970,7 +2970,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case KLANG_126:
       return evolution (this, from:"Klink", hp:HP090, type:M, retreatCost:3) {
         weakness R
@@ -2992,7 +2992,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case KLINKLANG_127:
       return evolution (this, from:"Klang", hp:HP150, type:M, retreatCost:3) {
         weakness R
@@ -3018,7 +3018,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_STUNFISK_V_128:
       return basic (this, hp:HP200, type:M, retreatCost:4) {
         weakness R
@@ -3041,7 +3041,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MELTAN_129:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -3062,7 +3062,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MELMETAL_130:
       return evolution (this, from:"Meltan", hp:HP150, type:M, retreatCost:4) {
         weakness R
@@ -3085,7 +3085,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case CUFANT_131:
       return basic (this, hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -3098,7 +3098,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case COPPERAJAH_132:
       return evolution (this, from:"Cufant", hp:HP190, type:M, retreatCost:4) {
         weakness R
@@ -3125,7 +3125,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             if (my.bench.find{ it.numberOfDamageCounters }) damage 120
           }
         }
-      };
+      }
       case KANGASKHAN_133:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -3144,7 +3144,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case TAUROS_134:
       return basic (this, hp:HP110, type:C, retreatCost:2) {
         weakness F
@@ -3156,7 +3156,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SENTRET_135:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -3165,7 +3165,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           energyCost C
           callForFamily basic:true, 1, delegate
         }
-      };
+      }
       case FURRET_136:
       return evolution (this, from:"Sentret", hp:HP110, type:C, retreatCost:1) {
         weakness F
@@ -3187,7 +3187,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip { damage 90 }
           }
         }
-      };
+      }
       case DUNSPARCE_137:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -3210,7 +3210,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TEDDIURSA_138:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -3230,7 +3230,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case URSARING_139:
       return evolution (this, from:"Teddiursa", hp:HP140, type:C, retreatCost:3) {
         weakness F
@@ -3253,7 +3253,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case LUGIA_140:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness L
@@ -3277,7 +3277,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SKITTY_141:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -3302,7 +3302,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DELCATTY_142:
       return evolution (this, from:"Skitty", hp:HP100, type:C, retreatCost:1) {
         weakness F
@@ -3325,7 +3325,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case SALAMENCE_V_143:
       return basic (this, hp:HP220, type:C, retreatCost:2) {
         weakness L
@@ -3346,7 +3346,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 160
           }
         }
-      };
+      }
       case SALAMENCE_VMAX_144:
       return evolution (this, from:"Salamence V", hp:HP320, type:C, retreatCost:2) {
         weakness L
@@ -3368,7 +3368,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case STARLY_145:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -3395,7 +3395,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case STARAVIA_146:
       return evolution (this, from:"Starly", hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -3417,7 +3417,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STARAPTOR_147:
       return evolution (this, from:"Staravia", hp:HP150, type:C, retreatCost:0) {
         weakness L
@@ -3432,13 +3432,13 @@ public enum DarknessAblaze implements LogicCardInfo {
               if (my.bench && confirm("Do you want to move any amount of Energy from your Pokémon to your other Pokémon in any way you like?"))
               while (true) {
                 def pl = (my.all.findAll {it.cards.filterByType(ENERGY)})
-                if (!pl) break;
+                if (!pl) break
                 def src = pl.select("Source for energy (cancel to stop)", false)
-                if (!src) break;
+                if (!src) break
                 def card=src.cards.filterByType(ENERGY).select("Energy to move").first()
 
                 def tar=my.all.findAll{it != src}.select("Target for energy (cancel to stop)", false)
-                if (!tar) break;
+                if (!tar) break
                 energySwitch(src, tar, card)
               }
             }
@@ -3453,7 +3453,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case DUCKLETT_148:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -3466,7 +3466,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SWANNA_149:
       return evolution (this, from:"Ducklett", hp:HP110, type:C, retreatCost:0) {
         weakness L
@@ -3494,7 +3494,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BUNNELBY_150:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -3506,7 +3506,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20 * my.discard.findAll{ it.cardTypes.is(POKEMON) && it.moves.any{it.name=="Mad Party"} }.size()
           }
         }
-      };
+      }
       case FLETCHLING_151:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -3519,7 +3519,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SKWOVET_152:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3531,7 +3531,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip { damage 40 }
           }
         }
-      };
+      }
       case GREEDENT_153:
       return evolution (this, from:"Skwovet", hp:HP120, type:C, retreatCost:1) {
         weakness F
@@ -3557,7 +3557,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ROOKIDEE_154:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -3573,7 +3573,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CORVISQUIRE_155:
       return evolution (this, from:"Rookidee", hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -3594,7 +3594,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             flip 3, { damage 40 }
           }
         }
-      };
+      }
       case CORVIKNIGHT_156:
       return evolution (this, from:"Corvisquire", hp:HP160, type:C, retreatCost:2) {
         weakness L
@@ -3619,7 +3619,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case BIG_PARASOL_157:
       return pokemonTool (this) {
         text "As long as the Pokémon this card is attached to is in the Active Spot, prevent all effects of attacks from your opponent’s Pokémon done to all of your Pokémon. (Existing effects are not removed. Damage is not an effect.)"
@@ -3642,7 +3642,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case BILLOWING_SMOKE_158:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to is Knocked Out by damage from an attack from your opponent’s Pokémon, that player discards any Prize cards they would take for that Knock Out instead of putting those cards into their hand."
@@ -3706,7 +3706,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           eff1.unregister()
         }
-      };
+      }
       case BIRD_KEEPER_159:
       return supporter (this) {
         text "Switch your Active Pokémon with 1 of your Benched Pokémon. If you do, draw 3 cards."
@@ -3733,7 +3733,7 @@ public enum DarknessAblaze implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CAPE_OF_TOUGHNESS_160:
       return pokemonTool (this) {
         text "The Basic Pokémon this card is attached to gets +50 HP, except Pokémon-GX."
@@ -3748,7 +3748,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case FAMILIAR_BELL_161:
       return itemCard (this) {
         text "Search your deck for a Pokémon with the same name as a Pokémon in your discard pile, reveal it, and put it into your hand. Then, shuffle your deck."
@@ -3764,7 +3764,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           assert my.deck : "You have no cards in your deck"
           assert my.discard.filterByType(POKEMON) : "You have no Pokémon in your discard pile"
         }
-      };
+      }
       case GLIMWOOD_TANGLE_162:
       return stadium (this) {
         text "Once during each player’s turn, after that player flips any coins for an attack, they may ignore all results of those coin flips and begin flipping those coins again."
@@ -3796,7 +3796,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case KABU_163:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, draw 4 cards. If your Active Pokémon if your only Pokémon in play, draw 8 cards instead."
@@ -3807,7 +3807,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         playRequirement{
           assert my.hand || my.deck : "No cards in hand or in deck"
         }
-      };
+      }
       case OLD_PC_164:
       return itemCard (this) {
         text "Flip 2 coins. If both are heads, put a card from your discard pile into your hand."
@@ -3821,7 +3821,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         playRequirement{
           assert my.discard : "You have no cards in your discard pile"
         }
-      };
+      }
       case PIERS_165:
       return supporter (this) {
         text "Search your deck for an Energy card and a [D] Pokémon, reveal them, and put them into your hand. Then, shuffle your deck."
@@ -3840,7 +3840,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           playRequirement{
             assert my.deck.notEmpty : "Deck is empty"
           }
-      };
+      }
       case POKEMON_BREEDER_S_NURTURING_166:
       return supporter (this) {
         text "Choose up to 2 of your Pokémon in play. For each of those Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. You can’t use this card during your first turn or on a Pokémon that was put into play this turn."
@@ -3885,7 +3885,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           assert my.all.any{bg().gm().hasEvolution(it.name)} : "No Pokémon with evolutions in play"
           assert my.all.any{it.turnCount < bg.turnCount && it.lastEvolved < bg.turnCount && bg().gm().hasEvolution(it.name)} : "Cannot use this on Pokémon put into play this turn"
         }
-      };
+      }
       case RARE_FOSSIL_167:
       return itemCard (this) {
         text "Play this card as if it were a 70-HP Basic [C] Pokémon. At any time during your turn, you may discard this card from play. This card can’t be affected by any Special Conditions, and it can’t retreat."
@@ -3942,7 +3942,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         playRequirement{
           assert bench.notFull
         }
-      };
+      }
       case ROSE_168:
       return supporter (this) {
         text "Attach up to 2 basic Energy cards from your discard pile to 1 of your Pokémon VMAX. If you attached any Energy cards in this way, discard your hand."
@@ -3954,7 +3954,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           assertMyAll(hasVariants: VMAX)
           assert my.discard.filterByType(BASIC_ENERGY) : "No Basic Energy in your discard pile"
         }
-      };
+      }
       case ROSE_TOWER_169:
       return stadium (this) {
         text "Once during each player’s turn, that player may draw cards until they have 3 cards in their hand."
@@ -3973,7 +3973,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case SPIKEMUTH_170:
       return stadium (this) {
         text "Whenever a player’s Active Pokémon moves to the Bench during their turn, put 2 damage counters on that Pokémon."
@@ -3996,7 +3996,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case STRUGGLE_GLOVES_171:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to has Weakness to your opponent’s Active Pokémon’s type, its attacks do 30 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
@@ -4023,7 +4023,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           increasedDmgEff.unregister()
         }
-      };
+      }
       case TURBO_PATCH_172:
       return itemCard (this) {
         text "Flip a coin. If heads, attach a basic Energy card from your discard pile to 1 of your Basic Pokémon that isn’t a Pokémon-GX."
@@ -4036,7 +4036,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           assert my.all.findAll{it.basic && !(it.pokemonGX)} : "You have no Basic Pokémon that aren't Pokémon-GX"
           assert my.discard.filterByType(BASIC_ENERGY) : "There are no basic Energy cards in your discard pile"
         }
-      };
+      }
       case YELL_HORN_173:
       return itemCard (this) {
         text "Both Active Pokémon are now Confused."
@@ -4047,7 +4047,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         playRequirement{
           assert !(opp.active.isSPC(CONFUSED) && my.active.isSPC(CONFUSED)) : "Both Active Pokémon are already confused"
         }
-      };
+      }
       case HEAT_FIRE_ENERGY_174:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon, it provides [R] Energy. The [R] Pokémon this card is attached to gets +20 HP."
@@ -4076,7 +4076,7 @@ public enum DarknessAblaze implements LogicCardInfo {
           if (eff1 != null) eff1.unregister()
           eff2.unregister()
         }
-      };
+      }
       case HIDING_DARKNESS_ENERGY_175:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon, it provides [D] Energy. The [D] Pokémon this card is attached to has no Retreat Cost."
@@ -4095,7 +4095,7 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case POWERFUL_COLORLESS_ENERGY_176:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon, it provides [C] Energy. The attacks of the [C] Pokémon this card is attached to do 20 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
@@ -4121,59 +4121,59 @@ public enum DarknessAblaze implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case BUTTERFREE_V_177:
-      return copy (BUTTERFREE_V_1, this);
+      return copy (BUTTERFREE_V_1, this)
       case HOUNDOOM_V_178:
-      return copy (HOUNDOOM_V_21, this);
+      return copy (HOUNDOOM_V_21, this)
       case CENTISKORCH_V_179:
-      return copy (CENTISKORCH_V_33, this);
+      return copy (CENTISKORCH_V_33, this)
       case VIKAVOLT_V_180:
-      return copy (VIKAVOLT_V_60, this);
+      return copy (VIKAVOLT_V_60, this)
       case RHYPERIOR_V_181:
-      return copy (RHYPERIOR_V_95, this);
+      return copy (RHYPERIOR_V_95, this)
       case CROBAT_V_182:
-      return copy (CROBAT_V_104, this);
+      return copy (CROBAT_V_104, this)
       case SCIZOR_V_183:
-      return copy (SCIZOR_V_118, this);
+      return copy (SCIZOR_V_118, this)
       case GALARIAN_STUNFISK_V_184:
-      return copy (GALARIAN_STUNFISK_V_128, this);
+      return copy (GALARIAN_STUNFISK_V_128, this)
       case SALAMENCE_V_185:
-      return copy (SALAMENCE_V_143, this);
+      return copy (SALAMENCE_V_143, this)
       case KABU_186:
-      return copy (KABU_163, this);
+      return copy (KABU_163, this)
       case PIERS_187:
-      return copy (PIERS_165, this);
+      return copy (PIERS_165, this)
       case POKEMON_BREEDER_S_NURTURING_188:
-      return copy (POKEMON_BREEDER_S_NURTURING_166, this);
+      return copy (POKEMON_BREEDER_S_NURTURING_166, this)
       case ROSE_189:
-      return copy (ROSE_168, this);
+      return copy (ROSE_168, this)
       case BUTTERFREE_VMAX_190:
-      return copy (BUTTERFREE_VMAX_2, this);
+      return copy (BUTTERFREE_VMAX_2, this)
       case CENTISKORCH_VMAX_191:
-      return copy (CENTISKORCH_VMAX_34, this);
+      return copy (CENTISKORCH_VMAX_34, this)
       case ETERNATUS_VMAX_192:
-      return copy (ETERNATUS_VMAX_117, this);
+      return copy (ETERNATUS_VMAX_117, this)
       case SCIZOR_VMAX_193:
-      return copy (SCIZOR_VMAX_119, this);
+      return copy (SCIZOR_VMAX_119, this)
       case SALAMENCE_VMAX_194:
-      return copy (SALAMENCE_VMAX_144, this);
+      return copy (SALAMENCE_VMAX_144, this)
       case POKEMON_BREEDER_S_NURTURING_195:
-      return copy (POKEMON_BREEDER_S_NURTURING_166, this);
+      return copy (POKEMON_BREEDER_S_NURTURING_166, this)
       case ROSE_196:
-      return copy (ROSE_168, this);
+      return copy (ROSE_168, this)
       case RILLABOOM_197:
-      return copy (SwordShield.RILLABOOM_14, this);
+      return copy (SwordShield.RILLABOOM_14, this)
       case COALOSSAL_198:
-      return copy (RebelClash.COALOSSAL_107, this);
+      return copy (RebelClash.COALOSSAL_107, this)
       case BIG_PARASOL_199:
-      return copy (BIG_PARASOL_157, this);
+      return copy (BIG_PARASOL_157, this)
       case TURBO_PATCH_200:
-      return copy (TURBO_PATCH_172, this);
+      return copy (TURBO_PATCH_172, this)
       case CAPTURE_ENERGY_201:
-      return copy (RebelClash.CAPTURE_ENERGY_171, this);
+      return copy (RebelClash.CAPTURE_ENERGY_171, this)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/EeveeHeroes.groovy
+++ b/src/tcgwars/logic/impl/gen8/EeveeHeroes.groovy
@@ -2,16 +2,16 @@ package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.card.pokemon.PokemonCard
 import tcgwars.logic.effect.EffectPriority
-import tcgwars.logic.effect.gm.Attack;
+import tcgwars.logic.effect.gm.Attack
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
 import static tcgwars.logic.card.CardType.*
-import static tcgwars.logic.effect.EffectPriority.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.effect.EffectPriority.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
@@ -124,53 +124,53 @@ public enum EeveeHeroes implements LogicCardInfo {
   GORDIE_97 ("Gordie", "97", Rarity.UNCOMMON, [TRAINER, SUPPORTER]),
   RAPID_SHAKE_98 ("Rapid Shake", "98", Rarity.UNCOMMON, [TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   EeveeHeroes(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.EEVEE_HEROES;
+    return tcgwars.logic.card.Collection.EEVEE_HEROES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -197,7 +197,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case LEAFEON_V_2:
       return basic (this, hp:HP200, type:G, retreatCost:1) {
         weakness R
@@ -219,7 +219,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip { damage 60 }
           }
         }
-      };
+      }
       case LEAFEON_VMAX_3:
       return evolution (this, from:"Leafeon V", hp:HP310, type:G, retreatCost:2) {
         weakness R
@@ -241,7 +241,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case SEWADDLE_4:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -253,7 +253,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             discardDefendingEnergyAfterDamage G
           }
         }
-      };
+      }
       case SWADLOON_5:
       return evolution (this, from:"Sewaddle", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -272,7 +272,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case LEAVANNY_6:
       return evolution (this, from:"Swadloon", hp:HP130, type:G, retreatCost:1) {
         weakness R
@@ -294,7 +294,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case DEWPIDER_7:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -305,7 +305,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ARAQUANID_8:
       return evolution (this, from:"Dewpider", hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -324,7 +324,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.bench.select("Move an Energy from $self to which Benched Pokémon?")
           }
         }
-      };
+      }
       case GOSSIFLEUR_9:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -336,7 +336,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             heal 10, self
           }
         }
-      };
+      }
       case ELDEGOSS_10:
       return evolution (this, from:"Gossifleur", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -359,7 +359,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             reduceDamageNextTurn hp(30), thisMove
           }
         }
-      };
+      }
       case FLAREON_V_11:
       return basic (this, hp:HP210, type:R, retreatCost:2) {
         weakness W
@@ -381,7 +381,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             applyAfterDamage BURNED
           }
         }
-      };
+      }
       case SLUGMA_12:
       return basic (this, hp:HP080, type:R, retreatCost:3) {
         weakness W
@@ -399,7 +399,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGCARGO_13:
       return evolution (this, from:"Slugma", hp:HP130, type:R, retreatCost:3) {
         weakness W
@@ -421,7 +421,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             discardSelfEnergyAfterDamage types
           }
         }
-      };
+      }
       case ENTEI_14:
       return basic (this, hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -443,7 +443,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case VAPOREON_V_15:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness L
@@ -465,7 +465,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             switchYourActive()
           }
         }
-      };
+      }
       case MARILL_16:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -484,7 +484,7 @@ public enum EeveeHeroes implements LogicCardInfo {
           energyCost C, C
           damageForEachCardWithMove thisMove.name, 20, my.bench, delegate
         }
-      };
+      }
       case AZUMARILL_17:
       return evolution (this, from:"Marill", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -507,7 +507,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case MANTINE_18:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -526,7 +526,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case MUDKIP_19:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -544,7 +544,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MARSHTOMP_20:
       return evolution (this, from:"Mudkip", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -563,7 +563,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             moveSelfEnergyAfterDamage hand
           }
         }
-      };
+      }
       case SWAMPERT_21:
       return evolution (this, from:"Marshtomp", hp:HP170, type:W, retreatCost:3) {
         weakness L
@@ -586,7 +586,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FEEBAS_22:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -597,7 +597,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip 3, { damage 10 }
           }
         }
-      };
+      }
       case MILOTIC_23:
       return evolution (this, from:"Feebas", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -618,7 +618,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip 2, { damage 70 }
           }
         }
-      };
+      }
       case GLACEON_V_24:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness M
@@ -637,7 +637,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GLACEON_VMAX_25:
       return evolution (this, from:"Glaceon V", hp:HP310, type:W, retreatCost:2) {
         weakness M
@@ -666,7 +666,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PIKACHU_26:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -687,7 +687,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RAICHU_27:
       return evolution (this, from:"Pikachu", hp:HP130, type:L, retreatCost:2) {
         weakness F
@@ -713,7 +713,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VOLTORB_28:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -724,7 +724,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case ELECTRODE_29:
       return evolution (this, from:"Voltorb", hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -743,7 +743,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 90, self
           }
         }
-      };
+      }
       case JOLTEON_V_30:
       return basic (this, hp:HP190, type:L, retreatCost:0) {
         weakness F
@@ -761,7 +761,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip 4, { damage 60 }
           }
         }
-      };
+      }
       case ROTOM_31:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -786,7 +786,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TYNAMO_32:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -804,7 +804,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EELEKTRIK_33:
       return evolution (this, from:"Tynamo", hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -823,7 +823,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case EELEKTROSS_34:
       return evolution (this, from:"Eelektrik", hp:HP160, type:L, retreatCost:3) {
         weakness F
@@ -845,7 +845,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case ESPEON_V_35:
       return basic (this, hp:HP200, type:P, retreatCost:1) {
         weakness D
@@ -867,7 +867,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case MAWILE_36:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness M
@@ -880,7 +880,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             defendingRetreatsCostsMore defending, 1
           }
         }
-      };
+      }
       case FLABEBE_37:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness M
@@ -894,7 +894,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case FLOETTE_38:
       return evolution (this, from:"Flabébé", hp:HP070, type:P, retreatCost:1) {
         weakness M
@@ -912,7 +912,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case FLORGES_39:
       return evolution (this, from:"Floette", hp:HP130, type:P, retreatCost:2) {
         weakness M
@@ -933,7 +933,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case SYLVEON_V_40:
       return basic (this, hp:HP200, type:P, retreatCost:1) {
         weakness M
@@ -956,7 +956,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SYLVEON_VMAX_41:
       return evolution (this, from:"Sylveon V", hp:HP310, type:P, retreatCost:2) {
         weakness M
@@ -986,7 +986,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SANDYGAST_42:
       return basic (this, hp:HP080, type:P, retreatCost:3) {
         weakness D
@@ -1005,7 +1005,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PALOSSAND_43:
       return evolution (this, from:"Sandygast", hp:HP140, type:P, retreatCost:4) {
         weakness D
@@ -1027,7 +1027,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             new Knockout(defending).run(bg)
           }
         }
-      };
+      }
       case MARSHADOW_44:
       return basic (this, hp:HP080, type:P, retreatCost:1) {
         weakness D
@@ -1052,7 +1052,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             additionalPrizesIfDefendingKnockedOutNextTurn 1, delegate
           }
         }
-      };
+      }
       case INDEEDEE_45:
       return basic (this, hp:HP100, type:P, retreatCost:1) {
         weakness D
@@ -1069,7 +1069,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case PANCHAM_46:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -1090,7 +1090,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case UMBREON_V_47:
       return basic (this, hp:HP200, type:D, retreatCost:2) {
         weakness G
@@ -1110,7 +1110,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             if (self.numberOfDamageCounters) damage 100
           }
         }
-      };
+      }
       case UMBREON_VMAX_48:
       return evolution (this, from:"Umbreon V", hp:HP310, type:D, retreatCost:2) {
         weakness G
@@ -1133,7 +1133,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 160
           }
         }
-      };
+      }
       case ZORUA_49:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -1144,7 +1144,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ZOROARK_50:
       return evolution (this, from:"Zorua", hp:HP120, type:D, retreatCost:2) {
         weakness G
@@ -1166,7 +1166,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case PANGORO_51:
       return evolution (this, from:"Pancham", hp:HP140, type:D, retreatCost:4) {
         weakness G
@@ -1188,7 +1188,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case IMPIDIMP_52:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -1200,7 +1200,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case MORGREM_53:
       return evolution (this, from:"Impidimp", hp:HP090, type:D, retreatCost:2) {
         weakness G
@@ -1219,7 +1219,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip { discardDefendingEnergyAfterDamage C }
           }
         }
-      };
+      }
       case GRIMMSNARL_54:
       return evolution (this, from:"Morgrem", hp:HP170, type:D, retreatCost:3) {
         weakness G
@@ -1238,7 +1238,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             if (bench.size() <= 2) damage 140
           }
         }
-      };
+      }
       case MEOWTH_55:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1250,7 +1250,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             draw 1
           }
         }
-      };
+      }
       case PERSIAN_56:
       return evolution (this, from:"Meowth", hp:HP110, type:C, retreatCost:1) {
         weakness F
@@ -1269,7 +1269,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case KANGASKHAN_57:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -1288,7 +1288,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             flip { damage 100 }
           }
         }
-      };
+      }
       case EEVEE_58:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1309,7 +1309,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SMEARGLE_59:
       return basic (this, hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1333,7 +1333,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RAPID_SHAKE_60:
       return itemCard (this) {
         text "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon to evolve it. Then" +
@@ -1353,7 +1353,7 @@ public enum EeveeHeroes implements LogicCardInfo {
           assert my.deck : "Your deck is empty"
           assert my.all.any { bg().gm().hasEvolution it.name } : "No Pokémon that evolve in play"
         }
-      };
+      }
       case DREAM_BALL_61:
       return itemCard (this) {
         text "You can play this card only if you took it as a face-down Prize card" +
@@ -1380,7 +1380,7 @@ public enum EeveeHeroes implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ELEMENTAL_BADGE_62:
       return pokemonTool (this) {
         text "If the Pokémon V this card is attached to has 'Flareon'" +
@@ -1404,7 +1404,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case SNOW_LEAF_BADGE_63:
       return pokemonTool (this) {
         text "If the Pokémon V this card is attached to has 'Leafeon' or 'Glaceon' in its name," +
@@ -1427,7 +1427,7 @@ public enum EeveeHeroes implements LogicCardInfo {
           eff1.unregister()
           eff2.unregister()
         }
-      };
+      }
       case MOON_AND_SUN_BADGE_64:
       return pokemonTool (this) {
         text "If the Pokémon V this card is attached to has 'Espeon' or 'Umbreon' in its name" +
@@ -1461,7 +1461,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RIBBON_BADGE_65:
       return pokemonTool (this) {
         text "If the Pokémon V this card is attached to has 'Sylveon' in its name and is Knocked Out by damage from an opponent's attack" +
@@ -1478,7 +1478,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case AROMA_LADY_66:
       return supporter (this) {
         text "Draw 2 cards. Then" +
@@ -1490,7 +1490,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         playRequirement{
           assert deck : "Your deck is empty"
         }
-      };
+      }
       case GORDIE_67:
       return supporter (this) {
         text "Look at the top 7 cards of your deck" +
@@ -1506,7 +1506,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         playRequirement{
           assert deck : "Your deck is empty"
         }
-      };
+      }
       case FASHION_MALL_68:
       return stadium (this) {
         text "Once during each player's turn" +
@@ -1533,7 +1533,7 @@ public enum EeveeHeroes implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg.gm().unregisterAction it }
         }
-      };
+      }
       case TREASURE_ENERGY_69:
       return specialEnergy (this, [[]]) {
         text "As long as this card is attached to a Pokémon" +
@@ -1563,67 +1563,67 @@ public enum EeveeHeroes implements LogicCardInfo {
         getEnergyTypesOverride {
           self != null ? [C] : []
         }
-      };
+      }
       case LEAFEON_V_70:
-      return copy (LEAFEON_V_2, this);
+      return copy (LEAFEON_V_2, this)
       case LEAFEON_V_71:
-      return copy (LEAFEON_V_2, this);
+      return copy (LEAFEON_V_2, this)
       case FLAREON_V_72:
-      return copy (FLAREON_V_11, this);
+      return copy (FLAREON_V_11, this)
       case FLAREON_V_73:
-      return copy (FLAREON_V_11, this);
+      return copy (FLAREON_V_11, this)
       case VAPOREON_V_74:
-      return copy (VAPOREON_V_15, this);
+      return copy (VAPOREON_V_15, this)
       case VAPOREON_V_75:
-      return copy (VAPOREON_V_15, this);
+      return copy (VAPOREON_V_15, this)
       case GLACEON_V_76:
-      return copy (GLACEON_V_24, this);
+      return copy (GLACEON_V_24, this)
       case GLACEON_V_77:
-      return copy (GLACEON_V_24, this);
+      return copy (GLACEON_V_24, this)
       case JOLTEON_V_78:
-      return copy (JOLTEON_V_30, this);
+      return copy (JOLTEON_V_30, this)
       case JOLTEON_V_79:
-      return copy (JOLTEON_V_30, this);
+      return copy (JOLTEON_V_30, this)
       case ESPEON_V_80:
-      return copy (ESPEON_V_35, this);
+      return copy (ESPEON_V_35, this)
       case ESPEON_V_81:
-      return copy (ESPEON_V_35, this);
+      return copy (ESPEON_V_35, this)
       case SYLVEON_V_82:
-      return copy (SYLVEON_V_40, this);
+      return copy (SYLVEON_V_40, this)
       case SYLVEON_V_83:
-      return copy (SYLVEON_V_40, this);
+      return copy (SYLVEON_V_40, this)
       case UMBREON_V_84:
-      return copy (UMBREON_V_47, this);
+      return copy (UMBREON_V_47, this)
       case UMBREON_V_85:
-      return copy (UMBREON_V_47, this);
+      return copy (UMBREON_V_47, this)
       case AROMA_LADY_86:
-      return copy (AROMA_LADY_66, this);
+      return copy (AROMA_LADY_66, this)
       case GORDIE_87:
-      return copy (GORDIE_67, this);
+      return copy (GORDIE_67, this)
       case LEAFEON_VMAX_88:
-      return copy (LEAFEON_VMAX_3, this);
+      return copy (LEAFEON_VMAX_3, this)
       case LEAFEON_VMAX_89:
-      return copy (LEAFEON_VMAX_3, this);
+      return copy (LEAFEON_VMAX_3, this)
       case GLACEON_VMAX_90:
-      return copy (GLACEON_VMAX_25, this);
+      return copy (GLACEON_VMAX_25, this)
       case GLACEON_VMAX_91:
-      return copy (GLACEON_VMAX_25, this);
+      return copy (GLACEON_VMAX_25, this)
       case SYLVEON_VMAX_92:
-      return copy (SYLVEON_VMAX_41, this);
+      return copy (SYLVEON_VMAX_41, this)
       case SYLVEON_VMAX_93:
-      return copy (SYLVEON_VMAX_41, this);
+      return copy (SYLVEON_VMAX_41, this)
       case UMBREON_VMAX_94:
-      return copy (UMBREON_VMAX_48, this);
+      return copy (UMBREON_VMAX_48, this)
       case UMBREON_VMAX_95:
-      return copy (UMBREON_VMAX_48, this);
+      return copy (UMBREON_VMAX_48, this)
       case AROMA_LADY_96:
-      return copy (AROMA_LADY_66, this);
+      return copy (AROMA_LADY_66, this)
       case GORDIE_97:
-      return copy (GORDIE_67, this);
+      return copy (GORDIE_67, this)
       case RAPID_SHAKE_98:
-      return copy (RAPID_SHAKE_60, this);
+      return copy (RAPID_SHAKE_60, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/EeveeHeroesVmaxSpecialSet.groovy
+++ b/src/tcgwars/logic/impl/gen8/EeveeHeroesVmaxSpecialSet.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen8;
+package tcgwars.logic.impl.gen8
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -40,53 +40,53 @@ public enum EeveeHeroesVmaxSpecialSet implements LogicCardInfo {
   JOLTEON_VMAX_3 ("Jolteon VMAX", "3", Rarity.HOLORARE, [POKEMON, EVOLUTION, POKEMON_V, VMAX, _LIGHTNING_]),
   ESPEON_VMAX_4 ("Espeon VMAX", "4", Rarity.HOLORARE, [POKEMON, EVOLUTION, POKEMON_V, VMAX, _PSYCHIC_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   EeveeHeroesVmaxSpecialSet(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.EEVEE_HEROES_VMAX_SPECIAL_SET;
+    return tcgwars.logic.card.Collection.EEVEE_HEROES_VMAX_SPECIAL_SET
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -107,7 +107,7 @@ public enum EeveeHeroesVmaxSpecialSet implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_VMAX_2:
       return evolution (this, from:"Vaporeon V", hp:HP320, type:W, retreatCost:2) {
         weakness L
@@ -127,7 +127,7 @@ public enum EeveeHeroesVmaxSpecialSet implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case JOLTEON_VMAX_3:
       return evolution (this, from:"Jolteon V", hp:HP300, type:L, retreatCost:0) {
         weakness F
@@ -139,7 +139,7 @@ public enum EeveeHeroesVmaxSpecialSet implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case ESPEON_VMAX_4:
       return evolution (this, from:"Espeon V", hp:HP310, type:P, retreatCost:2) {
         weakness D
@@ -157,9 +157,9 @@ public enum EeveeHeroesVmaxSpecialSet implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/EvolvingSkies.groovy
+++ b/src/tcgwars/logic/impl/gen8/EvolvingSkies.groovy
@@ -1,15 +1,15 @@
 package tcgwars.logic.impl.gen8
 
 import tcgwars.logic.effect.gm.Attack
-import tcgwars.logic.impl.gen3.TeamRocketReturns;
+import tcgwars.logic.impl.gen3.TeamRocketReturns
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
+import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
@@ -261,66 +261,66 @@ enum EvolvingSkies implements LogicCardInfo {
   DARKNESS_ENERGY_236("Darkness Energy", "236", Rarity.SECRET, [ENERGY, BASIC_ENERGY]),
   METAL_ENERGY_237("Metal Energy", "237", Rarity.SECRET, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   EvolvingSkies(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   String getName() {
-    return name;
+    return name
   }
 
   @Override
   Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.EVOLVING_SKIES;
+    return tcgwars.logic.card.Collection.EVOLVING_SKIES
   }
 
   @Override
   String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   Card getImplementation() {
     switch (this) {
       case PINSIR_1:
-        return copy(EeveeHeroes.PINSIR_1, this);
+        return copy(EeveeHeroes.PINSIR_1, this)
       case HOPPIP_2:
-        return copy(BlueSkyStream.HOPPIP_1, this);
+        return copy(BlueSkyStream.HOPPIP_1, this)
       case SKIPLOOM_3:
-        return copy(BlueSkyStream.SKIPLOOM_2, this);
+        return copy(BlueSkyStream.SKIPLOOM_2, this)
       case JUMPLUFF_4:
-        return copy(BlueSkyStream.JUMPLUFF_3, this);
+        return copy(BlueSkyStream.JUMPLUFF_3, this)
       case SEEDOT_5:
         return basic(this, hp: HP050, type: G, retreatCost: 1) {
           weakness FIRE
@@ -329,13 +329,13 @@ enum EvolvingSkies implements LogicCardInfo {
             energyCost COLORLESS, COLORLESS
             astonish()
           }
-        };
+        }
       case TROPIUS_6:
-        return copy(BlueSkyStream.TROPIUS_4, this);
+        return copy(BlueSkyStream.TROPIUS_4, this)
       case LEAFEON_V_7:
-        return copy(EeveeHeroes.LEAFEON_V_2, this);
+        return copy(EeveeHeroes.LEAFEON_V_2, this)
       case LEAFEON_VMAX_8:
-        return copy(EeveeHeroes.LEAFEON_VMAX_3, this);
+        return copy(EeveeHeroes.LEAFEON_VMAX_3, this)
       case PETILIL_9:
         return basic(this, hp: HP060, type: G, retreatCost: 1) {
           weakness FIRE
@@ -346,7 +346,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case LILLIGANT_10:
         return evolution(this, from: "Petilil", hp: HP100, type: G, retreatCost: 1) {
           weakness FIRE
@@ -358,7 +358,7 @@ enum EvolvingSkies implements LogicCardInfo {
               flip 1, { applyAfterDamage ASLEEP }, { applyAfterDamage CONFUSED }
             }
           }
-        };
+        }
       case DWEBBLE_11:
         return basic(this, hp: HP060, type: G, retreatCost: 2) {
           weakness FIRE
@@ -377,7 +377,7 @@ enum EvolvingSkies implements LogicCardInfo {
               flip { damage 30 }
             }
           }
-        };
+        }
       case CRUSTLE_12:
         return evolution(this, from: "Dwebble", hp: HP130, type: G, retreatCost: 3) {
           weakness FIRE
@@ -396,25 +396,25 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 130
             }
           }
-        };
+        }
       case TREVENANT_V_13:
-        return copy(BlueSkyStream.TREVENANT_V_7, this);
+        return copy(BlueSkyStream.TREVENANT_V_7, this)
       case TREVENANT_VMAX_14:
-        return copy(BlueSkyStream.TREVENANT_VMAX_8, this);
+        return copy(BlueSkyStream.TREVENANT_VMAX_8, this)
       case GOSSIFLEUR_15:
-        return copy(EeveeHeroes.GOSSIFLEUR_9, this);
+        return copy(EeveeHeroes.GOSSIFLEUR_9, this)
       case ELDEGOSS_16:
-        return copy(EeveeHeroes.ELDEGOSS_10, this);
+        return copy(EeveeHeroes.ELDEGOSS_10, this)
       case APPLIN_17:
-        return copy(BlueSkyStream.APPLIN_9, this);
+        return copy(BlueSkyStream.APPLIN_9, this)
       case FLAREON_VMAX_18:
-        return copy(EeveeHeroesVmaxSpecialSet.FLAREON_VMAX_1, this);
+        return copy(EeveeHeroesVmaxSpecialSet.FLAREON_VMAX_1, this)
       case ENTEI_19:
-        return copy(EeveeHeroes.ENTEI_14, this);
+        return copy(EeveeHeroes.ENTEI_14, this)
       case VICTINI_20:
-        return copy(BlueSkyStream.VICTINI_12, this);
+        return copy(BlueSkyStream.VICTINI_12, this)
       case VOLCARONA_V_21:
-        return copy(BlueSkyStream.VOLCARONA_V_15, this);
+        return copy(BlueSkyStream.VOLCARONA_V_15, this)
       case LITLEO_22:
         return basic(this, hp: HP060, type: R, retreatCost: 1) {
           weakness WATER
@@ -425,7 +425,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case PYROAR_23:
         return evolution(this, from: "Litleo", hp: HP130, type: R, retreatCost: 2) {
           weakness WATER
@@ -444,7 +444,7 @@ enum EvolvingSkies implements LogicCardInfo {
               discardDefendingEnergyAfterDamage()
             }
           }
-        };
+        }
       case PSYDUCK_24:
         return basic(this, hp: HP070, type: W, retreatCost: 2) {
           weakness LIGHTNING
@@ -455,7 +455,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case GOLDUCK_25:
         return evolution(this, from: "Psyduck", hp: HP120, type: W, retreatCost: 1) {
           weakness LIGHTNING
@@ -474,7 +474,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 70
             }
           }
-        };
+        }
       case TENTACOOL_26:
         return basic(this, hp: HP060, type: W, retreatCost: 1) {
           weakness LIGHTNING
@@ -485,7 +485,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 30
             }
           }
-        };
+        }
       case TENTACRUEL_27:
         return evolution(this, from: "Tentacool", hp: HP120, type: W, retreatCost: 2) {
           weakness LIGHTNING
@@ -505,21 +505,21 @@ enum EvolvingSkies implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case GYARADOS_V_28:
-        return copy(BlueSkyStream.GYARADOS_V_20, this);
+        return copy(BlueSkyStream.GYARADOS_V_20, this)
       case GYARADOS_VMAX_29:
-        return copy(BlueSkyStream.GYARADOS_VMAX_21, this);
+        return copy(BlueSkyStream.GYARADOS_VMAX_21, this)
       case VAPOREON_VMAX_30:
-        return copy(EeveeHeroesVmaxSpecialSet.VAPOREON_VMAX_2, this);
+        return copy(EeveeHeroesVmaxSpecialSet.VAPOREON_VMAX_2, this)
       case SUICUNE_V_31:
-        return copy(SkyscrapingPerfection.SUICUNE_V_1, this);
+        return copy(SkyscrapingPerfection.SUICUNE_V_1, this)
       case LOTAD_32:
-        return copy(SkyscrapingPerfection.LOTAD_2, this);
+        return copy(SkyscrapingPerfection.LOTAD_2, this)
       case LOMBRE_33:
-        return copy(SkyscrapingPerfection.LOMBRE_3, this);
+        return copy(SkyscrapingPerfection.LOMBRE_3, this)
       case LUDICOLO_34:
-        return copy(SkyscrapingPerfection.LUDICOLO_4, this);
+        return copy(SkyscrapingPerfection.LUDICOLO_4, this)
       case CARVANHA_35:
         return basic(this, hp: HP050, type: W, retreatCost: 1) {
           weakness LIGHTNING
@@ -537,7 +537,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case SHARPEDO_36:
         return evolution(this, from: "Carvanha", hp: HP120, type: W, retreatCost: 1) {
           weakness LIGHTNING
@@ -559,11 +559,11 @@ enum EvolvingSkies implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case FEEBAS_37:
-        return copy(EeveeHeroes.FEEBAS_22, this);
+        return copy(EeveeHeroes.FEEBAS_22, this)
       case MILOTIC_38:
-        return copy(EeveeHeroes.MILOTIC_23, this);
+        return copy(EeveeHeroes.MILOTIC_23, this)
       case LUVDISC_39:
         return basic(this, hp: HP070, type: W, retreatCost: 1) {
           weakness LIGHTNING
@@ -586,11 +586,11 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case GLACEON_V_40:
-        return copy(EeveeHeroes.GLACEON_V_24, this);
+        return copy(EeveeHeroes.GLACEON_V_24, this)
       case GLACEON_VMAX_41:
-        return copy(EeveeHeroes.GLACEON_VMAX_25, this);
+        return copy(EeveeHeroes.GLACEON_VMAX_25, this)
       case TYMPOLE_42:
         return basic(this, hp: HP070, type: W, retreatCost: 2) {
           weakness LIGHTNING
@@ -601,9 +601,9 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case CRYOGONAL_43:
-        return copy(BlueSkyStream.CRYOGONAL_24, this);
+        return copy(BlueSkyStream.CRYOGONAL_24, this)
       case BERGMITE_44:
         return basic(this, hp: HP070, type: W, retreatCost: 2) {
           weakness METAL
@@ -621,7 +621,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case AVALUGG_45:
         return evolution(this, from: "Bergmite", hp: HP150, type: W, retreatCost: 4) {
           weakness METAL
@@ -640,11 +640,11 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 140
             }
           }
-        };
+        }
       case WISHIWASHI_46:
-        return copy(BlueSkyStream.WISHIWASHI_25, this);
+        return copy(BlueSkyStream.WISHIWASHI_25, this)
       case EISCUE_47:
-        return copy(SkyscrapingPerfection.EISCUE_9, this);
+        return copy(SkyscrapingPerfection.EISCUE_9, this)
       case ARCTOVISH_V_48:
         return basic(this, hp: HP220, type: W, retreatCost: 2) {
           weakness LIGHTNING
@@ -666,13 +666,13 @@ enum EvolvingSkies implements LogicCardInfo {
               cantAttackNextTurn self
             }
           }
-        };
+        }
       case PIKACHU_49:
-        return copy(EeveeHeroes.PIKACHU_26, this);
+        return copy(EeveeHeroes.PIKACHU_26, this)
       case RAICHU_50:
-        return copy(EeveeHeroes.RAICHU_27, this);
+        return copy(EeveeHeroes.RAICHU_27, this)
       case JOLTEON_VMAX_51:
-        return copy(EeveeHeroesVmaxSpecialSet.JOLTEON_VMAX_3, this);
+        return copy(EeveeHeroesVmaxSpecialSet.JOLTEON_VMAX_3, this)
       case CHINCHOU_52:
         return basic(this, hp: HP070, type: L, retreatCost: 1) {
           weakness FIGHTING
@@ -683,7 +683,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case LANTURN_53:
         return evolution(this, from: "Chinchou", hp: HP120, type: L, retreatCost: 2) {
           weakness FIGHTING
@@ -702,13 +702,13 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 120
             }
           }
-        };
+        }
       case MAREEP_54:
-        return copy(BlueSkyStream.MAREEP_26, this);
+        return copy(BlueSkyStream.MAREEP_26, this)
       case FLAAFFY_55:
-        return copy(BlueSkyStream.FLAAFFY_27, this);
+        return copy(BlueSkyStream.FLAAFFY_27, this)
       case AMPHAROS_56:
-        return copy(BlueSkyStream.AMPHAROS_28, this);
+        return copy(BlueSkyStream.AMPHAROS_28, this)
       case EMOLGA_57:
         return basic(this, hp: HP070, type: L, retreatCost: null) {
           weakness FIGHTING
@@ -722,7 +722,7 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRACOZOLT_V_58:
         return basic(this, hp: HP220, type: L, retreatCost: 3) {
           weakness FIGHTING
@@ -761,7 +761,7 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DRACOZOLT_VMAX_59:
         return evolution(this, from: "Dracozolt V", hp: HP330, type: L, retreatCost: 3) {
           weakness FIGHTING
@@ -782,9 +782,9 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 200
             }
           }
-        };
+        }
       case REGIELEKI_60:
-        return copy(BlueSkyStream.REGIELEKI_33, this);
+        return copy(BlueSkyStream.REGIELEKI_33, this)
       case DROWZEE_61:
         return basic(this, hp: HP070, type: P, retreatCost: 2) {
           weakness DARKNESS
@@ -796,7 +796,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case HYPNO_62:
         return evolution(this, from: "Drowzee", hp: HP110, type: P, retreatCost: 2) {
           weakness DARKNESS
@@ -819,15 +819,15 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GALARIAN_ARTICUNO_63:
-        return copy(SkyscrapingPerfection.GALARIAN_ARTICUNO_12, this);
+        return copy(SkyscrapingPerfection.GALARIAN_ARTICUNO_12, this)
       case ESPEON_V_64:
-        return copy(EeveeHeroes.ESPEON_V_35, this);
+        return copy(EeveeHeroes.ESPEON_V_35, this)
       case ESPEON_VMAX_65:
-        return copy(EeveeHeroesVmaxSpecialSet.ESPEON_VMAX_4, this);
+        return copy(EeveeHeroesVmaxSpecialSet.ESPEON_VMAX_4, this)
       case WOBBUFFET_66:
-        return copy(SkyscrapingPerfection.WOBBUFFET_13, this);
+        return copy(SkyscrapingPerfection.WOBBUFFET_13, this)
       case SABLEYE_67:
         return basic(this, hp: HP070, type: P, retreatCost: 1) {
           weakness DARKNESS
@@ -851,7 +851,7 @@ enum EvolvingSkies implements LogicCardInfo {
               cantRetreat defending
             }
           }
-        };
+        }
       case WOOBAT_68:
         return basic(this, hp: HP060, type: P, retreatCost: 1) {
           weakness LIGHTNING
@@ -873,7 +873,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case SWOOBAT_69:
         return evolution(this, from: "Woobat", hp: HP090, type: P, retreatCost: 1) {
           weakness LIGHTNING
@@ -886,23 +886,23 @@ enum EvolvingSkies implements LogicCardInfo {
               if (opp.hand.size() == hand.size()) damage 80
             }
           }
-        };
+        }
       case GOLURK_V_70:
-        return copy(SkyscrapingPerfection.GOLURK_V_15, this);
+        return copy(SkyscrapingPerfection.GOLURK_V_15, this)
       case FLABEBE_71:
-        return copy(EeveeHeroes.FLABEBE_37, this);
+        return copy(EeveeHeroes.FLABEBE_37, this)
       case FLOETTE_72:
-        return copy(EeveeHeroes.FLOETTE_38, this);
+        return copy(EeveeHeroes.FLOETTE_38, this)
       case FLORGES_73:
-        return copy(EeveeHeroes.FLORGES_39, this);
+        return copy(EeveeHeroes.FLORGES_39, this)
       case SYLVEON_V_74:
-        return copy(EeveeHeroes.SYLVEON_V_40, this);
+        return copy(EeveeHeroes.SYLVEON_V_40, this)
       case SYLVEON_VMAX_75:
-        return copy(EeveeHeroes.SYLVEON_VMAX_41, this);
+        return copy(EeveeHeroes.SYLVEON_VMAX_41, this)
       case PUMPKABOO_76:
-        return copy(SkyscrapingPerfection.PUMPKABOO_16, this);
+        return copy(SkyscrapingPerfection.PUMPKABOO_16, this)
       case GOURGEIST_77:
-        return copy(SkyscrapingPerfection.GOURGEIST_17, this);
+        return copy(SkyscrapingPerfection.GOURGEIST_17, this)
       case CUTIEFLY_78:
         return basic(this, hp: HP030, type: P, retreatCost: null) {
           weakness METAL
@@ -913,7 +913,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case RIBOMBEE_79:
         return evolution(this, from: "Cutiefly", hp: HP070, type: P, retreatCost: null) {
           weakness METAL
@@ -925,15 +925,15 @@ enum EvolvingSkies implements LogicCardInfo {
               moveDefendingEnergyAfterDamage opp.bench
             }
           }
-        };
+        }
       case MARSHADOW_80:
-        return copy(EeveeHeroes.MARSHADOW_44, this);
+        return copy(EeveeHeroes.MARSHADOW_44, this)
       case HITMONCHAN_81:
-        return copy(SkyscrapingPerfection.HITMONCHAN_18, this);
+        return copy(SkyscrapingPerfection.HITMONCHAN_18, this)
       case GALARIAN_ZAPDOS_82:
-        return copy(SkyscrapingPerfection.GALARIAN_ZAPDOS_19, this);
+        return copy(SkyscrapingPerfection.GALARIAN_ZAPDOS_19, this)
       case MEDICHAM_V_83:
-        return copy(BlueSkyStream.MEDICHAM_V_36, this);
+        return copy(BlueSkyStream.MEDICHAM_V_36, this)
       case HIPPOPOTAS_84:
         return basic(this, hp: HP100, type: F, retreatCost: 4) {
           weakness GRASS
@@ -951,7 +951,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case HIPPOWDON_85:
         return evolution(this, from: "Hippopotas", hp: HP150, type: F, retreatCost: 4) {
           weakness GRASS
@@ -970,7 +970,7 @@ enum EvolvingSkies implements LogicCardInfo {
               discardSelfEnergyAfterDamage C, C
             }
           }
-        };
+        }
       case ROGGENROLA_86:
         return basic(this, hp: HP070, type: F, retreatCost: 3) {
           weakness GRASS
@@ -988,7 +988,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case BOLDORE_87:
         return evolution(this, from: "Roggenrola", hp: HP110, type: F, retreatCost: 4) {
           weakness GRASS
@@ -1007,7 +1007,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 60
             }
           }
-        };
+        }
       case GIGALITH_88:
         return evolution(this, from: "Boldore", hp: HP180, type: F, retreatCost: 4) {
           weakness GRASS
@@ -1027,7 +1027,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10 * self.numberOfDamageCounters, self
             }
           }
-        };
+        }
       case PALPITOAD_89:
         return evolution(this, from: "Tympole", hp: HP100, type: F, retreatCost: 3) {
           weakness GRASS
@@ -1045,7 +1045,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 50
             }
           }
-        };
+        }
       case SEISMITOAD_90:
         return evolution(this, from: "Palpitoad", hp: HP170, type: F, retreatCost: 3) {
           weakness GRASS
@@ -1065,17 +1065,17 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 160
             }
           }
-        };
+        }
       case LYCANROC_V_91:
-        return copy(SkyscrapingPerfection.LYCANROC_V_24, this);
+        return copy(SkyscrapingPerfection.LYCANROC_V_24, this)
       case LYCANROC_VMAX_92:
-        return copy(SkyscrapingPerfection.LYCANROC_VMAX_25, this);
+        return copy(SkyscrapingPerfection.LYCANROC_VMAX_25, this)
       case GALARIAN_MOLTRES_93:
-        return copy(SkyscrapingPerfection.GALARIAN_MOLTRES_26, this);
+        return copy(SkyscrapingPerfection.GALARIAN_MOLTRES_26, this)
       case UMBREON_V_94:
-        return copy(EeveeHeroes.UMBREON_V_47, this);
+        return copy(EeveeHeroes.UMBREON_V_47, this)
       case UMBREON_VMAX_95:
-        return copy(EeveeHeroes.UMBREON_VMAX_48, this);
+        return copy(EeveeHeroes.UMBREON_VMAX_48, this)
       case NUZLEAF_96:
         return evolution(this, from: "Seedot", hp: HP080, type: D, retreatCost: 1) {
           weakness GRASS
@@ -1089,7 +1089,7 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SHIFTRY_97:
         return evolution(this, from: "Nuzleaf", hp: HP150, type: D, retreatCost: 3) {
           weakness GRASS
@@ -1113,7 +1113,7 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case SCRAGGY_98:
         return basic(this, hp: HP070, type: D, retreatCost: 1) {
           weakness GRASS
@@ -1125,7 +1125,7 @@ enum EvolvingSkies implements LogicCardInfo {
               reduceDamageNextTurn hp(10), thisMove
             }
           }
-        };
+        }
       case SCRAFTY_99:
         return evolution(this, from: "Scraggy", hp: HP120, type: D, retreatCost: 2) {
           weakness GRASS
@@ -1146,59 +1146,59 @@ enum EvolvingSkies implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case GARBODOR_V_100:
-        return copy(SkyscrapingPerfection.GARBODOR_V_30, this);
+        return copy(SkyscrapingPerfection.GARBODOR_V_30, this)
       case GARBODOR_VMAX_101:
-        return copy(SkyscrapingPerfection.GARBODOR_VMAX_31, this);
+        return copy(SkyscrapingPerfection.GARBODOR_VMAX_31, this)
       case ZORUA_102:
-        return copy(EeveeHeroes.ZORUA_49, this);
+        return copy(EeveeHeroes.ZORUA_49, this)
       case ZOROARK_103:
-        return copy(EeveeHeroes.ZOROARK_50, this);
+        return copy(EeveeHeroes.ZOROARK_50, this)
       case NICKIT_104:
-        return copy(SkyscrapingPerfection.NICKIT_32, this);
+        return copy(SkyscrapingPerfection.NICKIT_32, this)
       case THIEVUL_105:
-        return copy(SkyscrapingPerfection.THIEVUL_33, this);
+        return copy(SkyscrapingPerfection.THIEVUL_33, this)
       case ALTARIA_106:
-        return copy(SkyscrapingPerfection.ALTARIA_40, this);
+        return copy(SkyscrapingPerfection.ALTARIA_40, this)
       case BAGON_107:
-        return copy(BlueSkyStream.BAGON_43, this);
+        return copy(BlueSkyStream.BAGON_43, this)
       case SHELGON_108:
-        return copy(BlueSkyStream.SHELGON_44, this);
+        return copy(BlueSkyStream.SHELGON_44, this)
       case SALAMENCE_109:
-        return copy(BlueSkyStream.SALAMENCE_45, this);
+        return copy(BlueSkyStream.SALAMENCE_45, this)
       case RAYQUAZA_V_110:
-        return copy(BlueSkyStream.RAYQUAZA_V_46, this);
+        return copy(BlueSkyStream.RAYQUAZA_V_46, this)
       case RAYQUAZA_VMAX_111:
-        return copy(BlueSkyStream.RAYQUAZA_VMAX_47, this);
+        return copy(BlueSkyStream.RAYQUAZA_VMAX_47, this)
       case DIALGA_112:
-        return copy(SkyscrapingPerfection.DIALGA_41, this);
+        return copy(SkyscrapingPerfection.DIALGA_41, this)
       case DEINO_113:
-        return copy(SkyscrapingPerfection.DEINO_42, this);
+        return copy(SkyscrapingPerfection.DEINO_42, this)
       case ZWEILOUS_114:
-        return copy(SkyscrapingPerfection.ZWEILOUS_43, this);
+        return copy(SkyscrapingPerfection.ZWEILOUS_43, this)
       case HYDREIGON_115:
-        return copy(SkyscrapingPerfection.HYDREIGON_44, this);
+        return copy(SkyscrapingPerfection.HYDREIGON_44, this)
       case KYUREM_116:
-        return copy(SkyscrapingPerfection.KYUREM_45, this);
+        return copy(SkyscrapingPerfection.KYUREM_45, this)
       case NOIVERN_V_117:
-        return copy(SkyscrapingPerfection.NOIVERN_V_46, this);
+        return copy(SkyscrapingPerfection.NOIVERN_V_46, this)
       case ZYGARDE_118:
-        return copy(BlueSkyStream.ZYGARDE_48, this);
+        return copy(BlueSkyStream.ZYGARDE_48, this)
       case DRAMPA_119:
-        return copy(SkyscrapingPerfection.DRAMPA_47, this);
+        return copy(SkyscrapingPerfection.DRAMPA_47, this)
       case FLAPPLE_120:
-        return copy(BlueSkyStream.FLAPPLE_50, this);
+        return copy(BlueSkyStream.FLAPPLE_50, this)
       case APPLETUN_121:
-        return copy(BlueSkyStream.APPLETUN_51, this);
+        return copy(BlueSkyStream.APPLETUN_51, this)
       case DURALUDON_V_122:
-        return copy(SkyscrapingPerfection.DURALUDON_V_48, this);
+        return copy(SkyscrapingPerfection.DURALUDON_V_48, this)
       case DURALUDON_VMAX_123:
-        return copy(SkyscrapingPerfection.DURALUDON_VMAX_49, this);
+        return copy(SkyscrapingPerfection.DURALUDON_VMAX_49, this)
       case REGIDRAGO_124:
-        return copy(BlueSkyStream.REGIDRAGO_52, this);
+        return copy(BlueSkyStream.REGIDRAGO_52, this)
       case EEVEE_125:
-        return copy(EeveeHeroes.EEVEE_58, this);
+        return copy(EeveeHeroes.EEVEE_58, this)
       case TEDDIURSA_126:
         return basic(this, hp: HP070, type: C, retreatCost: 2) {
           weakness FIGHTING
@@ -1209,7 +1209,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 10
             }
           }
-        };
+        }
       case URSARING_127:
         return evolution(this, from: "Teddiursa", hp: HP140, type: C, retreatCost: 3) {
           weakness FIGHTING
@@ -1227,17 +1227,17 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 110
             }
           }
-        };
+        }
       case SMEARGLE_128:
-        return copy(EeveeHeroes.SMEARGLE_59, this);
+        return copy(EeveeHeroes.SMEARGLE_59, this)
       case SLAKOTH_129:
-        return copy(SkyscrapingPerfection.SLAKOTH_50, this);
+        return copy(SkyscrapingPerfection.SLAKOTH_50, this)
       case VIGOROTH_130:
-        return copy(SkyscrapingPerfection.VIGOROTH_51, this);
+        return copy(SkyscrapingPerfection.VIGOROTH_51, this)
       case SLAKING_131:
-        return copy(SkyscrapingPerfection.SLAKING_52, this);
+        return copy(SkyscrapingPerfection.SLAKING_52, this)
       case SWABLU_132:
-        return copy(SkyscrapingPerfection.SWABLU_53, this);
+        return copy(SkyscrapingPerfection.SWABLU_53, this)
       case LILLIPUP_133:
         return basic(this, hp: HP060, type: C, retreatCost: 1) {
           weakness FIGHTING
@@ -1260,7 +1260,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20
             }
           }
-        };
+        }
       case HERDIER_134:
         return evolution(this, from: "Lillipup", hp: HP100, type: C, retreatCost: 2) {
           weakness FIGHTING
@@ -1279,7 +1279,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 20, self
             }
           }
-        };
+        }
       case STOUTLAND_135:
         return evolution(this, from: "Herdier", hp: HP160, type: C, retreatCost: 3) {
           weakness FIGHTING
@@ -1306,7 +1306,7 @@ enum EvolvingSkies implements LogicCardInfo {
               flip { damage 100 }
             }
           }
-        };
+        }
       case RUFFLET_136:
         return basic(this, hp: HP060, type: C, retreatCost: 1) {
           weakness LIGHTNING
@@ -1319,7 +1319,7 @@ enum EvolvingSkies implements LogicCardInfo {
               switchYourOpponentsBenchedWithActive()
             }
           }
-        };
+        }
       case BRAVIARY_137:
         return evolution(this, from: "Rufflet", hp: HP130, type: C, retreatCost: 1) {
           weakness LIGHTNING
@@ -1342,7 +1342,7 @@ enum EvolvingSkies implements LogicCardInfo {
               damage 50, self
             }
           }
-        };
+        }
       case FLETCHLING_138:
         return basic(this, hp: HP040, type: C, retreatCost: 1) {
           weakness LIGHTNING
@@ -1367,7 +1367,7 @@ enum EvolvingSkies implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case FLETCHINDER_139:
         return evolution(this, from: "Fletchling", hp: HP080, type: C, retreatCost: 1) {
           weakness LIGHTNING
@@ -1380,7 +1380,7 @@ enum EvolvingSkies implements LogicCardInfo {
               flip { damage 20 }
             }
           }
-        };
+        }
       case TALONFLAME_140:
         return evolution(this, from: "Fletchinder", hp: HP140, type: C, retreatCost: null) {
           weakness LIGHTNING
@@ -1401,203 +1401,203 @@ enum EvolvingSkies implements LogicCardInfo {
               if (self.cards.energyCount(R)) damage 80
             }
           }
-        };
+        }
       case AROMA_LADY_141:
-        return copy(EeveeHeroes.AROMA_LADY_66, this);
+        return copy(EeveeHeroes.AROMA_LADY_66, this)
       case BOOST_SHAKE_142:
-        return copy(EeveeHeroes.RAPID_SHAKE_60, this);
+        return copy(EeveeHeroes.RAPID_SHAKE_60, this)
       case COPYCAT_143:
-        return copy(TeamRocketReturns.COPYCAT_83, this);
+        return copy(TeamRocketReturns.COPYCAT_83, this)
       case CRYSTAL_CAVE_144:
-        return copy(SkyscrapingPerfection.CRYSTAL_CAVE_66, this);
+        return copy(SkyscrapingPerfection.CRYSTAL_CAVE_66, this)
       case DIGGING_GLOVES_145:
-        return copy(SkyscrapingPerfection.DIGGING_GLOVES_60, this);
+        return copy(SkyscrapingPerfection.DIGGING_GLOVES_60, this)
       case DREAM_BALL_146:
-        return copy(EeveeHeroes.DREAM_BALL_61, this);
+        return copy(EeveeHeroes.DREAM_BALL_61, this)
       case ELEMENTAL_BADGE_147:
-        return copy(EeveeHeroes.ELEMENTAL_BADGE_62, this);
+        return copy(EeveeHeroes.ELEMENTAL_BADGE_62, this)
       case FULL_FACE_GUARD_148:
-        return copy(SkyscrapingPerfection.FULL_FACE_GUARD_62, this);
+        return copy(SkyscrapingPerfection.FULL_FACE_GUARD_62, this)
       case GORDIE_149:
-        return copy(EeveeHeroes.GORDIE_67, this);
+        return copy(EeveeHeroes.GORDIE_67, this)
       case LUCKY_ICE_POP_150:
-        return copy(BlueSkyStream.LUCKY_ICE_POP_56, this);
+        return copy(BlueSkyStream.LUCKY_ICE_POP_56, this)
       case MOON_SUN_BADGE_151:
-        return copy(EeveeHeroes.MOON_AND_SUN_BADGE_64, this);
+        return copy(EeveeHeroes.MOON_AND_SUN_BADGE_64, this)
       case RAIHAN_152:
-        return copy(SkyscrapingPerfection.RAIHAN_63, this);
+        return copy(SkyscrapingPerfection.RAIHAN_63, this)
       case RAPID_STRIKE_SCROLL_OF_THE_FLYING_DRAGON_153:
-        return copy(BlueSkyStream.RAPID_STRIKE_SCROLL_OF_THE_FLYING_DRAGON_62, this);
+        return copy(BlueSkyStream.RAPID_STRIKE_SCROLL_OF_THE_FLYING_DRAGON_62, this)
       case RESCUE_CARRIER_154:
-        return copy(SkyscrapingPerfection.RESCUE_TROLLEY_59, this);
+        return copy(SkyscrapingPerfection.RESCUE_TROLLEY_59, this)
       case RIBBON_BADGE_155:
-        return copy(EeveeHeroes.RIBBON_BADGE_65, this);
+        return copy(EeveeHeroes.RIBBON_BADGE_65, this)
       case RUBBER_GLOVES_156:
-        return copy(BlueSkyStream.RUBBERY_GLOVES_60, this);
+        return copy(BlueSkyStream.RUBBERY_GLOVES_60, this)
       case SHOPPING_CENTER_157:
-        return copy(EeveeHeroes.FASHION_MALL_68, this);
+        return copy(EeveeHeroes.FASHION_MALL_68, this)
       case SINGLE_STRIKE_SCROLL_OF_THE_FANGED_DRAGON_158:
-        return copy(SkyscrapingPerfection.SINGLE_STRIKE_SCROLL_OF_THE_DRAGON_FANG_61, this);
+        return copy(SkyscrapingPerfection.SINGLE_STRIKE_SCROLL_OF_THE_DRAGON_FANG_61, this)
       case SNOW_LEAF_BADGE_159:
-        return copy(EeveeHeroes.SNOW_LEAF_BADGE_63, this);
+        return copy(EeveeHeroes.SNOW_LEAF_BADGE_63, this)
       case SPIRIT_MASK_160:
-        return copy(BlueSkyStream.NETHER_MASK_61, this);
+        return copy(BlueSkyStream.NETHER_MASK_61, this)
       case STORMY_MOUNTAINS_161:
-        return copy(BlueSkyStream.STORMY_MOUNTAIN_RANGE_66, this);
+        return copy(BlueSkyStream.STORMY_MOUNTAIN_RANGE_66, this)
       case SWITCHING_CUPS_162:
-        return copy(SkyscrapingPerfection.SWITCHEROO_CUP_58, this);
+        return copy(SkyscrapingPerfection.SWITCHEROO_CUP_58, this)
       case TOY_CATCHER_163:
-        return copy(BlueSkyStream.TOY_CATCHER_58, this);
+        return copy(BlueSkyStream.TOY_CATCHER_58, this)
       case ZINNIA_S_RESOLVE_164:
-        return copy(BlueSkyStream.ZINNIA_S_RESOLVE_65, this);
+        return copy(BlueSkyStream.ZINNIA_S_RESOLVE_65, this)
       case TREASURE_ENERGY_165:
-        return copy(EeveeHeroes.TREASURE_ENERGY_69, this);
+        return copy(EeveeHeroes.TREASURE_ENERGY_69, this)
       case LEAFEON_V_166:
-        return copy(LEAFEON_V_7, this);
+        return copy(LEAFEON_V_7, this)
       case LEAFEON_V_167:
-        return copy(LEAFEON_V_7, this);
+        return copy(LEAFEON_V_7, this)
       case TREVENANT_V_168:
-        return copy(TREVENANT_V_13, this);
+        return copy(TREVENANT_V_13, this)
       case FLAREON_V_169:
-        return copy(EeveeHeroes.FLAREON_V_11, this);
+        return copy(EeveeHeroes.FLAREON_V_11, this)
       case VOLCARONA_V_170:
-        return copy(VOLCARONA_V_21, this);
+        return copy(VOLCARONA_V_21, this)
       case GYARADOS_V_171:
-        return copy(GYARADOS_V_28, this);
+        return copy(GYARADOS_V_28, this)
       case VAPOREON_V_172:
-        return copy(EeveeHeroes.VAPOREON_V_15, this);
+        return copy(EeveeHeroes.VAPOREON_V_15, this)
       case SUICUNE_V_173:
-        return copy(SUICUNE_V_31, this);
+        return copy(SUICUNE_V_31, this)
       case GLACEON_V_174:
-        return copy(GLACEON_V_40, this);
+        return copy(GLACEON_V_40, this)
       case GLACEON_V_175:
-        return copy(GLACEON_V_40, this);
+        return copy(GLACEON_V_40, this)
       case ARCTOVISH_V_176:
-        return copy(ARCTOVISH_V_48, this);
+        return copy(ARCTOVISH_V_48, this)
       case JOLTEON_V_177:
-        return copy(EeveeHeroes.JOLTEON_V_30, this);
+        return copy(EeveeHeroes.JOLTEON_V_30, this)
       case DRACOZOLT_V_178:
-        return copy(DRACOZOLT_V_58, this);
+        return copy(DRACOZOLT_V_58, this)
       case ESPEON_V_179:
-        return copy(ESPEON_V_64, this);
+        return copy(ESPEON_V_64, this)
       case ESPEON_V_180:
-        return copy(ESPEON_V_64, this);
+        return copy(ESPEON_V_64, this)
       case GOLURK_V_181:
-        return copy(GOLURK_V_70, this);
+        return copy(GOLURK_V_70, this)
       case GOLURK_V_182:
-        return copy(GOLURK_V_70, this);
+        return copy(GOLURK_V_70, this)
       case SYLVEON_V_183:
-        return copy(SYLVEON_V_74, this);
+        return copy(SYLVEON_V_74, this)
       case SYLVEON_V_184:
-        return copy(SYLVEON_V_74, this);
+        return copy(SYLVEON_V_74, this)
       case MEDICHAM_V_185:
-        return copy(MEDICHAM_V_83, this);
+        return copy(MEDICHAM_V_83, this)
       case MEDICHAM_V_186:
-        return copy(MEDICHAM_V_83, this);
+        return copy(MEDICHAM_V_83, this)
       case LYCANROC_V_187:
-        return copy(LYCANROC_V_91, this);
+        return copy(LYCANROC_V_91, this)
       case UMBREON_V_188:
-        return copy(UMBREON_V_94, this);
+        return copy(UMBREON_V_94, this)
       case UMBREON_V_189:
-        return copy(UMBREON_V_94, this);
+        return copy(UMBREON_V_94, this)
       case GARBODOR_V_190:
-        return copy(GARBODOR_V_100, this);
+        return copy(GARBODOR_V_100, this)
       case DRAGONITE_V_191:
-        return copy(BlueSkyStream.DRAGONITE_V_42, this);
+        return copy(BlueSkyStream.DRAGONITE_V_42, this)
       case DRAGONITE_V_192:
-        return copy(DRAGONITE_V_191, this);
+        return copy(DRAGONITE_V_191, this)
       case RAYQUAZA_V_193:
-        return copy(RAYQUAZA_V_110, this);
+        return copy(RAYQUAZA_V_110, this)
       case RAYQUAZA_V_194:
-        return copy(RAYQUAZA_V_110, this);
+        return copy(RAYQUAZA_V_110, this)
       case NOIVERN_V_195:
-        return copy(NOIVERN_V_117, this);
+        return copy(NOIVERN_V_117, this)
       case NOIVERN_V_196:
-        return copy(NOIVERN_V_117, this);
+        return copy(NOIVERN_V_117, this)
       case DURALUDON_V_197:
-        return copy(DURALUDON_V_122, this);
+        return copy(DURALUDON_V_122, this)
       case DURALUDON_V_198:
-        return copy(DURALUDON_V_122, this);
+        return copy(DURALUDON_V_122, this)
       case AROMA_LADY_199:
-        return copy(AROMA_LADY_141, this);
+        return copy(AROMA_LADY_141, this)
       case COPYCAT_200:
-        return copy(COPYCAT_143, this);
+        return copy(COPYCAT_143, this)
       case GORDIE_201:
-        return copy(GORDIE_149, this);
+        return copy(GORDIE_149, this)
       case RAIHAN_202:
-        return copy(RAIHAN_152, this);
+        return copy(RAIHAN_152, this)
       case ZINNIA_S_RESOLVE_203:
-        return copy(ZINNIA_S_RESOLVE_164, this);
+        return copy(ZINNIA_S_RESOLVE_164, this)
       case LEAFEON_VMAX_204:
-        return copy(LEAFEON_VMAX_8, this);
+        return copy(LEAFEON_VMAX_8, this)
       case LEAFEON_VMAX_205:
-        return copy(LEAFEON_VMAX_8, this);
+        return copy(LEAFEON_VMAX_8, this)
       case TREVENANT_VMAX_206:
-        return copy(TREVENANT_VMAX_14, this);
+        return copy(TREVENANT_VMAX_14, this)
       case GYARADOS_VMAX_207:
-        return copy(GYARADOS_VMAX_29, this);
+        return copy(GYARADOS_VMAX_29, this)
       case GLACEON_VMAX_208:
-        return copy(GLACEON_VMAX_41, this);
+        return copy(GLACEON_VMAX_41, this)
       case GLACEON_VMAX_209:
-        return copy(GLACEON_VMAX_41, this);
+        return copy(GLACEON_VMAX_41, this)
       case DRACOZOLT_VMAX_210:
-        return copy(DRACOZOLT_VMAX_59, this);
+        return copy(DRACOZOLT_VMAX_59, this)
       case SYLVEON_VMAX_211:
-        return copy(SYLVEON_VMAX_75, this);
+        return copy(SYLVEON_VMAX_75, this)
       case SYLVEON_VMAX_212:
-        return copy(SYLVEON_VMAX_75, this);
+        return copy(SYLVEON_VMAX_75, this)
       case LYCANROC_VMAX_213:
-        return copy(LYCANROC_VMAX_92, this);
+        return copy(LYCANROC_VMAX_92, this)
       case UMBREON_VMAX_214:
-        return copy(UMBREON_VMAX_95, this);
+        return copy(UMBREON_VMAX_95, this)
       case UMBREON_VMAX_215:
-        return copy(UMBREON_VMAX_95, this);
+        return copy(UMBREON_VMAX_95, this)
       case GARBODOR_VMAX_216:
-        return copy(GARBODOR_VMAX_101, this);
+        return copy(GARBODOR_VMAX_101, this)
       case RAYQUAZA_VMAX_217:
-        return copy(RAYQUAZA_VMAX_111, this);
+        return copy(RAYQUAZA_VMAX_111, this)
       case RAYQUAZA_VMAX_218:
-        return copy(RAYQUAZA_VMAX_111, this);
+        return copy(RAYQUAZA_VMAX_111, this)
       case DURALUDON_VMAX_219:
-        return copy(DURALUDON_VMAX_123, this);
+        return copy(DURALUDON_VMAX_123, this)
       case DURALUDON_VMAX_220:
-        return copy(DURALUDON_VMAX_123, this);
+        return copy(DURALUDON_VMAX_123, this)
       case AROMA_LADY_221:
-        return copy(AROMA_LADY_141, this);
+        return copy(AROMA_LADY_141, this)
       case COPYCAT_222:
-        return copy(COPYCAT_143, this);
+        return copy(COPYCAT_143, this)
       case GORDIE_223:
-        return copy(GORDIE_149, this);
+        return copy(GORDIE_149, this)
       case RAIHAN_224:
-        return copy(RAIHAN_152, this);
+        return copy(RAIHAN_152, this)
       case ZINNIA_S_RESOLVE_225:
-        return copy(ZINNIA_S_RESOLVE_164, this);
+        return copy(ZINNIA_S_RESOLVE_164, this)
       case FROSLASS_226:
-        return copy(ChillingReign.FROSLASS_36, this);
+        return copy(ChillingReign.FROSLASS_36, this)
       case INTELEON_227:
-        return copy(ChillingReign.INTELEON_43, this);
+        return copy(ChillingReign.INTELEON_43, this)
       case CRESSELIA_228:
-        return copy(ChillingReign.CRESSELIA_64, this);
+        return copy(ChillingReign.CRESSELIA_64, this)
       case BOOST_SHAKE_229:
-        return copy(BOOST_SHAKE_142, this);
+        return copy(BOOST_SHAKE_142, this)
       case CRYSTAL_CAVE_230:
-        return copy(CRYSTAL_CAVE_144, this);
+        return copy(CRYSTAL_CAVE_144, this)
       case FULL_FACE_GUARD_231:
-        return copy(FULL_FACE_GUARD_148, this);
+        return copy(FULL_FACE_GUARD_148, this)
       case STORMY_MOUNTAINS_232:
-        return copy(STORMY_MOUNTAINS_161, this);
+        return copy(STORMY_MOUNTAINS_161, this)
       case TOY_CATCHER_233:
-        return copy(TOY_CATCHER_163, this);
+        return copy(TOY_CATCHER_163, this)
       case TURFFIELD_STADIUM_234:
-        return copy(RebelClash.TURRFIELD_170, this);
+        return copy(RebelClash.TURRFIELD_170, this)
       case LIGHTNING_ENERGY_235:
-        return basicEnergy(this, L);
+        return basicEnergy(this, L)
       case DARKNESS_ENERGY_236:
-        return basicEnergy(this, D);
+        return basicEnergy(this, D)
       case METAL_ENERGY_237:
-        return basicEnergy(this, M);
+        return basicEnergy(this, M)
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
+++ b/src/tcgwars/logic/impl/gen8/LegendaryHeartbeat.groovy
@@ -3,37 +3,37 @@ package tcgwars.logic.impl.gen8
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen5.EmergingPowers
 import tcgwars.logic.impl.gen5.NobleVictories
-import tcgwars.logic.impl.gen6.KalosStarterSet;
+import tcgwars.logic.impl.gen6.KalosStarterSet
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -135,53 +135,53 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
   HERO_S_MEDAL_93 ("Hero's Medal", "93", Rarity.UNCOMMON, [POKEMON_TOOL, TRAINER, ITEM]),
   CAPE_OF_TOUGHNESS_94 ("Cape of Toughness", "94", Rarity.UNCOMMON, [POKEMON_TOOL, TRAINER, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   LegendaryHeartbeat(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.LEGENDARY_HEARTBEAT;
+    return tcgwars.logic.card.Collection.LEGENDARY_HEARTBEAT
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -202,7 +202,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case KAKUNA_2:
       return evolution (this, from:"Weedle", hp:HP080, type:G, retreatCost:3) {
         weakness R
@@ -222,7 +222,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BEEDRILL_3:
       return evolution (this, from:"Kakuna", hp:HP130, type:G, retreatCost:0) {
         weakness R
@@ -255,7 +255,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case EXEGGCUTE_4:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -266,7 +266,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGUTOR_5:
       return evolution (this, from:"Exeggcute", hp:HP140, type:G, retreatCost:3) {
         weakness R
@@ -285,7 +285,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case YANMA_6:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -304,7 +304,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case YANMEGA_7:
       return evolution (this, from:"Yanma", hp:HP130, type:G, retreatCost:0) {
         weakness R
@@ -323,7 +323,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case PINECO_8:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -341,7 +341,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             flip { preventAllDamageNextTurn() }
           }
         }
-      };
+      }
       case CELEBI_9:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -370,7 +370,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case SHAYMIN_10:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -394,7 +394,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GENESECT_11:
       return basic (this, hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -414,7 +414,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case DHELMISE_12:
       return basic (this, hp:HP130, type:G, retreatCost:3) {
         weakness R
@@ -435,7 +435,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZARUDE_V_13:
       return basic (this, hp:HP210, type:G, retreatCost:1) {
         weakness R
@@ -467,7 +467,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case AMPHAROS_V_14:
       return basic (this, hp:HP210, type:L, retreatCost:3) {
         weakness F
@@ -488,7 +488,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             opp.bench.each { if(it.numberOfDamageCounters) damage(30, it) }
           }
         }
-      };
+      }
       case RAIKOU_15:
       return basic (this, hp:HP110, type:L, retreatCost:2) {
         weakness F
@@ -503,7 +503,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ELECTRIKE_16:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -524,7 +524,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MANECTRIC_17:
       return evolution (this, from:"Electrike", hp:HP120, type:L, retreatCost:0) {
         weakness F
@@ -543,7 +543,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case JOLTIK_18:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -554,7 +554,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GALVANTULA_19:
       return evolution (this, from:"Joltik", hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -576,7 +576,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20 * defending.numberOfDamageCounters
           }
         }
-      };
+      }
       case ZEKROM_20:
       return basic (this, hp:HP130, type:L, retreatCost:3) {
         weakness F
@@ -596,7 +596,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             applyAfterDamage PARALYZED
           }
         }
-      };
+      }
       case ZERAORA_21:
       return basic (this, hp:HP100, type:L, retreatCost:0) {
         weakness F
@@ -608,7 +608,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             if (defending.pokemonGX || defending.pokemonV) damage 80
           }
         }
-      };
+      }
       case PINCURCHIN_22:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -626,7 +626,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CLEFAIRY_23:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
@@ -644,7 +644,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             flip { metronome defending, delegate }
           }
         }
-      };
+      }
       case CLEFABLE_24:
       return evolution (this, from:"Clefairy", hp:HP100, type:P, retreatCost:1) {
         weakness M
@@ -670,7 +670,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case GIRAFARIG_25:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -694,7 +694,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SHUPPET_26:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -706,7 +706,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             directDamage 10, defending
           }
         }
-      };
+      }
       case BANETTE_27:
       return evolution (this, from:"Shuppet", hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -729,7 +729,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DEDENNE_28:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness M
@@ -741,7 +741,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case XERNEAS_29:
       return basic (this, hp:HP130, type:P, retreatCost:2) {
         weakness M
@@ -765,7 +765,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case DIANCIE_30:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness M
@@ -795,11 +795,11 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ALCREMIE_V_31:
-      return copy(ChampionsPath.ALCREMIE_V_22, this);
+      return copy(ChampionsPath.ALCREMIE_V_22, this)
       case ALCREMIE_VMAX_32:
-      return copy(ChampionsPath.ALCREMIE_VMAX_23, this);
+      return copy(ChampionsPath.ALCREMIE_VMAX_23, this)
       case ZACIAN_33:
       return basic (this, hp:HP110, type:P, retreatCost:2) {
         weakness M
@@ -819,7 +819,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             if (opp.all.any { it.pokemonVMAX }) damage 150
           }
         }
-      };
+      }
       case WOOPER_34:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -837,7 +837,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QUAGSIRE_35:
       return evolution (this, from:"Wooper", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -859,7 +859,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case SHUCKLE_36:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -880,7 +880,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case REGIROCK_37:
       return basic (this, hp:HP130, type:F, retreatCost:3) {
         weakness G
@@ -899,7 +899,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case RIOLU_38:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness P
@@ -910,7 +910,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case ZYGARDE_39:
       return basic (this, hp:HP150, type:F, retreatCost:4) {
         weakness G
@@ -929,7 +929,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             if (my.prizeCardSet.size() > opp.prizeCardSet.size()) damage 80
           }
         }
-      };
+      }
       case ROCKRUFF_40:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -947,7 +947,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LYCANROC_41:
       return evolution (this, from:"Rockruff", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -965,7 +965,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case COALOSSAL_V_42:
       return basic (this, hp:HP220, type:F, retreatCost:4) {
         weakness G
@@ -984,7 +984,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case COALOSSAL_VMAX_43:
       return evolution (this, from:"Coalossal V", hp:HP330, type:F, retreatCost:4) {
         weakness G
@@ -1008,7 +1008,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 240
           }
         }
-      };
+      }
       case ZAMAZENTA_44:
       return basic (this, hp:HP110, type:F, retreatCost:2) {
         weakness P
@@ -1028,7 +1028,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             preventAllDamageFromCustomPokemonNextTurn thisMove, self, { it.pokemonVMAX }
           }
         }
-      };
+      }
       case FORRETRESS_45:
       return evolution (this, from:"Pineco", hp:HP120, type:M, retreatCost:3) {
         weakness R
@@ -1051,7 +1051,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case STEELIX_V_46:
       return basic (this, hp:HP250, type:M, retreatCost:4) {
         weakness R
@@ -1072,7 +1072,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case BELDUM_47:
       return basic (this, hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -1089,7 +1089,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case METANG_48:
       return evolution (this, from:"Beldum", hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -1108,7 +1108,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case METAGROSS_49:
       return evolution (this, from:"Metang", hp:HP170, type:M, retreatCost:3) {
         weakness R
@@ -1127,7 +1127,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             if (defending.realEvolution) cantAttackNextTurn defending
           }
         }
-      };
+      }
       case JIRACHI_50:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -1156,7 +1156,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case LUCARIO_51:
       return evolution (this, from:"Riolu", hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -1177,7 +1177,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case DIALGA_52:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -1200,7 +1200,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             discardSelfEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case GALARIAN_STUNFISK_53:
       return basic (this, hp:HP120, type:M, retreatCost:3) {
         weakness R
@@ -1220,7 +1220,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case MAGEARNA_54:
       return basic (this, hp:HP090, type:M, retreatCost:1) {
         weakness R
@@ -1245,7 +1245,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20 * opp.bench.size()
           }
         }
-      };
+      }
       case LUGIA_55:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness L
@@ -1268,7 +1268,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 250
           }
         }
-      };
+      }
       case RAYQUAZA_56:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness L
@@ -1293,7 +1293,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHATOT_57:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -1318,7 +1318,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOGEKISS_V_58:
       return basic (this, hp:HP200, type:C, retreatCost:1) {
         weakness L
@@ -1338,7 +1338,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case TOGEKISS_VMAX_59:
       return evolution (this, from:"Togekiss V", hp:HP310, type:C, retreatCost:0) {
         weakness L
@@ -1354,7 +1354,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case TORNADUS_60:
       return basic (this, hp:HP120, type:C, retreatCost:1) {
         weakness L
@@ -1375,7 +1375,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             discardSelfEnergyAfterDamage C
           }
         }
-      };
+      }
       case PIKIPEK_61:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -1387,7 +1387,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TRUMBEAK_62:
       return evolution (this, from:"Pikipek", hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -1410,7 +1410,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TOUCANNON_63:
       return evolution (this, from:"Trumbeak", hp:HP150, type:C, retreatCost:2) {
         weakness L
@@ -1431,7 +1431,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.hand, C, C
           }
         }
-      };
+      }
       case GREAT_BALL_64:
       return copy(EmergingPowers.GREAT_BALL_93, this)
       case SWITCH_65:
@@ -1452,7 +1452,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         playRequirement{
           assert my.all.any { it.energyCards && it.numberOfDamageCounters } : "No Pokémon with Energy Cards that have damage"
         }
-      };
+      }
       case HERO_S_MEDAL_68:
       return pokemonTool (this) {
         text "The Pokémon VMAX this card is attached to gets -100 HP" +
@@ -1491,9 +1491,9 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         allowAttach {PokemonCardSet to->
           (!to.pokemonVMAX || to.remainingHP > hp(100))
         }
-      };
+      }
       case ROCKY_HELMET_69:
-      return copy(NobleVictories.ROCKY_HELMET_94, this);
+      return copy(NobleVictories.ROCKY_HELMET_94, this)
       case BEAUTY_70:
       return supporter (this) {
         text "This card can be played on the first turn of the first player. Draw 2 cards."
@@ -1503,7 +1503,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case ALLISTER_71:
       return supporter (this) {
         text "Draw 3 cards. If you do" +
@@ -1515,7 +1515,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case OPAL_72:
       return supporter (this) {
         text "Flip 2 coins. For each heads" +
@@ -1531,7 +1531,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case MARNIE_73:
       return copy(SwordShield.MARNIE_169, this)
       case AROMA_G_ENERGY_74:
@@ -1564,7 +1564,7 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
         onRemoveFromPlay {
           spcEff.unregister()
         }
-      };
+      }
       case STONE_F_ENERGY_75:
       return specialEnergy (this, [[]]) {
         text "This card provides [F] Energy only while this card is attached to a Pokémon. The [F] Pokémon this card is attached to takes 20 less damage from your opponent's attacks (after applying Weakness and Resistance)."
@@ -1591,47 +1591,47 @@ public enum LegendaryHeartbeat implements LogicCardInfo {
           if (self != null) return [[F] as Set]
           else return [[] as Set]
         }
-      };
+      }
       case TWIN_ENERGY_76:
       return copy (RebelClash.TWIN_ENERGY_174, this)
       case ZARUDE_V_77:
-      return copy (ZARUDE_V_13, this);
+      return copy (ZARUDE_V_13, this)
       case AMPHAROS_V_78:
-      return copy (AMPHAROS_V_14, this);
+      return copy (AMPHAROS_V_14, this)
       case ALCREMIE_V_79:
-      return copy (ALCREMIE_V_31, this);
+      return copy (ALCREMIE_V_31, this)
       case COALOSSAL_V_80:
-      return copy (COALOSSAL_V_42, this);
+      return copy (COALOSSAL_V_42, this)
       case STEELIX_V_81:
-      return copy (STEELIX_V_46, this);
+      return copy (STEELIX_V_46, this)
       case TOGEKISS_V_82:
-      return copy (TOGEKISS_V_58, this);
+      return copy (TOGEKISS_V_58, this)
       case BEAUTY_83:
-      return copy (BEAUTY_70, this);
+      return copy (BEAUTY_70, this)
       case ALLISTER_84:
-      return copy (ALLISTER_71, this);
+      return copy (ALLISTER_71, this)
       case OPAL_85:
-      return copy (OPAL_72, this);
+      return copy (OPAL_72, this)
       case ALCREMIE_VMAX_86:
-      return copy (ALCREMIE_VMAX_32, this);
+      return copy (ALCREMIE_VMAX_32, this)
       case COALOSSAL_VMAX_87:
-      return copy (COALOSSAL_VMAX_43, this);
+      return copy (COALOSSAL_VMAX_43, this)
       case TOGEKISS_VMAX_88:
-      return copy (TOGEKISS_VMAX_59, this);
+      return copy (TOGEKISS_VMAX_59, this)
       case BEAUTY_89:
-      return copy (BEAUTY_70, this);
+      return copy (BEAUTY_70, this)
       case ALLISTER_90:
-      return copy (ALLISTER_71, this);
+      return copy (ALLISTER_71, this)
       case OPAL_91:
-      return copy (OPAL_72, this);
+      return copy (OPAL_72, this)
       case ORANGURU_92:
       return copy (SwordShield.ORANGURU_148, this)
       case HERO_S_MEDAL_93:
-      return copy (HERO_S_MEDAL_68, this);
+      return copy (HERO_S_MEDAL_68, this)
       case CAPE_OF_TOUGHNESS_94:
       return copy (DarknessAblaze.CAPE_OF_TOUGHNESS_160, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -1,25 +1,25 @@
-package tcgwars.logic.impl.gen8;
+package tcgwars.logic.impl.gen8
 
-import tcgwars.logic.impl.gen3.FireRedLeafGreen;
+import tcgwars.logic.impl.gen3.FireRedLeafGreen
 import tcgwars.logic.impl.gen4.HeartgoldSoulsilver
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.effect.*;
+import tcgwars.logic.effect.*
 import tcgwars.logic.effect.ability.*
 import tcgwars.logic.effect.basic.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -236,53 +236,53 @@ public enum RebelClash implements LogicCardInfo {
   TOOL_SCRAPPER_208 ("Tool Scrapper", "208", Rarity.HOLORARE, [TRAINER, ITEM]),
   TWIN_ENERGY_209 ("Twin Energy", "209", Rarity.HOLORARE, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   RebelClash(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.REBEL_CLASH;
+    return tcgwars.logic.card.Collection.REBEL_CLASH
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -309,7 +309,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case METAPOD_2:
       return evolution (this, from:"Caterpie", hp:HP080, type:G, retreatCost:3) {
         weakness R
@@ -331,7 +331,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BUTTERFREE_3:
       return evolution (this, from:"Metapod", hp:HP140, type:G, retreatCost:1) {
         weakness R
@@ -352,7 +352,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case SCYTHER_4:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -370,7 +370,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHUCKLE_5:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -396,7 +396,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case HERACROSS_6:
       return basic (this, hp:HP130, type:G, retreatCost:2) {
         weakness R
@@ -419,7 +419,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case LOTAD_7:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -438,7 +438,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LOMBRE_8:
       return evolution (this, from:"Lotad", hp:HP090, type:G, retreatCost:1) {
         weakness R
@@ -463,7 +463,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 3, { damage 40 }
           }
         }
-      };
+      }
       case LUDICOLO_9:
       return evolution (this, from:"Lombre", hp:HP160, type:G, retreatCost:2) {
         weakness R
@@ -482,7 +482,7 @@ public enum RebelClash implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case SURSKIT_10:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -494,7 +494,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { preventAllEffectsNextTurn() }
           }
         }
-      };
+      }
       case MASQUERAIN_11:
       return evolution (this, from:"Surskit", hp:HP090, type:G, retreatCost:1) {
         weakness R
@@ -534,7 +534,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SNOVER_12:
       return basic (this, hp:HP090, type:G, retreatCost:3) {
         weakness R
@@ -552,7 +552,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ABOMASNOW_13:
       return evolution (this, from:"Snover", hp:HP140, type:G, retreatCost:3) {
         weakness R
@@ -571,7 +571,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case PHANTUMP_14:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -594,7 +594,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TREVENANT_15:
       return evolution (this, from:"Phantump", hp:HP130, type:G, retreatCost:3) {
         weakness R
@@ -613,7 +613,7 @@ public enum RebelClash implements LogicCardInfo {
             cantRetreat(defending)
           }
         }
-      };
+      }
       case GRUBBIN_16:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -624,7 +624,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RILLABOOM_V_17:
       return basic (this, hp:HP220, type:G, retreatCost:3) {
         weakness R
@@ -641,7 +641,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case RILLABOOM_VMAX_18:
       return evolution (this, from:"Rillaboom V", hp:HP330, type:G, retreatCost:3) {
         weakness R
@@ -663,7 +663,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ELDEGOSS_V_19:
       return basic (this, hp:HP180, type:G, retreatCost:1) {
         weakness R
@@ -690,7 +690,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case APPLIN_20:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -702,7 +702,7 @@ public enum RebelClash implements LogicCardInfo {
             flipUntilTails { damage 30 }
           }
         }
-      };
+      }
       case APPLIN_21:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -713,7 +713,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { preventAllDamageNextTurn() }
           }
         }
-      };
+      }
       case FLAPPLE_22:
       return evolution (this, from:"Applin", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -742,7 +742,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { discardDefendingEnergyAfterDamage() }
           }
         }
-      };
+      }
       case APPLETUN_23:
       return evolution (this, from:"Applin", hp:HP090, type:G, retreatCost:3) {
         weakness R
@@ -767,7 +767,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case VULPIX_24:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -785,7 +785,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NINETALES_25:
       return evolution (this, from:"Vulpix", hp:HP120, type:R, retreatCost:1) {
         weakness W
@@ -807,7 +807,7 @@ public enum RebelClash implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case NINETALES_V_26:
       return basic (this, hp:HP200, type:R, retreatCost:2) {
         weakness W
@@ -839,7 +839,7 @@ public enum RebelClash implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C)
           }
         }
-      };
+      }
       case GROWLITHE_27:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -862,7 +862,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case ARCANINE_28:
       return evolution (this, from:"Growlithe", hp:HP130, type:R, retreatCost:2) {
         weakness W
@@ -881,7 +881,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case MAGMAR_29:
       return basic (this, hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -900,7 +900,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case MAGMORTAR_30:
       return evolution (this, from:"Magmar", hp:HP140, type:R, retreatCost:3) {
         weakness W
@@ -927,7 +927,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LITWICK_31:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -938,7 +938,7 @@ public enum RebelClash implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case LAMPENT_32:
       return evolution (this, from:"Litwick", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -966,7 +966,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHANDELURE_33:
       return evolution (this, from:"Lampent", hp:HP140, type:R, retreatCost:2) {
         weakness W
@@ -987,7 +987,7 @@ public enum RebelClash implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case HEATMOR_34:
       return basic (this, hp:HP120, type:R, retreatCost:2) {
         weakness W
@@ -1007,7 +1007,7 @@ public enum RebelClash implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C)
           }
         }
-      };
+      }
       case CINDERACE_V_35:
       return basic (this, hp:HP210, type:R, retreatCost:2) {
         weakness W
@@ -1026,7 +1026,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case CINDERACE_VMAX_36:
       return evolution (this, from:"Cinderace V", hp:HP320, type:R, retreatCost:2) {
         weakness W
@@ -1060,7 +1060,7 @@ public enum RebelClash implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case GALARIAN_MR_MIME_37:
       return basic (this, hp:HP080, type:W, retreatCost:1) {
         weakness M
@@ -1079,7 +1079,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 3, { damage 20 }
           }
         }
-      };
+      }
       case GALARIAN_MR_RIME_38:
       return evolution (this, from:"Galarian Mr. Mime", hp:HP110, type:W, retreatCost:1) {
         weakness M
@@ -1102,7 +1102,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 3, { damage 50 }
           }
         }
-      };
+      }
       case MAGIKARP_39:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1116,7 +1116,7 @@ public enum RebelClash implements LogicCardInfo {
             sw self, my.bench.select()
           }
         }
-      };
+      }
       case GYARADOS_40:
       return evolution (this, from:"Magikarp", hp:HP180, type:W, retreatCost:4) {
         weakness L
@@ -1137,7 +1137,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WINGULL_41:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1156,7 +1156,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PELIPPER_42:
       return evolution (this, from:"Wingull", hp:HP120, type:W, retreatCost:2) {
         weakness L
@@ -1179,7 +1179,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MILOTIC_V_43:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness L
@@ -1198,7 +1198,7 @@ public enum RebelClash implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case TYMPOLE_44:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1209,7 +1209,7 @@ public enum RebelClash implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case PALPITOAD_45:
       return evolution (this, from:"Tympole", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -1221,7 +1221,7 @@ public enum RebelClash implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case SEISMITOAD_46:
       return evolution (this, from:"Palpitoad", hp:HP170, type:W, retreatCost:3) {
         weakness L
@@ -1241,7 +1241,7 @@ public enum RebelClash implements LogicCardInfo {
             if (opp.active.isSPC(CONFUSED)) damage 120
           }
         }
-      };
+      }
       case GALARIAN_DARUMAKA_47:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -1253,7 +1253,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case GALARIAN_DARMANITAN_48:
       return evolution (this, from:"Galarian Darumaka", hp:HP140, type:W, retreatCost:3) {
         weakness M
@@ -1275,7 +1275,7 @@ public enum RebelClash implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case INTELEON_V_49:
       return basic (this, hp:HP200, type:W, retreatCost:2) {
         weakness L
@@ -1294,7 +1294,7 @@ public enum RebelClash implements LogicCardInfo {
             if (opp.hand) opp.hand.shuffledCopy().showToMe("Opponent's hand.")
           }
         }
-      };
+      }
       case INTELEON_VMAX_50:
       return evolution (this, from:"Inteleon V", hp:HP320, type:W, retreatCost:2) {
         weakness L
@@ -1323,7 +1323,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CRAMORANT_51:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -1343,7 +1343,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 50+20*self.cards.energyCount(W)
           }
         }
-      };
+      }
       case ARROKUDA_52:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1354,7 +1354,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BARRASKEWDA_53:
       return evolution (this, from:"Arrokuda", hp:HP120, type:W, retreatCost:1) {
         weakness L
@@ -1376,7 +1376,7 @@ public enum RebelClash implements LogicCardInfo {
             my.hand.filterByType(BASIC_ENERGY).filterByEnergyType(W).select(count:2, "Discard 2 [W] Energies.").discard()
           }
         }
-      };
+      }
       case EISCUE_54:
       return basic (this, hp:HP120, type:W, retreatCost:2) {
         weakness M
@@ -1405,7 +1405,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case EISCUE_V_55:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness M
@@ -1430,7 +1430,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VOLTORB_56:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1441,7 +1441,7 @@ public enum RebelClash implements LogicCardInfo {
             flipUntilTails { damage 20 }
           }
         }
-      };
+      }
       case ELECTRODE_57:
       return evolution (this, from:"Voltorb", hp:HP090, type:L, retreatCost:0) {
         weakness F
@@ -1463,7 +1463,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ELECTABUZZ_58:
       return basic (this, hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -1481,7 +1481,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ELECTIVIRE_59:
       return evolution (this, from:"Electabuzz", hp:HP140, type:L, retreatCost:3) {
         weakness F
@@ -1501,7 +1501,7 @@ public enum RebelClash implements LogicCardInfo {
             if (self.cards.filterByType(SPECIAL_ENERGY)) damage 90
           }
         }
-      };
+      }
       case SHINX_60:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1515,7 +1515,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LUXIO_61:
       return evolution (this, from:"Shinx", hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -1540,7 +1540,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LUXRAY_62:
       return evolution (this, from:"Luxio", hp:HP160, type:L, retreatCost:1) {
         weakness F
@@ -1562,7 +1562,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case HELIOPTILE_63:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1574,7 +1574,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case HELIOLISK_64:
       return evolution (this, from:"Helioptile", hp:HP110, type:L, retreatCost:1) {
         weakness F
@@ -1600,7 +1600,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case CHARJABUG_65:
       return evolution (this, from:"Grubbin", hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -1622,7 +1622,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case VIKAVOLT_66:
       return evolution (this, from:"Charjabug", hp:HP150, type:L, retreatCost:2) {
         weakness F
@@ -1642,7 +1642,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case BOLTUND_V_67:
       return basic (this, hp:HP200, type:L, retreatCost:2) {
         weakness F
@@ -1666,7 +1666,7 @@ public enum RebelClash implements LogicCardInfo {
             my.all.each { damage 30*it.cards.energyCount(L) }
           }
         }
-      };
+      }
       case TOXEL_68:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -1678,7 +1678,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case TOXTRICITY_69:
       return evolution (this, from:"Toxel", hp:HP130, type:L, retreatCost:2) {
         weakness F
@@ -1699,7 +1699,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case TOXTRICITY_V_70:
       return basic (this, hp:HP210, type:L, retreatCost:2) {
         weakness F
@@ -1719,7 +1719,7 @@ public enum RebelClash implements LogicCardInfo {
             if (opp.active.isSPC(POISONED)) damage 90
           }
         }
-      };
+      }
       case TOXTRICITY_VMAX_71:
       return evolution (this, from:"Toxtricity V", hp:HP320, type:L, retreatCost:2) {
         weakness F
@@ -1731,7 +1731,7 @@ public enum RebelClash implements LogicCardInfo {
             if (opp.active.isSPC(POISONED)) damage 80
           }
         }
-      };
+      }
       case PINCURCHIN_V_72:
       return basic (this, hp:HP170, type:L, retreatCost:2) {
         weakness F
@@ -1751,7 +1751,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case MORPEKO_73:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1775,7 +1775,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CLEFAIRY_74:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
@@ -1793,7 +1793,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CLEFABLE_75:
       return evolution (this, from:"Clefairy", hp:HP110, type:P, retreatCost:2) {
         weakness M
@@ -1815,7 +1815,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case NATU_76:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1827,7 +1827,7 @@ public enum RebelClash implements LogicCardInfo {
             draw 1
           }
         }
-      };
+      }
       case XATU_77:
       return evolution (this, from:"Natu", hp:HP120, type:P, retreatCost:1) {
         weakness D
@@ -1839,7 +1839,7 @@ public enum RebelClash implements LogicCardInfo {
             assertOppBench(info: "with Energy attached to them", {it.cards.filterByType(ENERGY)})
           }
           onAttack {
-            def validSources = new PcsList();
+            def validSources = new PcsList()
             opp.bench.each {
               validSources.add(it)
             }
@@ -1854,7 +1854,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10+30*opp.active.cards.filterByType(ENERGY).size()
           }
         }
-      };
+      }
       case GALARIAN_CORSOLA_78:
       return basic (this, hp:HP080, type:P, retreatCost:2) {
         weakness D
@@ -1866,7 +1866,7 @@ public enum RebelClash implements LogicCardInfo {
             putDamageCountersOnOpponentsPokemon(3)
           }
         }
-      };
+      }
       case GALARIAN_CURSOLA_79:
       return evolution (this, from:"Galarian Corsola", hp:HP100, type:P, retreatCost:2) {
         weakness D
@@ -1893,7 +1893,7 @@ public enum RebelClash implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case SIGILYPH_80:
       return basic (this, hp:HP110, type:P, retreatCost:1) {
         weakness L
@@ -1912,7 +1912,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30+10*opp.active.numberOfDamageCounters
           }
         }
-      };
+      }
       case SANDYGAST_81:
       return basic (this, hp:HP080, type:P, retreatCost:3) {
         weakness D
@@ -1924,7 +1924,7 @@ public enum RebelClash implements LogicCardInfo {
             directDamage 10, opp.all.select()
           }
         }
-      };
+      }
       case PALOSSAND_82:
       return evolution (this, from:"Sandygast", hp:HP140, type:P, retreatCost:4) {
         weakness D
@@ -1950,7 +1950,7 @@ public enum RebelClash implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case HATENNA_83:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1973,7 +1973,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HATTREM_84:
       return evolution (this, from:"Hatenna", hp:HP080, type:P, retreatCost:1) {
         weakness D
@@ -1993,7 +1993,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case HATTERENE_85:
       return evolution (this, from:"Hattrem", hp:HP150, type:P, retreatCost:2) {
         weakness D
@@ -2034,7 +2034,7 @@ public enum RebelClash implements LogicCardInfo {
             directDamage my.discard.filterByType(POKEMON).size()*10, opp.active
           }
         }
-      };
+      }
       case MILCERY_86:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness M
@@ -2054,7 +2054,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ALCREMIE_87:
       return evolution (this, from:"Milcery", hp:HP110, type:P, retreatCost:1) {
         weakness M
@@ -2081,7 +2081,7 @@ public enum RebelClash implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case INDEEDEE_88:
       return basic (this, hp:HP100, type:P, retreatCost:1) {
         weakness D
@@ -2103,7 +2103,7 @@ public enum RebelClash implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case DREEPY_89:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -2116,7 +2116,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { damage 10 }
           }
         }
-      };
+      }
       case DRAKLOAK_90:
       return evolution (this, from:"Dreepy", hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -2141,7 +2141,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGAPULT_91:
       return evolution (this, from:"Drakloak", hp:HP150, type:P, retreatCost:0) {
         weakness D
@@ -2169,7 +2169,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DRAGAPULT_V_92:
       return basic (this, hp:HP210, type:P, retreatCost:1) {
         weakness D
@@ -2191,7 +2191,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DRAGAPULT_VMAX_93:
       return evolution (this, from:"Dragapult V", hp:HP320, type:P, retreatCost:1) {
         weakness D
@@ -2213,7 +2213,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_FARFETCH_D_94:
       return basic (this, hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -2232,7 +2232,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GALARIAN_SIRFETCH_D_95:
       return evolution (this, from:"Galarian Farfetch’d", hp:HP130, type:F, retreatCost:2) {
         weakness P
@@ -2264,7 +2264,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NOSEPASS_96:
       return basic (this, hp:HP080, type:F, retreatCost:3) {
         weakness G
@@ -2282,7 +2282,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MEDITITE_97:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness P
@@ -2294,7 +2294,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case MEDICHAM_98:
       return evolution (this, from:"Meditite", hp:HP110, type:F, retreatCost:1) {
         weakness P
@@ -2312,7 +2312,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 60+20*opp.active.cards.filterByType(ENERGY).size()
           }
         }
-      };
+      }
       case BARBOACH_99:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -2323,7 +2323,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WHISCASH_100:
       return evolution (this, from:"Barboach", hp:HP140, type:F, retreatCost:3) {
         weakness G
@@ -2350,7 +2350,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_YAMASK_101:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -2362,7 +2362,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case GALARIAN_RUNERIGUS_102:
       return evolution (this, from:"Galarian Yamask", hp:HP100, type:F, retreatCost:2) {
         weakness G
@@ -2386,7 +2386,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case BINACLE_103:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -2397,7 +2397,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 2, { damage 50 }
           }
         }
-      };
+      }
       case BARBARACLE_104:
       return evolution (this, from:"Binacle", hp:HP120, type:F, retreatCost:3) {
         weakness G
@@ -2419,7 +2419,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ROLYCOLY_105:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -2430,7 +2430,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CARKOAL_106:
       return evolution (this, from:"Rolycoly", hp:HP100, type:F, retreatCost:3) {
         weakness G
@@ -2448,7 +2448,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case COALOSSAL_107:
       return evolution (this, from:"Carkol", hp:HP160, type:F, retreatCost:4) {
         weakness G
@@ -2479,7 +2479,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case SANDACONDA_V_108:
       return basic (this, hp:HP220, type:F, retreatCost:3) {
         weakness G
@@ -2501,7 +2501,7 @@ public enum RebelClash implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C, C)
           }
         }
-      };
+      }
       case FALINKS_109:
       return basic (this, hp:HP090, type:F, retreatCost:1) {
         weakness P
@@ -2517,7 +2517,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30*my.bench.findAll { it.name.contains "Falinks" }.size()
           }
         }
-      };
+      }
       case FALINKS_V_110:
       return basic (this, hp:HP160, type:F, retreatCost:2) {
         weakness P
@@ -2542,7 +2542,7 @@ public enum RebelClash implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case STONJOURNER_111:
       return basic (this, hp:HP140, type:F, retreatCost:4) {
         weakness G
@@ -2563,7 +2563,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case KOFFING_112:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -2574,7 +2574,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GALARIAN_WEEZING_113:
       return evolution (this, from:"Koffing", hp:HP130, type:D, retreatCost:3) {
         weakness F
@@ -2602,7 +2602,7 @@ public enum RebelClash implements LogicCardInfo {
             extraPoison 3
           }
         }
-      };
+      }
       case STUNKY_114:
       return basic (this, hp:HP070, type:D, retreatCost:2) {
         weakness F
@@ -2614,7 +2614,7 @@ public enum RebelClash implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case SKUNTANK_115:
       return evolution (this, from:"Stunky", hp:HP120, type:D, retreatCost:3) {
         weakness F
@@ -2634,7 +2634,7 @@ public enum RebelClash implements LogicCardInfo {
             cantRetreat(defending)
           }
         }
-      };
+      }
       case SPIRITOMB_116:
       return basic (this, hp:HP060, type:D, retreatCost:2) {
         weakness G
@@ -2656,7 +2656,7 @@ public enum RebelClash implements LogicCardInfo {
             directDamage my.discard.filterByType(POKEMON).size()*10, opp.active
           }
         }
-      };
+      }
       case TRUBBISH_117:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -2668,7 +2668,7 @@ public enum RebelClash implements LogicCardInfo {
             if (opp.active.isSPC(POISONED)) damage 50
           }
         }
-      };
+      }
       case GARBODOR_118:
       return evolution (this, from:"Trubbish", hp:HP120, type:D, retreatCost:2) {
         weakness F
@@ -2689,7 +2689,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case VULLABY_119:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness L
@@ -2704,7 +2704,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MANDIBUZZ_120:
       return evolution (this, from:"Vullaby", hp:HP120, type:D, retreatCost:2) {
         weakness L
@@ -2726,7 +2726,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 100, opp.all.findAll { it.numberOfDamageCounters }.select()
           }
         }
-      };
+      }
       case MALAMAR_V_121:
       return basic (this, hp:HP210, type:D, retreatCost:2) {
         weakness G
@@ -2749,7 +2749,7 @@ public enum RebelClash implements LogicCardInfo {
             apply CONFUSED
           }
         }
-      };
+      }
       case MALAMAR_VMAX_122:
       return evolution (this, from:"Malamar V", hp:HP310, type:D, retreatCost:2) {
         weakness G
@@ -2766,7 +2766,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case IMPIDIMP_123:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -2784,7 +2784,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MORGREM_124:
       return evolution (this, from:"Impidimp", hp:HP090, type:D, retreatCost:2) {
         weakness G
@@ -2802,7 +2802,7 @@ public enum RebelClash implements LogicCardInfo {
             swiftDamage(60, defending)
           }
         }
-      };
+      }
       case GRIMMSNARL_125:
       return evolution (this, from:"Morgrem", hp:HP170, type:D, retreatCost:3) {
         weakness G
@@ -2827,7 +2827,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 100+30*opp.active.cards.energyCount(C)
           }
         }
-      };
+      }
       case GALARIAN_MEOWTH_126:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -2854,7 +2854,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GALARIAN_PERRSERKER_127:
       return evolution (this, from:"Galarian Meowth", hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -2873,7 +2873,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 3, { damage 80 }
           }
         }
-      };
+      }
       case SCIZOR_128:
       return evolution (this, from:"Scyther", hp:HP130, type:M, retreatCost:1) {
         weakness R
@@ -2897,7 +2897,7 @@ public enum RebelClash implements LogicCardInfo {
             reduceDamageNextTurn(hp(30), thisMove)
           }
         }
-      };
+      }
       case BRONZOR_129:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -2916,7 +2916,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BRONZONG_130:
       return evolution (this, from:"Bronzor", hp:HP130, type:M, retreatCost:3) {
         weakness R
@@ -2945,7 +2945,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PROBOPASS_131:
       return evolution (this, from:"Nosepass", hp:HP140, type:M, retreatCost:4) {
         weakness R
@@ -2964,7 +2964,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case DURANT_132:
       return basic (this, hp:HP100, type:M, retreatCost:1) {
         weakness R
@@ -2985,7 +2985,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case HONEDGE_133:
       return basic (this, hp:HP060, type:M, retreatCost:1) {
         weakness R
@@ -2997,7 +2997,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DOUBLADE_134:
       return evolution (this, from:"Honedge", hp:HP090, type:M, retreatCost:2) {
         weakness R
@@ -3016,7 +3016,7 @@ public enum RebelClash implements LogicCardInfo {
             flip 2, { damage 80 }
           }
         }
-      };
+      }
       case AEGISLASH_135:
       return evolution (this, from:"Doublade", hp:HP140, type:M, retreatCost:3) {
         weakness R
@@ -3044,7 +3044,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case COPPERAJAH_V_136:
       return basic (this, hp:HP220, type:M, retreatCost:4) {
         weakness R
@@ -3064,7 +3064,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case COPPERAJAH_VMAX_137:
       return evolution (this, from:"Copperajah V", hp:HP340, type:M, retreatCost:4) {
         weakness R
@@ -3086,7 +3086,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 240
           }
         }
-      };
+      }
       case DURALUDON_138:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -3108,7 +3108,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case ZACIAN_139:
       return basic (this, hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -3133,7 +3133,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZAMAZENTA_140:
       return basic (this, hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -3156,7 +3156,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SNORLAX_141:
       return basic (this, hp:HP150, type:C, retreatCost:4) {
         weakness F
@@ -3175,7 +3175,7 @@ public enum RebelClash implements LogicCardInfo {
             apply ASLEEP, self
           }
         }
-      };
+      }
       case CHATOT_142:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -3198,7 +3198,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PIDOVE_143:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -3223,7 +3223,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TRANQUILL_144:
       return evolution (this, from:"Pidove", hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -3242,7 +3242,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case UNFEZANT_145:
       return evolution (this, from:"Tranquill", hp:HP150, type:C, retreatCost:1) {
         weakness L
@@ -3263,7 +3263,7 @@ public enum RebelClash implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C)
           }
         }
-      };
+      }
       case BUNNELBY_146:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3284,7 +3284,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DIGGERSBY_147:
       return evolution (this, from:"Bunnelby", hp:HP130, type:C, retreatCost:3) {
         weakness F
@@ -3300,7 +3300,7 @@ public enum RebelClash implements LogicCardInfo {
               my.deck.subList(0,1).discard()
               n++
               if (!my.deck || (n < 6 && !confirm("Cards Discarded: ${n}/6. Damage being dealt: ${n * 30}. Discard another card from the top of the deck for +30 damage?") ) )
-                break;
+                break
             }
 
             damage 30 * n
@@ -3313,7 +3313,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case HAWLUCHA_148:
       return basic (this, hp:HP090, type:C, retreatCost:1) {
         weakness L
@@ -3333,7 +3333,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case STUFFUL_149:
       return basic (this, hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -3352,7 +3352,7 @@ public enum RebelClash implements LogicCardInfo {
             flip { damage 40 }
           }
         }
-      };
+      }
       case BEWEAR_150:
       return evolution (this, from:"Stufful", hp:HP140, type:C, retreatCost:3) {
         weakness F
@@ -3378,7 +3378,7 @@ public enum RebelClash implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SKWOVET_151:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3396,7 +3396,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GREEDENT_152:
       return evolution (this, from:"Skwovet", hp:HP120, type:C, retreatCost:1) {
         weakness F
@@ -3417,7 +3417,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case DUBWOOL_V_153:
       return basic (this, hp:HP210, type:C, retreatCost:2) {
         weakness F
@@ -3441,7 +3441,7 @@ public enum RebelClash implements LogicCardInfo {
             damage 120+30*opp.prizeCardSet.takenCount
           }
         }
-      };
+      }
       case BOSS_S_ORDERS_154:
       return supporter (this) {
         text "Choose 1 of your opponent’s Benched Pokémon and switch it with their Active Pokémon. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3451,7 +3451,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement {
           assertOppBench()
         }
-      };
+      }
       case BURNING_SCARF_155:
       return pokemonTool (this) {
         text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the [R] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponent’s attack, the Attacking Pokémon is now Burned. You may play as many Item cards as you like during your turn (before your attack)."
@@ -3461,7 +3461,7 @@ public enum RebelClash implements LogicCardInfo {
             apply BURNED, ef.attacker, TRAINER_CARD
           }
         }
-      };
+      }
       case CAPACIOUS_BUCKET_156:
       return itemCard (this) {
         text "Search your deck for 2 [W] Energy, reveal them, and put them into your hand. Then, shuffle your deck. You may play as many Item cards as you like during your turn (before your attack)."
@@ -3472,7 +3472,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!."
         }
-      };
+      }
       case CURSED_SHOVEL_157:
       return pokemonTool (this) {
         text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached to it. If the Pokémon this Tool is attached to is Knocked Out by damage from an opponent’s attack, discard the top 2 cards of your opponent’s deck. You may play as many Item cards as you like during your turn (before your attack)."
@@ -3500,7 +3500,7 @@ public enum RebelClash implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case DAN_158:
       return supporter (this) {
         text "Draw 2 cards. Play Rock-Paper-Scissors with your opponent. If you win, draw 2 more cards. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3515,9 +3515,9 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement {
           assert my.deck : "Your deck is empty!."
         }
-      };
+      }
       case FULL_HEAL_159:
-      return copy(HeartgoldSoulsilver.FULL_HEAL_93, this);
+      return copy(HeartgoldSoulsilver.FULL_HEAL_93, this)
       case GALAR_MINE_160:
       return stadium (this) {
         text "The Retreat Cost of each Active Pokémon (both yours and your opponent’s) is [C][C] more. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -3530,7 +3530,7 @@ public enum RebelClash implements LogicCardInfo {
         onRemoveFromPlay{
           eff.unregister()
         }
-      };
+      }
       case MILO_161:
       return supporter (this) {
         text "Discard up to 2 cards from your hand. Then draw twice as many cards as you discarded. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3542,7 +3542,7 @@ public enum RebelClash implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard) : "Not enough cards in your hand"
           assert my.deck : "Your deck is empty"
         }
-      };
+      }
       case NUGGET_162:
       return itemCard (this) {
         text "Play this card only when you draw it from your deck at the start of your turn (before putting it into your hand). Draw 3 cards. You may play as many Item cards as you like during your turn (before your attack)."
@@ -3564,7 +3564,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement {
           assert false : "Play this card only when you draw it from your deck at the start of your turn"
         }
-      };
+      }
       case OLEANA_163:
       return supporter (this) {
         text "Discard 2 cards from your hand in order to play this card. Your opponent reveals their hand. Choose a Trainer you find there and put it at the bottom of your opponent’s deck. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3580,9 +3580,9 @@ public enum RebelClash implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard).size() >= 2 : "You need 2 or more cards in your hand."
           assert opp.hand : "Opponent's hand is empty."
         }
-      };
+      }
       case POKEBALL_164:
-      return copy(FireRedLeafGreen.POKE_BALL_95, this);
+      return copy(FireRedLeafGreen.POKE_BALL_95, this)
       case SCOOP_UP_NET_165:
       return itemCard (this) {
         text "Put 1 of your Pokémon that isn’t a Pokémon V or a Pokémon-GX into your hand. (Discard all attached cards.)"
@@ -3596,7 +3596,7 @@ public enum RebelClash implements LogicCardInfo {
           assertMyAll(negateVariants: true, hasVariants: [POKEMON_V, POKEMON_GX])
           confirmScoopLastPokemon()
         }
-      };
+      }
       case SKYLA_166:
       return supporter (this) {
         text "Search your deck for a Trainer card, reveal it, and put it into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3607,7 +3607,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement {
           assert my.deck : "Your deck is empty!."
         }
-      };
+      }
       case SONIA_167:
       return supporter (this) {
         text "Search your deck for up to 2 Basic Pokémon or up to 2 Basic Energy, reveal them, and put them into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn (before your attack)."
@@ -3623,7 +3623,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement {
           assert my.deck : "Your deck is empty!."
         }
-      };
+      }
       case TOOL_SCRAPPER_168:
       return itemCard (this) {
         text "Discard up to 2 Pokémon Tools from either player’s Pokémon. You may play as many Item cards during your turn as you like (before your attack)."
@@ -3672,7 +3672,7 @@ public enum RebelClash implements LogicCardInfo {
         playRequirement{
           assert all.findAll {it.cards.hasType(POKEMON_TOOL)} : "No Pokémon Tools in play."
         }
-      };
+      }
       case TRAINING_COURT_169:
       return stadium (this) {
         text "Once during each player’s turn, that player may choose a basic Energy card from their discard pile, reveal it, and put it into their hand. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -3690,7 +3690,7 @@ public enum RebelClash implements LogicCardInfo {
         onRemoveFromPlay {
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case TURRFIELD_170:
       return stadium (this) {
         text "Once during each player’s turn, that player may search their deck for a [G] Evolution Pokémon, reveal it, and put it into their hand. Then, that player shuffles their deck. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can’t play this card."
@@ -3711,7 +3711,7 @@ public enum RebelClash implements LogicCardInfo {
         onRemoveFromPlay {
           actions.each { bg().gm().unregisterAction(it) }
         }
-      };
+      }
       case CAPTURE_ENERGY_171:
       return specialEnergy (this, [[]]) {
         text "This card provides [C] Energy only while attached to a Pokémon. When attaching this card from your hand to 1 of your Pokémon, search your deck for a Basic Pokémon and put it on your Bench. Then, shuffle your deck."
@@ -3727,7 +3727,7 @@ public enum RebelClash implements LogicCardInfo {
           if (self) return [[C] as Set]
           else return [[] as Set]
         }
-      };
+      }
       case HORROR_PSYCHIC_ENERGY_172:
       return specialEnergy (this, [[]]) {
         text "This card provides 1 [P] Energy while it’s attached to a Pokémon. When the [P] Pokémon this card is attached to is your Active Pokémon and is damaged by an opponents attack, put 2 damage counters on the Attacking Pokémon."
@@ -3761,7 +3761,7 @@ public enum RebelClash implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case SPEED_LIGHTNING_ENERGY_173:
       return specialEnergy (this, [[]]) {
         text "This card provides 1 [L] Energy while it’s attached to a Pokémon. When you attach this card from your hand to an [L] Pokémon, draw 2 cards"
@@ -3774,7 +3774,7 @@ public enum RebelClash implements LogicCardInfo {
           if (self) return [[L] as Set]
           else return [[] as Set]
         }
-      };
+      }
       case TWIN_ENERGY_174:
       return specialEnergy (this, []) {
         text "As long as this card is attached to a Pokémon that isn’t a Pokémon V or a Pokémon-GX, it provides [C][C] Energy. If this card is attached to a Pokémon V or a Pokémon-GX, it provides [C] Energy instead."
@@ -3791,79 +3791,79 @@ public enum RebelClash implements LogicCardInfo {
             return [[] as Set]
           }
         }
-      };
+      }
       case RILLABOOM_V_175:
-      return copy (RILLABOOM_V_17, this);
+      return copy (RILLABOOM_V_17, this)
       case ELDEGOSS_V_176:
-      return copy (ELDEGOSS_V_19, this);
+      return copy (ELDEGOSS_V_19, this)
       case NINETALES_V_177:
-      return copy (NINETALES_V_26, this);
+      return copy (NINETALES_V_26, this)
       case CINDERACE_V_178:
-      return copy (CINDERACE_V_35, this);
+      return copy (CINDERACE_V_35, this)
       case MILOTIC_V_179:
-      return copy (MILOTIC_V_43, this);
+      return copy (MILOTIC_V_43, this)
       case INTELEON_V_180:
-      return copy (INTELEON_V_49, this);
+      return copy (INTELEON_V_49, this)
       case BOLTUND_V_181:
-      return copy (BOLTUND_V_67, this);
+      return copy (BOLTUND_V_67, this)
       case TOXTRICITY_V_182:
-      return copy (TOXTRICITY_V_70, this);
+      return copy (TOXTRICITY_V_70, this)
       case DRAGAPULT_V_183:
-      return copy (DRAGAPULT_V_92, this);
+      return copy (DRAGAPULT_V_92, this)
       case SANDACONDA_V_184:
-      return copy (SANDACONDA_V_108, this);
+      return copy (SANDACONDA_V_108, this)
       case FALINKS_V_185:
-      return copy (FALINKS_V_110, this);
+      return copy (FALINKS_V_110, this)
       case MALAMAR_V_186:
-      return copy (MALAMAR_V_121, this);
+      return copy (MALAMAR_V_121, this)
       case COPPERAJAH_V_187:
-      return copy (COPPERAJAH_V_136, this);
+      return copy (COPPERAJAH_V_136, this)
       case DUBWOOL_V_188:
-      return copy (DUBWOOL_V_153, this);
+      return copy (DUBWOOL_V_153, this)
       case BOSS_S_ORDERS_189:
-      return copy (BOSS_S_ORDERS_154, this);
+      return copy (BOSS_S_ORDERS_154, this)
       case MILO_190:
-      return copy (MILO_161, this);
+      return copy (MILO_161, this)
       case OLEANA_191:
-      return copy (OLEANA_163, this);
+      return copy (OLEANA_163, this)
       case SONIA_192:
-      return copy (SONIA_167, this);
+      return copy (SONIA_167, this)
       case RILLABOOM_VMAX_193:
-      return copy (RILLABOOM_VMAX_18, this);
+      return copy (RILLABOOM_VMAX_18, this)
       case CINDERACE_VMAX_194:
-      return copy (CINDERACE_VMAX_36, this);
+      return copy (CINDERACE_VMAX_36, this)
       case INTELEON_VMAX_195:
-      return copy (INTELEON_VMAX_50, this);
+      return copy (INTELEON_VMAX_50, this)
       case TOXTRICITY_VMAX_196:
-      return copy (TOXTRICITY_VMAX_71, this);
+      return copy (TOXTRICITY_VMAX_71, this)
       case DRAGAPULT_VMAX_197:
-      return copy (DRAGAPULT_VMAX_93, this);
+      return copy (DRAGAPULT_VMAX_93, this)
       case MALAMAR_VMAX_198:
-      return copy (MALAMAR_VMAX_122, this);
+      return copy (MALAMAR_VMAX_122, this)
       case COPPERAJAH_VMAX_199:
-      return copy (COPPERAJAH_VMAX_137, this);
+      return copy (COPPERAJAH_VMAX_137, this)
       case BOSS_S_ORDERS_200:
-      return copy (BOSS_S_ORDERS_154, this);
+      return copy (BOSS_S_ORDERS_154, this)
       case MILO_201:
-      return copy (MILO_161, this);
+      return copy (MILO_161, this)
       case OLEANA_202:
-      return copy (OLEANA_163, this);
+      return copy (OLEANA_163, this)
       case SONIA_203:
-      return copy (SONIA_167, this);
+      return copy (SONIA_167, this)
       case FROSMOTH_204:
-      return copy(SwordShield.FROSMOTH_64, this);
+      return copy(SwordShield.FROSMOTH_64, this)
       case GALARIAN_PERRSERKER_205:
-      return copy(SwordShield.GALARIAN_PERRSERKER_128, this);
+      return copy(SwordShield.GALARIAN_PERRSERKER_128, this)
       case BIG_CHARM_206:
-      return copy(SwordShield.BIG_CHARM_158, this);
+      return copy(SwordShield.BIG_CHARM_158, this)
       case SCOOP_UP_NET_207:
-      return copy(SCOOP_UP_NET_165, this);
+      return copy(SCOOP_UP_NET_165, this)
       case TOOL_SCRAPPER_208:
-      return copy (TOOL_SCRAPPER_168, this);
+      return copy (TOOL_SCRAPPER_168, this)
       case TWIN_ENERGY_209:
-      return copy (TWIN_ENERGY_174, this);
+      return copy (TWIN_ENERGY_174, this)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/ShiningFates.groovy
+++ b/src/tcgwars/logic/impl/gen8/ShiningFates.groovy
@@ -1,36 +1,36 @@
 package tcgwars.logic.impl.gen8
 
-import tcgwars.logic.impl.gen5.BoundariesCrossed;
+import tcgwars.logic.impl.gen5.BoundariesCrossed
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -233,53 +233,53 @@ public enum ShiningFates implements LogicCardInfo {
   ETERNATUS_V_SV121 ("Eternatus V", "SV121", Rarity.ULTRARARE, [POKEMON, BASIC, POKEMON_V, _DARKNESS_]),
   ETERNATUS_VMAX_SV122 ("Eternatus VMAX", "SV122", Rarity.ULTRARARE, [POKEMON, EVOLUTION, POKEMON_V, VMAX, _DARKNESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ShiningFates(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SHINING_FATES;
+    return tcgwars.logic.card.Collection.SHINING_FATES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -304,7 +304,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case YANMEGA_2:
       return evolution (this, from:"Yanma", hp:HP120, type:G, retreatCost:0) {
         weakness R
@@ -325,7 +325,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case CELEBI_3:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -348,7 +348,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CACNEA_4:
       return basic (this, hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -360,7 +360,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TROPIUS_5:
       return basic (this, hp:HP110, type:G, retreatCost:1) {
         weakness R
@@ -385,15 +385,15 @@ public enum ShiningFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ROWLET_6:
-        return copy (DarknessAblaze.ROWLET_11, this);
+        return copy (DarknessAblaze.ROWLET_11, this)
       case DARTRIX_7:
-        return copy (DarknessAblaze.DARTRIX_12, this);
+        return copy (DarknessAblaze.DARTRIX_12, this)
       case DECIDUEYE_8:
-        return copy (DarknessAblaze.DECIDUEYE_13, this);
+        return copy (DarknessAblaze.DECIDUEYE_13, this)
       case DHELMISE_V_9:
-        return copy (SwordShield.DHELMISE_V_9, this);
+        return copy (SwordShield.DHELMISE_V_9, this)
       case DHELMISE_VMAX_10:
       return evolution (this, from:"Dhelmise V", hp:HP330, type:G, retreatCost:3) {
         weakness R
@@ -414,13 +414,13 @@ public enum ShiningFates implements LogicCardInfo {
             cantUseAttack thisMove, self
           }
         }
-      };
+      }
       case GROOKEY_11:
-        return copy (SwordShield.GROOKEY_10, this);
+        return copy (SwordShield.GROOKEY_10, this)
       case THWACKEY_12:
-        return copy (ShinyStarV.THWACKEY_1, this);
+        return copy (ShinyStarV.THWACKEY_1, this)
       case RILLABOOM_13:
-        return copy (SwordShield.RILLABOOM_14, this);
+        return copy (SwordShield.RILLABOOM_14, this)
       case GOSSIFLEUR_14:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -432,7 +432,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELDEGOSS_15:
       return evolution (this, from:"Gossifleur", hp:HP090, type:G, retreatCost:1) {
         weakness R
@@ -454,7 +454,7 @@ public enum ShiningFates implements LogicCardInfo {
             flip { damage 50 }
           }
         }
-      };
+      }
       case ZARUDE_16:
       return basic (this, hp:HP120, type:G, retreatCost:2) {
         weakness R
@@ -475,13 +475,13 @@ public enum ShiningFates implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case RESHIRAM_17:
-        return copy (ShinyStarV.RESHIRAM_2, this);
+        return copy (ShinyStarV.RESHIRAM_2, this)
       case CINDERACE_V_18:
-        return copy (SwordShieldPromos.CINDERACE_V_SWSH15, this);
+        return copy (SwordShieldPromos.CINDERACE_V_SWSH15, this)
       case CINDERACE_VMAX_19:
-        return copy (RebelClash.CINDERACE_VMAX_36, this);
+        return copy (RebelClash.CINDERACE_VMAX_36, this)
       case HORSEA_20:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -493,9 +493,9 @@ public enum ShiningFates implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KYOGRE_21:
-        return copy (ShinyStarV.KYOGRE_3, this);
+        return copy (ShinyStarV.KYOGRE_3, this)
       case BUIZEL_22:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -507,7 +507,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FLOATZEL_23:
       return evolution (this, from:"Buizel", hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -519,7 +519,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MANAPHY_24:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -542,7 +542,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VOLCANION_25:
       return basic (this, hp:HP130, type:W, retreatCost:3) {
         weakness L
@@ -562,7 +562,7 @@ public enum ShiningFates implements LogicCardInfo {
             flip 2, { damage 120 }
           }
         }
-      };
+      }
       case CHEWTLE_26:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -582,7 +582,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DREDNAW_27:
       return evolution (this, from:"Chewtle", hp:HP140, type:W, retreatCost:3) {
         weakness L
@@ -607,7 +607,7 @@ public enum ShiningFates implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case CRAMORANT_28:
       return basic (this, hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -621,45 +621,45 @@ public enum ShiningFates implements LogicCardInfo {
             damage 50, opp.bench.select(text)
           }
         }
-      };
+      }
       case SNOM_29:
-        return copy (ShinyStarV.SNOM_4, this);
+        return copy (ShinyStarV.SNOM_4, this)
       case FROSMOTH_30:
-        return copy (SwordShield.FROSMOTH_64, this);
+        return copy (SwordShield.FROSMOTH_64, this)
       case SHINX_31:
-        return copy (RebelClash.SHINX_60, this);
+        return copy (RebelClash.SHINX_60, this)
       case LUXIO_32:
-        return copy (RebelClash.LUXIO_61, this);
+        return copy (RebelClash.LUXIO_61, this)
       case LUXRAY_33:
-        return copy (RebelClash.LUXRAY_62, this);
+        return copy (RebelClash.LUXRAY_62, this)
       case ROTOM_34:
-        return copy (ShinyStarV.ROTOM_5, this);
+        return copy (ShinyStarV.ROTOM_5, this)
       case MORPEKO_35:
-        return copy (SwordShieldPromos.MORPEKO_SWSH31, this);
+        return copy (SwordShieldPromos.MORPEKO_SWSH31, this)
       case MORPEKO_36:
-        return copy (MORPEKO_35, this);
+        return copy (MORPEKO_35, this)
       case MORPEKO_V_37:
-        return copy (SwordShield.MORPEKO_V_79, this);
+        return copy (SwordShield.MORPEKO_V_79, this)
       case MORPEKO_VMAX_38:
-        return copy (SwordShield.MORPEKO_VMAX_80, this);
+        return copy (SwordShield.MORPEKO_VMAX_80, this)
       case INDEEDEE_V_39:
-        return copy (SwordShield.INDEEDEE_V_91, this);
+        return copy (SwordShield.INDEEDEE_V_91, this)
       case TRAPINCH_40:
-        return copy (DarknessAblaze.TRAPINCH_89, this);
+        return copy (DarknessAblaze.TRAPINCH_89, this)
       case KOFFING_41:
-        return copy (ShinyStarV.KOFFING_6, this);
+        return copy (ShinyStarV.KOFFING_6, this)
       case GALARIAN_WEEZING_42:
-        return copy (RebelClash.GALARIAN_WEEZING_113, this);
+        return copy (RebelClash.GALARIAN_WEEZING_113, this)
       case SPINARAK_43:
-        return copy (DarknessAblaze.SPINARAK_102, this);
+        return copy (DarknessAblaze.SPINARAK_102, this)
       case CROBAT_V_44:
-        return copy (DarknessAblaze.CROBAT_V_104, this);
+        return copy (DarknessAblaze.CROBAT_V_104, this)
       case CROBAT_VMAX_45:
-        return copy (ShinyStarV.CROBAT_VMAX_7, this);
+        return copy (ShinyStarV.CROBAT_VMAX_7, this)
       case YVELTAL_46:
-        return copy (ShinyStarV.YVELTAL_8, this);
+        return copy (ShinyStarV.YVELTAL_8, this)
       case NICKIT_47:
-        return copy (SwordShield.NICKIT_125, this);
+        return copy (SwordShield.NICKIT_125, this)
       case THIEVUL_48:
       return evolution (this, from:"Nickit", hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -687,15 +687,15 @@ public enum ShiningFates implements LogicCardInfo {
             cantRetreat(defending)
           }
         }
-      };
+      }
       case CUFANT_49:
-        return copy (DarknessAblaze.CUFANT_131, this);
+        return copy (DarknessAblaze.CUFANT_131, this)
       case DITTO_V_50:
-        return copy (ShinyStarV.DITTO_V_9, this);
+        return copy (ShinyStarV.DITTO_V_9, this)
       case DITTO_VMAX_51:
-        return copy (ShinyStarV.DITTO_VMAX_10, this);
+        return copy (ShinyStarV.DITTO_VMAX_10, this)
       case EEVEE_52:
-        return copy (SwordShieldPromos.EEVEE_SWSH42, this);
+        return copy (SwordShieldPromos.EEVEE_SWSH42, this)
       case GREEDENT_V_53:
       return basic (this, hp:HP200, type:C, retreatCost:2) {
         weakness F
@@ -716,9 +716,9 @@ public enum ShiningFates implements LogicCardInfo {
             flip { damage 180 }
           }
         }
-      };
+      }
       case CRAMORANT_V_54:
-        return copy (SwordShield.CRAMORANT_V_155, this);
+        return copy (SwordShield.CRAMORANT_V_155, this)
       case CRAMORANT_VMAX_55:
       return evolution (this, from:"Cramorant V", hp:HP320, type:C, retreatCost:2) {
         weakness L
@@ -731,7 +731,7 @@ public enum ShiningFates implements LogicCardInfo {
             flip self.cards.energyCount(C), { damage 80 }
           }
         }
-      };
+      }
       case INDEEDEE_56:
       return basic (this, hp:HP100, type:C, retreatCost:1) {
         weakness F
@@ -758,11 +758,11 @@ public enum ShiningFates implements LogicCardInfo {
             damage 20 + 20 * defending.cards.energyCount(C)
           }
         }
-      };
+      }
       case BALL_GUY_57:
-        return copy (ShinyStarV.BALL_GUY_14, this);
+        return copy (ShinyStarV.BALL_GUY_14, this)
       case BOSS_S_ORDERS_58:
-        return copy (RebelClash.BOSS_S_ORDERS_154, this);
+        return copy (RebelClash.BOSS_S_ORDERS_154, this)
       case GYM_TRAINER_59:
       return supporter (this) {
         text "Draw 2 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 2 more cards."
@@ -784,281 +784,281 @@ public enum ShiningFates implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case PROFESSOR_S_RESEARCH_60:
-        return copy (SwordShield.PROFESSOR_S_RESEARCH_178, this);
+        return copy (SwordShield.PROFESSOR_S_RESEARCH_178, this)
       case RUSTED_SHIELD_61:
-        return copy (ShinyStarV.RUSTED_SHIELD_13, this);
+        return copy (ShinyStarV.RUSTED_SHIELD_13, this)
       case RUSTED_SWORD_62:
-        return copy (ShinyStarV.RUSTED_SWORD_12, this);
+        return copy (ShinyStarV.RUSTED_SWORD_12, this)
       case TEAM_YELL_TOWEL_63:
-        return copy (ShinyStarV.TEAM_YELL_S_CHEERING_TOWEL_11, this);
+        return copy (ShinyStarV.TEAM_YELL_S_CHEERING_TOWEL_11, this)
       case ALCREMIE_V_64:
-        return copy (ChampionsPath.ALCREMIE_V_22, this);
+        return copy (ChampionsPath.ALCREMIE_V_22, this)
       case BALL_GUY_65:
-        return copy (BALL_GUY_57, this);
+        return copy (BALL_GUY_57, this)
       case BIRD_KEEPER_66:
-        return copy (DarknessAblaze.BIRD_KEEPER_159, this);
+        return copy (DarknessAblaze.BIRD_KEEPER_159, this)
       case CARA_LISS_67:
-        return copy (VividVoltage.CARA_LISS_149, this);
+        return copy (VividVoltage.CARA_LISS_149, this)
       case GYM_TRAINER_68:
-        return copy (GYM_TRAINER_59, this);
+        return copy (GYM_TRAINER_59, this)
       case PIERS_69:
-        return copy (DarknessAblaze.PIERS_165, this);
+        return copy (DarknessAblaze.PIERS_165, this)
       case POKE_KID_70:
-        return copy (SwordShield.POKE_KID_173, this);
+        return copy (SwordShield.POKE_KID_173, this)
       case ROSE_71:
-        return copy (DarknessAblaze.ROSE_168, this);
+        return copy (DarknessAblaze.ROSE_168, this)
       case SKYLA_72:
-        return copy (BoundariesCrossed.SKYLA_134, this);
+        return copy (BoundariesCrossed.SKYLA_134, this)
       case ALCREMIE_VMAX_73:
-        return copy (ChampionsPath.ALCREMIE_VMAX_23, this);
+        return copy (ChampionsPath.ALCREMIE_VMAX_23, this)
       case ROWLET_SV1:
-        return copy (ROWLET_6, this);
+        return copy (ROWLET_6, this)
       case DARTRIX_SV2:
-        return copy (DARTRIX_7, this);
+        return copy (DARTRIX_7, this)
       case DECIDUEYE_SV3:
-        return copy (DECIDUEYE_8, this);
+        return copy (DECIDUEYE_8, this)
       case GROOKEY_SV4:
-        return copy (GROOKEY_11, this);
+        return copy (GROOKEY_11, this)
       case THWACKEY_SV5:
-        return copy (THWACKEY_12, this);
+        return copy (THWACKEY_12, this)
       case RILLABOOM_SV6:
-        return copy (RILLABOOM_13, this);
+        return copy (RILLABOOM_13, this)
       case BLIPBUG_SV7:
-        return copy (SwordShield.BLIPBUG_16, this);
+        return copy (SwordShield.BLIPBUG_16, this)
       case DOTTLER_SV8:
-        return copy (SwordShield.DOTTLER_18, this);
+        return copy (SwordShield.DOTTLER_18, this)
       case ORBEETLE_SV9:
-        return copy (SwordShield.ORBEETLE_19, this);
+        return copy (SwordShield.ORBEETLE_19, this)
       case GOSSIFLEUR_SV10:
-        return copy (SwordShield.GOSSIFLEUR_20, this);
+        return copy (SwordShield.GOSSIFLEUR_20, this)
       case ELDEGOSS_SV11:
-        return copy (SwordShield.ELDEGOSS_21, this);
+        return copy (SwordShield.ELDEGOSS_21, this)
       case APPLIN_SV12:
-        return copy (RebelClash.APPLIN_21, this);
+        return copy (RebelClash.APPLIN_21, this)
       case FLAPPLE_SV13:
-        return copy (RebelClash.FLAPPLE_22, this);
+        return copy (RebelClash.FLAPPLE_22, this)
       case APPLETUN_SV14:
-        return copy (RebelClash.APPLETUN_23, this);
+        return copy (RebelClash.APPLETUN_23, this)
       case SCORBUNNY_SV15:
-        return copy (SwordShield.SCORBUNNY_30, this);
+        return copy (SwordShield.SCORBUNNY_30, this)
       case RABOOT_SV16:
-        return copy (SwordShield.RABOOT_32, this);
+        return copy (SwordShield.RABOOT_32, this)
       case CINDERACE_SV17:
-        return copy (SwordShield.CINDERACE_34, this);
+        return copy (SwordShield.CINDERACE_34, this)
       case SIZZLIPEDE_SV18:
-        return copy (SwordShield.SIZZLIPEDE_37, this);
+        return copy (SwordShield.SIZZLIPEDE_37, this)
       case CENTISKORCH_SV19:
-        return copy (SwordShield.CENTISKORCH_39, this);
+        return copy (SwordShield.CENTISKORCH_39, this)
       case GALARIAN_MR_MIME_SV20:
-        return copy (DarknessAblaze.GALARIAN_MR_MIME_35, this);
+        return copy (DarknessAblaze.GALARIAN_MR_MIME_35, this)
       case GALARIAN_MR_RIME_SV21:
-        return copy (DarknessAblaze.GALARIAN_MR_RIME_36, this);
+        return copy (DarknessAblaze.GALARIAN_MR_RIME_36, this)
       case SUICUNE_SV22:
-        return copy (DarknessAblaze.SUICUNE_37, this);
+        return copy (DarknessAblaze.SUICUNE_37, this)
       case GALARIAN_DARUMAKA_SV23:
-        return copy (RebelClash.GALARIAN_DARUMAKA_47, this);
+        return copy (RebelClash.GALARIAN_DARUMAKA_47, this)
       case GALARIAN_DARMANITAN_SV24:
-        return copy (RebelClash.GALARIAN_DARMANITAN_48, this);
+        return copy (RebelClash.GALARIAN_DARMANITAN_48, this)
       case SOBBLE_SV25:
-        return copy (SwordShield.SOBBLE_54, this);
+        return copy (SwordShield.SOBBLE_54, this)
       case DRIZZILE_SV26:
-        return copy (SwordShield.DRIZZILE_56, this);
+        return copy (SwordShield.DRIZZILE_56, this)
       case INTELEON_SV27:
-        return copy (SwordShield.INTELEON_58, this);
+        return copy (SwordShield.INTELEON_58, this)
       case CHEWTLE_SV28:
-        return copy (SwordShield.CHEWTLE_60, this);
+        return copy (SwordShield.CHEWTLE_60, this)
       case DREDNAW_SV29:
-        return copy (SwordShield.DREDNAW_61, this);
+        return copy (SwordShield.DREDNAW_61, this)
       case CRAMORANT_SV30:
-        return copy (RebelClash.CRAMORANT_51, this);
+        return copy (RebelClash.CRAMORANT_51, this)
       case ARROKUDA_SV31:
-        return copy (RebelClash.ARROKUDA_52, this);
+        return copy (RebelClash.ARROKUDA_52, this)
       case BARRASKEWDA_SV32:
-        return copy (RebelClash.BARRASKEWDA_53, this);
+        return copy (RebelClash.BARRASKEWDA_53, this)
       case SNOM_SV33:
-        return copy (SNOM_29, this);
+        return copy (SNOM_29, this)
       case FROSMOTH_SV34:
-        return copy (FROSMOTH_30, this);
+        return copy (FROSMOTH_30, this)
       case EISCUE_SV35:
-        return copy (RebelClash.EISCUE_54, this);
+        return copy (RebelClash.EISCUE_54, this)
       case DRACOVISH_SV36:
-        return copy (DarknessAblaze.DRACOVISH_53, this);
+        return copy (DarknessAblaze.DRACOVISH_53, this)
       case ARCTOVISH_SV37:
-        return copy (DarknessAblaze.ARCTOVISH_54, this);
+        return copy (DarknessAblaze.ARCTOVISH_54, this)
       case ROTOM_SV38:
-        return copy (ROTOM_34, this);
+        return copy (ROTOM_34, this)
       case YAMPER_SV39:
-        return copy (SwordShield.YAMPER_73, this);
+        return copy (SwordShield.YAMPER_73, this)
       case BOLTUND_SV40:
-        return copy (SwordShield.BOLTUND_75, this);
+        return copy (SwordShield.BOLTUND_75, this)
       case TOXEL_SV41:
-        return copy (DarknessAblaze.TOXEL_62, this);
+        return copy (DarknessAblaze.TOXEL_62, this)
       case TOXTRICITY_SV42:
-        return copy (DarknessAblaze.TOXTRICITY_63, this);
+        return copy (DarknessAblaze.TOXTRICITY_63, this)
       case PINCURCHIN_SV43:
-        return copy (SwordShield.PINCURCHIN_77, this);
+        return copy (SwordShield.PINCURCHIN_77, this)
       case MORPEKO_SV44:
-        return copy (RebelClash.MORPEKO_73, this);
+        return copy (RebelClash.MORPEKO_73, this)
       case DRACOZOLT_SV45:
-        return copy (DarknessAblaze.DRACOZOLT_65, this);
+        return copy (DarknessAblaze.DRACOZOLT_65, this)
       case ARCTOZOLT_SV46:
-        return copy (DarknessAblaze.ARCTOZOLT_66, this);
+        return copy (DarknessAblaze.ARCTOZOLT_66, this)
       case GALARIAN_PONYTA_SV47:
-        return copy (SwordShield.GALARIAN_PONYTA_81, this);
+        return copy (SwordShield.GALARIAN_PONYTA_81, this)
       case GALARIAN_RAPIDASH_SV48:
-        return copy (SwordShield.GALARIAN_RAPIDASH_82, this);
+        return copy (SwordShield.GALARIAN_RAPIDASH_82, this)
       case GALARIAN_CORSOLA_SV49:
-        return copy (RebelClash.GALARIAN_CORSOLA_78, this);
+        return copy (RebelClash.GALARIAN_CORSOLA_78, this)
       case GALARIAN_CURSOLA_SV50:
-        return copy (RebelClash.GALARIAN_CURSOLA_79, this);
+        return copy (RebelClash.GALARIAN_CURSOLA_79, this)
       case DEDENNE_SV51:
-        return copy (DarknessAblaze.DEDENNE_78, this);
+        return copy (DarknessAblaze.DEDENNE_78, this)
       case SINISTEA_SV52:
-        return copy (DarknessAblaze.SINISTEA_82, this);
+        return copy (DarknessAblaze.SINISTEA_82, this)
       case POLTEAGEIST_SV53:
-        return copy (DarknessAblaze.POLTEAGEIST_83, this);
+        return copy (DarknessAblaze.POLTEAGEIST_83, this)
       case HATENNA_SV54:
-        return copy (RebelClash.HATENNA_83, this);
+        return copy (RebelClash.HATENNA_83, this)
       case HATTREM_SV55:
-        return copy (RebelClash.HATTREM_84, this);
+        return copy (RebelClash.HATTREM_84, this)
       case HATTERENE_SV56:
-        return copy (RebelClash.HATTERENE_85, this);
+        return copy (RebelClash.HATTERENE_85, this)
       case MILCERY_SV57:
-        return copy (RebelClash.MILCERY_86, this);
+        return copy (RebelClash.MILCERY_86, this)
       case ALCREMIE_SV58:
-        return copy (RebelClash.ALCREMIE_87, this);
+        return copy (RebelClash.ALCREMIE_87, this)
       case INDEEDEE_SV59:
-        return copy (RebelClash.INDEEDEE_88, this);
+        return copy (RebelClash.INDEEDEE_88, this)
       case DREEPY_SV60:
-        return copy (RebelClash.DREEPY_89, this);
+        return copy (RebelClash.DREEPY_89, this)
       case DRAKLOAK_SV61:
-        return copy (RebelClash.DRAKLOAK_90, this);
+        return copy (RebelClash.DRAKLOAK_90, this)
       case DRAGAPULT_SV62:
-        return copy (RebelClash.DRAGAPULT_91, this);
+        return copy (RebelClash.DRAGAPULT_91, this)
       case GALARIAN_FARFETCH_D_SV63:
-        return copy (RebelClash.GALARIAN_FARFETCH_D_94, this);
+        return copy (RebelClash.GALARIAN_FARFETCH_D_94, this)
       case GALARIAN_SIRFETCH_D_SV64:
-        return copy (RebelClash.GALARIAN_SIRFETCH_D_95, this);
+        return copy (RebelClash.GALARIAN_SIRFETCH_D_95, this)
       case GALARIAN_YAMASK_SV65:
-        return copy (RebelClash.GALARIAN_YAMASK_101, this);
+        return copy (RebelClash.GALARIAN_YAMASK_101, this)
       case GALARIAN_RUNERIGUS_SV66:
-        return copy (RebelClash.GALARIAN_RUNERIGUS_102, this);
+        return copy (RebelClash.GALARIAN_RUNERIGUS_102, this)
       case ROLYCOLY_SV67:
-        return copy (RebelClash.ROLYCOLY_105, this);
+        return copy (RebelClash.ROLYCOLY_105, this)
       case CARKOL_SV68:
-        return copy (RebelClash.CARKOAL_106, this);
+        return copy (RebelClash.CARKOAL_106, this)
       case COALOSSAL_SV69:
-        return copy (RebelClash.COALOSSAL_107, this);
+        return copy (RebelClash.COALOSSAL_107, this)
       case SILICOBRA_SV70:
-        return copy (SwordShield.SILICOBRA_107, this);
+        return copy (SwordShield.SILICOBRA_107, this)
       case SANDACONDA_SV71:
-        return copy (SwordShield.SANDACONDA_109, this);
+        return copy (SwordShield.SANDACONDA_109, this)
       case CLOBBOPUS_SV72:
-        return copy (SwordShield.CLOBBOPUS_111, this);
+        return copy (SwordShield.CLOBBOPUS_111, this)
       case GRAPPLOCT_SV73:
-        return copy (SwordShield.GRAPPLOCT_113, this);
+        return copy (SwordShield.GRAPPLOCT_113, this)
       case FALINKS_SV74:
-        return copy (RebelClash.FALINKS_109, this);
+        return copy (RebelClash.FALINKS_109, this)
       case STONJOURNER_SV75:
-        return copy (RebelClash.STONJOURNER_111, this);
+        return copy (RebelClash.STONJOURNER_111, this)
       case KOFFING_SV76:
-        return copy (KOFFING_41, this);
+        return copy (KOFFING_41, this)
       case GALARIAN_WEEZING_SV77:
-        return copy (GALARIAN_WEEZING_42, this);
+        return copy (GALARIAN_WEEZING_42, this)
       case GALARIAN_ZIGZAGOON_SV78:
-        return copy (SwordShield.GALARIAN_ZIGZAGOON_117, this);
+        return copy (SwordShield.GALARIAN_ZIGZAGOON_117, this)
       case GALARIAN_LINOONE_SV79:
-        return copy (SwordShield.GALARIAN_LINOONE_118, this);
+        return copy (SwordShield.GALARIAN_LINOONE_118, this)
       case GALARIAN_OBSTAGOON_SV80:
-        return copy (SwordShield.GALARIAN_OBSTAGOON_119, this);
+        return copy (SwordShield.GALARIAN_OBSTAGOON_119, this)
       case NICKIT_SV81:
-        return copy (NICKIT_47, this);
+        return copy (NICKIT_47, this)
       case THIEVUL_SV82:
-        return copy (SwordShield.THIEVUL_126, this);
+        return copy (SwordShield.THIEVUL_126, this)
       case IMPIDIMP_SV83:
-        return copy (RebelClash.IMPIDIMP_123, this);
+        return copy (RebelClash.IMPIDIMP_123, this)
       case MORGREM_SV84:
-        return copy (RebelClash.MORGREM_124, this);
+        return copy (RebelClash.MORGREM_124, this)
       case GRIMMSNARL_SV85:
-        return copy (RebelClash.GRIMMSNARL_125, this);
+        return copy (RebelClash.GRIMMSNARL_125, this)
       case GALARIAN_MEOWTH_SV86:
-        return copy (RebelClash.GALARIAN_MEOWTH_126, this);
+        return copy (RebelClash.GALARIAN_MEOWTH_126, this)
       case GALARIAN_PERRSERKER_SV87:
-        return copy (SwordShield.GALARIAN_PERRSERKER_128, this);
+        return copy (SwordShield.GALARIAN_PERRSERKER_128, this)
       case GALARIAN_STUNFISK_SV88:
-        return copy (SwordShield.GALARIAN_STUNFISK_132, this);
+        return copy (SwordShield.GALARIAN_STUNFISK_132, this)
       case CORVIKNIGHT_SV89:
-        return copy (SwordShield.CORVIKNIGHT_135, this);
+        return copy (SwordShield.CORVIKNIGHT_135, this)
       case CUFANT_SV90:
-        return copy (CUFANT_49, this);
+        return copy (CUFANT_49, this)
       case COPPERAJAH_SV91:
-        return copy (DarknessAblaze.COPPERAJAH_132, this);
+        return copy (DarknessAblaze.COPPERAJAH_132, this)
       case DURALUDON_SV92:
-        return copy (RebelClash.DURALUDON_138, this);
+        return copy (RebelClash.DURALUDON_138, this)
       case MINCCINO_SV93:
-        return copy (SwordShield.MINCCINO_145, this);
+        return copy (SwordShield.MINCCINO_145, this)
       case CINCCINO_SV94:
-        return copy (SwordShield.CINCCINO_147, this);
+        return copy (SwordShield.CINCCINO_147, this)
       case DUCKLETT_SV95:
-        return copy (DarknessAblaze.DUCKLETT_148, this);
+        return copy (DarknessAblaze.DUCKLETT_148, this)
       case SWANNA_SV96:
-        return copy (DarknessAblaze.SWANNA_149, this);
+        return copy (DarknessAblaze.SWANNA_149, this)
       case BUNNELBY_SV97:
-        return copy (DarknessAblaze.BUNNELBY_150, this);
+        return copy (DarknessAblaze.BUNNELBY_150, this)
       case ORANGURU_SV98:
-        return copy (SwordShield.ORANGURU_148, this);
+        return copy (SwordShield.ORANGURU_148, this)
       case SKWOVET_SV99:
-        return copy (RebelClash.SKWOVET_151, this);
+        return copy (RebelClash.SKWOVET_151, this)
       case GREEDENT_SV100:
-        return copy (RebelClash.GREEDENT_152, this);
+        return copy (RebelClash.GREEDENT_152, this)
       case ROOKIDEE_SV101:
-        return copy (SwordShield.ROOKIDEE_150, this);
+        return copy (SwordShield.ROOKIDEE_150, this)
       case CORVISQUIRE_SV102:
-        return copy (SwordShield.CORVISQUIRE_151, this);
+        return copy (SwordShield.CORVISQUIRE_151, this)
       case WOOLOO_SV103:
-        return copy (SwordShield.WOOLOO_152, this);
+        return copy (SwordShield.WOOLOO_152, this)
       case DUBWOOL_SV104:
-        return copy (SwordShield.DUBWOOL_154, this);
+        return copy (SwordShield.DUBWOOL_154, this)
       case RILLABOOM_V_SV105:
-        return copy (SwordShieldPromos.RILLABOOM_V_SWSH14, this);
+        return copy (SwordShieldPromos.RILLABOOM_V_SWSH14, this)
       case RILLABOOM_VMAX_SV106:
-        return copy (RebelClash.RILLABOOM_VMAX_18, this);
+        return copy (RebelClash.RILLABOOM_VMAX_18, this)
       case CHARIZARD_VMAX_SV107:
-        return copy (DarknessAblaze.CHARIZARD_VMAX_20, this);
+        return copy (DarknessAblaze.CHARIZARD_VMAX_20, this)
       case CENTISKORCH_V_SV108:
-        return copy (DarknessAblaze.CENTISKORCH_V_33, this);
+        return copy (DarknessAblaze.CENTISKORCH_V_33, this)
       case CENTISKORCH_VMAX_SV109:
-        return copy (DarknessAblaze.CENTISKORCH_VMAX_34, this);
+        return copy (DarknessAblaze.CENTISKORCH_VMAX_34, this)
       case LAPRAS_V_SV110:
-        return copy (SwordShield.LAPRAS_V_49, this);
+        return copy (SwordShield.LAPRAS_V_49, this)
       case LAPRAS_VMAX_SV111:
-        return copy (SwordShield.LAPRAS_VMAX_50, this);
+        return copy (SwordShield.LAPRAS_VMAX_50, this)
       case TOXTRICITY_V_SV112:
-        return copy (RebelClash.TOXTRICITY_V_70, this);
+        return copy (RebelClash.TOXTRICITY_V_70, this)
       case TOXTRICITY_VMAX_SV113:
-        return copy (RebelClash.TOXTRICITY_VMAX_71, this);
+        return copy (RebelClash.TOXTRICITY_VMAX_71, this)
       case INDEEDEE_V_SV114:
-        return copy (INDEEDEE_V_39, this);
+        return copy (INDEEDEE_V_39, this)
       case FALINKS_V_SV115:
-        return copy (RebelClash.FALINKS_V_110, this);
+        return copy (RebelClash.FALINKS_V_110, this)
       case GRIMMSNARL_V_SV116:
-        return copy (DarknessAblaze.GRIMMSNARL_V_114, this);
+        return copy (DarknessAblaze.GRIMMSNARL_V_114, this)
       case GRIMMSNARL_VMAX_SV117:
-        return copy (DarknessAblaze.GRIMMSNARL_VMAX_115, this);
+        return copy (DarknessAblaze.GRIMMSNARL_VMAX_115, this)
       case DITTO_V_SV118:
-        return copy (DITTO_V_50, this);
+        return copy (DITTO_V_50, this)
       case DITTO_VMAX_SV119:
-        return copy (DITTO_VMAX_51, this);
+        return copy (DITTO_VMAX_51, this)
       case DUBWOOL_V_SV120:
-        return copy (RebelClash.DUBWOOL_V_153, this);
+        return copy (RebelClash.DUBWOOL_V_153, this)
       case ETERNATUS_V_SV121:
-        return copy (DarknessAblaze.ETERNATUS_V_116, this);
+        return copy (DarknessAblaze.ETERNATUS_V_116, this)
       case ETERNATUS_VMAX_SV122:
-        return copy (DarknessAblaze.ETERNATUS_VMAX_117, this);
+        return copy (DarknessAblaze.ETERNATUS_VMAX_117, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/ShinyStarV.groovy
+++ b/src/tcgwars/logic/impl/gen8/ShinyStarV.groovy
@@ -1,34 +1,34 @@
-package tcgwars.logic.impl.gen8;
+package tcgwars.logic.impl.gen8
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -50,53 +50,53 @@ public enum ShinyStarV implements LogicCardInfo {
   RUSTED_SHIELD_13 ("Rusted Shield", "13", Rarity.HOLORARE, [TRAINER, POKEMON_TOOL, ITEM]),
   BALL_GUY_14 ("Ball Guy", "14", Rarity.ULTRARARE, [TRAINER, SUPPORTER]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   ShinyStarV(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SHINY_STAR_V;
+    return tcgwars.logic.card.Collection.SHINY_STAR_V
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -109,7 +109,7 @@ public enum ShinyStarV implements LogicCardInfo {
           text "If you have any Stadium card in play, this Pokémon has no Retreat Cost."
           getterA GET_RETREAT_COST, BEFORE_LAST, self, { h->
             if (bg.stadiumInfoStruct?.stadiumCard?.player == self.owner) {
-              h.object = 0;
+              h.object = 0
             }
           }
         }
@@ -120,7 +120,7 @@ public enum ShinyStarV implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RESHIRAM_2:
       return basic (this, hp:HP120, type:R, retreatCost:3) {
         weakness W
@@ -132,7 +132,7 @@ public enum ShinyStarV implements LogicCardInfo {
             damage 60, self
           }
         }
-      };
+      }
       case KYOGRE_3:
       return basic (this, hp:HP120, type:W, retreatCost:3) {
         weakness L
@@ -143,7 +143,7 @@ public enum ShinyStarV implements LogicCardInfo {
             opp.all.each { damage 80, it }
           }
         }
-      };
+      }
       case SNOM_4:
       return basic (this, hp:HP050, type:W, retreatCost:2) {
         weakness M
@@ -152,7 +152,7 @@ public enum ShinyStarV implements LogicCardInfo {
           energyCost W
           callForFamily basic:true, 1, delegate
         }
-      };
+      }
       case ROTOM_5:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -175,7 +175,7 @@ public enum ShinyStarV implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case KOFFING_6:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -184,7 +184,7 @@ public enum ShinyStarV implements LogicCardInfo {
           energyCost D
           ascension delegate
         }
-      };
+      }
       case CROBAT_VMAX_7:
       return evolution (this, from:"Crobat V", hp:HP300, type:D, retreatCost:1) {
         weakness F
@@ -204,7 +204,7 @@ public enum ShinyStarV implements LogicCardInfo {
             damage 180
           }
         }
-      };
+      }
       case YVELTAL_8:
       return basic (this, hp:HP110, type:D, retreatCost:2) {
         weakness L
@@ -218,7 +218,7 @@ public enum ShinyStarV implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DITTO_V_9:
       return basic (this, hp:HP170, type:C, retreatCost:2) {
         weakness F
@@ -245,7 +245,7 @@ public enum ShinyStarV implements LogicCardInfo {
             attachEnergyFrom basic:true, my.discard, self
           }
         }
-      };
+      }
       case DITTO_VMAX_10:
       return evolution (this, from:"Ditto V", hp:HP320, type:C, retreatCost:3) {
         weakness F
@@ -256,7 +256,7 @@ public enum ShinyStarV implements LogicCardInfo {
             metronome defending, delegate
           }
         }
-      };
+      }
       case TEAM_YELL_S_CHEERING_TOWEL_11:
       return itemCard (this) {
         text "Heal 50 damage from both Active Pokémon."
@@ -267,7 +267,7 @@ public enum ShinyStarV implements LogicCardInfo {
         playRequirement{
           assert my.active.numberOfDamageCounters || opp.active.numberOfDamageCounters : "Neither Active Pokémon is damaged"
         }
-      };
+      }
       case RUSTED_SWORD_12:
       return pokemonTool (this) {
         text "The attacks of the Zacian V this card is attached to do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
@@ -288,7 +288,7 @@ public enum ShinyStarV implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case RUSTED_SHIELD_13:
       return pokemonTool (this) {
         text "The Zamazenta V this card is attached to gets +70 HP."
@@ -302,7 +302,7 @@ public enum ShinyStarV implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case BALL_GUY_14:
       return supporter (this) {
         text "Search your deck for up to 3 different Item cards that have the word 'Ball' in their name " +
@@ -326,9 +326,9 @@ public enum ShinyStarV implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/SkyscrapingPerfection.groovy
+++ b/src/tcgwars/logic/impl/gen8/SkyscrapingPerfection.groovy
@@ -119,53 +119,53 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
   CRYSTAL_CAVE_89 ("Crystal Cave", "89", Rarity.UNCOMMON, [TRAINER, STADIUM]),
   METAL_ENERGY_90 ("Metal Energy", "90", Rarity.COMMON, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SkyscrapingPerfection(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SKYSCRAPING_PERFECTION;
+    return tcgwars.logic.card.Collection.SKYSCRAPING_PERFECTION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -191,7 +191,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20 + 20 * all.findAll { it.benched }.size()
           }
         }
-      };
+      }
       case LOTAD_2:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -207,7 +207,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LOMBRE_3:
       return evolution (this, from:"Lotad", hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -218,7 +218,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LUDICOLO_4:
       return evolution (this, from:"Lombre", hp:HP140, type:W, retreatCost:2) {
         weakness L
@@ -250,7 +250,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case PANPOUR_5:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -262,7 +262,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             opp.hand.showToMe bg, "Your opponent's hand."
           }
         }
-      };
+      }
       case SIMIPOUR_6:
       return evolution (this, from:"Panpour", hp:HP100, type:W, retreatCost:1) {
         weakness L
@@ -285,7 +285,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 60 * opp.hand.count { it.cardTypes.is SUPPORTER }.intValue()
           }
         }
-      };
+      }
       case CLAUNCHER_7:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness L
@@ -303,7 +303,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAWITZER_8:
       return evolution (this, from:"Clauncher", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -321,7 +321,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case EISCUE_9:
       return basic (this, hp:HP120, type:W, retreatCost:2) {
         weakness M
@@ -340,7 +340,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             preventAllDamageFromCustomPokemonNextTurn thisMove, self, { it.basic }
           }
         }
-      };
+      }
       case JIGGLYPUFF_10:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness M
@@ -362,7 +362,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20 * my.bench.findAll { it.getTopPokemonCard().moves.any { it.name == "Everyone Rollout" } }.size()
           }
         }
-      };
+      }
       case WIGGLYTUFF_11:
       return evolution (this, from:"Jigglypuff", hp:HP120, type:P, retreatCost:2) {
         weakness M
@@ -384,7 +384,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case GALARIAN_ARTICUNO_12:
       return basic (this, hp:HP120, type:P, retreatCost:2) {
         weakness D
@@ -408,7 +408,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WOBBUFFET_13:
       return basic (this, hp:HP120, type:P, retreatCost:2) {
         weakness D
@@ -432,7 +432,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SIGILYPH_14:
       return basic (this, hp:HP100, type:P, retreatCost:1) {
         weakness L
@@ -453,7 +453,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             moveEnergy self, my.bench
           }
         }
-      };
+      }
       case GOLURK_V_15:
       return basic (this, hp:HP220, type:P, retreatCost:3) {
         weakness D
@@ -477,7 +477,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case PUMPKABOO_16:
       return basic (this, hp:HP060, type:P, retreatCost:2) {
         weakness D
@@ -498,7 +498,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOURGEIST_17:
       return evolution (this, from:"Pumpkaboo", hp:HP120, type:P, retreatCost:2) {
         weakness D
@@ -519,7 +519,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case HITMONCHAN_18:
       return basic (this, hp:HP110, type:F, retreatCost:1) {
         weakness P
@@ -538,7 +538,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             noResistanceDamage 40, defending
           }
         }
-      };
+      }
       case GALARIAN_ZAPDOS_19:
       return basic (this, hp:HP110, type:F, retreatCost:0) {
         weakness P
@@ -564,7 +564,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GLIGAR_20:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -582,7 +582,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GLISCOR_21:
       return evolution (this, from:"Gligar", hp:HP110, type:F, retreatCost:1) {
         weakness G
@@ -602,7 +602,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case MAKUHITA_22:
       return basic (this, hp:HP090, type:F, retreatCost:3) {
         weakness P
@@ -620,7 +620,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HARIYAMA_23:
       return evolution (this, from:"Makuhita", hp:HP140, type:F, retreatCost:4) {
         weakness P
@@ -645,7 +645,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case LYCANROC_V_24:
       return basic (this, hp:HP200, type:F, retreatCost:1) {
         weakness G
@@ -664,7 +664,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case LYCANROC_VMAX_25:
       return evolution (this, from:"Lycanroc V", hp:HP320, type:F, retreatCost:1) {
         weakness G
@@ -687,7 +687,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             if (opp.bench) damage 30, opp.bench.select("This attack also does 30 damage to 1 of your opponent's Benched Pokémon.")
           }
         }
-      };
+      }
       case GALARIAN_MOLTRES_26:
       return basic (this, hp:HP120, type:D, retreatCost:2) {
         weakness G
@@ -708,7 +708,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 50 * opp.prizeCardSet.takenCount
           }
         }
-      };
+      }
       case ABSOL_27:
       return basic (this, hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -730,7 +730,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case CROAGUNK_28:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -741,7 +741,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOXICROAK_29:
       return evolution (this, from:"Croagunk", hp:HP110, type:D, retreatCost:1) {
         weakness F
@@ -760,7 +760,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case GARBODOR_V_30:
       return basic (this, hp:HP210, type:D, retreatCost:3) {
         weakness F
@@ -780,7 +780,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case GARBODOR_VMAX_31:
       return evolution (this, from:"Garbodor V", hp:HP330, type:D, retreatCost:3) {
         weakness F
@@ -806,7 +806,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case NICKIT_32:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -817,7 +817,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case THIEVUL_33:
       return evolution (this, from:"Nickit", hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -851,7 +851,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case GALARIAN_MEOWTH_34:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -870,7 +870,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GALARIAN_PERRSERKER_35:
       return evolution (this, from:"Galarian Meowth", hp:HP120, type:M, retreatCost:1) {
         weakness R
@@ -893,7 +893,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case SKARMORY_36:
       return basic (this, hp:HP120, type:M, retreatCost:1) {
         weakness R
@@ -913,7 +913,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 110
           }
         }
-      };
+      }
       case KLEFKI_37:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -926,7 +926,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             draw 2
           }
         }
-      };
+      }
       case CUFANT_38:
       return basic (this, hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -946,7 +946,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case COPPERAJAH_39:
       return evolution (this, from:"Cufant", hp:HP190, type:M, retreatCost:4) {
         weakness R
@@ -966,7 +966,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case ALTARIA_40:
       return evolution (this, from:"Swablu", hp:HP090, type:N, retreatCost:0) {
         bwAbility "Luring Melody", {
@@ -986,7 +986,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case DIALGA_41:
       return basic (this, hp:HP130, type:N, retreatCost:2) {
         move "Chrono Wind", {
@@ -1006,7 +1006,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 210
           }
         }
-      };
+      }
       case DEINO_42:
       return basic (this, hp:HP060, type:N, retreatCost:1) {
         move "Call for Family", {
@@ -1021,7 +1021,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ZWEILOUS_43:
       return evolution (this, from:"Deino", hp:HP100, type:N, retreatCost:2) {
         move "Bite", {
@@ -1038,7 +1038,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case HYDREIGON_44:
       return evolution (this, from:"Zweilous", hp:HP170, type:N, retreatCost:3) {
         move "Dragon Counter", {
@@ -1056,7 +1056,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 210
           }
         }
-      };
+      }
       case KYUREM_45:
       return basic (this, hp:HP120, type:N, retreatCost:2) {
         move "Extreme Freeze", {
@@ -1078,7 +1078,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 60 * count
           }
         }
-      };
+      }
       case NOIVERN_V_46:
       return basic (this, hp:HP200, type:N, retreatCost:0) {
         move "Boomburst", {
@@ -1096,7 +1096,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             if (my.hand.size() == opp.hand.size()) damage 120
           }
         }
-      };
+      }
       case DRAMPA_47:
       return basic (this, hp:HP120, type:N, retreatCost:2) {
         move "Corkscrew Punch", {
@@ -1114,7 +1114,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             if (bench.any { it.numberOfDamageCounters }) damage 90
           }
         }
-      };
+      }
       case DURALUDON_V_48:
       return basic (this, hp:HP220, type:N, retreatCost:2) {
         move "Metal Claw", {
@@ -1132,7 +1132,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             reduceDamageFromDefendingNextTurn hp(30), thisMove, defending
           }
         }
-      };
+      }
       case DURALUDON_VMAX_49:
       return evolution (this, from:"Duraludon V", hp:HP330, type:N, retreatCost:3) {
         bwAbility "Skyscraper", {
@@ -1155,7 +1155,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             shredDamage 220
           }
         }
-      };
+      }
       case SLAKOTH_50:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -1169,7 +1169,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VIGOROTH_51:
       return evolution (this, from:"Slakoth", hp:HP090, type:C, retreatCost:1) {
         weakness F
@@ -1190,7 +1190,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SLAKING_52:
       return evolution (this, from:"Vigoroth", hp:HP180, type:C, retreatCost:4) {
         weakness F
@@ -1213,7 +1213,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 30 * opp.bench.size()
           }
         }
-      };
+      }
       case SWABLU_53:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1227,7 +1227,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WOOLOO_54:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1250,7 +1250,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 20 * my.bench.findAll { it.getTopPokemonCard().moves.any { it.name == "Everyone Rollout" } }.size()
           }
         }
-      };
+      }
       case DUBWOOL_55:
       return evolution (this, from:"Wooloo", hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -1269,11 +1269,11 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ESCAPE_ROPE_56:
-        return copy(PlasmaStorm.ESCAPE_ROPE_120, this);
+        return copy(PlasmaStorm.ESCAPE_ROPE_120, this)
       case EVOLUTION_INCENSE_57:
-      return copy(SwordShield.EVOLUTION_INCENSE_163, this);
+      return copy(SwordShield.EVOLUTION_INCENSE_163, this)
       case SWITCHEROO_CUP_58:
       return itemCard (this) {
         text "Switch a card from your hand with the top card of your deck."
@@ -1285,7 +1285,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
           assert hand.getExcludedList(thisCard) : "You have no other cards in your hand"
           assert deck : "Your deck is empty"
         }
-      };
+      }
       case RESCUE_TROLLEY_59:
       return itemCard (this) {
         text "Put up to 2 Pokémon with 90 HP or less from your discard pile into your hand."
@@ -1296,7 +1296,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         playRequirement{
           assert my.discard.any { it.cardTypes.is(POKEMON) && it.asPokemonCard().hp <= 90 } : "No Pokémon with 90 HP or less in your discard pile"
         }
-      };
+      }
       case DIGGING_GLOVES_60:
       return pokemonTool (this) {
         text "The attacks of the Pokémon this card is attached to do 30 more damage to your opponent's Active [F] Pokémon (before applying Weakness and Resistance)."
@@ -1316,7 +1316,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case SINGLE_STRIKE_SCROLL_OF_THE_DRAGON_FANG_61:
       return pokemonTool (this) {
         text "The Single Strike Pokémon this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)"
@@ -1352,7 +1352,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         onRemoveFromPlay {
           newMove.unregister()
         }
-      };
+      }
       case FULL_FACE_GUARD_62:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to has no Abilities" +
@@ -1375,7 +1375,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case RAIHAN_63:
       return supporter (this) {
         text "You can play this card only if 1 of your Pokémon was Knocked Out during your opponent's last turn. Attach a basic Energy card from your discard pile to 1 of your Pokémon. If you do" +
@@ -1398,7 +1398,7 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
           assert keyStore("Rosa_KO", thisCard, null) == bg.turnCount - 1: "No Pokémon was Knocked Out during your opponent’s last turn"
           assert my.discard.any { it.cardTypes.is(BASIC_ENERGY) } : "No basic Energy cards in your discard pile"
         }
-      };
+      }
       case SCHOOLGIRL_64:
       return supporter (this) {
         text "Draw 2 cards. If your opponent has exactly 2" +
@@ -1409,9 +1409,9 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case COPYCAT_65:
-        return copy(TeamRocketReturns.COPYCAT_83, this);
+        return copy(TeamRocketReturns.COPYCAT_83, this)
       case CRYSTAL_CAVE_66:
       return stadium (this) {
         text "Once during each player's turn" +
@@ -1433,57 +1433,57 @@ public enum SkyscrapingPerfection implements LogicCardInfo {
         onRemoveFromPlay{
           actions.each { bg.gm().unregisterAction(it) }
         }
-      };
+      }
       case TWIN_ENERGY_67:
         return copy (RebelClash.TWIN_ENERGY_174, this)
       case SUICUNE_V_68:
-      return copy (SUICUNE_V_1, this);
+      return copy (SUICUNE_V_1, this)
       case GOLURK_V_69:
-      return copy (GOLURK_V_15, this);
+      return copy (GOLURK_V_15, this)
       case GOLURK_V_70:
-      return copy (GOLURK_V_15, this);
+      return copy (GOLURK_V_15, this)
       case LYCANROC_V_71:
-      return copy (LYCANROC_V_24, this);
+      return copy (LYCANROC_V_24, this)
       case GARBODOR_V_72:
-      return copy (GARBODOR_V_30, this);
+      return copy (GARBODOR_V_30, this)
       case NOIVERN_V_73:
-      return copy (NOIVERN_V_46, this);
+      return copy (NOIVERN_V_46, this)
       case NOIVERN_V_74:
-      return copy (NOIVERN_V_46, this);
+      return copy (NOIVERN_V_46, this)
       case DURALUDON_V_75:
-      return copy (DURALUDON_V_48, this);
+      return copy (DURALUDON_V_48, this)
       case DURALUDON_V_76:
-      return copy (DURALUDON_V_48, this);
+      return copy (DURALUDON_V_48, this)
       case RAIHAN_77:
-      return copy (RAIHAN_63, this);
+      return copy (RAIHAN_63, this)
       case SCHOOLGIRL_78:
-      return copy (SCHOOLGIRL_64, this);
+      return copy (SCHOOLGIRL_64, this)
       case COPYCAT_79:
-      return copy (COPYCAT_65, this);
+      return copy (COPYCAT_65, this)
       case LYCANROC_VMAX_80:
-      return copy (LYCANROC_VMAX_25, this);
+      return copy (LYCANROC_VMAX_25, this)
       case GARBODOR_VMAX_81:
-      return copy (GARBODOR_VMAX_31, this);
+      return copy (GARBODOR_VMAX_31, this)
       case DURALUDON_VMAX_82:
-      return copy (DURALUDON_VMAX_49, this);
+      return copy (DURALUDON_VMAX_49, this)
       case DURALUDON_VMAX_83:
-      return copy (DURALUDON_VMAX_49, this);
+      return copy (DURALUDON_VMAX_49, this)
       case RAIHAN_84:
-      return copy (RAIHAN_63, this);
+      return copy (RAIHAN_63, this)
       case SCHOOLGIRL_85:
-      return copy (SCHOOLGIRL_64, this);
+      return copy (SCHOOLGIRL_64, this)
       case COPYCAT_86:
-      return copy (COPYCAT_65, this);
+      return copy (COPYCAT_65, this)
       case CRESSELIA_87:
-      return copy (ChillingReign.CRESSELIA_64, this);
+      return copy (ChillingReign.CRESSELIA_64, this)
       case FULL_FACE_GUARD_88:
-      return copy (FULL_FACE_GUARD_62, this);
+      return copy (FULL_FACE_GUARD_62, this)
       case CRYSTAL_CAVE_89:
-      return copy (CRYSTAL_CAVE_66, this);
+      return copy (CRYSTAL_CAVE_66, this)
       case METAL_ENERGY_90:
-      return basicEnergy (this, M);
+      return basicEnergy (this, M)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/SwordShield.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShield.groovy
@@ -1,45 +1,45 @@
-package tcgwars.logic.impl.gen8;
+package tcgwars.logic.impl.gen8
 
-import tcgwars.logic.impl.gen3.Emerald;
-import tcgwars.logic.impl.gen5.BlackWhite;
-import tcgwars.logic.impl.gen5.DarkExplorers;
-import tcgwars.logic.impl.gen5.EmergingPowers;
-import tcgwars.logic.impl.gen6.Flashfire;
+import tcgwars.logic.impl.gen3.Emerald
+import tcgwars.logic.impl.gen5.BlackWhite
+import tcgwars.logic.impl.gen5.DarkExplorers
+import tcgwars.logic.impl.gen5.EmergingPowers
+import tcgwars.logic.impl.gen6.Flashfire
 import tcgwars.logic.impl.gen6.KalosStarterSet
-import tcgwars.logic.impl.gen6.Xy;
-import tcgwars.logic.impl.gen7.SunMoon;
-import tcgwars.logic.impl.gen7.UltraPrism;
-import tcgwars.logic.impl.gen7.UnbrokenBonds;
+import tcgwars.logic.impl.gen6.Xy
+import tcgwars.logic.impl.gen7.SunMoon
+import tcgwars.logic.impl.gen7.UltraPrism
+import tcgwars.logic.impl.gen7.UnbrokenBonds
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author (Lithogen) luongthomasdev@gmail.com
@@ -272,53 +272,53 @@ public enum SwordShield implements LogicCardInfo {
   DARKNESS_ENERGY_224 ("Darkness Energy", "224", Rarity.COMMON, [BASIC_ENERGY, ENERGY]),
   FAIRY_ENERGY_225 ("Fairy Energy", "225", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SwordShield(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SWORD_SHIELD;
+    return tcgwars.logic.card.Collection.SWORD_SHIELD
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -345,7 +345,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50+20*my.bench.size()
           }
         }
-      };
+      }
       case ROSELIA_2:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -357,7 +357,7 @@ public enum SwordShield implements LogicCardInfo {
             heal 10, self
           }
         }
-      };
+      }
       case ROSELIA_3:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -378,7 +378,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ROSERADE_4:
       return evolution (this, from:"Roselia", hp:HP120, type:G, retreatCost:1) {
         weakness R
@@ -399,7 +399,7 @@ public enum SwordShield implements LogicCardInfo {
             heal 30, self
           }
         }
-      };
+      }
       case COTTONEE_5:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -410,7 +410,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WHIMSICOTT_6:
       return evolution (this, from:"Cottonee", hp:HP100, type:G, retreatCost:1) {
         weakness R
@@ -432,7 +432,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MARACTUS_7:
       return basic (this, hp:HP110, type:G, retreatCost:2) {
         weakness R
@@ -450,7 +450,7 @@ public enum SwordShield implements LogicCardInfo {
             flip self.cards.energyCount(C), { damage 60 }
           }
         }
-      };
+      }
       case DURANT_8:
       return basic (this, hp:HP110, type:G, retreatCost:1) {
         weakness R
@@ -464,7 +464,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case DHELMISE_V_9:
       return basic (this, hp:HP220, type:G, retreatCost:2) {
         weakness R
@@ -484,7 +484,7 @@ public enum SwordShield implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case GROOKEY_10:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -495,7 +495,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 3, { damage 10 }
           }
         }
-      };
+      }
       case GROOKEY_11:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -513,7 +513,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case THWACKEY_12:
       return evolution (this, from:"Grookey", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -534,7 +534,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 2, { damage 60 }
           }
         }
-      };
+      }
       case THWACKEY_13:
       return evolution (this, from:"Grookey", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -553,7 +553,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case RILLABOOM_14:
       return evolution (this, from:"Thwackey", hp:HP170, type:G, retreatCost:3) {
         weakness R
@@ -576,7 +576,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 140
           }
         }
-      };
+      }
       case RILLABOOM_15:
       return evolution (this, from:"Thwackey", hp:HP190, type:G, retreatCost:4) {
         weakness R
@@ -596,7 +596,7 @@ public enum SwordShield implements LogicCardInfo {
             cantUseAttack(thisMove, self)
           }
         }
-      };
+      }
       case BLIPBUG_16:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -607,7 +607,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BLIPBUG_17:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -616,7 +616,7 @@ public enum SwordShield implements LogicCardInfo {
           energyCost C
           callForFamily(basic: true, 1, delegate)
         }
-      };
+      }
       case DOTTLER_18:
       return evolution (this, from:"Blipbug", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -634,7 +634,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ORBEETLE_19:
       return evolution (this, from:"Dottler", hp:HP130, type:G, retreatCost:1) {
         weakness R
@@ -658,7 +658,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 90+30*self.cards.energyCount(P)
           }
         }
-      };
+      }
       case GOSSIFLEUR_20:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -674,7 +674,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELDEGOSS_21:
       return evolution (this, from:"Gossifleur", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -698,7 +698,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VULPIX_22:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -709,7 +709,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NINETALES_23:
       return evolution (this, from:"Vulpix", hp:HP120, type:R, retreatCost:1) {
         weakness W
@@ -730,7 +730,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case TORKOAL_V_24:
       return basic (this, hp:HP210, type:R, retreatCost:4) {
         weakness W
@@ -756,7 +756,7 @@ public enum SwordShield implements LogicCardInfo {
             discardDefendingEnergyAfterDamage C, C
           }
         }
-      };
+      }
       case VICTINI_V_25:
       return basic (this, hp:HP190, type:R, retreatCost:2) {
         weakness W
@@ -780,7 +780,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30*(self.cards.energyCount(C)+defending.cards.energyCount(C))
           }
         }
-      };
+      }
       case HEATMOR_26:
       return basic (this, hp:HP110, type:R, retreatCost:1) {
         weakness W
@@ -799,7 +799,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SALANDIT_27:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -810,7 +810,7 @@ public enum SwordShield implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case SALAZZLE_28:
       return evolution (this, from:"Salandit", hp:HP120, type:R, retreatCost:1) {
         weakness W
@@ -830,7 +830,7 @@ public enum SwordShield implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C, C)
           }
         }
-      };
+      }
       case TURTONATOR_29:
       return basic (this, hp:HP130, type:R, retreatCost:3) {
         weakness W
@@ -849,7 +849,7 @@ public enum SwordShield implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C, C)
           }
         }
-      };
+      }
       case SCORBUNNY_30:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -861,7 +861,7 @@ public enum SwordShield implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C)
           }
         }
-      };
+      }
       case SCORBUNNY_31:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -879,7 +879,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RABOOT_32:
       return evolution (this, from:"Scorbunny", hp:HP090, type:R, retreatCost:1) {
         weakness W
@@ -899,7 +899,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case RABOOT_33:
       return evolution (this, from:"Scorbunny", hp:HP090, type:R, retreatCost:1) {
         weakness W
@@ -917,7 +917,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CINDERACE_34:
       return evolution (this, from:"Raboot", hp:HP170, type:R, retreatCost:1) {
         weakness W
@@ -941,7 +941,7 @@ public enum SwordShield implements LogicCardInfo {
             discardSelfEnergyAfterDamage(C, C)
           }
         }
-      };
+      }
       case CINDERACE_35:
       return evolution (this, from:"Raboot", hp:HP170, type:R, retreatCost:1) {
         weakness W
@@ -961,7 +961,7 @@ public enum SwordShield implements LogicCardInfo {
             discardAllSelfEnergy(null)
           }
         }
-      };
+      }
       case CINDERACE_36:
       return evolution (this, from:"Raboot", hp:HP170, type:R, retreatCost:1) {
         weakness W
@@ -983,7 +983,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 1, {}, { discardSelfEnergyAfterDamage(C, C) }
           }
         }
-      };
+      }
       case SIZZLIPEDE_37:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1001,7 +1001,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SIZZLIPEDE_38:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1012,7 +1012,7 @@ public enum SwordShield implements LogicCardInfo {
             flipUntilTails { damage 40 }
           }
         }
-      };
+      }
       case CENTISKORCH_39:
       return evolution (this, from:"Sizzlipede", hp:HP130, type:R, retreatCost:3) {
         weakness W
@@ -1034,7 +1034,7 @@ public enum SwordShield implements LogicCardInfo {
             apply BURNED
           }
         }
-      };
+      }
       case SHELLDER_40:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1046,7 +1046,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case CLOYSTER_41:
       return evolution (this, from:"Shellder", hp:HP130, type:W, retreatCost:2) {
         weakness L
@@ -1065,7 +1065,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case KRABBY_42:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -1083,7 +1083,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KRABBY_43:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -1094,7 +1094,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 2,{},{},[2:{damage 120},1:{bc "$thisMove failed"},0:{bc "$thisMove failed"}]
           }
         }
-      };
+      }
       case KINGLER_44:
       return evolution (this, from:"Krabby", hp:HP130, type:W, retreatCost:2) {
         weakness L
@@ -1117,7 +1117,7 @@ public enum SwordShield implements LogicCardInfo {
               damage 60
           }
         }
-      };
+      }
       case GOLDEEN_45:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1128,7 +1128,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GOLDEEN_46:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1146,7 +1146,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEAKING_47:
       return evolution (this, from:"Goldeen", hp:HP110, type:W, retreatCost:2) {
         weakness L
@@ -1167,7 +1167,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LAPRAS_48:
       return basic (this, hp:HP130, type:W, retreatCost:3) {
         weakness L
@@ -1183,7 +1183,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case LAPRAS_V_49:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness L
@@ -1209,7 +1209,7 @@ public enum SwordShield implements LogicCardInfo {
             moveSelfEnergyAfterDamage my.hand, W, W
           }
         }
-      };
+      }
       case LAPRAS_VMAX_50:
       return evolution (this, from:"Lapras V", hp:HP320, type:W, retreatCost:3) {
         weakness L
@@ -1220,7 +1220,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 90+30*self.cards.energyCount(W)
           }
         }
-      };
+      }
       case QWILFISH_51:
       return basic (this, hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -1243,7 +1243,7 @@ public enum SwordShield implements LogicCardInfo {
             if (defending.isSPC(POISONED)) damage 60
           }
         }
-      };
+      }
       case MANTINE_52:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -1265,7 +1265,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case KELDEO_V_53:
       return basic (this, hp:HP210, type:W, retreatCost:2) {
         weakness L
@@ -1283,7 +1283,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50+30*self.cards.energyCount(W)
           }
         }
-      };
+      }
       case SOBBLE_54:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1294,7 +1294,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SOBBLE_55:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1312,7 +1312,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DRIZZILE_56:
       return evolution (this, from:"Sobble", hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -1333,7 +1333,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DRIZZILE_57:
       return evolution (this, from:"Sobble", hp:HP090, type:W, retreatCost:1) {
         weakness L
@@ -1351,7 +1351,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case INTELEON_58:
       return evolution (this, from:"Drizzile", hp:HP160, type:W, retreatCost:1) {
         weakness L
@@ -1373,7 +1373,7 @@ public enum SwordShield implements LogicCardInfo {
             if (opp.bench) damage 20, opp.bench.select()
           }
         }
-      };
+      }
       case INTELEON_59:
       return evolution (this, from:"Drizzile", hp:HP160, type:W, retreatCost:1) {
         weakness L
@@ -1397,7 +1397,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CHEWTLE_60:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -1415,7 +1415,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DREDNAW_61:
       return evolution (this, from:"Chewtle", hp:HP130, type:W, retreatCost:3) {
         weakness L
@@ -1434,7 +1434,7 @@ public enum SwordShield implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case CRAMORANT_62:
       return basic (this, hp:HP110, type:W, retreatCost:1) {
         weakness L
@@ -1452,7 +1452,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SNOM_63:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1463,7 +1463,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FROSMOTH_64:
       return evolution (this, from:"Snom", hp:HP090, type:W, retreatCost:2) {
         weakness M
@@ -1485,7 +1485,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PIKACHU_65:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1507,7 +1507,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RAICHU_66:
       return evolution (this, from:"Pikachu", hp:HP130, type:L, retreatCost:1) {
         weakness F
@@ -1525,7 +1525,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case CHINCHOU_67:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1536,7 +1536,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHINCHOU_68:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -1557,7 +1557,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LANTURN_69:
       return evolution (this, from:"Chinchou", hp:HP120, type:L, retreatCost:2) {
         weakness F
@@ -1579,7 +1579,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case JOLTIK_70:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1590,7 +1590,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GALVANTULA_71:
       return evolution (this, from:"Joltik", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -1602,7 +1602,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case TAPU_KOKO_V_72:
       return basic (this, hp:HP200, type:L, retreatCost:0) {
         weakness F
@@ -1622,7 +1622,7 @@ public enum SwordShield implements LogicCardInfo {
             cantAttackNextTurn(self)
           }
         }
-      };
+      }
       case YAMPER_73:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1640,7 +1640,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case YAMPER_74:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1658,7 +1658,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BOLTUND_75:
       return evolution (this, from:"Yamper", hp:HP130, type:L, retreatCost:1) {
         weakness F
@@ -1680,7 +1680,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case BOLTUND_76:
       return evolution (this, from:"Yamper", hp:HP120, type:L, retreatCost:0) {
         weakness F
@@ -1699,7 +1699,7 @@ public enum SwordShield implements LogicCardInfo {
             cantAttackNextTurn(self)
           }
         }
-      };
+      }
       case PINCURCHIN_77:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -1724,7 +1724,7 @@ public enum SwordShield implements LogicCardInfo {
             ]
           }
         }
-      };
+      }
       case MORPEKO_78:
       return basic (this, hp:HP090, type:L, retreatCost:1) {
         weakness F
@@ -1737,7 +1737,7 @@ public enum SwordShield implements LogicCardInfo {
               damage 50
           }
         }
-      };
+      }
       case MORPEKO_V_79:
       return basic (this, hp:HP170, type:L, retreatCost:2) {
         weakness F
@@ -1763,7 +1763,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MORPEKO_VMAX_80:
       return evolution (this, from:"Morpeko V", hp:HP300, type:L, retreatCost:1) {
         weakness F
@@ -1775,7 +1775,7 @@ public enum SwordShield implements LogicCardInfo {
             opp.bench.each { damage 20, it }
           }
         }
-      };
+      }
       case GALARIAN_PONYTA_81:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1788,7 +1788,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case GALARIAN_RAPIDASH_82:
       return evolution (this, from:"Galarian Ponyta", hp:HP100, type:P, retreatCost:1) {
         weakness D
@@ -1823,7 +1823,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30+30*opp.active.cards.filterByType(ENERGY).size()
           }
         }
-      };
+      }
       case GASTLY_83:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1838,7 +1838,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HAUNTER_84:
       return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1858,7 +1858,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GENGAR_85:
       return evolution (this, from:"Haunter", hp:HP110, type:P, retreatCost:2) {
         weakness D
@@ -1887,7 +1887,7 @@ public enum SwordShield implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case WOBBUFFET_V_86:
       return basic (this, hp:HP220, type:P, retreatCost:3) {
         weakness D
@@ -1897,9 +1897,9 @@ public enum SwordShield implements LogicCardInfo {
           energyCost C, C
           onAttack {
             targeted (opp.active) {
-              def tmp = opp.active.damage;
-              opp.active.damage = self.damage;
-              self.damage = tmp;
+              def tmp = opp.active.damage
+              opp.active.damage = self.damage
+              self.damage = tmp
               checkFaint()
             }
           }
@@ -1912,7 +1912,7 @@ public enum SwordShield implements LogicCardInfo {
             cantRetreat defending
           }
         }
-      };
+      }
       case MUNNA_87:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1931,7 +1931,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MUSHARNA_88:
       return evolution (this, from:"Munna", hp:HP120, type:P, retreatCost:3) {
         weakness D
@@ -1950,7 +1950,7 @@ public enum SwordShield implements LogicCardInfo {
               before ASLEEP_SPC, null, null, BEGIN_TURN, {
                 if(ef.target == defending){ //MARK parentEvent
                   flip "Asleep (Sleepy Pulse)", 2, {}, {}, [2:{
-                    ef.unregisterItself(bg.em());
+                    ef.unregisterItself(bg.em())
                   },1:{
                     bc "$ef.target is still asleep."
                   },0:{
@@ -1970,7 +1970,7 @@ public enum SwordShield implements LogicCardInfo {
             if (opp.active.isSPC(ASLEEP)) damage 120
           }
         }
-      };
+      }
       case SINISTEA_89:
       return basic (this, hp:HP030, type:P, retreatCost:1) {
         weakness D
@@ -1987,7 +1987,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case POLTEAGEIST_90:
       return evolution (this, from:"Sinistea", hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -2017,7 +2017,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case INDEEDEE_V_91:
       return basic (this, hp:HP180, type:P, retreatCost:2) {
         weakness D
@@ -2038,7 +2038,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10+60*opp.active.cards.filterByType(ENERGY).size()
           }
         }
-      };
+      }
       case DIGLETT_92:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -2049,7 +2049,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DUGTRIO_93:
       return evolution (this, from:"Diglett", hp:HP090, type:F, retreatCost:1) {
         weakness G
@@ -2060,7 +2060,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HITMONLEE_94:
       return basic (this, hp:HP120, type:F, retreatCost:1) {
         weakness P
@@ -2081,7 +2081,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case HITMONCHAN_95:
       return basic (this, hp:HP120, type:F, retreatCost:1) {
         weakness P
@@ -2102,7 +2102,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case RHYHORN_96:
       return basic (this, hp:HP100, type:F, retreatCost:3) {
         weakness G
@@ -2120,7 +2120,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RHYHORN_97:
       return basic (this, hp:HP090, type:F, retreatCost:2) {
         weakness G
@@ -2141,7 +2141,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case RHYDON_98:
       return evolution (this, from:"Rhyhorn", hp:HP120, type:F, retreatCost:4) {
         weakness G
@@ -2166,7 +2166,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case RHYPERIOR_99:
       return evolution (this, from:"Rhydon", hp:HP190, type:F, retreatCost:4) {
         weakness G
@@ -2187,7 +2187,7 @@ public enum SwordShield implements LogicCardInfo {
             my.bench.each{if(it.numberOfDamageCounters) damage 60,it}
           }
         }
-      };
+      }
       case SUDOWOODO_100:
       return basic (this, hp:HP100, type:F, retreatCost:1) {
         weakness G
@@ -2205,7 +2205,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case BALTOY_101:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2223,7 +2223,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BALTOY_102:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -2234,7 +2234,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLAYDOL_103:
       return evolution (this, from:"Baltoy", hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -2254,7 +2254,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 120, self
           }
         }
-      };
+      }
       case REGIROCK_V_104:
       return basic (this, hp:HP220, type:F, retreatCost:3) {
         weakness G
@@ -2273,7 +2273,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case MUDBRAY_105:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -2291,7 +2291,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MUDSDALE_106:
       return evolution (this, from:"Mudbray", hp:HP150, type:F, retreatCost:3) {
         weakness G
@@ -2302,7 +2302,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 2, { damage 120 }
           }
         }
-      };
+      }
       case SILICOBRA_107:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -2313,7 +2313,7 @@ public enum SwordShield implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case SILICOBRA_108:
       return basic (this, hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2331,7 +2331,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SANDACONDA_109:
       return evolution (this, from:"Silicobra", hp:HP140, type:F, retreatCost:2) {
         weakness G
@@ -2351,7 +2351,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SANDACONDA_110:
       return evolution (this, from:"Silicobra", hp:HP130, type:F, retreatCost:2) {
         weakness G
@@ -2379,7 +2379,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CLOBBOPUS_111:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -2391,7 +2391,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { apply PARALYZED }
           }
         }
-      };
+      }
       case CLOBBOPUS_112:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness P
@@ -2402,7 +2402,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GRAPPLOCT_113:
       return evolution (this, from:"Clobbopus", hp:HP130, type:F, retreatCost:2) {
         weakness P
@@ -2460,7 +2460,7 @@ public enum SwordShield implements LogicCardInfo {
             dontApplyResistance()
           }
         }
-      };
+      }
       case STONJOURNER_114:
       return basic (this, hp:HP120, type:F, retreatCost:2) {
         weakness G
@@ -2472,7 +2472,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10, self
           }
         }
-      };
+      }
       case STONJOURNER_V_115:
       return basic (this, hp:HP220, type:F, retreatCost:3) {
         weakness G
@@ -2491,7 +2491,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 150
           }
         }
-      };
+      }
       case STONJOURNER_VMAX_116:
       return evolution (this, from:"Stonjourner V", hp:HP330, type:F, retreatCost:3) {
         weakness G
@@ -2514,7 +2514,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 200
           }
         }
-      };
+      }
       case GALARIAN_ZIGZAGOON_117:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -2534,7 +2534,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case GALARIAN_LINOONE_118:
       return evolution (this, from:"Galarian Zigzagoon", hp:HP100, type:D, retreatCost:2) {
         weakness G
@@ -2557,7 +2557,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case GALARIAN_OBSTAGOON_119:
       return evolution (this, from:"Galarian Linoone", hp:HP160, type:D, retreatCost:2) {
         weakness G
@@ -2580,7 +2580,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SABLEYE_V_120:
       return basic (this, hp:HP170, type:D, retreatCost:2) {
         weakness G
@@ -2600,7 +2600,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10+60*opp.active.numberOfDamageCounters
           }
         }
-      };
+      }
       case SKORUPI_121:
       return basic (this, hp:HP080, type:D, retreatCost:2) {
         weakness F
@@ -2618,7 +2618,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DRAPION_122:
       return evolution (this, from:"Skorupi", hp:HP140, type:D, retreatCost:3) {
         weakness F
@@ -2638,7 +2638,7 @@ public enum SwordShield implements LogicCardInfo {
             apply POISONED
           }
         }
-      };
+      }
       case CROAGUNK_123:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -2656,7 +2656,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TOXICROAK_124:
       return evolution (this, from:"Croagunk", hp:HP110, type:D, retreatCost:1) {
         weakness F
@@ -2676,7 +2676,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { apply POISONED }
           }
         }
-      };
+      }
       case NICKIT_125:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness G
@@ -2691,7 +2691,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case THIEVUL_126:
       return evolution (this, from:"Nickit", hp:HP100, type:D, retreatCost:1) {
         weakness G
@@ -2714,7 +2714,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case GALARIAN_MEOWTH_127:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -2733,7 +2733,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GALARIAN_PERRSERKER_128:
       return evolution (this, from:"Galarian Meowth", hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -2760,7 +2760,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case MAWILE_129:
       return basic (this, hp:HP090, type:M, retreatCost:1) {
         weakness R
@@ -2784,7 +2784,7 @@ public enum SwordShield implements LogicCardInfo {
             discardDefendingEnergyAfterDamage()
           }
         }
-      };
+      }
       case FERROSEED_130:
       return basic (this, hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -2796,7 +2796,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FERROTHORN_131:
       return evolution (this, from:"Ferroseed", hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -2821,7 +2821,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GALARIAN_STUNFISK_132:
       return basic (this, hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -2846,7 +2846,7 @@ public enum SwordShield implements LogicCardInfo {
             flipUntilTails { damage 30 }
           }
         }
-      };
+      }
       case PAWNIARD_133:
       return basic (this, hp:HP070, type:M, retreatCost:1) {
         weakness R
@@ -2865,7 +2865,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BISHARP_134:
       return evolution (this, from:"Pawniard", hp:HP120, type:M, retreatCost:2) {
         weakness R
@@ -2887,7 +2887,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CORVIKNIGHT_135:
       return evolution (this, from:"Corvisquire", hp:HP170, type:M, retreatCost:2) {
         weakness L
@@ -2926,7 +2926,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CUFANT_136:
       return basic (this, hp:HP100, type:M, retreatCost:3) {
         weakness R
@@ -2939,7 +2939,7 @@ public enum SwordShield implements LogicCardInfo {
             flip { damage 20 }
           }
         }
-      };
+      }
       case COPPERAJAH_137:
       return evolution (this, from:"Cufant", hp:HP190, type:M, retreatCost:4) {
         weakness R
@@ -2959,7 +2959,7 @@ public enum SwordShield implements LogicCardInfo {
             if (self.numberOfDamageCounters < 8) damage 220
           }
         }
-      };
+      }
       case ZACIAN_V_138:
       return basic (this, hp:HP220, type:M, retreatCost:2) {
         weakness R
@@ -2990,7 +2990,7 @@ public enum SwordShield implements LogicCardInfo {
             cantAttackNextTurn(self)
           }
         }
-      };
+      }
       case ZAMAZENTA_V_139:
       return basic (this, hp:HP230, type:M, retreatCost:2) {
         weakness R
@@ -3016,7 +3016,7 @@ public enum SwordShield implements LogicCardInfo {
             discardDefendingSpecialEnergy(delegate)
           }
         }
-      };
+      }
       case SNORLAX_140:
       return basic (this, hp:HP150, type:C, retreatCost:4) {
         weakness F
@@ -3034,7 +3034,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case SNORLAX_V_141:
       return basic (this, hp:HP220, type:C, retreatCost:4) {
         weakness F
@@ -3054,7 +3054,7 @@ public enum SwordShield implements LogicCardInfo {
             apply ASLEEP, self
           }
         }
-      };
+      }
       case SNORLAX_VMAX_142:
       return evolution (this, from:"Snorlax V", hp:HP340, type:C, retreatCost:4) {
         weakness F
@@ -3065,7 +3065,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 60+30*my.bench.size()
           }
         }
-      };
+      }
       case HOOTHOOT_143:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -3087,7 +3087,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NOCTOWL_144:
       return evolution (this, from:"Hoothoot", hp:HP110, type:C, retreatCost:1) {
         weakness L
@@ -3117,7 +3117,7 @@ public enum SwordShield implements LogicCardInfo {
             removePCS(self)
           }
         }
-      };
+      }
       case MINCCINO_145:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3135,7 +3135,7 @@ public enum SwordShield implements LogicCardInfo {
             flip 2, { damage 20 }
           }
         }
-      };
+      }
       case MINCCINO_146:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -3146,7 +3146,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CINCCINO_147:
       return evolution (this, from:"Minccino", hp:HP090, type:C, retreatCost:1) {
         weakness F
@@ -3169,7 +3169,7 @@ public enum SwordShield implements LogicCardInfo {
             attachEnergyFrom(basic: true, my.discard, my.bench)
           }
         }
-      };
+      }
       case ORANGURU_148:
       return basic (this, hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -3191,7 +3191,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case DRAMPA_149:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -3203,7 +3203,7 @@ public enum SwordShield implements LogicCardInfo {
             if(my.deck) my.deck.subList(0, 2).discard()
           }
         }
-      };
+      }
       case ROOKIDEE_150:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -3222,7 +3222,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CORVISQUIRE_151:
       return evolution (this, from:"Rookidee", hp:HP080, type:C, retreatCost:1) {
         weakness L
@@ -3244,7 +3244,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case WOOLOO_152:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3256,7 +3256,7 @@ public enum SwordShield implements LogicCardInfo {
             reduceDamageNextTurn(hp(10),thisMove)
           }
         }
-      };
+      }
       case WOOLOO_153:
       return basic (this, hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -3274,7 +3274,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DUBWOOL_154:
       return evolution (this, from:"Wooloo", hp:HP130, type:C, retreatCost:2) {
         weakness F
@@ -3294,7 +3294,7 @@ public enum SwordShield implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case CRAMORANT_V_155:
       return basic (this, hp:HP200, type:C, retreatCost:1) {
         weakness L
@@ -3320,7 +3320,7 @@ public enum SwordShield implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case AIR_BALLOON_156:
       return pokemonTool (this) {
         text "The Retreat Cost of the Pokémon this card is attached to is [C][C] less."
@@ -3333,7 +3333,7 @@ public enum SwordShield implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case BEDE_157:
       return supporter (this) {
         text "Attach a basic Energy card from your hand to 1 of your Benched Pokémon."
@@ -3344,7 +3344,7 @@ public enum SwordShield implements LogicCardInfo {
           assertMyBench()
           assert my.hand.filterByType(BASIC_ENERGY) : "You don't have any Basic Energy cards in your hand"
         }
-      };
+      }
       case BIG_CHARM_158:
       return pokemonTool (this) {
         text "The Pokémon this card is attached to gets +30 HP."
@@ -3357,15 +3357,15 @@ public enum SwordShield implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case CRUSHING_HAMMER_159:
-      return copy(EmergingPowers.CRUSHING_HAMMER_92, this);
+      return copy(EmergingPowers.CRUSHING_HAMMER_92, this)
       case ENERGY_RETRIEVAL_160:
       return copy(BlackWhite.ENERGY_RETRIEVAL_92, this)
       case ENERGY_SEARCH_161:
-      return copy(BlackWhite.ENERGY_SEARCH_93, this);
+      return copy(BlackWhite.ENERGY_SEARCH_93, this)
       case ENERGY_SWITCH_162:
-      return copy(BlackWhite.ENERGY_SWITCH_94, this);
+      return copy(BlackWhite.ENERGY_SWITCH_94, this)
       case EVOLUTION_INCENSE_163:
       return itemCard (this) {
         text "Search your deck for an Evolution Pokémon, reveal it, and put it into your hand. Then, shuffle your deck."
@@ -3376,11 +3376,11 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case GREAT_BALL_164:
-      return copy(EmergingPowers.GREAT_BALL_93, this);
+      return copy(EmergingPowers.GREAT_BALL_93, this)
       case HOP_165:
-      return copy(SunMoon.HAU_120, this);
+      return copy(SunMoon.HAU_120, this)
       case HYPER_POTION_166:
       return itemCard (this) {
         text "Heal 120 damage from 1 of your Pokémon that has at least 2 Energy attached. If you healed any damage in this way, discard 2 Energy from it."
@@ -3392,7 +3392,7 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement{
           assertMyAll(info: "with damage on them and at least 2 Energy attached", {it.numberOfDamageCounters && it.cards.energyCount() >= 2})
         }
-      };
+      }
       case LUCKY_EGG_167:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to is Knocked Out by damage from an opponent’s attack, draw cards until you have 7 cards in your hand."
@@ -3411,7 +3411,7 @@ public enum SwordShield implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case LUM_BERRY_168:
         return pokemonTool (this) {
           text "Attach a Pokémon Tool to 1 of your Pokémon that doesn’t already have a Pokémon Tool attached.\nAt the end of each turn, if the Pokémon this card is attached to is affected by any Special Conditions, it recovers from all of them, and discard this card."
@@ -3430,7 +3430,7 @@ public enum SwordShield implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case MARNIE_169:
       return supporter (this) {
         text "Each player shuffles their hand and puts it on the bottom of their deck. If either player put any cards on the bottom of their deck in this way, you draw 5 cards, and your opponent draws 4 cards."
@@ -3454,7 +3454,7 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement{
           assert (my.hand.getExcludedList(thisCard) || opp.hand) : "One of the two players must be able to put any cards into their deck in order for you to play this card"
         }
-      };
+      }
       case METAL_SAUCER_170:
       return itemCard (this) {
         text "Attach a [M] Energy card from your discard pile to 1 of your Benched [M] Pokémon."
@@ -3465,7 +3465,7 @@ public enum SwordShield implements LogicCardInfo {
           assert my.discard.findAll(basicEnergyFilter(M))
           assertMyBench(hasType: M)
         }
-      };
+      }
       case ORDINARY_ROD_171:
       return itemCard (this) {
         text "Choose 1 or both:" +
@@ -3494,9 +3494,9 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement {
           assert my.discard.filterByType(BASIC_ENERGY, POKEMON) : "No Pokémon or Basic Energy cards in your discard."
         }
-      };
+      }
       case PAL_PAD_172:
-      return copy(UltraPrism.PAL_PAD_132, this);
+      return copy(UltraPrism.PAL_PAD_132, this)
       case POKE_KID_173:
       return supporter (this) {
         text "Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck."
@@ -3507,17 +3507,17 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case POKEGEAR_3_0_174:
-      return copy (UnbrokenBonds.POKEGEAR_3_0_182, this);
+      return copy (UnbrokenBonds.POKEGEAR_3_0_182, this)
       case POKEMON_CATCHER_175:
-      return copy (KalosStarterSet.POKEMON_CATCHER_36, this);
+      return copy (KalosStarterSet.POKEMON_CATCHER_36, this)
       case POKEMON_CENTER_LADY_176:
-      return copy(Flashfire.POKEMON_CENTER_LADY_93, this);
+      return copy(Flashfire.POKEMON_CENTER_LADY_93, this)
       case POTION_177:
-      return copy(BlackWhite.POTION_100, this);
+      return copy(BlackWhite.POTION_100, this)
       case PROFESSOR_S_RESEARCH_178:
-      return copy(Xy.PROFESSOR_SYCAMORE_122, this);
+      return copy(Xy.PROFESSOR_SYCAMORE_122, this)
       case QUICK_BALL_179:
       return itemCard (this) {
         text "You can play this card only if you discard another card from your hand." +
@@ -3531,9 +3531,9 @@ public enum SwordShield implements LogicCardInfo {
           assert my.deck
           assert my.hand.getExcludedList(thisCard).size() >= 1
         }
-      };
+      }
       case RARE_CANDY_180:
-      return copy(DarkExplorers.RARE_CANDY_100, this);
+      return copy(DarkExplorers.RARE_CANDY_100, this)
       case ROTOM_BIKE_181:
       return itemCard (this) {
         text "Draw cards until you have 6 cards in your hand. Your turn ends."
@@ -3545,7 +3545,7 @@ public enum SwordShield implements LogicCardInfo {
           assert my.deck
           assert my.hand.getExcludedList(thisCard).size() < 6
         }
-      };
+      }
       case SITRUS_BERRY_182:
       return pokemonTool (this) {
         text "At the end of each turn, if the Pokémon this card is attached to has 3 or more damage counters on it, heal 30 damage from it and discard this card."
@@ -3564,9 +3564,9 @@ public enum SwordShield implements LogicCardInfo {
         onRemoveFromPlay {
           eff.unregister()
         }
-      };
+      }
       case SWITCH_183:
-      return copy(BlackWhite.SWITCH_104, this);
+      return copy(BlackWhite.SWITCH_104, this)
       case TEAM_YELL_GRUNT_184:
       return supporter (this) {
         text "Put an Energy attached to 1 of your opponent’s Pokémon into their hand."
@@ -3580,7 +3580,7 @@ public enum SwordShield implements LogicCardInfo {
         playRequirement {
           assertOppAll(info: "with Energy attached to them", {it.cards.energyCount(C)})
         }
-      };
+      }
       case VITALITY_BAND_185:
       return pokemonTool (this) {
         text "The attacks of the Pokémon this card is attached to do 10 more damage to your opponent’s Active Pokémon (before applying Weakness and Resistance)."
@@ -3600,7 +3600,7 @@ public enum SwordShield implements LogicCardInfo {
         onRemoveFromPlay {
           eff1.unregister()
         }
-      };
+      }
       case AURORA_ENERGY_186:
       return specialEnergy (this, [[]]) {
         text "You can attach this card to 1 of your Pokémon only if you discard another card from your hand." +
@@ -3618,67 +3618,67 @@ public enum SwordShield implements LogicCardInfo {
         allowAttach {to->
           to.owner.pbg.hand.getExcludedList(thisCard).size() >= 1
         }
-      };
+      }
       case DHELMISE_V_187:
-      return copy (DHELMISE_V_9, this);
+      return copy (DHELMISE_V_9, this)
       case TORKOAL_V_188:
-      return copy (TORKOAL_V_24, this);
+      return copy (TORKOAL_V_24, this)
       case LAPRAS_V_189:
-      return copy (LAPRAS_V_49, this);
+      return copy (LAPRAS_V_49, this)
       case MORPEKO_V_190:
-      return copy (MORPEKO_V_79, this);
+      return copy (MORPEKO_V_79, this)
       case WOBBUFFET_V_191:
-      return copy (WOBBUFFET_V_86, this);
+      return copy (WOBBUFFET_V_86, this)
       case INDEEDEE_V_192:
-      return copy (INDEEDEE_V_91, this);
+      return copy (INDEEDEE_V_91, this)
       case STONJOURNER_V_193:
-      return copy (STONJOURNER_V_115, this);
+      return copy (STONJOURNER_V_115, this)
       case SABLEYE_V_194:
-      return copy (SABLEYE_V_120, this);
+      return copy (SABLEYE_V_120, this)
       case ZACIAN_V_195:
-      return copy (ZACIAN_V_138, this);
+      return copy (ZACIAN_V_138, this)
       case ZAMAZENTA_V_196:
-      return copy (ZAMAZENTA_V_139, this);
+      return copy (ZAMAZENTA_V_139, this)
       case SNORLAX_V_197:
-      return copy (SNORLAX_V_141, this);
+      return copy (SNORLAX_V_141, this)
       case CRAMORANT_V_198:
-      return copy (CRAMORANT_V_155, this);
+      return copy (CRAMORANT_V_155, this)
       case BEDE_199:
-      return copy (BEDE_157, this);
+      return copy (BEDE_157, this)
       case MARNIE_200:
-      return copy (MARNIE_169, this);
+      return copy (MARNIE_169, this)
       case PROFESSOR_S_RESEARCH_201:
-      return copy (PROFESSOR_S_RESEARCH_178, this);
+      return copy (PROFESSOR_S_RESEARCH_178, this)
       case TEAM_YELL_GRUNT_202:
-      return copy (TEAM_YELL_GRUNT_184, this);
+      return copy (TEAM_YELL_GRUNT_184, this)
       case LAPRAS_VMAX_203:
-      return copy (LAPRAS_VMAX_50, this);
+      return copy (LAPRAS_VMAX_50, this)
       case MORPEKO_VMAX_204:
-      return copy (MORPEKO_VMAX_80, this);
+      return copy (MORPEKO_VMAX_80, this)
       case STONJOURNER_VMAX_205:
-      return copy (STONJOURNER_VMAX_116, this);
+      return copy (STONJOURNER_VMAX_116, this)
       case SNORLAX_VMAX_206:
-      return copy (SNORLAX_VMAX_142, this);
+      return copy (SNORLAX_VMAX_142, this)
       case BEDE_207:
-      return copy (BEDE_157, this);
+      return copy (BEDE_157, this)
       case MARNIE_208:
-      return copy (MARNIE_169, this);
+      return copy (MARNIE_169, this)
       case PROFESSOR_S_RESEARCH_209:
-      return copy (PROFESSOR_S_RESEARCH_178, this);
+      return copy (PROFESSOR_S_RESEARCH_178, this)
       case TEAM_YELL_GRUNT_210:
-      return copy (TEAM_YELL_GRUNT_184, this);
+      return copy (TEAM_YELL_GRUNT_184, this)
       case ZACIAN_V_211:
-      return copy (ZACIAN_V_138, this);
+      return copy (ZACIAN_V_138, this)
       case ZAMAZENTA_V_212:
-      return copy (ZAMAZENTA_V_139, this);
+      return copy (ZAMAZENTA_V_139, this)
       case AIR_BALLOON_213:
-      return copy (AIR_BALLOON_156, this);
+      return copy (AIR_BALLOON_156, this)
       case METAL_SAUCER_214:
-      return copy (METAL_SAUCER_170, this);
+      return copy (METAL_SAUCER_170, this)
       case ORDINARY_ROD_215:
-      return copy (ORDINARY_ROD_171, this);
+      return copy (ORDINARY_ROD_171, this)
       case QUICK_BALL_216:
-      return copy (QUICK_BALL_179, this);
+      return copy (QUICK_BALL_179, this)
       case PSYCHIC_ENERGY_217:
         return basicEnergy (this, PSYCHIC)
       case METAL_ENERGY_218:
@@ -3698,7 +3698,7 @@ public enum SwordShield implements LogicCardInfo {
       case FAIRY_ENERGY_225:
         return basicEnergy (this, FAIRY)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -1,10 +1,10 @@
 package tcgwars.logic.impl.gen8
 
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.EffectType.*
 import static tcgwars.logic.effect.EffectPriority.*
@@ -12,7 +12,7 @@ import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
 import tcgwars.logic.card.*
-import tcgwars.logic.util.*;
+import tcgwars.logic.util.*
 
 /**
  * @author thezipcompany@gmail.com
@@ -136,53 +136,53 @@ public enum SwordShieldPromos implements LogicCardInfo {
   EEVEE_SWSH118 ("Eevee", "SWSH118", Rarity.PROMO, [POKEMON, BASIC, _COLORLESS_]),
   SNORLAX_SWSH119 ("Snorlax", "SWSH119", Rarity.PROMO, [POKEMON, BASIC, SINGLE_STRIKE, _COLORLESS_]),
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   SwordShieldPromos(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.SWORD_SHIELD_PROMOS;
+    return tcgwars.logic.card.Collection.SWORD_SHIELD_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -198,7 +198,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCORBUNNY_SWSH02:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -210,7 +210,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             flip { applyAfterDamage BURNED }
           }
         }
-      };
+      }
       case SOBBLE_SWSH03:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -222,7 +222,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case MEOWTH_V_SWSH04:
       return basic (this, hp:HP180, type:C, retreatCost:2) {
         weakness F
@@ -241,7 +241,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case MEOWTH_VMAX_SWSH05:
       return evolution (this, from:"Meowth V", hp:HP300, type:C, retreatCost:2) {
         weakness F
@@ -253,15 +253,15 @@ public enum SwordShieldPromos implements LogicCardInfo {
             draw 3
           }
         }
-      };
+      }
       case RILLABOOM_SWSH06:
-      return copy (SwordShield.RILLABOOM_14, this);
+      return copy (SwordShield.RILLABOOM_14, this)
       case FROSMOTH_SWSH07:
-      return copy (SwordShield.FROSMOTH_64, this);
+      return copy (SwordShield.FROSMOTH_64, this)
       case GALARIAN_PERRSERKER_SWSH08:
-      return copy (SwordShield.GALARIAN_PERRSERKER_128, this);
+      return copy (SwordShield.GALARIAN_PERRSERKER_128, this)
       case CINCCINO_SWSH09:
-     return copy (SwordShield.CINCCINO_147, this);
+     return copy (SwordShield.CINCCINO_147, this)
       case GOSSIFLEUR_SWSH10:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -272,7 +272,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case WOOLOO_SWSH11:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -289,7 +289,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MORPEKO_SWSH12:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -301,7 +301,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case GALARIAN_PONYTA_SWSH13:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -320,13 +320,13 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RILLABOOM_V_SWSH14:
-      return copy (RebelClash.RILLABOOM_V_17, this);
+      return copy (RebelClash.RILLABOOM_V_17, this)
       case CINDERACE_V_SWSH15:
-      return copy (RebelClash.CINDERACE_V_35, this);
+      return copy (RebelClash.CINDERACE_V_35, this)
       case INTELEON_V_SWSH16:
-      return copy (RebelClash.INTELEON_V_49, this);
+      return copy (RebelClash.INTELEON_V_49, this)
       case TOXTRICITY_V_SWSH17:
       return basic (this, hp:HP210, type:L, retreatCost:2) {
         weakness F
@@ -348,11 +348,11 @@ public enum SwordShieldPromos implements LogicCardInfo {
             applyAfterDamage POISONED
           }
         }
-      };
+      }
       case ZACIAN_V_SWSH18:
-      return copy (SwordShield.ZACIAN_V_138, this);
+      return copy (SwordShield.ZACIAN_V_138, this)
       case ZAMAZENTA_V_SWSH19:
-      return copy (SwordShield.ZAMAZENTA_V_139, this);
+      return copy (SwordShield.ZAMAZENTA_V_139, this)
       case PIKACHU_SWSH20:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -370,7 +370,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case POLTEAGEIST_V_SWSH21:
       return basic (this, hp:HP170, type:P, retreatCost:1) {
         weakness D
@@ -393,19 +393,19 @@ public enum SwordShieldPromos implements LogicCardInfo {
             applyAfterDamage CONFUSED
           }
         }
-      };
+      }
       case FLAPPLE_SWSH22:
-      return copy (RebelClash.FLAPPLE_22, this);
+      return copy (RebelClash.FLAPPLE_22, this)
       case LUXRAY_SWSH23:
-      return copy (RebelClash.LUXRAY_62, this);
+      return copy (RebelClash.LUXRAY_62, this)
       case COALOSSAL_SWSH24:
-      return copy (RebelClash.COALOSSAL_107, this);
+      return copy (RebelClash.COALOSSAL_107, this)
       case GARBODOR_SWSH25:
-      return copy (RebelClash.GARBODOR_118, this);
+      return copy (RebelClash.GARBODOR_118, this)
       case MANTINE_SWSH26:
-      return copy (SwordShield.MANTINE_52, this);
+      return copy (SwordShield.MANTINE_52, this)
       case NOCTOWL_SWSH27:
-      return copy (SwordShield.NOCTOWL_144, this);
+      return copy (SwordShield.NOCTOWL_144, this)
       case DURALUDON_SWSH28:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -425,7 +425,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 40, self
           }
         }
-      };
+      }
       case RAYQUAZA_SWSH29:
       return basic (this, hp:HP130, type:C, retreatCost:2) {
         weakness L
@@ -446,9 +446,9 @@ public enum SwordShieldPromos implements LogicCardInfo {
             discardSelfEnergyAfterDamage C
           }
         }
-      };
+      }
       case COPPERAJAH_V_SWSH30:
-      return copy (RebelClash.COPPERAJAH_V_136, this);
+      return copy (RebelClash.COPPERAJAH_V_136, this)
       case MORPEKO_SWSH31:
       return basic (this, hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -467,9 +467,9 @@ public enum SwordShieldPromos implements LogicCardInfo {
             flip { applyAfterDamage PARALYZED }
           }
         }
-      };
+      }
       case SNORLAX_SWSH32:
-      return copy (SwordShield.SNORLAX_140, this);
+      return copy (SwordShield.SNORLAX_140, this)
       case ZACIAN_SWSH33:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -492,7 +492,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZAMAZENTA_SWSH34:
       return basic (this, hp:HP130, type:M, retreatCost:2) {
         weakness R
@@ -517,15 +517,15 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 130
           }
         }
-      };
+      }
       case DECIDUEYE_SWSH35:
-      return copy (DarknessAblaze.DECIDUEYE_13, this);
+      return copy (DarknessAblaze.DECIDUEYE_13, this)
       case ARCTOZOLT_SWSH36:
-      return copy (DarknessAblaze.ARCTOZOLT_66, this);
+      return copy (DarknessAblaze.ARCTOZOLT_66, this)
       case HYDREIGON_SWSH37:
-      return copy (DarknessAblaze.HYDREIGON_110, this);
+      return copy (DarknessAblaze.HYDREIGON_110, this)
       case KANGASKHAN_SWSH38:
-      return copy (DarknessAblaze.KANGASKHAN_133, this);
+      return copy (DarknessAblaze.KANGASKHAN_133, this)
       case PIKACHU_SWSH39:
       return basic (this, hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -545,9 +545,9 @@ public enum SwordShieldPromos implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HATENNA_SWSH40:
-      return copy (RebelClash.HATENNA_83, this);
+      return copy (RebelClash.HATENNA_83, this)
       case FLAREON_SWSH41:
       return evolution (this, from:"Eevee", hp:HP110, type:R, retreatCost:2) {
         weakness W
@@ -571,7 +571,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case EEVEE_SWSH42:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -593,7 +593,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case GALARIAN_SIRFETCH_D_V_SWSH43:
       return basic (this, hp:HP210, type:F, retreatCost:2) {
         weakness P
@@ -628,29 +628,29 @@ public enum SwordShieldPromos implements LogicCardInfo {
             cantAttackNextTurn self
           }
         }
-      };
+      }
       case ETERNATUS_V_SWSH44:
-      return copy (DarknessAblaze.ETERNATUS_V_116, this);
+      return copy (DarknessAblaze.ETERNATUS_V_116, this)
       case ETERNATUS_VMAX_SWSH45:
-      return copy (DarknessAblaze.ETERNATUS_VMAX_117, this);
+      return copy (DarknessAblaze.ETERNATUS_VMAX_117, this)
       case ELDEGOSS_SWSH46:
-      return copy (SwordShield.ELDEGOSS_21, this);
+      return copy (SwordShield.ELDEGOSS_21, this)
       case DREDNAW_SWSH47:
-      return copy (SwordShield.DREDNAW_61, this);
+      return copy (SwordShield.DREDNAW_61, this)
       case CENTISKORCH_SWSH48:
-      return copy (SwordShield.CENTISKORCH_39, this);
+      return copy (SwordShield.CENTISKORCH_39, this)
       case DUBWOOL_V_SWSH49:
-      return copy (RebelClash.DUBWOOL_V_153, this);
+      return copy (RebelClash.DUBWOOL_V_153, this)
       case CHARIZARD_V_SWSH50:
-      return copy (DarknessAblaze.CHARIZARD_V_19, this);
+      return copy (DarknessAblaze.CHARIZARD_V_19, this)
       case LAPRAS_SWSH51:
-      return copy (SwordShield.LAPRAS_48, this);
+      return copy (SwordShield.LAPRAS_48, this)
       case GENGAR_SWSH52:
-      return copy (SwordShield.GENGAR_85, this);
+      return copy (SwordShield.GENGAR_85, this)
       case MACHAMP_SWSH53:
-      return copy (ChampionsPath.MACHAMP_26, this);
+      return copy (ChampionsPath.MACHAMP_26, this)
       case COALOSSAL_SWSH54:
-      return copy (RebelClash.COALOSSAL_107, this);
+      return copy (RebelClash.COALOSSAL_107, this)
       case HATTERENE_V_SWSH55:
       return basic (this, hp:HP200, type:P, retreatCost:2) {
         weakness D
@@ -708,7 +708,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
         }
       }
       case ETERNATUS_V_SWSH64:
-      return copy (DarknessAblaze.ETERNATUS_V_116, this);
+      return copy (DarknessAblaze.ETERNATUS_V_116, this)
       case EEVEE_V_SWSH65:
       return basic (this, hp:HP190, type:C, retreatCost:1) {
         weakness F
@@ -1170,7 +1170,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
         }
       }
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/gen8/VividVoltage.groovy
+++ b/src/tcgwars/logic/impl/gen8/VividVoltage.groovy
@@ -1,36 +1,36 @@
 package tcgwars.logic.impl.gen8
 
-import tcgwars.logic.effect.gm.PlayTrainer;
+import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -241,354 +241,354 @@ public enum VividVoltage implements LogicCardInfo {
   MEMORY_CAPSULE_202 ("Memory Capsule", "202", Rarity.UNCOMMON, [TRAINER, POKEMON_TOOL, ITEM]),
   TELESCOPIC_SIGHT_203 ("Telescopic Sight", "203", Rarity.UNCOMMON, [TRAINER, POKEMON_TOOL, ITEM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   VividVoltage(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.VIVID_VOLTAGE;
+    return tcgwars.logic.card.Collection.VIVID_VOLTAGE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case WEEDLE_1:
-      return copy (LegendaryHeartbeat.WEEDLE_1, this);
+      return copy (LegendaryHeartbeat.WEEDLE_1, this)
       case KAKUNA_2:
-      return copy (LegendaryHeartbeat.KAKUNA_2, this);
+      return copy (LegendaryHeartbeat.KAKUNA_2, this)
       case BEEDRILL_3:
-      return copy (LegendaryHeartbeat.BEEDRILL_3, this);
+      return copy (LegendaryHeartbeat.BEEDRILL_3, this)
       case EXEGGCUTE_4:
-      return copy (LegendaryHeartbeat.EXEGGCUTE_4, this);
+      return copy (LegendaryHeartbeat.EXEGGCUTE_4, this)
       case EXEGGUTOR_5:
-      return copy (LegendaryHeartbeat.EXEGGUTOR_5, this);
+      return copy (LegendaryHeartbeat.EXEGGUTOR_5, this)
       case YANMA_6:
-      return copy (LegendaryHeartbeat.YANMA_6, this);
+      return copy (LegendaryHeartbeat.YANMA_6, this)
       case YANMEGA_7:
-      return copy (LegendaryHeartbeat.YANMEGA_7, this);
+      return copy (LegendaryHeartbeat.YANMEGA_7, this)
       case PINECO_8:
-      return copy (LegendaryHeartbeat.PINECO_8, this);
+      return copy (LegendaryHeartbeat.PINECO_8, this)
       case CELEBI_9:
-      return copy (LegendaryHeartbeat.CELEBI_9, this);
+      return copy (LegendaryHeartbeat.CELEBI_9, this)
       case SEEDOT_10:
-      return copy (AmazingVoltTackle.SEEDOT_1, this);
+      return copy (AmazingVoltTackle.SEEDOT_1, this)
       case NUZLEAF_11:
-      return copy (AmazingVoltTackle.NUZLEAF_2, this);
+      return copy (AmazingVoltTackle.NUZLEAF_2, this)
       case SHIFTRY_12:
-      return copy (AmazingVoltTackle.SHIFTRY_3, this);
+      return copy (AmazingVoltTackle.SHIFTRY_3, this)
       case NINCADA_13:
-      return copy (AmazingVoltTackle.NINCADA_4, this);
+      return copy (AmazingVoltTackle.NINCADA_4, this)
       case NINJASK_14:
-      return copy (AmazingVoltTackle.NINJASK_5, this);
+      return copy (AmazingVoltTackle.NINJASK_5, this)
       case SHAYMIN_15:
-      return copy (LegendaryHeartbeat.SHAYMIN_10, this);
+      return copy (LegendaryHeartbeat.SHAYMIN_10, this)
       case GENESECT_16:
-      return copy (LegendaryHeartbeat.GENESECT_11, this);
+      return copy (LegendaryHeartbeat.GENESECT_11, this)
       case SKIDDO_17:
-      return copy (AmazingVoltTackle.SKIDDO_6, this);
+      return copy (AmazingVoltTackle.SKIDDO_6, this)
       case GOGOAT_18:
-      return copy (AmazingVoltTackle.GOGOAT_7, this);
+      return copy (AmazingVoltTackle.GOGOAT_7, this)
       case DHELMISE_19:
-      return copy (LegendaryHeartbeat.DHELMISE_12, this);
+      return copy (LegendaryHeartbeat.DHELMISE_12, this)
       case ORBEETLE_V_20:
-      return copy (AmazingVoltTackle.ORBEETLE_V_8, this);
+      return copy (AmazingVoltTackle.ORBEETLE_V_8, this)
       case ORBEETLE_VMAX_21:
-      return copy (AmazingVoltTackle.ORBEETLE_VMAX_9, this);
+      return copy (AmazingVoltTackle.ORBEETLE_VMAX_9, this)
       case ZARUDE_V_22:
-      return copy (LegendaryHeartbeat.ZARUDE_V_13, this);
+      return copy (LegendaryHeartbeat.ZARUDE_V_13, this)
       case CHARMANDER_23:
-      return copy (AmazingVoltTackle.CHARMANDER_10, this);
+      return copy (AmazingVoltTackle.CHARMANDER_10, this)
       case CHARMELEON_24:
-      return copy (AmazingVoltTackle.CHARMELEON_11, this);
+      return copy (AmazingVoltTackle.CHARMELEON_11, this)
       case CHARIZARD_25:
-      return copy (AmazingVoltTackle.CHARIZARD_12, this);
+      return copy (AmazingVoltTackle.CHARIZARD_12, this)
       case FLAREON_26:
-      return copy (AmazingVoltTackle.FLAREON_13, this);
+      return copy (AmazingVoltTackle.FLAREON_13, this)
       case SLUGMA_27:
-      return copy (AmazingVoltTackle.SLUGMA_14, this);
+      return copy (AmazingVoltTackle.SLUGMA_14, this)
       case MAGCARGO_28:
-      return copy (AmazingVoltTackle.MAGCARGO_15, this);
+      return copy (AmazingVoltTackle.MAGCARGO_15, this)
       case TALONFLAME_V_29:
-      return copy (AmazingVoltTackle.TALONFLAME_V_16, this);
+      return copy (AmazingVoltTackle.TALONFLAME_V_16, this)
       case VAPOREON_30:
-      return copy (AmazingVoltTackle.VAPOREON_17, this);
+      return copy (AmazingVoltTackle.VAPOREON_17, this)
       case WAILMER_31:
-      return copy (AmazingVoltTackle.WAILMER_18, this);
+      return copy (AmazingVoltTackle.WAILMER_18, this)
       case WAILORD_32:
-      return copy (AmazingVoltTackle.WAILORD_19, this);
+      return copy (AmazingVoltTackle.WAILORD_19, this)
       case OSHAWOTT_33:
-      return copy (AmazingVoltTackle.OSHAWOTT_20, this);
+      return copy (AmazingVoltTackle.OSHAWOTT_20, this)
       case DEWOTT_34:
-      return copy (AmazingVoltTackle.DEWOTT_21, this);
+      return copy (AmazingVoltTackle.DEWOTT_21, this)
       case SAMUROTT_35:
-      return copy (AmazingVoltTackle.SAMUROTT_22, this);
+      return copy (AmazingVoltTackle.SAMUROTT_22, this)
       case GALARIAN_DARMANITAN_V_36:
-      return copy (AmazingVoltTackle.GALARIAN_DARMANITAN_V_23, this);
+      return copy (AmazingVoltTackle.GALARIAN_DARMANITAN_V_23, this)
       case GALARIAN_DARMANITAN_VMAX_37:
-      return copy (AmazingVoltTackle.GALARIAN_DARMANITAN_VMAX_24, this);
+      return copy (AmazingVoltTackle.GALARIAN_DARMANITAN_VMAX_24, this)
       case CHEWTLE_38:
-      return copy (AmazingVoltTackle.CHEWTLE_25, this);
+      return copy (AmazingVoltTackle.CHEWTLE_25, this)
       case DREDNAW_39:
-      return copy (AmazingVoltTackle.DREDNAW_26, this);
+      return copy (AmazingVoltTackle.DREDNAW_26, this)
       case CRAMORANT_40:
-      return copy (AmazingVoltTackle.CRAMORANT_27, this);
+      return copy (AmazingVoltTackle.CRAMORANT_27, this)
       case ARROKUDA_41:
-      return copy (AmazingVoltTackle.ARROKUDA_28, this);
+      return copy (AmazingVoltTackle.ARROKUDA_28, this)
       case BARRASKEWDA_42:
-      return copy (AmazingVoltTackle.BARRASKEWDA_29, this);
+      return copy (AmazingVoltTackle.BARRASKEWDA_29, this)
       case PIKACHU_V_43:
-      return copy (AmazingVoltTackle.PIKACHU_V_30, this);
+      return copy (AmazingVoltTackle.PIKACHU_V_30, this)
       case PIKACHU_VMAX_44:
-      return copy (AmazingVoltTackle.PIKACHU_VMAX_31, this);
+      return copy (AmazingVoltTackle.PIKACHU_VMAX_31, this)
       case VOLTORB_45:
-      return copy (AmazingVoltTackle.VOLTORB_32, this);
+      return copy (AmazingVoltTackle.VOLTORB_32, this)
       case ELECTRODE_46:
-      return copy (AmazingVoltTackle.ELECTRODE_33, this);
+      return copy (AmazingVoltTackle.ELECTRODE_33, this)
       case JOLTEON_47:
-      return copy (AmazingVoltTackle.JOLTEON_34, this);
+      return copy (AmazingVoltTackle.JOLTEON_34, this)
       case ZAPDOS_48:
-      return copy (AmazingVoltTackle.ZAPDOS_35, this);
+      return copy (AmazingVoltTackle.ZAPDOS_35, this)
       case AMPHAROS_V_49:
-      return copy (LegendaryHeartbeat.AMPHAROS_V_14, this);
+      return copy (LegendaryHeartbeat.AMPHAROS_V_14, this)
       case RAIKOU_50:
-      return copy (LegendaryHeartbeat.RAIKOU_15, this);
+      return copy (LegendaryHeartbeat.RAIKOU_15, this)
       case ELECTRIKE_51:
-      return copy (LegendaryHeartbeat.ELECTRIKE_16, this);
+      return copy (LegendaryHeartbeat.ELECTRIKE_16, this)
       case MANECTRIC_52:
-      return copy (LegendaryHeartbeat.MANECTRIC_17, this);
+      return copy (LegendaryHeartbeat.MANECTRIC_17, this)
       case BLITZLE_53:
-      return copy (AmazingVoltTackle.BLITZLE_36, this);
+      return copy (AmazingVoltTackle.BLITZLE_36, this)
       case ZEBSTRIKA_54:
-      return copy (AmazingVoltTackle.ZEBSTRIKA_37, this);
+      return copy (AmazingVoltTackle.ZEBSTRIKA_37, this)
       case JOLTIK_55:
-      return copy (LegendaryHeartbeat.JOLTIK_18, this);
+      return copy (LegendaryHeartbeat.JOLTIK_18, this)
       case GALVANTULA_56:
-      return copy (LegendaryHeartbeat.GALVANTULA_19, this);
+      return copy (LegendaryHeartbeat.GALVANTULA_19, this)
       case TYNAMO_57:
-      return copy (AmazingVoltTackle.TYNAMO_38, this);
+      return copy (AmazingVoltTackle.TYNAMO_38, this)
       case EELEKTRIK_58:
-      return copy (AmazingVoltTackle.EELEKTRIK_39, this);
+      return copy (AmazingVoltTackle.EELEKTRIK_39, this)
       case EELEKTROSS_59:
-      return copy (AmazingVoltTackle.EELEKTROSS_40, this);
+      return copy (AmazingVoltTackle.EELEKTROSS_40, this)
       case ZEKROM_60:
-      return copy (LegendaryHeartbeat.ZEKROM_20, this);
+      return copy (LegendaryHeartbeat.ZEKROM_20, this)
       case ZERAORA_61:
-      return copy (LegendaryHeartbeat.ZERAORA_21, this);
+      return copy (LegendaryHeartbeat.ZERAORA_21, this)
       case PINCURCHIN_62:
-      return copy (LegendaryHeartbeat.PINCURCHIN_22, this);
+      return copy (LegendaryHeartbeat.PINCURCHIN_22, this)
       case CLEFAIRY_63:
-      return copy (LegendaryHeartbeat.CLEFAIRY_23, this);
+      return copy (LegendaryHeartbeat.CLEFAIRY_23, this)
       case CLEFABLE_64:
-      return copy (LegendaryHeartbeat.CLEFABLE_24, this);
+      return copy (LegendaryHeartbeat.CLEFABLE_24, this)
       case GIRAFARIG_65:
-      return copy (LegendaryHeartbeat.GIRAFARIG_25, this);
+      return copy (LegendaryHeartbeat.GIRAFARIG_25, this)
       case SHEDINJA_66:
-      return copy (AmazingVoltTackle.SHEDINJA_42, this);
+      return copy (AmazingVoltTackle.SHEDINJA_42, this)
       case SHUPPET_67:
-      return copy (LegendaryHeartbeat.SHUPPET_26, this);
+      return copy (LegendaryHeartbeat.SHUPPET_26, this)
       case BANETTE_68:
-      return copy (LegendaryHeartbeat.BANETTE_27, this);
+      return copy (LegendaryHeartbeat.BANETTE_27, this)
       case DUSKULL_69:
-      return copy (AmazingVoltTackle.DUSKULL_43, this);
+      return copy (AmazingVoltTackle.DUSKULL_43, this)
       case DUSCLOPS_70:
-      return copy (AmazingVoltTackle.DUSCLOPS_44, this);
+      return copy (AmazingVoltTackle.DUSCLOPS_44, this)
       case DUSKNOIR_71:
-      return copy (AmazingVoltTackle.DUSKNOIR_45, this);
+      return copy (AmazingVoltTackle.DUSKNOIR_45, this)
       case CHIMECHO_72:
-      return copy (AmazingVoltTackle.CHIMECHO_46, this);
+      return copy (AmazingVoltTackle.CHIMECHO_46, this)
       case WOOBAT_73:
-      return copy (AmazingVoltTackle.WOOBAT_47, this);
+      return copy (AmazingVoltTackle.WOOBAT_47, this)
       case SWOOBAT_74:
-      return copy (AmazingVoltTackle.SWOOBAT_48, this);
+      return copy (AmazingVoltTackle.SWOOBAT_48, this)
       case COTTONEE_75:
-      return copy (AmazingVoltTackle.COTTONEE_49, this);
+      return copy (AmazingVoltTackle.COTTONEE_49, this)
       case WHIMSICOTT_76:
-      return copy (AmazingVoltTackle.WHIMSICOTT_50, this);
+      return copy (AmazingVoltTackle.WHIMSICOTT_50, this)
       case DEDENNE_77:
-      return copy (LegendaryHeartbeat.DEDENNE_28, this);
+      return copy (LegendaryHeartbeat.DEDENNE_28, this)
       case XERNEAS_78:
-      return copy (LegendaryHeartbeat.XERNEAS_29, this);
+      return copy (LegendaryHeartbeat.XERNEAS_29, this)
       case DIANCIE_79:
-      return copy (LegendaryHeartbeat.DIANCIE_30, this);
+      return copy (LegendaryHeartbeat.DIANCIE_30, this)
       case MILCERY_80:
-      return copy (AmazingVoltTackle.MILCERY_51, this);
+      return copy (AmazingVoltTackle.MILCERY_51, this)
       case ALCREMIE_81:
-      return copy (AmazingVoltTackle.ALCREMIE_52, this);
+      return copy (AmazingVoltTackle.ALCREMIE_52, this)
       case ZACIAN_82:
-      return copy (LegendaryHeartbeat.ZACIAN_33, this);
+      return copy (LegendaryHeartbeat.ZACIAN_33, this)
       case WOOPER_83:
-      return copy (LegendaryHeartbeat.WOOPER_34, this);
+      return copy (LegendaryHeartbeat.WOOPER_34, this)
       case QUAGSIRE_84:
-      return copy (LegendaryHeartbeat.QUAGSIRE_35, this);
+      return copy (LegendaryHeartbeat.QUAGSIRE_35, this)
       case SHUCKLE_85:
-      return copy (LegendaryHeartbeat.SHUCKLE_36, this);
+      return copy (LegendaryHeartbeat.SHUCKLE_36, this)
       case PHANPY_86:
-      return copy (AmazingVoltTackle.PHANPY_56, this);
+      return copy (AmazingVoltTackle.PHANPY_56, this)
       case DONPHAN_87:
-      return copy (AmazingVoltTackle.DONPHAN_57, this);
+      return copy (AmazingVoltTackle.DONPHAN_57, this)
       case HITMONTOP_88:
-      return copy (AmazingVoltTackle.HITMONTOP_58, this);
+      return copy (AmazingVoltTackle.HITMONTOP_58, this)
       case REGIROCK_89:
-      return copy (LegendaryHeartbeat.REGIROCK_37, this);
+      return copy (LegendaryHeartbeat.REGIROCK_37, this)
       case RIOLU_90:
-      return copy (LegendaryHeartbeat.RIOLU_38, this);
+      return copy (LegendaryHeartbeat.RIOLU_38, this)
       case DRILBUR_91:
-      return copy (AmazingVoltTackle.DRILBUR_59, this);
+      return copy (AmazingVoltTackle.DRILBUR_59, this)
       case TERRAKION_92:
-      return copy (AmazingVoltTackle.TERRAKION_60, this);
+      return copy (AmazingVoltTackle.TERRAKION_60, this)
       case ZYGARDE_93:
-      return copy (LegendaryHeartbeat.ZYGARDE_39, this);
+      return copy (LegendaryHeartbeat.ZYGARDE_39, this)
       case ROCKRUFF_94:
-      return copy (LegendaryHeartbeat.ROCKRUFF_40, this);
+      return copy (LegendaryHeartbeat.ROCKRUFF_40, this)
       case LYCANROC_95:
-      return copy (LegendaryHeartbeat.LYCANROC_41, this);
+      return copy (LegendaryHeartbeat.LYCANROC_41, this)
       case MUDBRAY_96:
-      return copy (AmazingVoltTackle.MUDBRAY_61, this);
+      return copy (AmazingVoltTackle.MUDBRAY_61, this)
       case MUDSDALE_97:
-      return copy (AmazingVoltTackle.MUDSDALE_62, this);
+      return copy (AmazingVoltTackle.MUDSDALE_62, this)
       case COALOSSAL_V_98:
-      return copy (LegendaryHeartbeat.COALOSSAL_V_42, this);
+      return copy (LegendaryHeartbeat.COALOSSAL_V_42, this)
       case COALOSSAL_VMAX_99:
-      return copy (LegendaryHeartbeat.COALOSSAL_VMAX_43, this);
+      return copy (LegendaryHeartbeat.COALOSSAL_VMAX_43, this)
       case CLOBBOPUS_100:
-      return copy (AmazingVoltTackle.CLOBBOPUS_63, this);
+      return copy (AmazingVoltTackle.CLOBBOPUS_63, this)
       case GRAPPLOCT_101:
-      return copy (AmazingVoltTackle.GRAPPLOCT_64, this);
+      return copy (AmazingVoltTackle.GRAPPLOCT_64, this)
       case ZAMAZENTA_102:
-      return copy (LegendaryHeartbeat.ZAMAZENTA_44, this);
+      return copy (LegendaryHeartbeat.ZAMAZENTA_44, this)
       case POOCHYENA_103:
-      return copy (AmazingVoltTackle.POOCHYENA_66, this);
+      return copy (AmazingVoltTackle.POOCHYENA_66, this)
       case MIGHTYENA_104:
-      return copy (AmazingVoltTackle.MIGHTYENA_67, this);
+      return copy (AmazingVoltTackle.MIGHTYENA_67, this)
       case SABLEYE_105:
-      return copy (AmazingVoltTackle.SABLEYE_68, this);
+      return copy (AmazingVoltTackle.SABLEYE_68, this)
       case DRAPION_V_106:
-      return copy (AmazingVoltTackle.DRAPION_V_69, this);
+      return copy (AmazingVoltTackle.DRAPION_V_69, this)
       case SANDILE_107:
-      return copy (AmazingVoltTackle.SANDILE_70, this);
+      return copy (AmazingVoltTackle.SANDILE_70, this)
       case KROKOROK_108:
-      return copy (AmazingVoltTackle.KROKOROK_71, this);
+      return copy (AmazingVoltTackle.KROKOROK_71, this)
       case KROOKODILE_109:
-      return copy (AmazingVoltTackle.KROOKODILE_72, this);
+      return copy (AmazingVoltTackle.KROOKODILE_72, this)
       case TRUBBISH_110:
-      return copy (AmazingVoltTackle.TRUBBISH_73, this);
+      return copy (AmazingVoltTackle.TRUBBISH_73, this)
       case GARBODOR_111:
-      return copy (AmazingVoltTackle.GARBODOR_74, this);
+      return copy (AmazingVoltTackle.GARBODOR_74, this)
       case GALARIAN_MEOWTH_112:
-      return copy (AmazingVoltTackle.GALARIAN_MEOWTH_75, this);
+      return copy (AmazingVoltTackle.GALARIAN_MEOWTH_75, this)
       case GALARIAN_PERRSERKER_113:
-      return copy (AmazingVoltTackle.GALARIAN_PERRSERKER_76, this);
+      return copy (AmazingVoltTackle.GALARIAN_PERRSERKER_76, this)
       case FORRETRESS_114:
-      return copy (LegendaryHeartbeat.FORRETRESS_45, this);
+      return copy (LegendaryHeartbeat.FORRETRESS_45, this)
       case STEELIX_V_115:
-      return copy (LegendaryHeartbeat.STEELIX_V_46, this);
+      return copy (LegendaryHeartbeat.STEELIX_V_46, this)
       case BELDUM_116:
-      return copy (LegendaryHeartbeat.BELDUM_47, this);
+      return copy (LegendaryHeartbeat.BELDUM_47, this)
       case METANG_117:
-      return copy (LegendaryHeartbeat.METANG_48, this);
+      return copy (LegendaryHeartbeat.METANG_48, this)
       case METAGROSS_118:
-      return copy (LegendaryHeartbeat.METAGROSS_49, this);
+      return copy (LegendaryHeartbeat.METAGROSS_49, this)
       case JIRACHI_119:
-      return copy (LegendaryHeartbeat.JIRACHI_50, this);
+      return copy (LegendaryHeartbeat.JIRACHI_50, this)
       case LUCARIO_120:
-      return copy (LegendaryHeartbeat.LUCARIO_51, this);
+      return copy (LegendaryHeartbeat.LUCARIO_51, this)
       case DIALGA_121:
-      return copy (LegendaryHeartbeat.DIALGA_52, this);
+      return copy (LegendaryHeartbeat.DIALGA_52, this)
       case EXCADRILL_122:
-      return copy (AmazingVoltTackle.EXCADRILL_77, this);
+      return copy (AmazingVoltTackle.EXCADRILL_77, this)
       case FERROSEED_123:
-      return copy (AmazingVoltTackle.FERROSEED_78, this);
+      return copy (AmazingVoltTackle.FERROSEED_78, this)
       case FERROTHORN_124:
-      return copy (AmazingVoltTackle.FERROTHORN_79, this);
+      return copy (AmazingVoltTackle.FERROTHORN_79, this)
       case GALARIAN_STUNFISK_125:
-      return copy (LegendaryHeartbeat.GALARIAN_STUNFISK_53, this);
+      return copy (LegendaryHeartbeat.GALARIAN_STUNFISK_53, this)
       case AEGISLASH_V_126:
-      return copy (AmazingVoltTackle.AEGISLASH_V_80, this);
+      return copy (AmazingVoltTackle.AEGISLASH_V_80, this)
       case AEGISLASH_VMAX_127:
-      return copy (AmazingVoltTackle.AEGISLASH_VMAX_81, this);
+      return copy (AmazingVoltTackle.AEGISLASH_VMAX_81, this)
       case MAGEARNA_128:
-      return copy (LegendaryHeartbeat.MAGEARNA_54, this);
+      return copy (LegendaryHeartbeat.MAGEARNA_54, this)
       case DURALUDON_129:
-      return copy (AmazingVoltTackle.DURALUDON_82, this);
+      return copy (AmazingVoltTackle.DURALUDON_82, this)
       case EEVEE_130:
-      return copy (AmazingVoltTackle.EEVEE_83, this);
+      return copy (AmazingVoltTackle.EEVEE_83, this)
       case SNORLAX_131:
-      return copy (AmazingVoltTackle.SNORLAX_84, this);
+      return copy (AmazingVoltTackle.SNORLAX_84, this)
       case LUGIA_132:
-      return copy (LegendaryHeartbeat.LUGIA_55, this);
+      return copy (LegendaryHeartbeat.LUGIA_55, this)
       case TAILLOW_133:
-      return copy (AmazingVoltTackle.TAILLOW_85, this);
+      return copy (AmazingVoltTackle.TAILLOW_85, this)
       case SWELLOW_134:
-      return copy (AmazingVoltTackle.SWELLOW_86, this);
+      return copy (AmazingVoltTackle.SWELLOW_86, this)
       case WHISMUR_135:
-      return copy (AmazingVoltTackle.WHISMUR_87, this);
+      return copy (AmazingVoltTackle.WHISMUR_87, this)
       case LOUDRED_136:
-      return copy (AmazingVoltTackle.LOUDRED_88, this);
+      return copy (AmazingVoltTackle.LOUDRED_88, this)
       case EXPLOUD_137:
-      return copy (AmazingVoltTackle.EXPLOUD_89, this);
+      return copy (AmazingVoltTackle.EXPLOUD_89, this)
       case RAYQUAZA_138:
-      return copy (LegendaryHeartbeat.RAYQUAZA_56, this);
+      return copy (LegendaryHeartbeat.RAYQUAZA_56, this)
       case CHATOT_139:
-      return copy (LegendaryHeartbeat.CHATOT_57, this);
+      return copy (LegendaryHeartbeat.CHATOT_57, this)
       case TOGEKISS_V_140:
-      return copy (LegendaryHeartbeat.TOGEKISS_V_58, this);
+      return copy (LegendaryHeartbeat.TOGEKISS_V_58, this)
       case TOGEKISS_VMAX_141:
-      return copy (LegendaryHeartbeat.TOGEKISS_VMAX_59, this);
+      return copy (LegendaryHeartbeat.TOGEKISS_VMAX_59, this)
       case TORNADUS_142:
-      return copy (LegendaryHeartbeat.TORNADUS_60, this);
+      return copy (LegendaryHeartbeat.TORNADUS_60, this)
       case PIKIPEK_143:
-      return copy (LegendaryHeartbeat.PIKIPEK_61, this);
+      return copy (LegendaryHeartbeat.PIKIPEK_61, this)
       case TRUMBEAK_144:
-      return copy (LegendaryHeartbeat.TRUMBEAK_62, this);
+      return copy (LegendaryHeartbeat.TRUMBEAK_62, this)
       case TOUCANNON_145:
-      return copy (LegendaryHeartbeat.TOUCANNON_63, this);
+      return copy (LegendaryHeartbeat.TOUCANNON_63, this)
       case ALLISTER_146:
-      return copy (LegendaryHeartbeat.ALLISTER_71, this);
+      return copy (LegendaryHeartbeat.ALLISTER_71, this)
       case BEA_147:
-      return copy (AmazingVoltTackle.BEA_93, this);
+      return copy (AmazingVoltTackle.BEA_93, this)
       case BEAUTY_148:
-      return copy (LegendaryHeartbeat.BEAUTY_70, this);
+      return copy (LegendaryHeartbeat.BEAUTY_70, this)
       case CARA_LISS_149:
       return supporter (this) {
         text "Search your deck for up to 2 Rare Fossil cards and put them onto your Bench. Then" +
@@ -605,117 +605,117 @@ public enum VividVoltage implements LogicCardInfo {
           assert my.bench.notFull : "Bench is already full"
           assert my.deck : "Deck is empty"
         }
-      };
+      }
       case CIRCHESTER_BATH_150:
       return copy (AmazingVoltTackle.HERO_S_BATH_97, this)
       case DRONE_ROTOM_151:
-      return copy (AmazingVoltTackle.DRONE_ROTOM_90, this);
+      return copy (AmazingVoltTackle.DRONE_ROTOM_90, this)
       case HERO_S_MEDAL_152:
-      return copy (LegendaryHeartbeat.HERO_S_MEDAL_68, this);
+      return copy (LegendaryHeartbeat.HERO_S_MEDAL_68, this)
       case LEAGUE_STAFF_153:
-      return copy (AmazingVoltTackle.LEAGUE_STAFF_95, this);
+      return copy (AmazingVoltTackle.LEAGUE_STAFF_95, this)
       case LEON_154:
-      return copy (AmazingVoltTackle.LEON_94, this);
+      return copy (AmazingVoltTackle.LEON_94, this)
       case MEMORY_CAPSULE_155:
-      return copy (AmazingVoltTackle.MEMORY_CAPSULE_92, this);
+      return copy (AmazingVoltTackle.MEMORY_CAPSULE_92, this)
       case MOOMOO_CHEESE_156:
-      return copy (LegendaryHeartbeat.MOOMOO_CHEESE_67, this);
+      return copy (LegendaryHeartbeat.MOOMOO_CHEESE_67, this)
       case NESSA_157:
-      return copy (AmazingVoltTackle.NESSA_96, this);
+      return copy (AmazingVoltTackle.NESSA_96, this)
       case OPAL_158:
-      return copy (LegendaryHeartbeat.OPAL_72, this);
+      return copy (LegendaryHeartbeat.OPAL_72, this)
       case ROCKY_HELMET_159:
-      return copy (LegendaryHeartbeat.ROCKY_HELMET_69, this);
+      return copy (LegendaryHeartbeat.ROCKY_HELMET_69, this)
       case TELESCOPIC_SIGHT_160:
-      return copy (AmazingVoltTackle.TELEPHOTO_SCOPE_91, this);
+      return copy (AmazingVoltTackle.TELEPHOTO_SCOPE_91, this)
       case WYNDON_STADIUM_161:
-      return copy (AmazingVoltTackle.WYNDON_STADIUM_98, this);
+      return copy (AmazingVoltTackle.WYNDON_STADIUM_98, this)
       case AROMATIC_G_ENERGY_162:
-      return copy (LegendaryHeartbeat.AROMA_G_ENERGY_74, this);
+      return copy (LegendaryHeartbeat.AROMA_G_ENERGY_74, this)
       case COATING_M_ENERGY_163:
-      return copy (AmazingVoltTackle.COATING_M_ENERGY_100, this);
+      return copy (AmazingVoltTackle.COATING_M_ENERGY_100, this)
       case STONE_F_ENERGY_164:
-      return copy (LegendaryHeartbeat.STONE_F_ENERGY_75, this);
+      return copy (LegendaryHeartbeat.STONE_F_ENERGY_75, this)
       case WASH_W_ENERGY_165:
-      return copy (AmazingVoltTackle.WASH_W_ENERGY_99, this);
+      return copy (AmazingVoltTackle.WASH_W_ENERGY_99, this)
       case ORBEETLE_V_166:
-      return copy (ORBEETLE_V_20, this);
+      return copy (ORBEETLE_V_20, this)
       case ZARUDE_V_167:
-      return copy (ZARUDE_V_22, this);
+      return copy (ZARUDE_V_22, this)
       case TALONFLAME_V_168:
-      return copy (TALONFLAME_V_29, this);
+      return copy (TALONFLAME_V_29, this)
       case GALARIAN_DARMANITAN_V_169:
-      return copy (GALARIAN_DARMANITAN_V_36, this);
+      return copy (GALARIAN_DARMANITAN_V_36, this)
       case PIKACHU_V_170:
-      return copy (PIKACHU_V_43, this);
+      return copy (PIKACHU_V_43, this)
       case AMPHAROS_V_171:
-      return copy (AMPHAROS_V_49, this);
+      return copy (AMPHAROS_V_49, this)
       case ALAKAZAM_V_172:
-      return copy (AmazingVoltTackle.ALAKAZAM_V_41, this);
+      return copy (AmazingVoltTackle.ALAKAZAM_V_41, this)
       case COALOSSAL_V_173:
-      return copy (COALOSSAL_V_98, this);
+      return copy (COALOSSAL_V_98, this)
       case GALARIAN_SIRFETCH_D_V_174:
-      return copy (AmazingVoltTackle.GALARIAN_SIRFETCH_D_V_106, this);
+      return copy (AmazingVoltTackle.GALARIAN_SIRFETCH_D_V_106, this)
       case DRAPION_V_175:
-      return copy (DRAPION_V_106, this);
+      return copy (DRAPION_V_106, this)
       case STEELIX_V_176:
-      return copy (STEELIX_V_115, this);
+      return copy (STEELIX_V_115, this)
       case AEGISLASH_V_177:
-      return copy (AEGISLASH_V_126, this);
+      return copy (AEGISLASH_V_126, this)
       case TOGEKISS_V_178:
-      return copy (TOGEKISS_V_140, this);
+      return copy (TOGEKISS_V_140, this)
       case ALLISTER_179:
-      return copy (ALLISTER_146, this);
+      return copy (ALLISTER_146, this)
       case BEA_180:
-      return copy (BEA_147, this);
+      return copy (BEA_147, this)
       case BEAUTY_181:
-      return copy (BEAUTY_148, this);
+      return copy (BEAUTY_148, this)
       case LEON_182:
-      return copy (LEON_154, this);
+      return copy (LEON_154, this)
       case NESSA_183:
-      return copy (NESSA_157, this);
+      return copy (NESSA_157, this)
       case OPAL_184:
-      return copy (OPAL_158, this);
+      return copy (OPAL_158, this)
       case POKEMON_CENTER_LADY_185:
-      return copy (SwordShield.POKEMON_CENTER_LADY_176, this);
+      return copy (SwordShield.POKEMON_CENTER_LADY_176, this)
       case ORBEETLE_VMAX_186:
-      return copy (ORBEETLE_VMAX_21, this);
+      return copy (ORBEETLE_VMAX_21, this)
       case GALARIAN_DARMANITAN_VMAX_187:
-      return copy (GALARIAN_DARMANITAN_VMAX_37, this);
+      return copy (GALARIAN_DARMANITAN_VMAX_37, this)
       case PIKACHU_VMAX_188:
-      return copy (PIKACHU_VMAX_44, this);
+      return copy (PIKACHU_VMAX_44, this)
       case COALOSSAL_VMAX_189:
-      return copy (COALOSSAL_VMAX_99, this);
+      return copy (COALOSSAL_VMAX_99, this)
       case AEGISLASH_VMAX_190:
-      return copy (AEGISLASH_VMAX_127, this);
+      return copy (AEGISLASH_VMAX_127, this)
       case TOGEKISS_VMAX_191:
-      return copy (TOGEKISS_VMAX_141, this);
+      return copy (TOGEKISS_VMAX_141, this)
       case ALLISTER_192:
-      return copy (ALLISTER_146, this);
+      return copy (ALLISTER_146, this)
       case BEA_193:
-      return copy (BEA_147, this);
+      return copy (BEA_147, this)
       case BEAUTY_194:
-      return copy (BEAUTY_148, this);
+      return copy (BEAUTY_148, this)
       case LEON_195:
-      return copy (LEON_154, this);
+      return copy (LEON_154, this)
       case NESSA_196:
-      return copy (NESSA_157, this);
+      return copy (NESSA_157, this)
       case OPAL_197:
-      return copy (OPAL_158, this);
+      return copy (OPAL_158, this)
       case GALARIAN_OBSTAGOON_198:
-      return copy (SwordShield.GALARIAN_OBSTAGOON_119, this);
+      return copy (SwordShield.GALARIAN_OBSTAGOON_119, this)
       case ORANGURU_199:
-      return copy (LegendaryHeartbeat.ORANGURU_92, this);
+      return copy (LegendaryHeartbeat.ORANGURU_92, this)
       case CAPE_OF_TOUGHNESS_200:
-      return copy (DarknessAblaze.CAPE_OF_TOUGHNESS_160, this);
+      return copy (DarknessAblaze.CAPE_OF_TOUGHNESS_160, this)
       case HERO_S_MEDAL_201:
-      return copy (HERO_S_MEDAL_152, this);
+      return copy (HERO_S_MEDAL_152, this)
       case MEMORY_CAPSULE_202:
-      return copy (MEMORY_CAPSULE_155, this);
+      return copy (MEMORY_CAPSULE_155, this)
       case TELESCOPIC_SIGHT_203:
-      return copy (TELESCOPIC_SIGHT_160, this);
+      return copy (TELESCOPIC_SIGHT_160, this)
       default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodAquapolis.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodAquapolis.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -234,53 +234,53 @@ public enum PokemodAquapolis implements LogicCardInfo {
   TYPHLOSION_EX_197 ("Typhlosion ex", "197", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE2, EX, _FIRE_]),
   MACHAMP_EX_198 ("Machamp ex", "198", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE2, EX, _FIGHTING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodAquapolis(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_AQUAPOLIS;
+    return tcgwars.logic.card.Collection.POKEMOD_AQUAPOLIS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -305,7 +305,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ARCANINE_2:
       return evolution (this, from:"Growlithe", hp:HP090, type:R, retreatCost:3) {
         weakness W
@@ -322,7 +322,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARIADOS_3:
       return evolution (this, from:"Spinarak", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -339,7 +339,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case AZUMARILL_4:
       return evolution (this, from:"Marill", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -356,7 +356,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BELLOSSOM_5:
       return evolution (this, from:"Gloom", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -374,7 +374,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BLISSEY_6:
       return evolution (this, from:"Chansey", hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -392,7 +392,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DONPHAN_7:
       return evolution (this, from:"Phanpy", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -413,7 +413,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ELECTRODE_8:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -430,7 +430,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ELEKID_9:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:L, retreatCost:0) {
         move "Energy Kick", {
@@ -441,7 +441,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ENTEI_10:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -458,7 +458,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ESPEON_11:
       return evolution (this, from:"Eevee", hp:HP080, type:P, retreatCost:0) {
         weakness P
@@ -475,7 +475,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case EXEGGUTOR_12:
       return evolution (this, from:"Exeggcute", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -495,7 +495,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGUTOR_13:
       return evolution (this, from:"Exeggcute", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -515,7 +515,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HOUNDOOM_14:
       return evolution (this, from:"Houndour", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -535,7 +535,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HOUNDOOM_15:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -556,7 +556,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HYPNO_16:
       return evolution (this, from:"Drowzee", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -573,7 +573,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JUMPLUFF_17:
       return evolution (this, from:"Skiploom", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -591,7 +591,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JYNX_18:
       return basic (this, hp:HP060, type:P, retreatCost:2) {
         weakness P
@@ -611,7 +611,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KINGDRA_19:
       return evolution (this, from:"Seadra", hp:HP120, type:W, retreatCost:3) {
         weakness L
@@ -628,7 +628,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LANTURN_20:
       return evolution (this, from:"Chinchou", hp:HP080, type:W, retreatCost:1) {
         weakness G
@@ -648,7 +648,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LANTURN_21:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -665,7 +665,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNETON_22:
       return evolution (this, from:"Magnemite", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -683,7 +683,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MUK_23:
       return evolution (this, from:"Grimer", hp:HP070, type:G, retreatCost:2) {
         weakness P
@@ -700,7 +700,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NIDOKING_24:
       return evolution (this, from:"Nidorino", hp:HP110, type:F, retreatCost:3) {
         weakness G
@@ -718,7 +718,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NINETALES_25:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -738,7 +738,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case OCTILLERY_26:
       return evolution (this, from:"Remoraid", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -755,7 +755,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PARASECT_27:
       return evolution (this, from:"Paras", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -775,7 +775,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PORYGON2_28:
       return evolution (this, from:"Porygon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -793,7 +793,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PRIMEAPE_29:
       return evolution (this, from:"Mankey", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -813,7 +813,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case QUAGSIRE_30:
       return evolution (this, from:"Wooper", hp:HP080, type:W, retreatCost:2) {
         weakness G
@@ -833,7 +833,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAPIDASH_31:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:0) {
         weakness W
@@ -853,7 +853,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCIZOR_32:
       return evolution (this, from:"Scyther", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -878,7 +878,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLOWBRO_33:
       return evolution (this, from:"Slowpoke", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -895,7 +895,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLOWKING_34:
       return evolution (this, from:"Slowpoke", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -915,7 +915,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STEELIX_35:
       return evolution (this, from:"Onix", hp:HP100, type:M, retreatCost:4) {
         weakness R
@@ -936,7 +936,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SUDOWOODO_36:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness W
@@ -956,7 +956,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SUICUNE_37:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -973,7 +973,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TENTACRUEL_38:
       return evolution (this, from:"Tentacool", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -990,7 +990,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOGETIC_39:
       return evolution (this, from:"Togepi", hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -1008,7 +1008,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TYRANITAR_40:
       return evolution (this, from:"Pupitar", hp:HP120, type:D, retreatCost:3) {
         weakness F
@@ -1037,7 +1037,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case UMBREON_41:
       return evolution (this, from:"Eevee", hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -1055,7 +1055,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VICTREEBEL_42:
       return evolution (this, from:"Weepinbell", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -1072,7 +1072,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VILEPLUME_43:
       return evolution (this, from:"Gloom", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -1092,7 +1092,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ZAPDOS_44:
       return basic (this, hp:HP080, type:L, retreatCost:2) {
         pokeBody "Anti-Lightning", {
@@ -1116,7 +1116,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BELLSPROUT_45:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1128,7 +1128,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DODRIO_46:
       return evolution (this, from:"Doduo", hp:HP070, type:C, retreatCost:1) {
         weakness L
@@ -1149,7 +1149,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FLAAFFY_47:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1169,7 +1169,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FURRET_48:
       return evolution (this, from:"Sentret", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1187,7 +1187,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GLOOM_49:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1204,7 +1204,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDUCK_50:
       return evolution (this, from:"Psyduck", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1224,7 +1224,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROWLITHE_51:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1236,7 +1236,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGNEMITE_52:
       return basic (this, hp:HP040, type:M, retreatCost:1) {
         weakness R
@@ -1257,7 +1257,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MARILL_53:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1277,7 +1277,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAROWAK_54:
       return evolution (this, from:"Cubone", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1298,7 +1298,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDORINO_55:
       return evolution (this, from:"Nidoran♂", hp:HP060, type:G, retreatCost:1) {
         weakness P
@@ -1318,7 +1318,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PUPITAR_56:
       return evolution (this, from:"Larvitar", hp:HP080, type:F, retreatCost:1) {
         weakness W
@@ -1330,7 +1330,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SCYTHER_57:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1350,7 +1350,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEADRA_58:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1370,7 +1370,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEAKING_59:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1390,7 +1390,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKIPLOOM_60:
       return evolution (this, from:"Hoppip", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1408,7 +1408,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SMOOCHUM_61:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:P, retreatCost:0) {
         move "Energy Kiss", {
@@ -1419,7 +1419,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPINARAK_62:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1439,7 +1439,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TYROGUE_63:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:F, retreatCost:0) {
         move "Energy Punch", {
@@ -1450,7 +1450,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VOLTORB_64:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1470,7 +1470,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WEEPINBELL_65:
       return evolution (this, from:"Bellsprout", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1490,7 +1490,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WOOPER_66:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1510,7 +1510,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case AIPOM_67:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1531,7 +1531,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BELLSPROUT_68:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -1551,7 +1551,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHANSEY_69:
       return basic (this, hp:HP100, type:C, retreatCost:2) {
         weakness F
@@ -1572,7 +1572,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHINCHOU_70:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1592,7 +1592,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHINCHOU_71:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1612,7 +1612,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CUBONE_72:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1633,7 +1633,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DODUO_73:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1654,7 +1654,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DROWZEE_74:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1674,7 +1674,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EEVEE_75:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1695,7 +1695,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EXEGGCUTE_76:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1715,7 +1715,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGCUTE_77:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1735,7 +1735,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GOLDEEN_78:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1747,7 +1747,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRIMER_79:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1759,7 +1759,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GROWLITHE_80:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1779,7 +1779,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HITMONCHAN_81:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -1799,7 +1799,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HITMONTOP_82:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -1819,7 +1819,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOPPIP_83:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1837,7 +1837,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HORSEA_84:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1849,7 +1849,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HORSEA_85:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1861,7 +1861,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_86:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1881,7 +1881,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOUNDOUR_87:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1894,7 +1894,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KANGASKHAN_88:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -1915,7 +1915,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LARVITAR_89:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -1935,7 +1935,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LICKITUNG_90:
       return basic (this, hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -1956,7 +1956,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_91:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1973,7 +1973,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MANKEY_92:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
@@ -1993,7 +1993,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAREEP_93:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -2013,7 +2013,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MILTANK_94:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2034,7 +2034,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MR__MIME_95:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2051,7 +2051,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NIDORAN_MALE_96:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -2071,7 +2071,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ODDISH_97:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2091,7 +2091,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ONIX_98:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness W
@@ -2103,7 +2103,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PARAS_99:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2123,7 +2123,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PHANPY_100:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -2144,7 +2144,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINSIR_101:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -2164,7 +2164,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case PONYTA_102:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2184,7 +2184,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PORYGON_103:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2205,7 +2205,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PSYDUCK_104:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2225,7 +2225,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case REMORAID_105:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2237,7 +2237,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SCYTHER_106:
       return basic (this, hp:HP060, type:G, retreatCost:0) {
         weakness L
@@ -2258,7 +2258,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SENTRET_107:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2279,7 +2279,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLOWPOKE_108:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2299,7 +2299,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SMEARGLE_109:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2320,7 +2320,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNEASEL_110:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -2341,7 +2341,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SPINARAK_111:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -2353,7 +2353,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TANGELA_112:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -2374,7 +2374,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TENTACOOL_113:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2394,7 +2394,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case TOGEPI_114:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2415,7 +2415,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VOLTORB_115:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -2427,7 +2427,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VULPIX_116:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2439,7 +2439,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WOOPER_117:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2459,7 +2459,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case APRICORN_FOREST_118:
       return stadium (this) {
         text "Once during each player's turn (before attacking), if that player's Bench isn't full, that player flips a coin. If heads, that player shows his or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffles his or her deck afterward."
@@ -2467,7 +2467,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DARKNESS_CUBE_01_119:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [D] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Darkness Cube 01." +
@@ -2476,7 +2476,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SWITCH_120:
       return basicTrainer (this) {
         text "Move a basic Energy card attached to 1 of your Pokémon to another of your Pokémon."
@@ -2484,7 +2484,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FIGHTING_CUBE_01_121:
       return basicTrainer (this) {
         text "Attach this card to 1 of our [F] Pokémon in play. That Pokémon my use this card's attack instead of its own. At the end of your turn, discard Fighting Cube 01." +
@@ -2493,7 +2493,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FIRE_CUBE_01_122:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [R] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Fire Cube 01." +
@@ -2502,7 +2502,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FOREST_GUARDIAN_123:
       return supporter (this) {
         text "Shuffle your deck. Then, look at the top 7 cards of your deck. Choose 1 of those cards and put it into your hand. Shuffle the rest into your deck afterward."
@@ -2510,7 +2510,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GRASS_CUBE_01_124:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [G] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Grass Cube 01." +
@@ -2519,7 +2519,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DESERT_RUINS_125:
       return stadium (this) {
         text "At any time between turns, each player puts 1 damage counter on his or her Pokémon-ex with a remaining HP of 80 or more."
@@ -2527,7 +2527,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case JUGGLER_126:
       return supporter (this) {
         text "Discard up to 2 basic Energy cards from your hand. If you discarded 1 basic Energy card, draw 3 cards. If you discarded 2 basic Energy cards, draw 5 cards."
@@ -2535,7 +2535,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LIGHTNING_CUBE_01_127:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [L] Pokémon in play. That Pokémon may use this attack instead of it own. At the end of your turn, discard Lightning Cube 01." +
@@ -2544,7 +2544,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MEMORY_BERRY_128:
       return pokemonTool (this) {
         text "The Pokémon this card is attached to (exluding Pokémon-ex) can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
@@ -2554,7 +2554,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case METAL_CUBE_01_129:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [M] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Metal Cube 01." +
@@ -2563,7 +2563,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_FAN_CLUB_130:
       return supporter (this) {
         text "Search your deck for up to 2 Baby Pokémon and/or Basic Pokémon cards and put them onto your Bench. Shuffle your deck afterward."
@@ -2571,7 +2571,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_PARK_131:
       return stadium (this) {
         text "Once during each of his or her turns, whenever a player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon (exluding Pokémon-ex), he or she removes 1 damage counter, if any, from that Pokémon."
@@ -2579,7 +2579,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case PSYCHIC_CUBE_01_132:
       return basicTrainer (this) {
         text "Attach this card to 1 of your [P] Pokémon in play. That Pokémon may us this card's attack instead of its own. At the end of your turn, discard Psychic Cube 01." +
@@ -2588,7 +2588,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SEER_133:
       return supporter (this) {
         text "Look at the top 6 cards of your deck. Take all basic Energy cards you find there, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
@@ -2596,7 +2596,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HEALING_FIELDS_134:
       return stadium (this) {
         text "Once during each player's turn, he or she may flip a coin. If heads, that player's Active Pokémon (exluding Pokémon-ex) is no longer affected by any Special Conditions."
@@ -2604,7 +2604,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case TIME_SHARD_135:
       return pokemonTool (this) {
         text "If the Pokémon this card is attached to is Knocked Out by damage from the Defending Pokémon's attack during your opponent's turn, your may return up to 2 basic Energy cards attached to that Pokémon to your hand."
@@ -2614,7 +2614,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case TOWN_VOLUNTEERS_136:
       return supporter (this) {
         text "Take 5 Baby Pokémon, Basic Pokémon, Evolution, and/or basic Energy cards from your discard pile and then show them to your opponent. Shuffle them into your deck."
@@ -2622,7 +2622,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TRAVELING_SALESMAN_137:
       return supporter (this) {
         text "Search your deck for up to 2 Technical Machine and/or Pokémon Tool cards, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
@@ -2630,7 +2630,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case UNDERSEA_RUINS_138:
       return stadium (this) {
         text "Once during each player's turn (before attacking), that player may flip a coin. If heads, that player chooses 1 of his or her Evolved Pokémon in play and discards the top Evolution card from that Pokémon, devolving it."
@@ -2638,7 +2638,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case POWER_PLANT_139:
       return stadium (this) {
         text "Once during each of his or her turns, a player may discard a basic Energy card from his or her hand. If that player does, he or she chooses a basic Energy card from his or her discard pile, shows it to his or her opponent, and then puts it into his or her hand."
@@ -2646,7 +2646,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case WATER_CUBE_01_140:
       return basicTrainer (this) {
         text "Attach this card to 1 of you [W] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Water Cube 01." +
@@ -2655,7 +2655,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case WEAKNESS_GUARD_141:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon. Discard it at the end of your opponent's next turn." +
@@ -2664,7 +2664,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DARKNESS_ENERGY_142:
       return specialEnergy (this, [[C]]) {
         text "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon." +
@@ -2678,7 +2678,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case METAL_ENERGY_143:
       return specialEnergy (this, [[C]]) {
         text "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon Metal Energy is attached to isn't [M]." +
@@ -2691,7 +2691,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RAINBOW_ENERGY_144:
       return specialEnergy (this, [[C]]) {
         text "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon."
@@ -2703,7 +2703,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BOOST_ENERGY_145:
       return specialEnergy (this, [[C]]) {
         text "Boost Energy provides [C] energy. While in play, if you have more prize cards than your opponent, Boost Energy provides [C][C][C]. If the Pokémon Boost Energy is attached to is a Pokémon-ex, or has a Poké-Power, Poké-Body, or any other Special Energy cards attached to it (at any time), discard Boost Energy."
@@ -2715,7 +2715,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CRYSTAL_ENERGY_146:
       return specialEnergy (this, [[C]]) {
         text "Crystal Energy provides 1 Energy of all types (colors) of all basic Energy cards attached to the Pokémon Crystal Energy is attached to." +
@@ -2728,7 +2728,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case WARP_ENERGY_147:
       return specialEnergy (this, [[C]]) {
         text "Warp Energy provides 1 [C] Energy." +
@@ -2741,7 +2741,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case KINGDRA_148:
       return evolution (this, from:"Seadra", hp:HP110, type:C, retreatCost:3) {
         weakness L
@@ -2766,7 +2766,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case LUGIA_149:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness P
@@ -2791,7 +2791,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDOKING_150:
       return evolution (this, from:"Nidorino", hp:HP100, type:C, retreatCost:3) {
         weakness P
@@ -2816,7 +2816,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case BOOST_ENERGY_151:
       return specialEnergy (this, [[C]]) {
         text "Boost Energy provides [C] energy. While in play, if you have more prize cards than your opponent, Boost Energy provides [C][C][C]. If the Pokémon Boost Energy is attached to has a Poké-Power, or any other Special Energy cards attached to it (at any time), discard Boost Energy. If the Pokémon Boost Energy is attached to is a Pokémon-ex, Discard Boost Energy."
@@ -2828,11 +2828,11 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CRYSTAL_ENERGY_152:
-      return copy (CRYSTAL_ENERGY_146, this);
+      return copy (CRYSTAL_ENERGY_146, this)
       case WARP_ENERGY_153:
-      return copy (WARP_ENERGY_147, this);
+      return copy (WARP_ENERGY_147, this)
       case BLEND_ENERGY_GRPD_154:
       return specialEnergy (this, [[C]]) {
         text "This card provides 1 [C] Energy." +
@@ -2845,7 +2845,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BLEND_ENERGY_WLFM_155:
       return specialEnergy (this, [[C]]) {
         text "This card provides 1 [C] Energy." +
@@ -2858,7 +2858,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case KABUTOPS_156:
       return evolution (this, from:"Kabuto", hp:HP090, type:F, retreatCost:3) {
         weakness G
@@ -2876,7 +2876,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SNEASEL_157:
       return basic (this, hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -2894,73 +2894,73 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case AMPHAROS_158:
-      return copy (AMPHAROS_1, this);
+      return copy (AMPHAROS_1, this)
       case ARCANINE_159:
-      return copy (ARCANINE_2, this);
+      return copy (ARCANINE_2, this)
       case ARIADOS_160:
-      return copy (ARIADOS_3, this);
+      return copy (ARIADOS_3, this)
       case AZUMARILL_161:
-      return copy (AZUMARILL_4, this);
+      return copy (AZUMARILL_4, this)
       case BELLOSSOM_162:
-      return copy (BELLOSSOM_5, this);
+      return copy (BELLOSSOM_5, this)
       case BLISSEY_163:
-      return copy (BLISSEY_6, this);
+      return copy (BLISSEY_6, this)
       case ELECTRODE_164:
-      return copy (ELECTRODE_8, this);
+      return copy (ELECTRODE_8, this)
       case ENTEI_165:
-      return copy (ENTEI_10, this);
+      return copy (ENTEI_10, this)
       case ESPEON_166:
-      return copy (ESPEON_11, this);
+      return copy (ESPEON_11, this)
       case EXEGGUTOR_167:
-      return copy (EXEGGUTOR_12, this);
+      return copy (EXEGGUTOR_12, this)
       case HOUNDOOM_168:
-      return copy (HOUNDOOM_15, this);
+      return copy (HOUNDOOM_15, this)
       case HYPNO_169:
-      return copy (HYPNO_16, this);
+      return copy (HYPNO_16, this)
       case JUMPLUFF_170:
-      return copy (JUMPLUFF_17, this);
+      return copy (JUMPLUFF_17, this)
       case KINGDRA_171:
-      return copy (KINGDRA_19, this);
+      return copy (KINGDRA_19, this)
       case LANTURN_172:
-      return copy (LANTURN_21, this);
+      return copy (LANTURN_21, this)
       case MAGNETON_173:
-      return copy (MAGNETON_22, this);
+      return copy (MAGNETON_22, this)
       case MUK_174:
-      return copy (MUK_23, this);
+      return copy (MUK_23, this)
       case NIDOKING_175:
-      return copy (NIDOKING_24, this);
+      return copy (NIDOKING_24, this)
       case NINETALES_176:
-      return copy (NINETALES_25, this);
+      return copy (NINETALES_25, this)
       case OCTILLERY_177:
-      return copy (OCTILLERY_26, this);
+      return copy (OCTILLERY_26, this)
       case SCIZOR_178:
-      return copy (SCIZOR_32, this);
+      return copy (SCIZOR_32, this)
       case SLOWKING_179:
-      return copy (SLOWKING_34, this);
+      return copy (SLOWKING_34, this)
       case STEELIX_180:
-      return copy (STEELIX_35, this);
+      return copy (STEELIX_35, this)
       case SUDOWOODO_181:
-      return copy (SUDOWOODO_36, this);
+      return copy (SUDOWOODO_36, this)
       case SUICUNE_182:
-      return copy (SUICUNE_37, this);
+      return copy (SUICUNE_37, this)
       case TENTACRUEL_183:
-      return copy (TENTACRUEL_38, this);
+      return copy (TENTACRUEL_38, this)
       case TOGETIC_184:
-      return copy (TOGETIC_39, this);
+      return copy (TOGETIC_39, this)
       case TYRANITAR_185:
-      return copy (TYRANITAR_40, this);
+      return copy (TYRANITAR_40, this)
       case UMBREON_186:
-      return copy (UMBREON_41, this);
+      return copy (UMBREON_41, this)
       case VICTREEBEL_187:
-      return copy (VICTREEBEL_42, this);
+      return copy (VICTREEBEL_42, this)
       case VILEPLUME_188:
-      return copy (VILEPLUME_43, this);
+      return copy (VILEPLUME_43, this)
       case ZAPDOS_189:
-      return copy (ZAPDOS_44, this);
+      return copy (ZAPDOS_44, this)
       case DONPHAN_190:
-      return copy (DONPHAN_7, this);
+      return copy (DONPHAN_7, this)
       case RAIKOU_EX_191:
       return basic (this, hp:HP100, type:L, retreatCost:2) {
         weakness F
@@ -2980,7 +2980,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ENTEI_EX_192:
       return basic (this, hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -3000,7 +3000,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case SUICUNE_EX_193:
       return basic (this, hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -3020,7 +3020,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KABUTOPS_EX_194:
       return evolution (this, from:"Kabuto", hp:HP150, type:W, retreatCost:2) {
         weakness G
@@ -3042,7 +3042,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case RAICHU_EX_195:
       return evolution (this, from:"Pikachu", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -3062,7 +3062,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case AERODACTYL_EX_196:
       return evolution (this, from:"Mysterious Fossil", hp:HP100, type:C, retreatCost:1) {
         weakness G
@@ -3088,7 +3088,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TYPHLOSION_EX_197:
       return evolution (this, from:"Quilava", hp:HP150, type:R, retreatCost:2) {
         weakness W
@@ -3109,7 +3109,7 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case MACHAMP_EX_198:
       return evolution (this, from:"Machoke", hp:HP150, type:F, retreatCost:3) {
         weakness P
@@ -3135,9 +3135,9 @@ public enum PokemodAquapolis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet.groovy
@@ -6,35 +6,35 @@ import tcgwars.logic.effect.gm.PlayTrainer
 import tcgwars.logic.impl.gen1.BaseSetNG
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -164,53 +164,53 @@ public enum PokemodBaseSet implements LogicCardInfo {
   MIRACLE_ENERGY_OPTION_1 ("Miracle Energy", "121", Rarity.UNCOMMON, [ENERGY, SPECIAL_ENERGY]),
   MIRACLE_ENERGY_OPTION_2 ("Miracle Energy", "122", Rarity.UNCOMMON, [ENERGY, SPECIAL_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodBaseSet(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_BASE_SET;
+    return tcgwars.logic.card.Collection.POKEMOD_BASE_SET
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -246,7 +246,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(CONFUSED) }
           }
         }
-      };
+      }
       case BLASTOISE_2:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -272,9 +272,9 @@ public enum PokemodBaseSet implements LogicCardInfo {
             extraEnergyDamage(2, hp(10), W, thisMove)
           }
         }
-      };
+      }
       case BLASTOISE_111:
-      return copy (BLASTOISE_2, this);
+      return copy (BLASTOISE_2, this)
       case CHANSEY_3:
       return basic (this, hp:HP120, type:C, retreatCost:1) {
         weakness F
@@ -294,7 +294,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 80, self
           }
         }
-      };
+      }
       case CHARIZARD_4:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:3) {
         weakness W
@@ -326,9 +326,9 @@ public enum PokemodBaseSet implements LogicCardInfo {
             discardSelfEnergyInOrderTo(R)
           }
         }
-      };
+      }
       case CHARIZARD_112:
-      return copy (CHARIZARD_4, this);
+      return copy (CHARIZARD_4, this)
       case CLEFAIRY_5:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -347,7 +347,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             def moveList = []
             def labelList = []
 
-            moveList.addAll(defending.topPokemonCard.moves);
+            moveList.addAll(defending.topPokemonCard.moves)
             labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
             def move=choose(moveList, labelList)
@@ -356,7 +356,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             bef.unregisterItself(bg().em())
           }
         }
-      };
+      }
       case GYARADOS_6:
       return evolution (this, from:"Magikarp", hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -376,7 +376,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case HITMONCHAN_7:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness P
@@ -394,7 +394,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MACHAMP_8:
       return evolution (this, from:"Machoke", hp:HP100, type:F, retreatCost:3) {
         weakness P
@@ -416,7 +416,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MAGNETON_9:
       return evolution (this, from:"Magnemite", hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -438,7 +438,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 80, self
           }
         }
-      };
+      }
       case MEWTWO_10:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -457,7 +457,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             preventAllEffectsNextTurn()
           }
         }
-      };
+      }
       case NIDOKING_11:
       return evolution (this, from:"Nidorino", hp:HP100, type:G, retreatCost:3) {
         weakness P
@@ -480,7 +480,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NINETALES_12:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -506,7 +506,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case POLIWRATH_13:
       return evolution (this, from:"Poliwhirl", hp:HP100, type:W, retreatCost:3) {
         weakness G
@@ -526,7 +526,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             afterDamage { discardDefendingEnergy() }
           }
         }
-      };
+      }
       case RAICHU_14:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -546,7 +546,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 1, {}, {damage 30, self}
           }
         }
-      };
+      }
       case VENUSAUR_15:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -574,9 +574,9 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case VENUSAUR_113:
-      return copy (VENUSAUR_15, this);
+      return copy (VENUSAUR_15, this)
       case ZAPDOS_16:
       return basic (this, hp:HP090, type:L, retreatCost:3) {
         resistance F, MINUS30
@@ -598,7 +598,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case BEEDRILL_17:
       return evolution (this, from:"Kakuna", hp:HP090, type:G, retreatCost:0) {
         weakness R
@@ -618,7 +618,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(POISONED) }
           }
         }
-      };
+      }
       case DRAGONAIR_18:
       return evolution (this, from:"Dratini", hp:HP080, type:C, retreatCost:2) {
         resistance P, MINUS30
@@ -637,7 +637,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             discardDefendingEnergy()
           }
         }
-      };
+      }
       case DUGTRIO_19:
       return evolution (this, from:"Diglett", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -657,7 +657,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             my.bench.each({ damage 10, it})
           }
         }
-      };
+      }
       case ELECTABUZZ_20:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -677,7 +677,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 1, {damage 10}, {damage 10, self}
           }
         }
-      };
+      }
       case ELECTRODE_21:
       return evolution (this, from:"Voltorb", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -713,7 +713,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 1, {}, {damage 10, self}
           }
         }
-      };
+      }
       case PIDGEOTTO_22:
       return evolution (this, from:"Pidgey", hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -748,7 +748,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage lastDamage.value
           }
         }
-      };
+      }
       case ARCANINE_23:
       return evolution (this, from:"Growlithe", hp:HP100, type:R, retreatCost:3) {
         weakness W
@@ -768,7 +768,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 30, self
           }
         }
-      };
+      }
       case CHARMELEON_24:
       return evolution (this, from:"Charmander", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -787,7 +787,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             discardSelfEnergyInOrderTo(R)
           }
         }
-      };
+      }
       case DEWGONG_25:
       return evolution (this, from:"Seel", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -806,7 +806,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case DRATINI_26:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -817,7 +817,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FARFETCH_D_27:
       return basic (this, hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -841,7 +841,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GROWLITHE_28:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -852,7 +852,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HAUNTER_29:
       return evolution (this, from:"Gastly", hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -874,7 +874,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case IVYSAUR_30:
       return evolution (this, from:"Bulbasaur", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -893,7 +893,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             applyAfterDamage(POISONED)
           }
         }
-      };
+      }
       case JYNX_31:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -912,7 +912,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20+10*opp.active.numberOfDamageCounters
           }
         }
-      };
+      }
       case KADABRA_32:
       return evolution (this, from:"Abra", hp:HP060, type:P, retreatCost:3) {
         weakness P
@@ -934,7 +934,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case KAKUNA_33:
       return evolution (this, from:"Weedle", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -952,7 +952,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(POISONED) }
           }
         }
-      };
+      }
       case MACHOKE_34:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:3) {
         weakness P
@@ -971,7 +971,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case MAGIKARP_35:
       return basic (this, hp:HP030, type:W, retreatCost:0) {
         weakness L
@@ -989,7 +989,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case MAGMAR_36:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -1008,7 +1008,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDORINO_37:
       return evolution (this, from:"Nidoran♂", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1027,7 +1027,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case POLIWHIRL_38:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -1045,7 +1045,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 2, {damage 30}
           }
         }
-      };
+      }
       case PORYGON_39:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         weakness F
@@ -1064,7 +1064,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             // TODO:
           }
         }
-      };
+      }
       case RATICATE_40:
       return evolution (this, from:"Rattata", hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1083,7 +1083,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage ceil((defending.hp/10)/2)*10
           }
         }
-      };
+      }
       case SEEL_41:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1094,7 +1094,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WARTORTLE_42:
       return evolution (this, from:"Squirtle", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1112,7 +1112,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ABRA_43:
       return basic (this, hp:HP030, type:P, retreatCost:0) {
         weakness P
@@ -1124,7 +1124,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case BULBASAUR_44:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1143,7 +1143,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case CATERPIE_45:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1155,7 +1155,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case CHARMANDER_46:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1174,7 +1174,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DIGLETT_47:
       return basic (this, hp:HP030, type:F, retreatCost:0) {
         weakness G
@@ -1193,7 +1193,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DODUO_48:
       return basic (this, hp:HP050, type:C, retreatCost:0) {
         weakness L
@@ -1206,7 +1206,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 3, {damage 10}
           }
         }
-      };
+      }
       case DROWZEE_49:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1225,7 +1225,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(CONFUSED) }
           }
         }
-      };
+      }
       case GASTLY_50:
       return basic (this, hp:HP040, type:P, retreatCost:0) {
         weakness D
@@ -1255,7 +1255,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case KOFFING_51:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1270,7 +1270,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MACHOP_52:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1281,7 +1281,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_53:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1303,7 +1303,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 40, self
           }
         }
-      };
+      }
       case METAPOD_54:
       return evolution (this, from:"Caterpie", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1322,7 +1322,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case NIDORAN_MALE_55:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -1333,7 +1333,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { damage 30 }
           }
         }
-      };
+      }
       case ONIX_56:
       return basic (this, hp:HP090, type:F, retreatCost:3) {
         weakness G
@@ -1351,7 +1351,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             bg.em().run(new Harden("Harden", hp(30)))
           }
         }
-      };
+      }
       case PIDGEY_57:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1364,7 +1364,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             whirlwind()
           }
         }
-      };
+      }
       case PIKACHU_58:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1383,7 +1383,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip 1, {}, {damage 10, self}
           }
         }
-      };
+      }
       case POLIWAG_59:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness G
@@ -1395,7 +1395,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             extraEnergyDamage(2,hp(10),W,thisMove)
           }
         }
-      };
+      }
       case PONYTA_60:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1413,7 +1413,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RATTATA_61:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         weakness F
@@ -1425,7 +1425,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SANDSHREW_62:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1438,7 +1438,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             sandAttack(thisMove)
           }
         }
-      };
+      }
       case SQUIRTLE_63:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1457,7 +1457,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { preventAllDamageNextTurn() }
           }
         }
-      };
+      }
       case STARMIE_64:
       return evolution (this, from:"Staryu", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1477,7 +1477,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(PARALYZED) }
           }
         }
-      };
+      }
       case STARYU_65:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1488,7 +1488,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TANGELA_66:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1508,7 +1508,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             applyAfterDamage(POISONED)
           }
         }
-      };
+      }
       case VOLTORB_67:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1519,7 +1519,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VULPIX_68:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1531,7 +1531,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(CONFUSED) }
           }
         }
-      };
+      }
       case WEEDLE_69:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1543,7 +1543,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             flip { applyAfterDamage(POISONED) }
           }
         }
-      };
+      }
       case CLEFAIRY_DOLL_70:
       return basicTrainer (this) {
         text "Play Clefairy Doll as if it were a Basic Pokémon. While in play, Clefairy Doll counts as a Pokémon (instead of a Trainer card.) Clefairy Doll has no attacks, can''t retreat, and can''t be Asleep, Confused, Paralyzed, or Poisoned. If Clefairy Doll is Knocked Out, it doesn''t count as a Knocked Out Pokémon. At any time during tyour turn before your attack, you may discard Clefairy Doll."
@@ -1595,7 +1595,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert bench.notFull
         }
-      };
+      }
       case COMPUTER_SEARCH_71:
       return basicTrainer (this) {
         text "Discard 2 of the other cards from your hand in order to search your deck for any card and put it into your hand. Shuffle your deck afterward."
@@ -1608,9 +1608,9 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard).size() >= 2
           assert my.deck
         }
-      };
+      }
       case DEVOLUTION_SPRAY_72:
-        return copy(BaseSetNG.DEVOLUTION_SPRAY, this);
+        return copy(BaseSetNG.DEVOLUTION_SPRAY, this)
       case IMPOSTER_PROFESSOR_OAK_73:
       return basicTrainer (this) {
         text "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards."
@@ -1622,7 +1622,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert opp.deck
         }
-      };
+      }
       case ITEM_FINDER_74:
       return basicTrainer (this) {
         text "Discard 2 of the other cards from your hand in order to put a Trainer card from your discard pile into your hand."
@@ -1635,7 +1635,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard).size() >= 2
           assert my.discard.hasType(TRAINER)
         }
-      };
+      }
       case LASS_75:
       return supporter (this) {
         text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
@@ -1652,7 +1652,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert (opp.hand || my.hand) : "Neither player has any cards in hand"
         }
-      };
+      }
       case POKEMON_BREEDER_76: //TODO: Use the implementation of Rare Candy (admin: they are not the same!)
       return basicTrainer (this) {
         text "Put a Stage 2 Evolution card from your hand on the matching Basic Pokémon. You can only play this card when you would be allowed to evolve that Pokémon anyway."
@@ -1674,7 +1674,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert stage2_to_basic : "No matching Stage 2 card in hand"
         }
-      };
+      }
       case POKEMON_TRADER_77:
       return basicTrainer (this) {
         text "Trade 1 of the Basic Pokémon or Evolution cards in your hand for 1 of the Basic Pokémon or Evolution cards from your deck. Show both cards to your opponent. Shuffle your deck afterward."
@@ -1686,7 +1686,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.hand.find(cardTypeFilter(POKEMON))
         }
-      };
+      }
       case SCOOP_UP_78:
       return basicTrainer (this) {
         text "Choose 1 of your own Pokémon in play and return its Basic Pokémon card to your hand. (Discard all cards attached to that card.)"
@@ -1704,7 +1704,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             removePCS pcs
           }
         }
-      };
+      }
       case SUPER_ENERGY_REMOVAL_79:
       return basicTrainer (this) {
         text "Discard 1 Special Energy attached to 1 of your opponent's Pokémon."
@@ -1720,7 +1720,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert opp.all.findAll {it.cards.filterByType(SPECIAL_ENERGY)}
         }
-      };
+      }
       case DEFENDER_80:
       return basicTrainer (this) {
         text "Attach Defender to 1 of your Pokémon. At the end of your opponent''s next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -1729,7 +1729,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_RETRIEVAL_81:
       return basicTrainer (this) {
         text "Trade 1 of the other cards in your hand for up to 2 basic Energy cards from your discard pile."
@@ -1737,7 +1737,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FULL_HEAL_82:
       return basicTrainer (this) {
         text "Remove all Special Conditions from your Active Pokémon"
@@ -1747,7 +1747,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert !my.active.specialConditions.isEmpty()
         }
-      };
+      }
       case MAINTENANCE_83:
       return basicTrainer (this) {
         text "Shuffle 2 of the other cards from your hand into your deck in order to draw 2 cards."
@@ -1759,7 +1759,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert hand.getExcludedList(thisCard).size() >= 2
         }
-      };
+      }
       case PLUSPOWER_84:
       return basicTrainer (this) {
         text "Attach PlusPower to your Active Pokémonn. At the end of your turn, discard PlusPower. If this Pokémon''s attack does damage to the defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
@@ -1768,7 +1768,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_CENTER_85:
       return basicTrainer (this) {
         text "Remove all damage counters from 1 of your own Pokémon, then discard all Energy cards attached to those Pokémon."
@@ -1780,7 +1780,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.all.findAll{it.numberOfDamageCounters}
         }
-      };
+      }
       case POKEMON_FLUTE_86:
       return basicTrainer (this) {
         text "Choose 1 Basic Pokémon card from your opponent's discard pile and put it onto his or her Bench. (You can't play Pokémon Flute if your opponent's Bench is full.)"
@@ -1793,7 +1793,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert opp.discard.find(cardTypeFilter(BASIC)) : "No basic in opponent's discard"
           assert opp.bench.notFull : "Opponent bench is full"
         }
-      };
+      }
       case POKEDEX_87:
       return basicTrainer (this) {
         text "Look at up to 5 cards from the top of your deck and rearrange them as you like."
@@ -1804,7 +1804,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case PROFESSOR_OAK_88:
       return supporter (this) {
         text "Discard your hand, then draw 7 cards."
@@ -1815,7 +1815,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case REVIVE_89:
       return basicTrainer (this) {
         text "Put 1 Basic Pokémon card (excluding Pokémon-ex) from your discard pile onto your Bench. Put damage counters on that Pokémon equal to half its HP (rounded down to the nearest 10). (You can't play Revive if your Bench is full.)"
@@ -1828,7 +1828,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.discard.find(cardTypeFilter(BASIC) && !it.asPokemonCard().types.contains(EX)) && my.bench.notFull
         }
-      };
+      }
       case SUPER_POTION_90:
       return basicTrainer (this) {
         text "Discard 1 Energy card attached to 1 of your own Pokémon (excluding Pokémon-ex) in order to remove up to 4 damage counters from that Pokémon."
@@ -1845,7 +1845,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.all.findAll { it.cards.energyCount(C) && it.numberOfDamageCounters && !it.EX }
         }
-      };
+      }
       case BILL_91:
       return basicTrainer (this) {
         text "Draw 2 cards."
@@ -1855,7 +1855,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.deck
         }
-      };
+      }
       case ENERGY_REMOVAL_92:
       return basicTrainer (this) {
         text "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
@@ -1873,7 +1873,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert opp.all.findAll {it.cards.energyCount(C)}
         }
-      };
+      }
       case GUST_OF_WIND_93:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
@@ -1886,7 +1886,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert opp.bench
         }
-      };
+      }
       case POTION_94:
       return basicTrainer (this) {
         text "Remove up to 2 damage counters from 1 of your Pokémon."
@@ -1897,26 +1897,26 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.all.findAll{it.numberOfDamageCounters}
         }
-      };
+      }
       case SWITCH_95:
-      return copy(FireRedLeafGreen.SWITCH_102, this);
+      return copy(FireRedLeafGreen.SWITCH_102, this)
       case DOUBLE_COLORLESS_ENERGY_96:
       return specialEnergy (this, [[C],[C]]) {
         text "Double Colorless Energy provides [C][C] Energy."
         onPlay {}
-      };
+      }
       case FIGHTING_ENERGY:
-      return basicEnergy (this, F);
+      return basicEnergy (this, F)
       case FIRE_ENERGY_98:
-      return basicEnergy (this, R);
+      return basicEnergy (this, R)
       case GRASS_ENERGY_99:
-      return basicEnergy (this, G);
+      return basicEnergy (this, G)
       case LIGHTNING_ENERGY_100:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       case PSYCHIC_ENERGY_101:
-      return basicEnergy (this, P);
+      return basicEnergy (this, P)
       case WATER_ENERGY_102:
-      return basicEnergy (this, W);
+      return basicEnergy (this, W)
       case DUAL_BALL_103:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a basic Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -1933,7 +1933,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case ENERGY_SWITCH_104:
       return basicTrainer (this) {
         text "Move a basic Energy card from 1 of your Pokémon to another of your Pokémon"
@@ -1946,7 +1946,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.all.findAll{it.cards.filterByType(BASIC_ENERGY)} : "You have no basic Energy attached to your Pokémon."
           assert my.all.size() >= 2 : "You only have one Pokémon in play."
         }
-      };
+      }
       case SUPER_ENERGY_RETRIEVAL_105:
       return basicTrainer (this) {
         text "Trade 2 of the other cards in your hand for up to 4 basic Energy cards from your discard pile."
@@ -1960,7 +1960,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.hand.getExcludedList(thisCard).size() >= 2 : "You don't have 2 other cards to discard"
           assert my.discard.filterByType(BASIC_ENERGY) : "You don't have any basic Energy in your discard"
         }
-      };
+      }
       case SUPER_SCOOP_UP_106:
       return basicTrainer (this) {
         text "Flip a coin. If heads, return 1 of your Pokémon in play and all cards attached to it to your hand."
@@ -1975,7 +1975,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CRUSHING_HAMMER_107:
       return basicTrainer (this) {
         text "Discard 1 Energy card attached to 1 of your Pokémon in order to choose 1 of your opponent's Pokémon and up to 2 Energy cards attached to it. Discard those Energy cards."
@@ -1991,7 +1991,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.all.findAll{it.cards.filterByType(ENERGY)} : "You have no energy attached to your Pokémon."
           assert opp.all.findAll{it.cards.filterByType(ENERGY)} : "Your opponent has no energy attached to their Pokémon."
         }
-      };
+      }
       case DOWSING_MACHINE_108:
       return basicTrainer (this) {
         text "Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand."
@@ -2003,7 +2003,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.discard.filterByType(TRAINER) : "You have no trainers in your discard pile."
           assert !bg.em().retrieveObject("G_SPEC_"+thisCard.player) : "You have already used your G-SPEC card"
         }
-      };
+      }
       case Elixir_109:
       return basicTrainer (this) {
         text "Remove up to 6 damage counters from 1 of your Pokémon."
@@ -2018,7 +2018,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.all.findAll{it.numberOfDamageCounters}
           assert !bg.em().retrieveObject("G_SPEC_"+thisCard.player) : "You have already used your G-SPEC card"
         }
-      };
+      }
       case Hacker_110:
       return basicTrainer (this) {
         text "Search your deck for a card and put it into your hand. Shuffle your deck afterward."
@@ -2031,7 +2031,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
           assert my.deck
           assert !bg.em().retrieveObject("G_SPEC_"+thisCard.player) : "You have already used your G-SPEC card"
         }
-      };
+      }
       case MEWTWO_114:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -2049,13 +2049,13 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SQUIRTLE_115:
-      return copy (SQUIRTLE_63, this);
+      return copy (SQUIRTLE_63, this)
       case KOFFING_116:
-      return copy (KOFFING_51, this);
+      return copy (KOFFING_51, this)
       case ARCANINE_117:
-      return copy (ARCANINE_23, this);
+      return copy (ARCANINE_23, this)
       case CHARIZARD_EX_118:
       return evolution (this, from:"Charmeleon", hp:HP150, type:R, retreatCost:2) {
         weakness W
@@ -2084,7 +2084,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             discardSelfEnergy(R,R,R,R,R)
           }
         }
-      };
+      }
       case BLASTOISE_EX_119:
       return evolution (this, from:"Wartortle", hp:HP150, type:W, retreatCost:3) {
         weakness G
@@ -2111,7 +2111,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VENUSAUR_EX_120:
       return evolution (this, from:"Ivysaur", hp:HP150, type:G, retreatCost:3) {
         weakness R
@@ -2144,7 +2144,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case MIRACLE_ENERGY_OPTION_1:
       return specialEnergy (this, [[]]) {
         def check = {
@@ -2194,7 +2194,7 @@ public enum PokemodBaseSet implements LogicCardInfo {
         getEnergyTypesOverride{
           return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
         }
-      };
+      }
       case MIRACLE_ENERGY_OPTION_2:
       return specialEnergy (this, [[]]) {
         def check = {
@@ -2241,9 +2241,9 @@ public enum PokemodBaseSet implements LogicCardInfo {
         getEnergyTypesOverride{
           return [[R, D, F, G, W, Y, L, M, P] as Set, [R, D, F, G, W, Y, L, M, P] as Set]
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodBaseSet2.groovy
@@ -1,36 +1,36 @@
-package tcgwars.logic.impl.pokemod;
+package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import tcgwars.logic.impl.pokemod.PokemodBaseSet;
+import tcgwars.logic.impl.pokemod.PokemodBaseSet
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author
@@ -168,66 +168,66 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
   PSYCHIC_ENERGY_129 ("Psychic Energy", "129", Rarity.COMMON, [ENERGY, BASIC_ENERGY]),
   WATER_ENERGY_130 ("Water Energy", "130", Rarity.COMMON, [ENERGY, BASIC_ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodBaseSet2(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_BASE_SET_2;
+    return tcgwars.logic.card.Collection.POKEMOD_BASE_SET_2
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
     switch (this) {
       case ALAKAZAM_1:
-      return copy (PokemodBaseSet.ALAKAZAM_1, this);
+      return copy (PokemodBaseSet.ALAKAZAM_1, this)
       case BLASTOISE_2:
-      return copy (PokemodBaseSet.BLASTOISE_2, this);
+      return copy (PokemodBaseSet.BLASTOISE_2, this)
       case CHANSEY_3:
-      return copy (PokemodBaseSet.CHANSEY_3, this);
+      return copy (PokemodBaseSet.CHANSEY_3, this)
       case CHARIZARD_4:
-      return copy (PokemodBaseSet.CHARIZARD_4, this);
+      return copy (PokemodBaseSet.CHARIZARD_4, this)
       case CLEFABLE_5:
       return evolution (this, from:"Clefairy", hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -240,7 +240,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             def moveList = []
             def labelList = []
 
-            moveList.addAll(defending.topPokemonCard.moves);
+            moveList.addAll(defending.topPokemonCard.moves)
             labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
             def move=choose(moveList, labelList)
@@ -257,19 +257,19 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             reduceDamageNextTurn(hp(20), thisMove)
           }
         }
-      };
+      }
       case CLEFAIRY_6:
-      return copy (PokemodBaseSet.CLEFAIRY_5, this);
+      return copy (PokemodBaseSet.CLEFAIRY_5, this)
       case GYARADOS_7:
-      return copy (PokemodBaseSet.GYARADOS_6, this);
+      return copy (PokemodBaseSet.GYARADOS_6, this)
       case HITMONCHAN_8:
-      return copy (PokemodBaseSet.HITMONCHAN_7, this);
+      return copy (PokemodBaseSet.HITMONCHAN_7, this)
       case MAGNETON_9:
-      return copy (PokemodBaseSet.MAGNETON_9, this);
+      return copy (PokemodBaseSet.MAGNETON_9, this)
       case MEWTWO_10:
-      return copy (PokemodBaseSet.MEWTWO_10, this);
+      return copy (PokemodBaseSet.MEWTWO_10, this)
       case NIDOKING_11:
-      return copy (PokemodBaseSet.NIDOKING_11, this);
+      return copy (PokemodBaseSet.NIDOKING_11, this)
       case NIDOQUEEN_12:
       return evolution (this, from:"Nidorina", hp:HP100, type:G, retreatCost:3) {
         weakness P
@@ -294,9 +294,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NINETALES_13:
-      return copy (PokemodBaseSet.NINETALES_12, this);
+      return copy (PokemodBaseSet.NINETALES_12, this)
       case PIDGEOT_14:
       return evolution (this, from:"Pidgeotto", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -322,11 +322,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case POLIWRATH_15:
-      return copy (PokemodBaseSet.POLIWRATH_13, this);
+      return copy (PokemodBaseSet.POLIWRATH_13, this)
       case RAICHU_16:
-      return copy (PokemodBaseSet.RAICHU_14, this);
+      return copy (PokemodBaseSet.RAICHU_14, this)
       case SCYTHER_17:
       return basic (this, hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -347,9 +347,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VENUSAUR_18:
-      return copy (PokemodBaseSet.VENUSAUR_15, this);
+      return copy (PokemodBaseSet.VENUSAUR_15, this)
       case WIGGLYTUFF_19:
       return evolution (this, from:"Jigglypuff", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -373,19 +373,19 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ZAPDOS_20:
-      return copy (PokemodBaseSet.ZAPDOS_16, this);
+      return copy (PokemodBaseSet.ZAPDOS_16, this)
       case BEEDRILL_21:
-      return copy (PokemodBaseSet.BEEDRILL_17, this);
+      return copy (PokemodBaseSet.BEEDRILL_17, this)
       case DRAGONAIR_22:
-      return copy (PokemodBaseSet.DRAGONAIR_18, this);
+      return copy (PokemodBaseSet.DRAGONAIR_18, this)
       case DUGTRIO_23:
-      return copy (PokemodBaseSet.DUGTRIO_19, this);
+      return copy (PokemodBaseSet.DUGTRIO_19, this)
       case ELECTABUZZ_24:
-      return copy (PokemodBaseSet.ELECTABUZZ_20, this);
+      return copy (PokemodBaseSet.ELECTABUZZ_20, this)
       case ELECTRODE_25:
-      return copy (PokemodBaseSet.ELECTRODE_21, this);
+      return copy (PokemodBaseSet.ELECTRODE_21, this)
       case KANGASKHAN_26:
       return basic (this, hp:HP090, type:C, retreatCost:3) {
         weakness F
@@ -408,7 +408,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MR_MIME_27:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -435,9 +435,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 10+10*defending.numberOfDamageCounters
           }
         }
-      };
+      }
       case PIDGEOTTO_28:
-      return copy (PokemodBaseSet.PIGEOTTO_22, this);
+      return copy (PokemodBaseSet.PIGEOTTO_22, this)
       case PINSIR_29:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -460,7 +460,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SNORLAX_30:
       return basic (this, hp:HP090, type:C, retreatCost:4) {
         weakness F
@@ -490,7 +490,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VENOMOTH_31:
       return evolution (this, from:"Venonat", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -530,7 +530,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case VICTREEBEL_32:
       return evolution (this, from:"Weepinbell", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -553,9 +553,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case ARCANINE_33:
-      return copy (PokemodBaseSet.ARCANINE_23, this);
+      return copy (PokemodBaseSet.ARCANINE_23, this)
       case BUTTERFREE_34:
       return evolution (this, from:"Metapod", hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -580,11 +580,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             removeDamageCounterEqualToHalfDamageDone()
           }
         }
-      };
+      }
       case CHARMELEON_35:
-      return copy (PokemodBaseSet.CHARMELEON_24, this);
+      return copy (PokemodBaseSet.CHARMELEON_24, this)
       case DEWGONG_36:
-      return copy (PokemodBaseSet.DEWGONG_25, this);
+      return copy (PokemodBaseSet.DEWGONG_25, this)
       case DODRIO_37:
       return evolution (this, from:"Doduo", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -605,9 +605,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 10+10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case DRATINI_38:
-      return copy (PokemodBaseSet.DRATINI_26, this);
+      return copy (PokemodBaseSet.DRATINI_26, this)
       case EXEGGUTOR_39:
       return evolution (this, from:"Exeggcute", hp:HP080, type:G, retreatCost:3) {
         weakness R
@@ -629,9 +629,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case FARFETCH_D_40:
-      return copy (PokemodBaseSet.FARFETCH_D_27, this);
+      return copy (PokemodBaseSet.FARFETCH_D_27, this)
       case FEAROW_41:
       return evolution (this, from:"Spearow", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -655,19 +655,19 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GROWLITHE_42:
-      return copy (PokemodBaseSet.GROWLITHE_28, this);
+      return copy (PokemodBaseSet.GROWLITHE_28, this)
       case HAUNTER_43:
-      return copy (PokemodBaseSet.HAUNTER_29, this);
+      return copy (PokemodBaseSet.HAUNTER_29, this)
       case IVYSAUR_44:
-      return copy (PokemodBaseSet.IVYSAUR_30, this);
+      return copy (PokemodBaseSet.IVYSAUR_30, this)
       case JYNX_45:
-      return copy (PokemodBaseSet.JYNX_31, this);
+      return copy (PokemodBaseSet.JYNX_31, this)
       case KADABRA_46:
-      return copy (PokemodBaseSet.KADABRA_32, this);
+      return copy (PokemodBaseSet.KADABRA_32, this)
       case KAKUNA_47:
-      return copy (PokemodBaseSet.KAKUNA_33, this);
+      return copy (PokemodBaseSet.KAKUNA_33, this)
       case LICKITUNG_48:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness F
@@ -694,13 +694,13 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case MACHOKE_49:
-      return copy (PokemodBaseSet.MACHOKE_34, this);
+      return copy (PokemodBaseSet.MACHOKE_34, this)
       case MAGIKARP_50:
-      return copy (PokemodBaseSet.MAGIKARP_35, this);
+      return copy (PokemodBaseSet.MAGIKARP_35, this)
       case MAGMAR_51:
-      return copy (PokemodBaseSet.MAGMAR_36, this);
+      return copy (PokemodBaseSet.MAGMAR_36, this)
       case MAROWAK_52:
       return evolution (this, from:"Cubone", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -729,7 +729,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case NIDORINA_53:
       return evolution (this, from:"Nidoran♀", hp:HP080, type:G, retreatCost:1) {
         weakness P
@@ -753,9 +753,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case NIDORINO_54:
-      return copy (PokemodBaseSet.NIDORINO_37, this);
+      return copy (PokemodBaseSet.NIDORINO_37, this)
       case PARASECT_55:
       return evolution (this, from:"Paras", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -775,7 +775,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PERSIAN_56:
       return evolution (this, from:"Meowth", hp:HP070, type:C, retreatCost:0) {
         weakness F
@@ -797,11 +797,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             reduceDamageFromDefendingNextTurn(hp(10),thisMove,defending)
           }
         }
-      };
+      }
       case POLIWHIRL_57:
-      return copy (PokemodBaseSet.POLIWHIRL_38, this);
+      return copy (PokemodBaseSet.POLIWHIRL_38, this)
       case RATICATE_58:
-      return copy (PokemodBaseSet.RATICATE_40, this);
+      return copy (PokemodBaseSet.RATICATE_40, this)
       case RHYDON_59:
       return evolution (this, from:"Rhyhorn", hp:HP100, type:F, retreatCost:3) {
         weakness G
@@ -826,7 +826,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case SEAKING_60:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -846,9 +846,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEEL_61:
-      return copy (PokemodBaseSet.SEEL_41, this);
+      return copy (PokemodBaseSet.SEEL_41, this)
       case TAUROS_62:
       return basic (this, hp:HP060, type:C, retreatCost:2) {
         weakness F
@@ -877,9 +877,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case WARTORTLE_63:
-      return copy (PokemodBaseSet.WARTORTLE_42, this);
+      return copy (PokemodBaseSet.WARTORTLE_42, this)
       case WEEPINBELL_64:
       return evolution (this, from:"Bellsprout", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -902,9 +902,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ABRA_65:
-      return copy (PokemodBaseSet.ABRA_43, this);
+      return copy (PokemodBaseSet.ABRA_43, this)
       case BELLSPROUT_66:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -930,13 +930,13 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case BULBASAUR_67:
-      return copy (PokemodBaseSet.BULBASAUR_44, this);
+      return copy (PokemodBaseSet.BULBASAUR_44, this)
       case CATERPIE_68:
-      return copy (PokemodBaseSet.CATERPIE_45, this);
+      return copy (PokemodBaseSet.CATERPIE_45, this)
       case CHARMANDER_69:
-      return copy (PokemodBaseSet.CHARMANDER_46, this);
+      return copy (PokemodBaseSet.CHARMANDER_46, this)
       case CUBONE_70:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -957,13 +957,13 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 10+10*self.numberOfDamageCounters
           }
         }
-      };
+      }
       case DIGLETT_71:
-      return copy (PokemodBaseSet.DIGLETT_47, this);
+      return copy (PokemodBaseSet.DIGLETT_47, this)
       case DODUO_72:
-      return copy (PokemodBaseSet.DODUO_48, this);
+      return copy (PokemodBaseSet.DODUO_48, this)
       case DROWZEE_73:
-      return copy (PokemodBaseSet.DROWZEE_49, this);
+      return copy (PokemodBaseSet.DROWZEE_49, this)
       case EXEGGCUTE_74:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -993,9 +993,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case GASTLY_75:
-      return copy (PokemodBaseSet.GASTLY_50, this);
+      return copy (PokemodBaseSet.GASTLY_50, this)
       case GOLDEEN_76:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -1007,7 +1007,7 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case JIGGLYPUFF_77:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1028,11 +1028,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOP_78:
-      return copy (PokemodBaseSet.MACHOP_52, this);
+      return copy (PokemodBaseSet.MACHOP_52, this)
       case MAGNEMITE_79:
-      return copy (PokemodBaseSet.MAGNEMITE_53, this);
+      return copy (PokemodBaseSet.MAGNEMITE_53, this)
       case MEOWTH_80:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1048,9 +1048,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             }
           }
         }
-      };
+      }
       case METAPOD_81:
-      return copy (PokemodBaseSet.METAPOD_54, this);
+      return copy (PokemodBaseSet.METAPOD_54, this)
       case NIDORAN_FEMALE_82:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness P
@@ -1078,11 +1078,11 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             shuffleDeck()
           }
         }
-      };
+      }
       case NIDORAN_MALE_83:
-      return copy (PokemodBaseSet.NIDORAN_MALE_55, this);
+      return copy (PokemodBaseSet.NIDORAN_MALE_55, this)
       case ONIX_84:
-      return copy (PokemodBaseSet.ONIX_56, this);
+      return copy (PokemodBaseSet.ONIX_56, this)
       case PARAS_85:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1102,15 +1102,15 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             apply ASLEEP
           }
         }
-      };
+      }
       case PIDGEY_86:
-      return copy (PokemodBaseSet.PIDGEY_57, this);
+      return copy (PokemodBaseSet.PIDGEY_57, this)
       case PIKACHU_87:
-      return copy (PokemodBaseSet.PIKACHU_58, this);
+      return copy (PokemodBaseSet.PIKACHU_58, this)
       case POLIWAG_88:
-      return copy (PokemodBaseSet.POLIWAG_59, this);
+      return copy (PokemodBaseSet.POLIWAG_59, this)
       case RATTATA_89:
-      return copy (PokemodBaseSet.RATTATA_61, this);
+      return copy (PokemodBaseSet.RATTATA_61, this)
       case RHYHORN_90:
       return basic (this, hp:HP070, type:F, retreatCost:3) {
         weakness G
@@ -1149,9 +1149,9 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SANDSHREW_91:
-      return copy (PokemodBaseSet.SANDSHREW_62, this);
+      return copy (PokemodBaseSet.SANDSHREW_62, this)
       case SPEAROW_92:
       return basic (this, hp:HP050, type:C, retreatCost:0) {
         weakness L
@@ -1186,15 +1186,15 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             damage lastDamage.value
           }
         }
-      };
+      }
       case SQUIRTLE_93:
-      return copy (PokemodBaseSet.SQUIRTLE_63, this);
+      return copy (PokemodBaseSet.SQUIRTLE_63, this)
       case STARMIE_94:
-      return copy (PokemodBaseSet.STARMIE_64, this);
+      return copy (PokemodBaseSet.STARMIE_64, this)
       case STARYU_95:
-      return copy (PokemodBaseSet.STARYU_65, this);
+      return copy (PokemodBaseSet.STARYU_65, this)
       case TANGELA_96:
-      return copy (PokemodBaseSet.TANGELA_66, this);
+      return copy (PokemodBaseSet.TANGELA_66, this)
       case VENONAT_97:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1218,53 +1218,53 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
             removeDamageCounterEqualToDamageDone()
           }
         }
-      };
+      }
       case VOLTORB_98:
-      return copy (PokemodBaseSet.VOLTORB_67, this);
+      return copy (PokemodBaseSet.VOLTORB_67, this)
       case VULPIX_99:
-      return copy (PokemodBaseSet.VULPIX_68, this);
+      return copy (PokemodBaseSet.VULPIX_68, this)
       case WEEDLE_100:
-      return copy (PokemodBaseSet.WEEDLE_69, this);
+      return copy (PokemodBaseSet.WEEDLE_69, this)
       case COMPUTER_SEARCH_101:
-      return copy (PokemodBaseSet.COMPUTER_SEARCH_71, this);
+      return copy (PokemodBaseSet.COMPUTER_SEARCH_71, this)
       case IMPOSTER_PROFESSOR_OAK_102:
-      return copy (PokemodBaseSet.IMPOSTER_PROFESSOR_OAK_73, this);
+      return copy (PokemodBaseSet.IMPOSTER_PROFESSOR_OAK_73, this)
       case ITEM_FINDER_103:
-      return copy (PokemodBaseSet.ITEM_FINDER_74, this);
+      return copy (PokemodBaseSet.ITEM_FINDER_74, this)
       case LASS_104:
-      return copy (PokemodBaseSet.LASS_75, this);
+      return copy (PokemodBaseSet.LASS_75, this)
       case POKEMON_BREEDER_105:
-      return copy (PokemodBaseSet.POKEMON_BREEDER_76, this);
+      return copy (PokemodBaseSet.POKEMON_BREEDER_76, this)
       case POKEMON_TRADER_106:
-      return copy (PokemodBaseSet.POKEMON_TRADER_77, this);
+      return copy (PokemodBaseSet.POKEMON_TRADER_77, this)
       case SCOOP_UP_107:
-      return copy (PokemodBaseSet.SCOOP_UP_78, this);
+      return copy (PokemodBaseSet.SCOOP_UP_78, this)
       case SUPER_ENERGY_REMOVAL_108:
-      return copy (PokemodBaseSet.SUPER_ENERGY_REMOVAL_79, this);
+      return copy (PokemodBaseSet.SUPER_ENERGY_REMOVAL_79, this)
       case DEFENDER_109:
-      return copy (PokemodBaseSet.DEFENDER_80, this);
+      return copy (PokemodBaseSet.DEFENDER_80, this)
       case ENERGY_RETRIEVAL_110:
-      return copy (PokemodBaseSet.ENERGY_RETRIEVAL_81, this);
+      return copy (PokemodBaseSet.ENERGY_RETRIEVAL_81, this)
       case FULL_HEAL_111:
-      return copy (PokemodBaseSet.FULL_HEAL_82, this);
+      return copy (PokemodBaseSet.FULL_HEAL_82, this)
       case MAINTENANCE_112:
-      return copy (PokemodBaseSet.MAINTENANCE_83, this);
+      return copy (PokemodBaseSet.MAINTENANCE_83, this)
       case PLUSPOWER_113:
-      return copy (PokemodBaseSet.PLUSPOWER_84, this);
+      return copy (PokemodBaseSet.PLUSPOWER_84, this)
       case POKEMON_CENTER_114:
-      return copy (PokemodBaseSet.POKEMON_CENTER_85, this);
+      return copy (PokemodBaseSet.POKEMON_CENTER_85, this)
       case POKEDEX_115:
-      return copy (PokemodBaseSet.POKEDEX_87, this);
+      return copy (PokemodBaseSet.POKEDEX_87, this)
       case PROFESSOR_OAK_116:
-      return copy (PokemodBaseSet.PROFESSOR_OAK_88, this);
+      return copy (PokemodBaseSet.PROFESSOR_OAK_88, this)
       case SUPER_POTION_117:
-      return copy (PokemodBaseSet.SUPER_POTION_90, this);
+      return copy (PokemodBaseSet.SUPER_POTION_90, this)
       case BILL_118:
-      return copy (PokemodBaseSet.BILL_91, this);
+      return copy (PokemodBaseSet.BILL_91, this)
       case ENERGY_REMOVAL_119:
-      return copy (PokemodBaseSet.ENERGY_REMOVAL_92, this);
+      return copy (PokemodBaseSet.ENERGY_REMOVAL_92, this)
       case GUST_OF_WIND_120:
-      return copy (PokemodBaseSet.GUST_OF_WIND_93, this);
+      return copy (PokemodBaseSet.GUST_OF_WIND_93, this)
       case POKE_BALL_121:
       return basicTrainer (this) {
         text "Flip a coin. If heads, you may search your deck for any Basic Pokémon or Evolution card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
@@ -1275,27 +1275,27 @@ public enum PokemodBaseSet2 implements LogicCardInfo {
         playRequirement{
           assert my.deck : "Your deck is empty!"
         }
-      };
+      }
       case POTION_122:
-      return copy (PokemodBaseSet.POTION_94, this);
+      return copy (PokemodBaseSet.POTION_94, this)
       case SWITCH_123:
-      return copy (PokemodBaseSet.SWITCH_95, this);
+      return copy (PokemodBaseSet.SWITCH_95, this)
       case DOUBLE_COLORLESS_ENERGY_124:
-      return copy (PokemodBaseSet.DOUBLE_COLORLESS_ENERGY_96, this);
+      return copy (PokemodBaseSet.DOUBLE_COLORLESS_ENERGY_96, this)
       case FIGHTING_ENERGY_125:
-      return basicEnergy (this, F);
+      return basicEnergy (this, F)
       case FIRE_ENERGY_126:
-      return basicEnergy (this, R);
+      return basicEnergy (this, R)
       case GRASS_ENERGY_127:
-      return basicEnergy (this, G);
+      return basicEnergy (this, G)
       case LIGHTNING_ENERGY_128:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       case PSYCHIC_ENERGY_129:
-      return basicEnergy (this, P);
+      return basicEnergy (this, P)
       case WATER_ENERGY_130:
-      return basicEnergy (this, W);
+      return basicEnergy (this, W)
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodExpedition.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodExpedition.groovy
@@ -2,35 +2,35 @@ package tcgwars.logic.impl.pokemod
 
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -223,53 +223,53 @@ public enum PokemodExpedition implements LogicCardInfo {
   POKEMON_MASTER_KEY_185 ("Pokémon Master Key", "185", Rarity.RARE, [TRAINER]),
   POKEMON_LEGEND_BOX_186 ("Pokémon Legend Box", "186", Rarity.RARE, [TRAINER, STADIUM]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodExpedition(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_EXPEDITION;
+    return tcgwars.logic.card.Collection.POKEMOD_EXPEDITION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -291,7 +291,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case AMPHAROS_2:
       return evolution (this, from:"Flaaffy", hp:HP100, type:L, retreatCost:2) {
         weakness F
@@ -308,7 +308,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ARBOK_3:
       return evolution (this, from:"Ekans", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -328,7 +328,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BLASTOISE_4:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -345,7 +345,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BUTTERFREE_5:
       return evolution (this, from:"Metapod", hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -362,7 +362,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHARIZARD_6:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:3) {
         weakness W
@@ -380,7 +380,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case CLEFABLE_7:
       return evolution (this, from:"Clefairy", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -398,7 +398,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLOYSTER_8:
       return evolution (this, from:"Shellder", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -418,7 +418,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DRAGONITE_9:
       return evolution (this, from:"Dragonair", hp:HP100, type:C, retreatCost:2) {
         resistance F, MINUS30
@@ -435,7 +435,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DUGTRIO_10:
       return evolution (this, from:"Diglett", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -456,7 +456,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FEAROW_11:
       return evolution (this, from:"Spearow", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -477,7 +477,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case FERALIGATR_12:
       return evolution (this, from:"Croconaw", hp:HP120, type:W, retreatCost:3) {
         weakness L
@@ -494,7 +494,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case GENGAR_13:
       return evolution (this, from:"Haunter", hp:HP090, type:P, retreatCost:1) {
         weakness D
@@ -512,7 +512,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GOLEM_14:
       return evolution (this, from:"Graveler", hp:HP100, type:F, retreatCost:4) {
         weakness W
@@ -529,7 +529,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case KINGLER_15:
       return evolution (this, from:"Krabby", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -549,7 +549,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case MACHAMP_16:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -566,7 +566,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MAGBY_17:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:R, retreatCost:0) {
         move "Energy Catch", {
@@ -577,7 +577,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEGANIUM_18:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -595,7 +595,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEW_19:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -607,7 +607,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEWTWO_20:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -627,7 +627,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NINETALES_21:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -647,7 +647,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PICHU_22:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:L, retreatCost:0) {
         move "Energy Patch", {
@@ -658,7 +658,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PIDGEOT_23:
       return evolution (this, from:"Pidgeotto", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -676,7 +676,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWRATH_24:
       return evolution (this, from:"Poliwhirl", hp:HP100, type:W, retreatCost:2) {
         weakness G
@@ -693,7 +693,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAICHU_25:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -713,7 +713,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case RAPIDASH_26:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:0) {
         weakness W
@@ -733,7 +733,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SKARMORY_27:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -754,7 +754,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TYPHLOSION_28:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -771,7 +771,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TYRANITAR_29:
       return evolution (this, from:"Pupitar", hp:HP120, type:D, retreatCost:4) {
         weakness F
@@ -789,7 +789,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case VENUSAUR_30:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -806,7 +806,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VILEPLUME_31:
       return evolution (this, from:"Gloom", hp:HP090, type:G, retreatCost:2) {
         weakness P
@@ -823,7 +823,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WEEZING_32:
       return evolution (this, from:"Koffing", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -843,13 +843,13 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ALAKAZAM_33:
-      return copy (ALAKAZAM_1, this);
+      return copy (ALAKAZAM_1, this)
       case AMPHAROS_34:
-      return copy (AMPHAROS_2, this);
+      return copy (AMPHAROS_2, this)
       case ARBOK_35:
-      return copy (ARBOK_3, this);
+      return copy (ARBOK_3, this)
       case BLASTOISE_36:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -869,11 +869,11 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BLASTOISE_37:
-      return copy (BLASTOISE_4, this);
+      return copy (BLASTOISE_4, this)
       case BUTTERFREE_38:
-      return copy (BUTTERFREE_5, this);
+      return copy (BUTTERFREE_5, this)
       case CHARIZARD_39:
       return evolution (this, from:"Charmeleon", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -894,19 +894,19 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CHARIZARD_40:
-      return copy (CHARIZARD_6, this);
+      return copy (CHARIZARD_6, this)
       case CLEFABLE_41:
-      return copy (CLEFABLE_7, this);
+      return copy (CLEFABLE_7, this)
       case CLOYSTER_42:
-      return copy (CLOYSTER_8, this);
+      return copy (CLOYSTER_8, this)
       case DRAGONITE_43:
-      return copy (DRAGONITE_9, this);
+      return copy (DRAGONITE_9, this)
       case DUGTRIO_44:
-      return copy (DUGTRIO_10, this);
+      return copy (DUGTRIO_10, this)
       case FEAROW_45:
-      return copy (FEAROW_11, this);
+      return copy (FEAROW_11, this)
       case FERALIGATR_46:
       return evolution (this, from:"Croconaw", hp:HP100, type:W, retreatCost:2) {
         weakness L
@@ -926,19 +926,19 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FERALIGATR_47:
-      return copy (FERALIGATR_12, this);
+      return copy (FERALIGATR_12, this)
       case GENGAR_48:
-      return copy (GENGAR_13, this);
+      return copy (GENGAR_13, this)
       case GOLEM_49:
-      return copy (GOLEM_14, this);
+      return copy (GOLEM_14, this)
       case KINGLER_50:
-      return copy (KINGLER_15, this);
+      return copy (KINGLER_15, this)
       case MACHAMP_51:
-      return copy (MACHAMP_16, this);
+      return copy (MACHAMP_16, this)
       case MAGBY_52:
-      return copy (MAGBY_17, this);
+      return copy (MAGBY_17, this)
       case MEGANIUM_53:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -959,27 +959,27 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MEGANIUM_54:
-      return copy (MEGANIUM_18, this);
+      return copy (MEGANIUM_18, this)
       case MEW_55:
-      return copy (MEW_19, this);
+      return copy (MEW_19, this)
       case MEWTWO_56:
-      return copy (MEWTWO_20, this);
+      return copy (MEWTWO_20, this)
       case NINETALES_57:
-      return copy (NINETALES_21, this);
+      return copy (NINETALES_21, this)
       case PICHU_58:
-      return copy (PICHU_22, this);
+      return copy (PICHU_22, this)
       case PIDGEOT_59:
-      return copy (PIDGEOT_23, this);
+      return copy (PIDGEOT_23, this)
       case POLIWRATH_60:
-      return copy (POLIWRATH_24, this);
+      return copy (POLIWRATH_24, this)
       case RAICHU_61:
-      return copy (RAICHU_25, this);
+      return copy (RAICHU_25, this)
       case RAPIDASH_62:
-      return copy (RAPIDASH_26, this);
+      return copy (RAPIDASH_26, this)
       case SKARMORY_63:
-      return copy (SKARMORY_27, this);
+      return copy (SKARMORY_27, this)
       case TYPHLOSION_64:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -999,11 +999,11 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TYPHLOSION_65:
-      return copy (TYPHLOSION_28, this);
+      return copy (TYPHLOSION_28, this)
       case TYRANITAR_66:
-      return copy (TYRANITAR_29, this);
+      return copy (TYRANITAR_29, this)
       case VENUSAUR_67:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -1023,13 +1023,13 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VENUSAUR_68:
-      return copy (VENUSAUR_30, this);
+      return copy (VENUSAUR_30, this)
       case VILEPLUME_69:
-      return copy (VILEPLUME_31, this);
+      return copy (VILEPLUME_31, this)
       case WEEZING_70:
-      return copy (WEEZING_32, this);
+      return copy (WEEZING_32, this)
       case BAYLEEF_71:
       return evolution (this, from:"Chikorita", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1050,7 +1050,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHANSEY_72:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness F
@@ -1071,7 +1071,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHARMELEON_73:
       return evolution (this, from:"Charmander", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -1091,7 +1091,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CROCONAW_74:
       return evolution (this, from:"Totodile", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1111,7 +1111,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGONAIR_75:
       return evolution (this, from:"Dratini", hp:HP070, type:C, retreatCost:2) {
         resistance P, MINUS30
@@ -1123,7 +1123,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELECTABUZZ_76:
       return basic (this, hp:HP060, type:L, retreatCost:2) {
         weakness F
@@ -1143,7 +1143,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FLAAFFY_77:
       return evolution (this, from:"Mareep", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -1163,7 +1163,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GLOOM_78:
       return evolution (this, from:"Oddish", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1183,7 +1183,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRAVELER_79:
       return evolution (this, from:"Geodude", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -1203,7 +1203,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HAUNTER_80:
       return evolution (this, from:"Gastly", hp:HP060, type:P, retreatCost:1) {
         weakness D
@@ -1224,7 +1224,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HITMONLEE_81:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness P
@@ -1244,7 +1244,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case IVYSAUR_82:
       return evolution (this, from:"Bulbasaur", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1264,7 +1264,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case JYNX_83:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness M
@@ -1284,7 +1284,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KADABRA_84:
       return evolution (this, from:"Abra", hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -1304,7 +1304,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOKE_85:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1324,7 +1324,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MAGMAR_86:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1344,7 +1344,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case METAPOD_87:
       return evolution (this, from:"Caterpie", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1361,7 +1361,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIDGEOTTO_88:
       return evolution (this, from:"Pidgey", hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -1374,7 +1374,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWHIRL_89:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -1394,7 +1394,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PUPITAR_90:
       return evolution (this, from:"Larvitar", hp:HP070, type:F, retreatCost:1) {
         weakness W
@@ -1406,7 +1406,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QUILAVA_91:
       return evolution (this, from:"Cyndaquil", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1426,7 +1426,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WARTORTLE_92:
       return evolution (this, from:"Squirtle", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1446,7 +1446,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ABRA_93:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1466,7 +1466,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BULBASAUR_94:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1486,7 +1486,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case BULBASAUR_95:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1506,7 +1506,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CATERPIE_96:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1526,7 +1526,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHARMANDER_97:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1546,7 +1546,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARMANDER_98:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1566,7 +1566,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHIKORITA_99:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1587,7 +1587,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHIKORITA_100:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1608,7 +1608,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CLEFAIRY_101:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1629,7 +1629,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CORSOLA_102:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness G
@@ -1649,7 +1649,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CUBONE_103:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1670,7 +1670,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CYNDAQUIL_104:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1690,7 +1690,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CYNDAQUIL_105:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1710,7 +1710,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DIGLETT_106:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1723,7 +1723,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DRATINI_107:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -1735,7 +1735,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case EKANS_108:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1747,7 +1747,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GASTLY_109:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness D
@@ -1760,7 +1760,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GEODUDE_110:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1772,7 +1772,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GOLDEEN_111:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1784,7 +1784,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOPPIP_112:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1797,7 +1797,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HOUNDOUR_113:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness F
@@ -1810,7 +1810,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KOFFING_114:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1830,7 +1830,7 @@ public enum PokemodExpedition implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case KRABBY_115:
       return basic (this, hp:HP050, type:W, retreatCost:2) {
         weakness L
@@ -1842,7 +1842,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LARVITAR_116:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness W
@@ -1862,7 +1862,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOP_117:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1882,7 +1882,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_118:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1894,7 +1894,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAREEP_119:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1906,7 +1906,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MARILL_120:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1926,7 +1926,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEOWTH_121:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1947,7 +1947,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ODDISH_122:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1967,7 +1967,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIDGEY_123:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1988,7 +1988,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIKACHU_124:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2008,7 +2008,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWAG_125:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -2028,7 +2028,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PONYTA_126:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -2048,7 +2048,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QWILFISH_127:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -2060,7 +2060,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RATTATA_128:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         weakness F
@@ -2073,7 +2073,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHELLDER_129:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2093,7 +2093,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPEAROW_130:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -2106,7 +2106,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SQUIRTLE_131:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2126,7 +2126,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SQUIRTLE_132:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2146,7 +2146,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TAUROS_133:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -2164,7 +2164,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TOTODILE_134:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2184,7 +2184,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOTODILE_135:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2204,7 +2204,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VULPIX_136:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -2224,7 +2224,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BILL_S_MAINTENANCE_137:
       return supporter (this) {
         text "If you have any cards in your hand, shuffle 2 of them into your deck, then draw 4 cards."
@@ -2232,7 +2232,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case COPYCAT_138:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards."
@@ -2240,7 +2240,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DUAL_BALL_139:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card other than a Baby Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2248,7 +2248,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case KARATE_BELT_140:
       return pokemonTool (this) {
         text "If you have more Prize cards left than your opponent, the attacks of the Stage 1 or 2 [F] Pokémon this card is attached to cost [F] less. This card can't be attached to a Pokémon with Light, Dark or an Owner in it's name."
@@ -2258,7 +2258,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ENERGY_RESTORE_141:
       return basicTrainer (this) {
         text "Flip 3 coins. For each heads, put a Basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
@@ -2266,7 +2266,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MARY_S_IMPULSE_142:
       return supporter (this) {
         text "Flip a coin until you get tails. For each heads, draw 2 cards."
@@ -2274,7 +2274,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case COMPUTER_SEARCH_143:
       return basicTrainer (this) {
         text "Discard 2 of the other cards from your hand in order to search your deck for any card and put it into your hand. Shuffle your deck afterward."
@@ -2282,7 +2282,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GOOP_GAS_ATTACK_144:
       return basicTrainer (this) {
         text "All Poké-Powers and Poké-Bodies stop working until the end of your opponent's next turn."
@@ -2290,7 +2290,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MARTIAL_ARTS_DOJO_145:
       return stadium (this) {
         text "The attacks of Stage 1 or 2 [F] Pokémon that have any basic [F] Energy attached to them (both yours and your opponent's) do 10 more damage to the opponent's Active Pokémon (after applying Weakness and Resistance). If the attacking player has more Prize cards remaining than their opponent, those attacks do 20 more damage instead."
@@ -2298,7 +2298,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case GUST_OF_WIND_146:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
@@ -2306,7 +2306,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_ELM_S_TRAINING_METHOD_148:
       return supporter (this) {
         text "Search your deck for an Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2314,7 +2314,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_OAK_S_RESEARCH_149:
       return supporter (this) {
         text "Shuffle your hand into your deck, then draw 5 cards."
@@ -2322,7 +2322,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SILENT_LAB_150:
       return stadium (this) {
         text "Each Basic Pokémon in play, and in each player's discard pile have their Poké-Powers disabled."
@@ -2330,7 +2330,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case SUPER_SCOOP_UP_151:
       return basicTrainer (this) {
         text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
@@ -2338,7 +2338,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case WARP_POINT_152:
       return basicTrainer (this) {
         text "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any; then you switch your Active Pokémon with 1 of your Benched Pokémon, if any."
@@ -2346,7 +2346,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SEARCH_153:
       return basicTrainer (this) {
         text "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2354,7 +2354,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FULL_HEAL_154:
       return basicTrainer (this) {
         text "Remove all Special Conditions from your Active Pokémon."
@@ -2362,7 +2362,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_CATCHER_155:
       return basicTrainer (this) {
         text "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
@@ -2370,7 +2370,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POTION_156:
       return basicTrainer (this) {
         text "Remove 2 damage counters from 1 of your Pokémon (1 if it has only 1)."
@@ -2378,9 +2378,9 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SWITCH_157:
-      return copy(FireRedLeafGreen.SWITCH_102, this);
+      return copy(FireRedLeafGreen.SWITCH_102, this)
       case DARKNESS_ENERGY_158:
       return specialEnergy (this, [[C]]) {
         text "If the Pokémon Darkness Energy is attached to does damage with an attack (after applying Weakness and Resistance), the attack does 10 more damage. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it's [D]. Darkness Energy provides [D] Energy. (Doesn't count as a basic Energy card.)"
@@ -2392,7 +2392,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case METAL_ENERGY_159:
       return specialEnergy (this, [[C]]) {
         text "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon Metal Energy is attached to isn't [M]." +
@@ -2405,19 +2405,19 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case FIGHTING_ENERGY_160:
-      return basicEnergy (this, F);
+      return basicEnergy (this, F)
       case FIRE_ENERGY_161:
-      return basicEnergy (this, R);
+      return basicEnergy (this, R)
       case GRASS_ENERGY_162:
-      return basicEnergy (this, G);
+      return basicEnergy (this, G)
       case LIGHTNING_ENERGY_163:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       case PSYCHIC_ENERGY_164:
-      return basicEnergy (this, P);
+      return basicEnergy (this, P)
       case WATER_ENERGY_165:
-      return basicEnergy (this, W);
+      return basicEnergy (this, W)
       case POKEGEAR_3_0_166:
       return basicTrainer (this) {
         text "Look at the top 7 cards of your deck. Choose a Supporter card you find there, show it to your opponent, and put it into your hand. Shuffle the other cards back into your deck."
@@ -2425,7 +2425,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_COLLECTOR_167:
       return supporter (this) {
         text "Discard 1 card from your hand in order to play this card. Search your deck for up to 3 Basic Pokémon with 50HP or less, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2433,7 +2433,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ITEM_FINDER_168:
       return basicTrainer (this) {
         text "You may choose to Discard 1 card from your hand in order to search your discard pile for a Supporter card. Show it to your opponent and put it into your hand. Or, you may choose to Discard 2 cards from your hand in order to search your discard pile for a Trainer card (excluding Supporter cards). Show it to your opponent and put it into your hand."
@@ -2441,7 +2441,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BATTLE_FRONTIER_150:
       return stadium (this) {
         text "Each Player's [C] Evolved Pokémon, [D] Evolved Pokémon, and [M] Evolved Pokémon can't use any Poké-Powers or Poké-Bodies."
@@ -2449,7 +2449,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case CRYSTAL_BEACH_170:
       return stadium (this) {
         text "Each Special Energy that provides 2 or more Energy (both yours and your opponent's) now only provide 1 [C] Energy. This isn't affected by Poké-Powers or Poké-Bodies."
@@ -2457,7 +2457,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DARK_PATCH_171:
       return basicTrainer (this) {
         text "If it's your first turn, you can’t play this card. Attach a basic [D] Energy from your discard pile to 1 of your Benched [D] Pokémon."
@@ -2465,7 +2465,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LIGHTNING_STORM_172:
       return stadium (this) {
         text "All Poké-Bodies of Evolved Pokémon in play are Disabled."
@@ -2473,7 +2473,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case METAL_PATCH_173:
       return basicTrainer (this) {
         text "If it's your first turn, you can’t play this card. Attach a basic [M] Energy from your discard pile to 1 of your Benched [M] Pokémon."
@@ -2481,11 +2481,11 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case METAL_ENERGY_174:
-      return copy (METAL_ENERGY_159, this);
+      return copy (METAL_ENERGY_159, this)
       case DARKNESS_ENERGY_175:
-      return copy (DARKNESS_ENERGY_158, this);
+      return copy (DARKNESS_ENERGY_158, this)
       case TYRANITAR_176:
       return evolution (this, from:"Pupitar", hp:HP100, type:D, retreatCost:4) {
         weakness F
@@ -2503,7 +2503,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case ELECTABUZZ_EX_176:
       return basic (this, hp:HP090, type:L, retreatCost:2) {
         weakness F
@@ -2524,7 +2524,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case HITMONCHAN_EX_178:
       return basic (this, hp:HP090, type:F, retreatCost:2) {
         weakness P
@@ -2544,7 +2544,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LAPRAS_EX_179:
       return basic (this, hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -2564,7 +2564,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGMAR_EX_180:
       return basic (this, hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -2584,7 +2584,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEWTWO_EX_181:
       return basic (this, hp:HP100, type:P, retreatCost:3) {
         weakness P
@@ -2604,7 +2604,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SNEASEL_EX_181:
       return basic (this, hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -2625,7 +2625,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SCYTHER_EX_181:
       return basic (this, hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -2646,7 +2646,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CHANSEY_EX_184:
       return basic (this, hp:HP120, type:C, retreatCost:3) {
         weakness F
@@ -2667,7 +2667,7 @@ public enum PokemodExpedition implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case POKEMON_MASTER_KEY_185:
       return basicTrainer (this) {
         text "Flip a coin. If heads, you may look at the top 2 cards of your opponent's deck and choose whether or not they  shuffle their deck. If tails, look at the top 2 cards of your deck and choose whether or not you want to shuffle your deck."
@@ -2675,7 +2675,7 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_LEGEND_BOX_186:
       return stadium (this) {
         text "Once during each player’s turn, if he or she plays the Pokémon Master Key Trainer card, they may use the rule on this card instead. Search your deck for a Trainer card and put it into your hand. Shuffle your deck afterward."
@@ -2683,9 +2683,9 @@ public enum PokemodExpedition implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodFossil.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodFossil.groovy
@@ -4,35 +4,35 @@ import tcgwars.logic.impl.gen1.Fossil
 import tcgwars.logic.impl.gen7.CelestialStorm
 import tcgwars.logic.impl.gen7.GuardiansRising
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -131,53 +131,53 @@ public enum PokemodFossil implements LogicCardInfo {
   MOLTRES_EX_87("Moltres", "86", Rarity.ULTRARARE, [BASIC, POKEMON, _FIRE_]),
   ZAPDOS_EX_88("Zapdos", "87", Rarity.ULTRARARE, [BASIC, POKEMON, _LIGHTNING_]),
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodFossil(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_FOSSIL;
+    return tcgwars.logic.card.Collection.POKEMOD_FOSSIL
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -207,7 +207,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ARTICUNO_2:
         return basic(this, hp: HP070, type: WATER, retreatCost: 2) {
           weakness METAL
@@ -235,11 +235,11 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DITTO_3:
         break
       case DRAGONITE_4:
-        return copy(Fossil.DRAGONITE_4, this);
+        return copy(Fossil.DRAGONITE_4, this)
       case GENGAR_5:
         return evolution(this, from: "Haunter", hp: HP080, type: PSYCHIC, retreatCost: 1) {
           weakness DARKNESS
@@ -268,7 +268,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HAUNTER_6:
         return evolution(this, from: "Gastly", hp: HP060, type: PSYCHIC, retreatCost: 0) {
           weakness DARKNESS
@@ -316,7 +316,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HITMONLEE_7:
         return basic(this, hp: HP080, type: FIGHTING, retreatCost: 1) {
           weakness PSYCHIC
@@ -339,7 +339,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HYPNO_8:
         return evolution(this, from: "Drowzee", hp: HP090, type: PSYCHIC, retreatCost: 2) {
           weakness PSYCHIC
@@ -358,7 +358,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KABUTOPS_9:
         return evolution(this, from: "Kabuto", hp: HP080, type: FIGHTING, retreatCost: 1) {
           weakness GRASS
@@ -381,7 +381,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case LAPRAS_10:
         return basic(this, hp: HP080, type: WATER, retreatCost: 2) {
           weakness LIGHTNING
@@ -405,9 +405,9 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGNETON_11:
-        return copy(Fossil.MAGNETON_11, this);
+        return copy(Fossil.MAGNETON_11, this)
       case MOLTRES_12:
         return basic(this, hp: HP080, type: FIRE, retreatCost: 2) {
           resistance FIGHTING, MINUS30
@@ -433,7 +433,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MUK_13:
         return evolution(this, from: "Grimer", hp: HP060, type: PSYCHIC, retreatCost: 0) {
           weakness PSYCHIC
@@ -462,7 +462,7 @@ public enum PokemodFossil implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case RAICHU_14:
         return evolution(this, from: "Pikachu", hp: HP090, type: LIGHTNING, retreatCost: 1) {
           weakness FIGHTING
@@ -482,7 +482,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZAPDOS_15:
         return basic(this, hp: HP080, type: LIGHTNING, retreatCost: 2) {
           move "Thunderstorm", {
@@ -506,37 +506,37 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case AERODACTYL_16:
-        return copy(AERODACTYL_1, this);
+        return copy(AERODACTYL_1, this)
       case ARTICUNO_17:
-        return copy(ARTICUNO_2, this);
+        return copy(ARTICUNO_2, this)
       case DITTO_18:
-        return copy(DITTO_3, this);
+        return copy(DITTO_3, this)
       case DRAGONITE_19:
-        return copy(Fossil.DRAGONITE_4, this);
+        return copy(Fossil.DRAGONITE_4, this)
       case GENGAR_20:
-        return copy(GENGAR_5, this);
+        return copy(GENGAR_5, this)
       case HAUNTER_21:
-        return copy(HAUNTER_6, this);
+        return copy(HAUNTER_6, this)
       case HITMONLEE_22:
-        return copy(HITMONLEE_7, this);
+        return copy(HITMONLEE_7, this)
       case HYPNO_23:
-        return copy(HYPNO_8, this);
+        return copy(HYPNO_8, this)
       case KABUTOPS_24:
-        return copy(KABUTOPS_9, this);
+        return copy(KABUTOPS_9, this)
       case LAPRAS_25:
-        return copy(LAPRAS_10, this);
+        return copy(LAPRAS_10, this)
       case MAGNETON_26:
-        return copy(Fossil.MAGNETON_11, this);
+        return copy(Fossil.MAGNETON_11, this)
       case MOLTRES_27:
-        return copy(MOLTRES_12, this);
+        return copy(MOLTRES_12, this)
       case MUK_28:
-        return copy(MUK_13, this);
+        return copy(MUK_13, this)
       case RAICHU_29:
-        return copy(RAICHU_14, this);
+        return copy(RAICHU_14, this)
       case ZAPDOS_30:
-        return copy(ZAPDOS_15, this);
+        return copy(ZAPDOS_15, this)
       case ARBOK_31:
         return evolution(this, from: "Ekans", hp: HP060, type: GRASS, retreatCost: 2) {
           weakness PSYCHIC
@@ -560,7 +560,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case CLOYSTER_32:
         return evolution(this, from: "Shellder", hp: HP080, type: WATER, retreatCost: 2) {
           weakness LIGHTNING
@@ -582,7 +582,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GASTLY_33:
         return basic(this, hp: HP050, type: PSYCHIC, retreatCost: 0) {
           weakness DARKNESS
@@ -607,7 +607,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLBAT_34:
         return evolution(this, from: "Zubat", hp: HP060, type: GRASS, retreatCost: 0) {
           weakness PSYCHIC
@@ -630,7 +630,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLDUCK_35:
         return evolution(this, from: "Psyduck", hp: HP080, type: WATER, retreatCost: 1) {
           weakness LIGHTNING
@@ -653,7 +653,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GOLEM_36:
         return evolution(this, from: "Graveler", hp: HP100, type: FIGHTING, retreatCost: 4) {
           weakness GRASS
@@ -677,7 +677,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRAVELER_37:
         return evolution(this, from: "Geodude", hp: HP070, type: FIGHTING, retreatCost: 2) {
           weakness GRASS
@@ -711,7 +711,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KINGLER_38:
         return evolution(this, from: "Krabby", hp: HP060, type: WATER, retreatCost: 3) {
           weakness LIGHTNING
@@ -732,9 +732,9 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGMAR_39:
-        return copy(Fossil.MAGMAR_39, this);
+        return copy(Fossil.MAGMAR_39, this)
       case OMASTAR_40:
         return evolution(this, from: "Omanyte", hp: HP070, type: WATER, retreatCost: 1) {
           weakness GRASS
@@ -757,7 +757,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SANDSLASH_41:
         return evolution(this, from: "Sandshrew", hp: HP070, type: FIGHTING, retreatCost: 1) {
           weakness GRASS
@@ -779,7 +779,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEADRA_42:
         return evolution(this, from: "Horsea", hp: HP070, type: WATER, retreatCost: 1) {
           weakness LIGHTNING
@@ -802,7 +802,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWBRO_43:
         return evolution(this, from: "Slowbro", hp: HP060, type: PSYCHIC, retreatCost: 1) {
           weakness PSYCHIC
@@ -829,7 +829,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TENTACRUEL_44:
         return evolution(this, from: "Tentacool", hp: HP060, type: WATER, retreatCost: 0) {
           weakness LIGHTNING
@@ -852,11 +852,11 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case WEEZING_45:
-        return copy(Fossil.WEEZING, this);
+        return copy(Fossil.WEEZING, this)
       case EKANS_46:
-        return copy(Fossil.EKANS, this);
+        return copy(Fossil.EKANS, this)
       case GEODUDE_47:
         return basic(this, hp: HP050, type: FIGHTING, retreatCost: 1) {
           weakness GRASS
@@ -869,11 +869,11 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER_48:
-        return copy(Fossil.GRIMER, this);
+        return copy(Fossil.GRIMER, this)
       case HORSEA_49:
-        return copy(Fossil.HORSEA, this);
+        return copy(Fossil.HORSEA, this)
       case KABUTO_50:
         return evolution(this, from: "Mysterious Fossil", hp: HP040, type: FIGHTING, retreatCost: 1) {
           weakness GRASS
@@ -908,7 +908,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KRABBY_51:
         return basic(this, hp: HP050, type: WATER, retreatCost: 2) {
           weakness LIGHTNING
@@ -935,7 +935,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case OMANYTE_52:
         return evolution(this, from: "Mysterious Fossil", hp: HP050, type: WATER, retreatCost: 1) {
           weakness GRASS
@@ -959,7 +959,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PSYDUCK_53:
         return basic(this, hp: HP050, type: WATER, retreatCost: 1) {
           weakness LIGHTNING
@@ -990,7 +990,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SHELLDER_54:
         return basic(this, hp: HP050, type: WATER, retreatCost: 1) {
           weakness LIGHTNING
@@ -1012,9 +1012,9 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SLOWPOKE_55:
-        return copy(Fossil.SLOWPOKE, this);
+        return copy(Fossil.SLOWPOKE, this)
       case TENTACOOL_56:
         return basic(this, hp: HP040, type: WATER, retreatCost: 0) {
           weakness LIGHTNING
@@ -1038,9 +1038,9 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ZUBAT_57:
-        return copy(Fossil.ZUBAT, this);
+        return copy(Fossil.ZUBAT, this)
       case MR_FUJI_58:
         return supporter(this) {
           text "Choose a Pokémon on your Bench. Shuffle it any any cards attached to it into your deck."
@@ -1052,15 +1052,15 @@ public enum PokemodFossil implements LogicCardInfo {
           playRequirement {
             assert my.bench: "There is no Benched Pokémon"
           }
-        };
+        }
       case ENERGY_SEARCH_59:
-        return copy(Fossil.ENERGY_SEARCH, this);
+        return copy(Fossil.ENERGY_SEARCH, this)
       case GAMBLER_60:
-        return copy(Fossil.GAMBLER, this);
+        return copy(Fossil.GAMBLER, this)
       case RECYCLE_61:
-        return copy(Fossil.RECYCLE, this);
+        return copy(Fossil.RECYCLE, this)
       case MYSTERIOUS_FOSSIL_62:
-        return copy(Fossil.MYSTERIOUS_FOSSIL, this);
+        return copy(Fossil.MYSTERIOUS_FOSSIL, this)
       case CRYSTAL_GUARD_63:
         break
       case HEAVY_BALL_64:
@@ -1073,7 +1073,7 @@ public enum PokemodFossil implements LogicCardInfo {
           playRequirement {
             assert my.deck: "Your deck is empty."
           }
-        };
+        }
       case POKEMON_BREEDER_FIELDS_65:
         break
       case RELIC_HUNTER_66:
@@ -1085,7 +1085,7 @@ public enum PokemodFossil implements LogicCardInfo {
           playRequirement {
             assert my.discard.filterByType(STADIUM)
           }
-        };
+        }
       case LOST_EXPEDITION_67:
         return basicTrainer(this) {
           text "You may play 2 Lost Expedition at the same time. If you play 1 Lost Expedition, draw a card. If you play 2 Lost Expedition, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
@@ -1101,9 +1101,9 @@ public enum PokemodFossil implements LogicCardInfo {
           playRequirement {
             assert my.deck: "Your deck is empty"
           }
-        };
+        }
       case UNDERGROUND_EXPEDITION_68:
-        return copy(CelestialStorm.UNDERGROUND_EXPEDITION_150, this);
+        return copy(CelestialStorm.UNDERGROUND_EXPEDITION_150, this)
       case LOST_WORLD_69:
         break
       case CRYSTAL_BEACH_70:
@@ -1120,11 +1120,11 @@ public enum PokemodFossil implements LogicCardInfo {
           onRemoveFromPlay {
             eff.unregister()
           }
-        };
+        }
       case DNA_ENERGY_71:
         break
       case DOUBLE_COLORLESS_ENERGY_72:
-        return copy(GuardiansRising.DOUBLE_COLORLESS_ENERGY_166, this);
+        return copy(GuardiansRising.DOUBLE_COLORLESS_ENERGY_166, this)
       case LOST_ENERGY_73:
         break
       case SEEKER_74:
@@ -1136,11 +1136,11 @@ public enum PokemodFossil implements LogicCardInfo {
       case DITTO_77:
         break
       case PSYDUCK_78:
-        return copy(PSYDUCK_53, this);
+        return copy(PSYDUCK_53, this)
       case DRAGONITE_79:
-        return copy(DRAGONITE_4, this);
+        return copy(DRAGONITE_4, this)
       case GENGAR_80:
-        return copy(GENGAR_5, this);
+        return copy(GENGAR_5, this)
       case HO_OH_81:
         break
       case LUGIA_82:
@@ -1166,13 +1166,13 @@ public enum PokemodFossil implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ARTICUNO_83:
-        return copy(ARTICUNO_2, this);
+        return copy(ARTICUNO_2, this)
       case MOLTRES_84:
-        return copy(MOLTRES_12, this);
+        return copy(MOLTRES_12, this)
       case ZAPDOS_85:
-        return copy(ZAPDOS_15, this);
+        return copy(ZAPDOS_15, this)
       case ARTICUNO_EX_86:
         return basic(this, hp: HP100, type: WATER, retreatCost: 2) {
           weakness METAL
@@ -1184,9 +1184,9 @@ public enum PokemodFossil implements LogicCardInfo {
                 sw my.active, self
                 while (1) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(W) && it != self })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for basic [W] Energy (cancel to stop moving)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(W).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -1207,7 +1207,7 @@ public enum PokemodFossil implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MOLTRES_EX_87:
         return basic(this, hp: HP100, type: FIRE, retreatCost: 2) {
           weakness WATER
@@ -1219,9 +1219,9 @@ public enum PokemodFossil implements LogicCardInfo {
                 sw my.active, self
                 while (1) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(R) && it != self })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for basic [R] Energy (cancel to stop moving)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(R).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -1239,7 +1239,7 @@ public enum PokemodFossil implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case ZAPDOS_EX_88:
         return basic(this, hp: HP100, type: LIGHTNING, retreatCost: 2) {
           weakness LIGHTNING
@@ -1251,9 +1251,9 @@ public enum PokemodFossil implements LogicCardInfo {
                 sw my.active, self
                 while (1) {
                   def pl = (my.all.findAll { it.cards.filterByBasicEnergyType(L) && it != self })
-                  if (!pl) break;
+                  if (!pl) break
                   def src = pl.select("Source for basic [L] Energy (cancel to stop moving)", false)
-                  if (!src) break;
+                  if (!src) break
                   def card = src.cards.filterByBasicEnergyType(L).select("Card to move").first()
                   energySwitch(src, self, card)
                 }
@@ -1271,9 +1271,9 @@ public enum PokemodFossil implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       default:
-        return null;
+        return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodGymChallenge.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodGymChallenge.groovy
@@ -145,58 +145,58 @@ public enum PokemodGymChallenge implements LogicCardInfo {
   PSYCHIC_ENERGY_131 ("Psychic Energy", "131", Rarity.COMMON, [BASIC_ENERGY, ENERGY]),
   WATER_ENERGY_132 ("Water Energy", "132", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodGymChallenge(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_GYM_CHALLENGE;
+    return tcgwars.logic.card.Collection.POKEMOD_GYM_CHALLENGE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
-    return null;
+    return null
   }
 
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodGymHeroes.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodGymHeroes.groovy
@@ -145,58 +145,58 @@ public enum PokemodGymHeroes implements LogicCardInfo {
   PSYCHIC_ENERGY_131 ("Psychic Energy", "131", Rarity.COMMON, [BASIC_ENERGY, ENERGY]),
   WATER_ENERGY_132 ("Water Energy", "132", Rarity.COMMON, [BASIC_ENERGY, ENERGY]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodGymHeroes(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_GYM_HEROES;
+    return tcgwars.logic.card.Collection.POKEMOD_GYM_HEROES
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
   public Card getImplementation() {
-    return null;
+    return null
   }
 
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodImperium.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodImperium.groovy
@@ -2,35 +2,35 @@ package tcgwars.logic.impl.pokemod
 
 import tcgwars.logic.impl.gen3.FireRedLeafGreen
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -300,53 +300,53 @@ public enum PokemodImperium implements LogicCardInfo {
   LOST_MEDALLION_261 ("Lost Medallion", "261", Rarity.SECRET, [TRAINER, G_SPEC]),
   MASTER_BALL_262 ("Master Ball", "262", Rarity.SECRET, [TRAINER, G_SPEC]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodImperium(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_IMPERIUM;
+    return tcgwars.logic.card.Collection.POKEMOD_IMPERIUM
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -363,7 +363,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case IVYSAUR_2:
       return evolution (this, from:"Bulbasaur", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -383,7 +383,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case VENUSAUR_3:
       return evolution (this, from:"Ivysaur", hp:HP100, type:G, retreatCost:2) {
         weakness R
@@ -400,7 +400,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case CHARMANDER_4:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -420,7 +420,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHARMELEON_5:
       return evolution (this, from:"Charmander", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -440,7 +440,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CHARIZARD_6:
       return evolution (this, from:"Charmeleon", hp:HP120, type:R, retreatCost:3) {
         weakness W
@@ -458,7 +458,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SQUIRTLE_7:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -470,7 +470,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WARTORTLE_8:
       return evolution (this, from:"Squirtle", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -490,7 +490,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BLASTOISE_9:
       return evolution (this, from:"Wartortle", hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -507,7 +507,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CATERPIE_10:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -519,7 +519,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case METAPOD_11:
       return evolution (this, from:"Caterpie", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -539,7 +539,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BUTTERFREE_12:
       return evolution (this, from:"Metapod", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -560,7 +560,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WEEDLE_13:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -572,7 +572,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KAKUNA_14:
       return evolution (this, from:"Weedle", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -592,7 +592,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case BEEDRILL_15:
       return evolution (this, from:"Kakuna", hp:HP090, type:G, retreatCost:0) {
         weakness R
@@ -613,7 +613,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PIDGEY_16:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -626,7 +626,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIDGEOTTO_17:
       return evolution (this, from:"Pidgey", hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -647,7 +647,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PIDGEOT_18:
       return evolution (this, from:"Pidgeotto", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -665,7 +665,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RATTATA_19:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         weakness F
@@ -678,7 +678,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RATICATE_20:
       return evolution (this, from:"Rattata", hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -699,7 +699,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SPEAROW_21:
       return basic (this, hp:HP050, type:C, retreatCost:0) {
         weakness L
@@ -720,7 +720,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FEAROW_22:
       return evolution (this, from:"Spearow", hp:HP080, type:C, retreatCost:0) {
         weakness L
@@ -741,7 +741,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case EKANS_23:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -761,7 +761,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_ARBOK_24:
       return evolution (this, from:"Ekans", hp:HP060, type:G, retreatCost:2) {
         weakness P
@@ -781,7 +781,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PIKACHU_25:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -801,7 +801,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case RAICHU_26:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -821,7 +821,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case SANDSHREW_27:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -834,7 +834,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSLASH_28:
       return evolution (this, from:"Sandshrew", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -855,7 +855,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_29:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness P
@@ -875,7 +875,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NIDORINA_30:
       return evolution (this, from:"Nidoran♀", hp:HP080, type:G, retreatCost:1) {
         weakness P
@@ -895,7 +895,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NIDOQUEEN_7:
       return evolution (this, from:"Nidorina", hp:HP100, type:G, retreatCost:3) {
         weakness P
@@ -915,7 +915,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDORAN_MALE_32:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness P
@@ -927,7 +927,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NIDORINO_33:
       return evolution (this, from:"Nidoran♂", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -947,7 +947,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case NIDOKING_34:
       return evolution (this, from:"Nidorino", hp:HP100, type:G, retreatCost:3) {
         weakness P
@@ -967,7 +967,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CLEFAIRY_35:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -988,7 +988,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CLEFABLE_36:
       return evolution (this, from:"Clefairy", hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -1009,7 +1009,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GOLEM_36:
       return evolution (this, from:"Graveler", hp:HP100, type:F, retreatCost:4) {
         weakness G
@@ -1029,7 +1029,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case VULPIX_37:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1041,7 +1041,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NINETALES_38:
       return evolution (this, from:"Vulpix", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -1061,7 +1061,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case JIGGLYPUFF_39:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1082,7 +1082,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case WIGGLYTUFF_40:
       return evolution (this, from:"Jigglypuff", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -1103,7 +1103,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZUBAT_41:
       return basic (this, hp:HP040, type:G, retreatCost:0) {
         weakness P
@@ -1124,7 +1124,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_GOLBAT_42:
       return evolution (this, from:"Zubat", hp:HP050, type:G, retreatCost:0) {
         weakness P
@@ -1142,7 +1142,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ODDISH_43:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1162,7 +1162,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_GLOOM_44:
       return evolution (this, from:"Oddish", hp:HP050, type:G, retreatCost:2) {
         weakness R
@@ -1179,7 +1179,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DARK_VILEPLUME_45:
       return evolution (this, from:"Gloom", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -1196,7 +1196,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PARAS_46:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1216,7 +1216,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PARASECT_47:
       return evolution (this, from:"Paras", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1236,7 +1236,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VENONAT_48:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1256,7 +1256,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VENOMOTH_49:
       return evolution (this, from:"Venonat", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -1274,7 +1274,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DIGLETT_50:
       return basic (this, hp:HP030, type:F, retreatCost:0) {
         weakness G
@@ -1295,7 +1295,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DUGTRIO_51:
       return evolution (this, from:"Diglett", hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -1316,7 +1316,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case MEOWTH_52:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1329,7 +1329,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PERSIAN_53:
       return evolution (this, from:"Meowth", hp:HP070, type:C, retreatCost:0) {
         weakness F
@@ -1350,7 +1350,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PSYDUCK_54:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1370,7 +1370,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDUCK_55:
       return evolution (this, from:"Psyduck", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1390,7 +1390,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLOWPOKE_79:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1410,7 +1410,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MANKEY_56:
       return basic (this, hp:HP050, type:F, retreatCost:0) {
         weakness P
@@ -1427,7 +1427,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DARK_PRIMEAPE_57:
       return evolution (this, from:"Mankey", hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -1444,7 +1444,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GROWLITHE_58:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1456,7 +1456,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ARCANINE_59:
       return evolution (this, from:"Growlithe", hp:HP100, type:R, retreatCost:3) {
         weakness W
@@ -1476,7 +1476,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case POLIWAG_60:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness G
@@ -1488,7 +1488,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case POLIWHIRL_61:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -1508,7 +1508,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case POLIWRATH_62:
       return evolution (this, from:"Poliwhirl", hp:HP100, type:W, retreatCost:3) {
         weakness G
@@ -1528,7 +1528,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case ABRA_63:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1548,7 +1548,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KADABRA_64:
       return evolution (this, from:"Abra", hp:HP060, type:P, retreatCost:3) {
         weakness P
@@ -1568,7 +1568,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ALAKAZAM_65:
       return evolution (this, from:"Kadabra", hp:HP080, type:P, retreatCost:3) {
         weakness P
@@ -1585,7 +1585,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MACHOP_66:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1597,7 +1597,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOKE_67:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:3) {
         weakness P
@@ -1617,7 +1617,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MACHAMP_68:
       return evolution (this, from:"Machoke", hp:HP100, type:F, retreatCost:3) {
         weakness P
@@ -1634,7 +1634,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case BELLSPROUT_69:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1654,7 +1654,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case WEEPINBELL_70:
       return evolution (this, from:"Bellsprout", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1674,7 +1674,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case VICTREEBEL_71:
       return evolution (this, from:"Weepinbell", hp:HP090, type:G, retreatCost:2) {
         weakness R
@@ -1694,7 +1694,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TENTACOOL_72:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -1711,7 +1711,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TENTACRUEL_73:
       return evolution (this, from:"Tentacool", hp:HP060, type:W, retreatCost:0) {
         weakness L
@@ -1731,7 +1731,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GEODUDE_74:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1743,7 +1743,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRAVELER_75:
       return evolution (this, from:"Geodude", hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -1763,7 +1763,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PONYTA_77:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1783,7 +1783,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RAPIDASH_78:
       return evolution (this, from:"Ponyta", hp:HP070, type:R, retreatCost:0) {
         weakness W
@@ -1803,7 +1803,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLOWBRO_80:
       return evolution (this, from:"Slowpoke", hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -1820,7 +1820,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGNEMITE_81:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1840,7 +1840,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DARK_MAGNETON_82:
       return evolution (this, from:"Magnemite", hp:HP060, type:L, retreatCost:2) {
         weakness F
@@ -1860,7 +1860,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FARFETCHD_83:
       return basic (this, hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -1881,7 +1881,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DODUO_84:
       return basic (this, hp:HP050, type:C, retreatCost:0) {
         weakness L
@@ -1894,7 +1894,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DODRIO_85:
       return evolution (this, from:"Doduo", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -1912,7 +1912,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEEL_86:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1924,7 +1924,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DEWGONG_87:
       return evolution (this, from:"Seel", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1944,7 +1944,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRIMER_88:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1964,7 +1964,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_MUK_89:
       return evolution (this, from:"Grimer", hp:HP060, type:G, retreatCost:2) {
         weakness P
@@ -1981,7 +1981,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SHELLDER_90:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2001,7 +2001,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CLOYSTER_91:
       return evolution (this, from:"Shellder", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -2021,7 +2021,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GASTLY_92:
       return basic (this, hp:HP050, type:P, retreatCost:0) {
         weakness D
@@ -2042,7 +2042,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HAUNTER_93:
       return evolution (this, from:"Gastly", hp:HP060, type:P, retreatCost:0) {
         weakness D
@@ -2060,7 +2060,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GENGAR_94:
       return evolution (this, from:"Haunter", hp:HP080, type:P, retreatCost:1) {
         weakness D
@@ -2078,7 +2078,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ONIX_95:
       return basic (this, hp:HP090, type:F, retreatCost:3) {
         weakness G
@@ -2098,7 +2098,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DROWZEE_96:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -2115,7 +2115,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HYPNO_97:
       return evolution (this, from:"Drowzee", hp:HP090, type:P, retreatCost:2) {
         weakness P
@@ -2135,7 +2135,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KRABBY_98:
       return basic (this, hp:HP050, type:W, retreatCost:2) {
         weakness L
@@ -2155,7 +2155,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KINGLER_99:
       return evolution (this, from:"Krabby", hp:HP060, type:W, retreatCost:3) {
         weakness L
@@ -2175,7 +2175,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VOLTORB_100:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2187,7 +2187,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ELECTRODE_101:
       return evolution (this, from:"Voltorb", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -2204,7 +2204,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case EXEGGCUTE_102:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2224,7 +2224,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case EXEGGUTOR_103:
       return evolution (this, from:"Exeggcute", hp:HP080, type:G, retreatCost:3) {
         weakness R
@@ -2244,7 +2244,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CUBONE_104:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2265,7 +2265,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAROWAK_105:
       return evolution (this, from:"Cubone", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2286,7 +2286,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HITMONLEE_106:
       return basic (this, hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -2306,7 +2306,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HITMONCHAN_107:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness P
@@ -2326,7 +2326,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LICKITUNG_108:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness F
@@ -2347,7 +2347,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KOFFING_109:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2359,7 +2359,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_WEEZING_110:
       return evolution (this, from:"Koffing", hp:HP060, type:G, retreatCost:1) {
         weakness P
@@ -2379,7 +2379,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RHYHORN_111:
       return basic (this, hp:HP070, type:F, retreatCost:3) {
         weakness G
@@ -2400,7 +2400,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RHYDON_112:
       return evolution (this, from:"Rhyhorn", hp:HP100, type:F, retreatCost:3) {
         weakness G
@@ -2421,7 +2421,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CHANSEY_113:
       return basic (this, hp:HP100, type:C, retreatCost:1) {
         weakness F
@@ -2442,7 +2442,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case TANGELA_114:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -2463,7 +2463,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KANGASKHAN_115:
       return basic (this, hp:HP090, type:C, retreatCost:3) {
         weakness F
@@ -2484,7 +2484,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HORSEA_116:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -2496,7 +2496,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEADRA_117:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -2516,7 +2516,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDEEN_118:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -2528,7 +2528,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEAKING_119:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:0) {
         weakness L
@@ -2548,7 +2548,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case STARYU_120:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2560,7 +2560,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STARMIE_121:
       return evolution (this, from:"Staryu", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -2580,7 +2580,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MR_MIME_122:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -2597,7 +2597,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SCYTHER_123:
       return basic (this, hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -2618,7 +2618,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JYNX_124:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -2638,7 +2638,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ELECTABUZZ_125:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -2658,7 +2658,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGMAR_126:
       return basic (this, hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -2678,7 +2678,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINSIR_127:
       return basic (this, hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -2698,7 +2698,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case TAUROS_128:
       return basic (this, hp:HP060, type:C, retreatCost:2) {
         weakness F
@@ -2719,7 +2719,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_129:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -2739,7 +2739,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GYARADOS_130:
       return evolution (this, from:"Magikarp", hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -2760,7 +2760,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LAPRAS_131:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -2780,7 +2780,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DITTO_132:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2791,7 +2791,7 @@ public enum PokemodImperium implements LogicCardInfo {
           }
         }
 
-      };
+      }
       case EEVEE_133:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2812,7 +2812,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DARK_VAPOREON_134:
       return evolution (this, from:"Eevee", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -2832,7 +2832,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_JOLTEON_135:
       return evolution (this, from:"Eevee", hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -2852,7 +2852,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_FLAREON_136:
       return evolution (this, from:"Eevee", hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -2872,7 +2872,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PORYGON_137:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         resistance P, MINUS30
@@ -2892,7 +2892,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FLOAT_STONE_137:
       return pokemonTool (this) {
         text "The Retreat Cost of the Pokémon this card is attached to is reduced by [C][C]."
@@ -2902,7 +2902,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case OMANYTE_138:
       return evolution (this, from:"Mysterious Fossil", hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -2920,7 +2920,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case OMASTAR_139:
       return evolution (this, from:"Omanyte", hp:HP080, type:W, retreatCost:1) {
         weakness G
@@ -2941,7 +2941,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KABUTO_140:
       return evolution (this, from:"Mysterious Fossil", hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -2959,7 +2959,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KABUTOPS_141:
       return evolution (this, from:"Kabuto", hp:HP080, type:F, retreatCost:1) {
         weakness G
@@ -2980,7 +2980,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case AERODACTYL_142:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -2998,7 +2998,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SNORLAX_143:
       return basic (this, hp:HP090, type:C, retreatCost:4) {
         weakness F
@@ -3016,7 +3016,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARTICUNO_144:
       return basic (this, hp:HP070, type:W, retreatCost:2) {
         weakness M
@@ -3037,7 +3037,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ZAPDOS_145:
       return basic (this, hp:HP090, type:L, retreatCost:3) {
         move "Thunder", {
@@ -3056,7 +3056,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case MOLTRES_146:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         resistance F, MINUS30
@@ -3076,7 +3076,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case DRATINI_147:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -3088,7 +3088,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DRAGONAIR_148:
       return evolution (this, from:"Dratini", hp:HP080, type:C, retreatCost:2) {
         resistance P, MINUS30
@@ -3108,7 +3108,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DRAGONITE_149:
       return evolution (this, from:"Dragonair", hp:HP100, type:C, retreatCost:1) {
         resistance F, MINUS30
@@ -3125,7 +3125,7 @@ public enum PokemodImperium implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEWTWO_150:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -3145,7 +3145,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEW_151:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -3165,7 +3165,7 @@ public enum PokemodImperium implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case POKE_BALL_152:
       return basicTrainer (this) {
         text "Flip a coin. If heads, you may search your deck for any Basic Pokémon or Evolution card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward."
@@ -3173,7 +3173,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DUAL_BALL_153:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a Basic Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -3181,7 +3181,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LEVEL_BALL_154:
       return basicTrainer (this) {
         text "Search your deck for a Pokémon with 50 HP or less, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -3189,7 +3189,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HEAVY_BALL_155:
       return basicTrainer (this) {
         text "Search your deck for a Pokémon with a Retreat cost of 3 or more, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -3197,7 +3197,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ROCKET_BALL_156:
       return basicTrainer (this) {
         text "Flip 2 coins. For each heads, search your deck for a Pokémon with Dark in its name. Show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -3205,7 +3205,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_BREEDER_157:
       return basicTrainer (this) {
         text "Put a Stage 2 Evolution card from your hand on the matching Basic Pokémon. You can only play this card when you would be allowed to evolve that Pokémon anyway."
@@ -3213,7 +3213,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_BREEDER_FIELDS_158:
       return basicTrainer (this) {
         text "Flip a coin for 1 or 2 of your Pokémon in play that can evolve. For each heads, search your deck for a later-Stage card that matches that Pokémon. Then put that card into your hand. Shuffle your deck afterward."
@@ -3221,7 +3221,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_TRADER_159:
       return basicTrainer (this) {
         text "Trade 1 of the Basic Pokémon or Evolution cards in your hand for 1 of the Basic Pokémon or Evolution cards from your deck. Show both cards to your opponent. Shuffle your deck afterward."
@@ -3229,7 +3229,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_FLUTE_160:
       return basicTrainer (this) {
         text "Choose 1 Basic Pokémon card from your opponent's discard pile and put it onto his or her Bench. (You can't play Pokémon Flute if your opponent's Bench is full.)"
@@ -3237,7 +3237,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEDEX_161:
       return basicTrainer (this) {
         text "Look at up to 5 cards from the top of your deck and rearrange them as you like."
@@ -3245,7 +3245,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POTION_162:
       return basicTrainer (this) {
         text "Remove up to 2 damage counters from 1 of your Pokémon."
@@ -3253,7 +3253,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SUPER_POTION_163:
       return basicTrainer (this) {
         text "Discard 1 Energy card attached to 1 of your own Pokémon in order to remove up to 4 damage counters from that Pokémon."
@@ -3261,7 +3261,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FULL_HEAL_164:
       return basicTrainer (this) {
         text "Remove all Special Conditions from your Active Pokémon."
@@ -3269,7 +3269,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case REVIVE_165:
       return basicTrainer (this) {
         text "Put 1 Basic Pokémon card (excluding Pokémon-ex) from your discard pile onto your Bench. Put damage counters on that Pokémon equal to half its HP (rounded down to the nearest 10). (You can't play Revive if your Bench is full.)"
@@ -3277,7 +3277,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PLUSPOWER_166:
       return basicTrainer (this) {
         text "Attach PlusPower to your Active Pokémon (excluding [D] Pokémon). At the end of your turn, discard PlusPower. If this Pokémon's attack does damage to the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
@@ -3285,7 +3285,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DEFENDER_167:
       return basicTrainer (this) {
         text "Attach Defender to 1 of your Pokémon (excluding [M] Pokémon). At the end of your opponent's next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -3293,7 +3293,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DEVOLUTION_SPRAY_168:
       return basicTrainer (this) {
         text "Choose 1 of your own Pokémon in play and a Stage of Evolution. Discard all Evolution cards of that Stage or higher attached to that Pokémon. That Pokémon is no longer affected by a Special Condition, or anything else that might be the result of an attack (just as if you had evolved it)."
@@ -3301,7 +3301,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BROCK_169:
       return basicTrainer (this) {
         text "Remove 1 damage counter from each of your Pokémon (excluding Pokémon-ex) that has any damage counters on it."
@@ -3309,7 +3309,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LT_SURGE_170:
       return basicTrainer (this) {
         text "You can play this card only if you have at least 1 Basic Pokémon card in your hand. Put a Basic Pokémon card from your hand into play as your Active Pokémon. Put your old Active Pokémon onto your Bench. (You can't play this card if your Bench is full.)"
@@ -3317,7 +3317,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ERIKA_171:
       return basicTrainer (this) {
         text "You may draw up to 3 cards, then your opponent may draw up to 3 cards."
@@ -3325,7 +3325,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LORELEI_172:
       return supporter (this) {
         text "Search your deck for a Trainer card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -3333,7 +3333,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BRUNO_173:
       return supporter (this) {
         text "If it's your first turn, you can't play this card. Draw 2 cards. During this turn, your Pokémon's attacks do 10 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)."
@@ -3341,7 +3341,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case AGATHA_174:
       return supporter (this) {
         text "Choose 1 of your Pokémon in play (excluding Pokémon-ex). Return that Pokémon and all cards attached to it to your hand."
@@ -3349,7 +3349,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LANCE_175:
       return supporter (this) {
         text "Move as many Energy cards attached to 1 of your Pokémon as you like to another of your Pokémon."
@@ -3357,7 +3357,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GARY_OAK_176:
       return supporter (this) {
         text "Draw cards until you have 6 cards in your hand. If it's your first turn, draw cards until you have 8 cards in your hand."
@@ -3365,7 +3365,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ASH_177:
       return supporter (this) {
         text "If it's your first turn, you can't play this card. Attach a basic Energy card from your hand to 1 of your Benched Pokémon."
@@ -3373,7 +3373,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_OAK_178:
       return supporter (this) {
         text "Discard your hand, then draw 7 cards."
@@ -3381,7 +3381,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case IMPOSTER_PROFESSOR_OAK_179:
       return basicTrainer (this) {
         text "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards."
@@ -3389,7 +3389,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case IMPOSTER_OAKS_REVENGE_180:
       return supporter (this) {
         text "Discard a card from your hand in order to play this card. Your opponent shuffles his or her hand into his or her deck, then draws 4 cards."
@@ -3397,7 +3397,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case NURSE_JOY_181:
       return supporter (this) {
         text "Remove up to 3 damage counters and all Special Conditions from 1 of your Pokémon."
@@ -3405,7 +3405,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_CENTER_182:
       return basicTrainer (this) {
         text "Remove all damage counters from 1 of your own Pokémon, then discard all Energy cards attached to that Pokémon."
@@ -3413,7 +3413,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case OFFICER_JENNY_183:
       return supporter (this) {
         text "Search your deck for up to 3 Basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -3421,7 +3421,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BILL_184:
       return basicTrainer (this) {
         text "Draw 2 cards."
@@ -3429,7 +3429,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MR_FUJI_185:
       return supporter (this) {
         text "Choose a Pokémon on your Bench (excluding Pokémon-ex). Shuffle it and any cards attached to it into your deck."
@@ -3437,7 +3437,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case THE_EEVEE_BROTHERS_WAGER_186:
       return supporter (this) {
         text "Each player shuffles his or her hand into his or her deck, then you and your opponent play "Rock-Paper-Scissors". The player who wins draws up to 6 cards. The player who loses draws up to 3 cards. (You draw your cards first.)"
@@ -3445,7 +3445,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case RITCHIE_187:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, draw 4 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 4 more cards."
@@ -3453,7 +3453,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_IVY_188:
       return supporter (this) {
         text "Search your deck for up to 2 in any combination of Basic Pokémon and Basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -3461,7 +3461,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LASS_189:
       return supporter (this) {
         text "You and your opponent show each other your hands, then shuffle all the Trainer cards from your hands into your decks."
@@ -3469,7 +3469,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SAMURAI_190:
       return supporter (this) {
         text "Draw 3 cards"
@@ -3477,7 +3477,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HEALING_FIELDS_191:
       return stadium (this) {
         text "Once during each player's turn, he or she may flip a coin. If heads, that player's Active Pokémon (exluding Pokémon-ex) is no longer affected by any Special Conditions."
@@ -3485,7 +3485,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case POKEMON_POOL_PARTY_192:
       return stadium (this) {
         text "Once during each player's turn, that player may draw cards until he or she has 7 cards in his or her hand. If he or she does, that player's turn ends."
@@ -3493,7 +3493,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case LOST_WORLD_193:
       return stadium (this) {
         text "Once during each player's turn, he or she may flip a coin. If heads, put 1 damage counter on each of their opponent's Benched Pokémon. If tails, put 1 damage counter on each of their own Benched Pokémon. (This can't be done if either player has less than 3 Benched Pokémon in play."
@@ -3501,7 +3501,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case CRYSTAL_BEACH_194:
       return stadium (this) {
         text "Each Special Energy that provides 2 or more Energy (both yours and your opponent's) now provides only 1 [C] Energy. This isn't affected by any Poké-Powers or Poké-Bodies."
@@ -3509,7 +3509,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case ROCKETS_DUNGEON_195:
       return stadium (this) {
         text "Each Pokémon in play with Dark in its name can use the attack on this card instead of its own."
@@ -3517,7 +3517,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case ROCKETS_HIDEOUT_196:
       return stadium (this) {
         text "Each Pokémon in play with Dark or Rocket's in its name (excluding Pokémon-ex) gets +10 HP."
@@ -3525,7 +3525,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case THE_ROCKETS_TRAINING_GYM_197:
       return stadium (this) {
         text "Each player pays [C, C] more to retreat his or her Active Pokémon."
@@ -3533,7 +3533,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case HERE_COMES_TEAM_ROCKET_198:
       return basicTrainer (this) {
         text "Each player plays with his or her Prize cards face up for the rest of the game."
@@ -3541,7 +3541,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GOOP_GAS_ATTACK_199:
       return basicTrainer (this) {
         text "All Poké-Powers and Poké-Bodies stop working until the end of your opponent's next turn."
@@ -3549,7 +3549,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case THE_BOSSS_WAY_200:
       return basicTrainer (this) {
         text "Search your deck for an Evolution card with Dark in its name. Show it to your opponent and put it into your hand. Shuffle your deck afterward."
@@ -3557,7 +3557,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case THE_ROCKETS_TRAP_201:
       return basicTrainer (this) {
         text "Flip a coin. If heads, choose up to 3 cards at random from your opponent's hand (without looking at them). Your opponent shuffles those cards into his or her deck. You can't play The Rocket's Trap more than once each turn."
@@ -3565,7 +3565,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ROCKETS_ACE_IN_THE_HOLE_202:
       return supporter (this) {
         text "You can play this card only when it is the last card in your hand. Put a Dark Pokémon card or basic Energy card from your discard pile into your hand. Then, draw 5 cards."
@@ -3573,7 +3573,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ROCKET_S_COUNTER_ATTACK_203:
       return basicTrainer (this) {
         text "You may use this card only if you have more Prize cards left than your opponent. Search your deck for any 2 cards and put them into your hand. Shuffle your deck afterward."
@@ -3581,7 +3581,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_RETRIEVER_204:
       return basicTrainer (this) {
         text "Flip 2 coins. If you get a heads, search your discard pile for Basic Pokémon and Evolution cards. You may either show up to 2 Basic Pokémon and/or Evolution cards to your opponent and put them into your hand, or show a combination of up to 4 Basic Pokémon and/or Evolution cards to your opponent and shuffle them into your deck."
@@ -3589,7 +3589,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DIGGER_205:
       return basicTrainer (this) {
         text "Flip a coin. If tails, do 10 damage to your Active Pokémon. If heads, your opponent flips a coin. If tails, your opponent does 10 damage to his or her Active Pokémon. If heads, you flip a coin. Keep doing this until a player gets tails."
@@ -3597,7 +3597,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case NIGHTLY_GARBAGE_RUN_206:
       return basicTrainer (this) {
         text "Choose up to 3 Basic Pokémon cards, Evolution cards, and/or Basic Energy cards from your discard pile. Show them to your opponent and shuffle them into your deck."
@@ -3605,7 +3605,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POW_HAND_EXTENSION_207:
       return basicTrainer (this) {
         text "You may only use this card if you have more Prize cards left than your opponent. If you do, you may choose 1 Energy card attached to the Defending Pokémon and move it to another of your opponent's Pokémon (if your opponent has no Benched Pokémon, discard that Energy card.) Or, you may have your opponent choose 1 of their Benched Pokémon for you to switch with the Defending Pokémon."
@@ -3613,7 +3613,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SURPRISE_TIME_MACHINE_208:
       return basicTrainer (this) {
         text "Choose 1 of your Evolved Pokémon, remove the highest Stage Evolution card from it, and shuffle it into your deck (this counts as devolving that Pokémon). If that Pokémon remains in play, search your deck for an Evolution card that evolves from that Pokémon and put it onto that Pokémon (this counts as evolving that Pokémon). Shuffle your deck afterward."
@@ -3621,7 +3621,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SWOOP_TELEPORTER_209:
       return basicTrainer (this) {
         text "Search your deck for a Basic Pokémon (excluding Pokémon-ex) and switch it with 1 of your Basic Pokémon in play (excluding Pokémon-ex). (Any cards attached to that Pokémon, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) Place the first Basic Pokémon in your discard pile. Shuffle your deck afterward."
@@ -3629,7 +3629,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SLEEP_210:
       return basicTrainer (this) {
         text "Flip a coin. If heads, the Defending Pokémon is now Asleep."
@@ -3637,7 +3637,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CLEFAIRY_DOLL_211:
       return basicTrainer (this) {
         text "Play Clefairy Doll as if it were a Basic Pokémon. While in play, Clefairy Doll counts as a Pokémon (instead of a Trainer card.) Clefairy Doll has no attacks, can't retreat, and can't be affected by a Special Condition. If Clefairy Doll is Knocked Out, it doesn't count as a Knocked Out Pokémon. At any time during your turn before your attack, you may discard Clefairy Doll."
@@ -3645,7 +3645,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERIOUS_FOSSIL_212:
       return basicTrainer (this) {
         text "Play Mysterious Fossil as if it were a Basic Pokémon. While in play, Mysterious Fossil counts as a Pokémon (instead of a Trainer card). Mysterious Fossil has no attacks, can't retreat, and can't be affected by a Special Condition. If Mysterious Fossil is Knocked Out, it doesn't count as a Knocked Out Pokémon. (Discard it anyway.) At any time during your turn before your attack, you may discard Mysterious Fossil from play."
@@ -3653,7 +3653,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SCOOP_UP_213:
       return basicTrainer (this) {
         text "Choose 1 of your own Pokémon in play and return its Basic Pokémon card to your hand. (Discard all cards attached to that card.)"
@@ -3661,7 +3661,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GUST_OF_WIND_214:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
@@ -3669,9 +3669,9 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SWITCH_215:
-      return copy(FireRedLeafGreen.SWITCH_102, this);
+      return copy(FireRedLeafGreen.SWITCH_102, this)
       case SUPER_SCOOP_UP_216:
       return basicTrainer (this) {
         text "Flip a coin. If heads, return 1 of your Pokémon in play and all cards attached to it to your hand."
@@ -3679,7 +3679,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case COMPUTER_SEARCH_217:
       return basicTrainer (this) {
         text "Discard 2 of the other cards from your hand in order to search your deck for any card and put it into your hand. Shuffle your deck afterward."
@@ -3687,7 +3687,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ITEM_FINDER_218:
       return basicTrainer (this) {
         text "You may choose to discard 1 card from your hand in order to search your discard pile for a Supporter card. Show it to your opponent and put it into your hand. Or" +
@@ -3696,7 +3696,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MAINTENANCE_219:
       return basicTrainer (this) {
         text "Shuffle 2 of the other cards from your hand into your deck in order to draw 2 cards."
@@ -3704,7 +3704,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case GAMBLER_220:
       return basicTrainer (this) {
         text "Shuffle your hand into your deck. Flip a coin. If heads, draw 8 cards. If tails, draw 1 card."
@@ -3712,7 +3712,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case RECYCLE_221:
       return basicTrainer (this) {
         text "Flip a coin. If heads, put a card in your discard pile on top of your deck."
@@ -3720,7 +3720,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CHALLENGE_222:
       return basicTrainer (this) {
         text "Ask your opponent if he or she accepts your challenge. If your opponent declines (or if both Benches are full), draw 2 cards. If your opponent accepts, each of you searches your decks for any number of Basic Pokémon cards (excluding Pokémon-ex) and puts them face down onto your Benches. (A player can't do this if his or her Bench is full.) When you both have finished, shuffle your decks and turn those cards face up."
@@ -3728,7 +3728,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CRYSTAL_GUARD_223:
       return pokemonTool (this) {
         text "As long as the Pokémon Crystal Guard is attached to (excluding Pokémon-ex) is 1 of your Benched Pokémon, ignore all effects of attacks and Poké-Powers (including damage) done to that Pokémon by your opponent's Pokémon"
@@ -3738,7 +3738,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RELIC_HUNTER_224:
       return basicTrainer (this) {
         text "Search your discard pile for up to 2 Stadium cards, show them to your opponent, and shuffle them into your deck."
@@ -3746,7 +3746,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LOST_EXPEDITION_225:
       return basicTrainer (this) {
         text "You may play 2 Lost Expedition at the same time. If you play 1 Lost Expedition, draw a card. If you play 2 Lost Expedition, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward."
@@ -3754,7 +3754,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case UNDERGROUND_EXPEDITION_226:
       return supporter (this) {
         text "Look at the bottom 4 cards of your deck. Put 2 of the cards you find there into your hand. Return the remaining cards to the bottom of your deck in any order you like."
@@ -3762,7 +3762,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_RESTORE_227:
       return basicTrainer (this) {
         text "Flip 3 coins. For each heads, choose a Basic Energy card from your discard pile. Show them to your opponent and put them into your hand."
@@ -3770,7 +3770,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SEARCH_228:
       return basicTrainer (this) {
         text "Search your deck for a Basic Energy card and put it into your hand. Shuffle your deck afterward."
@@ -3778,7 +3778,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_SWITCH_229:
       return basicTrainer (this) {
         text "Move a basic Energy card from 1 of your Pokémon to another of your Pokémon"
@@ -3786,7 +3786,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_RETRIEVAL_230:
       return basicTrainer (this) {
         text "Trade 1 of the other cards in your hand for up to 2 Basic Energy cards from your discard pile."
@@ -3794,7 +3794,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SUPER_ENERGY_RETRIEVAL_231:
       return basicTrainer (this) {
         text "Trade 2 of the other cards in your hand for up to 4 Basic Energy cards from your discard pile."
@@ -3802,7 +3802,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_REMOVAL_232:
       return basicTrainer (this) {
         text "Discard 1 Energy card attached to your opponent's Active Pokémon."
@@ -3810,7 +3810,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SUPER_ENERGY_REMOVAL_233:
       return basicTrainer (this) {
         text "Discard 1 Special Energy attached to 1 of your opponent's Pokémon."
@@ -3818,7 +3818,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case TOOL_SCRAPPER_234:
       return basicTrainer (this) {
         text "Choose up to 2 Trainer cards attached to your opponent's Pokémon and discard them."
@@ -3826,7 +3826,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROTECTIVE_ORB_236:
       return pokemonTool (this) {
         text "As long as Protective Orb is attached to an Evolved Pokémon (excluding Pokémon-ex), that Pokémon has no Weakness."
@@ -3836,19 +3836,19 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case FIGHTING_ENERGY_237:
-      return basicEnergy (this, F);
+      return basicEnergy (this, F)
       case FIRE_ENERGY_238:
-      return basicEnergy (this, R);
+      return basicEnergy (this, R)
       case GRASS_ENERGY_239:
-      return basicEnergy (this, G);
+      return basicEnergy (this, G)
       case LIGHTNING_ENERGY_240:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       case PSYCHIC_ENERGY_241:
-      return basicEnergy (this, P);
+      return basicEnergy (this, P)
       case WATER_ENERGY_242:
-      return basicEnergy (this, W);
+      return basicEnergy (this, W)
       case DOUBLE_COLORLESS_ENERGY_243:
       return specialEnergy (this, [[C]]) {
         text "Provides [C][C] energy. Doesn't count as a basic energy card."
@@ -3860,7 +3860,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case MIRACLE_ENERGY_244:
       return specialEnergy (this, [[C]]) {
         text "Miracle Energy can only be attached to a Stage 2 Pokémon. While in play, Miracle Energy counts as every type of Energy but only provides 2 at a time in any combination. (Doesn't count as a Basic Energy card when not in play.) Miracle Energy can't be discarded by your opponent's Trainer cards. If the Pokémon Miracle Energy is attached to isn't a Stage 2 Pokémon, discard Miracle Energy."
@@ -3872,7 +3872,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BOOST_ENERGY_245:
       return specialEnergy (this, [[C]]) {
         text "Boost Energy provides [C] Energy. While in play, if you have more Prize cards left than your opponent, Boost Energy provides [C][C][C]. If the Pokémon Boost Energy is attached to has a Poké-Power, or has any other Special Energy cards attached to it (at any time), discard Boost Energy. If the Pokémon Boost Energy is attached to is a Pokémon-ex, discard Boost Energy."
@@ -3884,7 +3884,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DNA_ENERGY_246:
       return specialEnergy (this, [[C]]) {
         text "DNA Energy provides [C] energy. During your turn, if DNA Energy is attached to your Active Pokémon, you may move it to 1 of your Benched Pokémon with the same name as your Active Pokémon. This action cannot be done more than once each turn."
@@ -3896,7 +3896,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case FULL_HEAL_ENERGY_247:
       return specialEnergy (this, [[C]]) {
         text "If you play this card from your hand, the Pokémon you attach it to is no longer affected by a Special Condition. Full Heal Energy provides [C] Energy."
@@ -3908,7 +3908,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case LOST_ENERGY_248:
       return specialEnergy (this, [[C]]) {
         text "Lost Energy provides [C] energy. Once during your turn, if the Pokémon Lost Energy is attached to is your Active Pokémon, you may search your deck for up to 2 Basic Pokémon and put them onto your bench. If you do, shuffle your deck and your turn ends."
@@ -3920,7 +3920,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case POTION_ENERGY_249:
       return specialEnergy (this, [[C]]) {
         text "If you play this card from your hand, remove 1 damage counter from the Pokémon you attach it to, if it has any. Potion Energy provides [C] Energy."
@@ -3932,7 +3932,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case SCRAMBLE_ENERGY_250:
       return specialEnergy (this, [[C]]) {
         text "Scramble Energy can only be attached to an Evolved Pokémon. Scramble Energy provides [C] Energy. While in play, if you have more Prize cards left than your opponent, Scramble Energy provides every type of Energy but provides only 3 at a time in any combination. If the Pokémon Scramble Energy is attached to isn't an Evolved Pokémon, discard Scramble Energy. If the Pokémon Scramble Energy is attached to is a Pokémon-ex, discard Scramble Energy."
@@ -3944,7 +3944,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ROCKETS_ENERGY_RF_251:
       return specialEnergy (this, [[C]]) {
         text "Rocket's Energy RF provides [C] Energy. If the Pokémon that Rocket's Energy RF is attached to also has a Basic [R] Energy card attached to it, that Pokémon has no Weakness. If the Pokémon that Rocket's Energy RF is attached to also has a Basic [F] Energy card attached to it, damage done to that Pokémon's attacks isn't affected by Resistance. If the Pokémon Rocket's Energy RF is attached to is a Pokémon-ex, discard Rocket's Energy RF."
@@ -3956,7 +3956,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ROCKETS_ENERGY_GL_252:
       return specialEnergy (this, [[C]]) {
         text "Rocket's Energy GL provides [C] Energy. If the Pokémon that Rocket's Energy GL is attached to also has a Basic [G] Energy card attached to it, that Pokémon can't be affected by any Special Conditions. If the Pokémon that Rocket's Energy GL is attached to also has a Basic [L] Energy card attached to it, that Pokémon's maximum HP is increased by 10. If the Pokémon Rocket's Energy GL is attached to is a Pokémon-ex, discard Rocket's Energy GL."
@@ -3968,7 +3968,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ROCKETS_ENERGY_WP_253:
       return specialEnergy (this, [[C]]) {
         text "Rocket's Energy WP provides [C] Energy. If the Pokémon that Rocket's Energy WP is attached to also has a Basic [W] Energy card attached to it, prevent all effects, excluding damage, done to that Pokémon by your opponent's Pokémon. If the Pokémon that Rocket's Energy WP is attached to also has a Basic [P] Energy card attached to it, that Pokémon's Retreat Cost is 0. If the Pokémon Rocket's Energy WP is attached to is a Pokémon-ex, discard Rocket's Energy WP."
@@ -3980,9 +3980,9 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case ROCKET_S_COUNTER_ATTACK_254:
-      return copy (ROCKET_S_COUNTER_ATTACK_203, this);
+      return copy (ROCKET_S_COUNTER_ATTACK_203, this)
       case CRUSHING_HAMMER_255:
       return basicTrainer (this) {
         text "Discard 1 Energy card attached to 1 of your Pokémon in order to choose 1 of your opponent's Pokémon and up to 2 Energy cards attached to it. Discard those Energy cards."
@@ -3990,7 +3990,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DOWSING_MACHINE_256:
       return basicTrainer (this) {
         text "Search your discard pile for a Trainer card, show it to your opponent, and put it into your hand."
@@ -3998,7 +3998,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case Elixir_257:
       return basicTrainer (this) {
         text "Remove up to 6 damage counters from 1 of your Pokémon."
@@ -4006,7 +4006,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case EXPERT_BELT_258:
       return basicTrainer (this) {
         text "If you have 6 remaining Prize cards, you cannot play this card. Attach Expert Belt to 1 of your Pokémon. The Pokémon this card is attached to gets +20HP and that Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 more Prize card."
@@ -4014,7 +4014,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case G_SCOPE_259:
       return basicTrainer (this) {
         text "Attach G Scope to 1 of your Pokémon. The Pokémon this card is attached to can also use the attack on this card. After you use the attack, discard G Scope (you still need the necessary Energy to use the attack)."
@@ -4022,7 +4022,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case Hacker_260:
       return basicTrainer (this) {
         text "Search your deck for a card and put it into your hand. Shuffle your deck afterward."
@@ -4030,7 +4030,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LOST_MEDALLION_261:
       return basicTrainer (this) {
         text "You may use this card only if you have more Prize cards left than your opponent. Attach Lost Medallion to 1 of your Pokémon. If the Pokémon this card is attached to is Knocked Out, your opponent takes 1 fewer Prize card."
@@ -4038,7 +4038,7 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MASTER_BALL_262:
       return basicTrainer (this) {
         text "Search your deck for up to 3 Basic Pokémon. Show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -4046,9 +4046,9 @@ public enum PokemodImperium implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodJungle.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodJungle.groovy
@@ -2,35 +2,35 @@ package tcgwars.logic.impl.pokemod
 
 import tcgwars.logic.impl.gen1.Jungle
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author axpendix@hotmail.com
@@ -121,53 +121,53 @@ public enum PokemodJungle implements LogicCardInfo {
   VAPOREON_EX_81 ("Vaporeon ex", "81", Rarity.SECRET, [POKEMON, EVOLUTION, STAGE1, _WATER_]),
   JOLTEON_EX_82 ("Jolteon ex", "82", Rarity.SECRET, [POKEMON, EVOLUTION, STAGE1, _LIGHTNING_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodJungle(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_JUNGLE;
+    return tcgwars.logic.card.Collection.POKEMOD_JUNGLE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -185,7 +185,7 @@ public enum PokemodJungle implements LogicCardInfo {
               def moveList = []
               def labelList = []
 
-              moveList.addAll(defending.topPokemonCard.moves);
+              moveList.addAll(defending.topPokemonCard.moves)
               labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
               def move=choose(moveList, labelList, "Which move do you want to use")
@@ -203,7 +203,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ELECTRODE_2:
         return evolution (this, from:"Voltorb", hp:HP090, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -230,7 +230,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_3:
         return evolution (this, from:"Eevee", hp:HP080, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -253,7 +253,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JOLTEON_4:
         return evolution (this, from:"Eevee", hp:HP080, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -275,9 +275,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KANGASKHAN_5:
-        return copy (Jungle.KANGASKHAN_5, this);
+        return copy (Jungle.KANGASKHAN_5, this)
       case MR_MIME_6:
         return basic (this, hp:HP040, type:PSYCHIC, retreatCost:1) {
           weakness PSYCHIC
@@ -305,7 +305,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDOQUEEN_7:
         return evolution (this, from:"Nidorina", hp:HP100, type:GRASS, retreatCost:3) {
           weakness PSYCHIC
@@ -329,7 +329,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIDGEOT_8:
         return evolution (this, from:"Pidgeotto", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -354,7 +354,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PINSIR_9:
         return basic (this, hp:HP080, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -376,9 +376,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SCYTHER_10:
-        return copy (Jungle.SCYTHER_10, this);
+        return copy (Jungle.SCYTHER_10, this)
       case SNORLAX_11:
         return basic (this, hp:HP090, type:COLORLESS, retreatCost:4) {
           weakness FIGHTING
@@ -404,7 +404,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VAPOREON_12:
         return evolution (this, from:"Eevee", hp:HP080, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -427,7 +427,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VENOMOTH_13:
         break
       case VICTREEBEL_14:
@@ -452,43 +452,43 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_15:
-        return copy (Jungle.VILEPLUME_15, this);
+        return copy (Jungle.VILEPLUME_15, this)
       case WIGGLYTUFF_16:
-        return copy (Jungle.WIGGLYTUFF_16, this);
+        return copy (Jungle.WIGGLYTUFF_16, this)
       case CLEFABLE_17:
-        return copy (CLEFABLE_1, this);
+        return copy (CLEFABLE_1, this)
       case ELECTRODE_18:
-        return copy (ELECTRODE_2, this);
+        return copy (ELECTRODE_2, this)
       case FLAREON_19:
-        return copy (FLAREON_3, this);
+        return copy (FLAREON_3, this)
       case JOLTEON_20:
-        return copy (JOLTEON_4, this);
+        return copy (JOLTEON_4, this)
       case KANGASKHAN_21:
-        return copy (Jungle.KANGASKHAN_5, this);
+        return copy (Jungle.KANGASKHAN_5, this)
       case MR_MIME_22:
-        return copy (MR_MIME_6, this);
+        return copy (MR_MIME_6, this)
       case NIDOQUEEN_23:
-        return copy (NIDOQUEEN_7, this);
+        return copy (NIDOQUEEN_7, this)
       case PIDGEOT_24:
-        return copy (PIDGEOT_8, this);
+        return copy (PIDGEOT_8, this)
       case PINSIR_25:
-        return copy (PINSIR_9, this);
+        return copy (PINSIR_9, this)
       case SCYTHER_26:
-        return copy (Jungle.SCYTHER_10, this);
+        return copy (Jungle.SCYTHER_10, this)
       case SNORLAX_27:
-        return copy (SNORLAX_11, this);
+        return copy (SNORLAX_11, this)
       case VAPOREON_28:
-        return copy (VAPOREON_12, this);
+        return copy (VAPOREON_12, this)
       case VENOMOTH_29:
-        return copy (VENOMOTH_13, this);
+        return copy (VENOMOTH_13, this)
       case VICTREEBEL_30:
-        return copy (VICTREEBEL_14, this);
+        return copy (VICTREEBEL_14, this)
       case VILEPLUME_31:
-        return copy (Jungle.VILEPLUME_15, this);
+        return copy (Jungle.VILEPLUME_15, this)
       case WIGGLYTUFF_32:
-        return copy (Jungle.WIGGLYTUFF_16, this);
+        return copy (Jungle.WIGGLYTUFF_16, this)
       case BUTTERFREE_33:
         return evolution (this, from:"Metapod", hp:HP080, type:GRASS, retreatCost:0) {
           weakness FIRE
@@ -514,7 +514,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DODRIO_34:
         return evolution (this, from:"Doduo", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -536,9 +536,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EXEGGUTOR_35:
-        return copy (Jungle.EXEGGUTOR_35, this);
+        return copy (Jungle.EXEGGUTOR_35, this)
       case FEAROW_36:
         return evolution (this, from:"Spearow", hp:HP080, type:COLORLESS, retreatCost:0) {
           weakness LIGHTNING
@@ -561,9 +561,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GLOOM_37:
-        return copy (Jungle.GLOOM_37, this);
+        return copy (Jungle.GLOOM_37, this)
       case LICKITUNG_38:
         return basic (this, hp:HP080, type:COLORLESS, retreatCost:3) {
           weakness FIGHTING
@@ -587,7 +587,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAROWAK_39:
         return evolution (this, from:"Cubone", hp:HP070, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -615,7 +615,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORINA_40:
         return evolution (this, from:"Nidoran♀", hp:HP080, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -636,7 +636,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PARASECT_41:
         return evolution (this, from:"Paras", hp:HP060, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -657,7 +657,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PERSIAN_42:
         return evolution (this, from:"Meowth", hp:HP070, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -694,9 +694,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PRIMEAPE_43:
-        return copy (Jungle.PRIMEAPE_43, this);
+        return copy (Jungle.PRIMEAPE_43, this)
       case RAPIDASH_44:
         return evolution (this, from:"Ponyta", hp:HP070, type:FIRE, retreatCost:0) {
           weakness WATER
@@ -719,7 +719,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYDON_45:
         return evolution (this, from:"Rhyhorn", hp:HP100, type:FIGHTING, retreatCost:3) {
           weakness GRASS
@@ -747,7 +747,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case SEAKING_46:
         return evolution (this, from:"Goldeen", hp:HP070, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -768,9 +768,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case TAUROS_47:
-        return copy (Jungle.TAUROS_47, this);
+        return copy (Jungle.TAUROS_47, this)
       case WEEPINBELL_48:
         return evolution (this, from:"Bellsprout", hp:HP070, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -792,7 +792,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case BELLSPROUT_49:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -818,7 +818,7 @@ public enum PokemodJungle implements LogicCardInfo {
               shuffleDeck()
             }
           }
-        };
+        }
       case CUBONE_50:
         return basic (this, hp:HP050, type:FIGHTING, retreatCost:1) {
           weakness GRASS
@@ -856,11 +856,11 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case EEVEE_51:
-        return copy (Jungle.EEVEE_51, this);
+        return copy (Jungle.EEVEE_51, this)
       case EXEGGCUTE_52:
-        return copy (Jungle.EXEGGCUTE_52, this);
+        return copy (Jungle.EXEGGCUTE_52, this)
       case GOLDEEN_53:
         return basic (this, hp:HP040, type:WATER, retreatCost:0) {
           weakness LIGHTNING
@@ -873,9 +873,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case JIGGLYPUFF_54:
-        return copy (Jungle.JIGGLYPUFF_54, this);
+        return copy (Jungle.JIGGLYPUFF_54, this)
       case MANKEY_55:
         return basic (this, hp:HP040, type:FIGHTING, retreatCost:0) {
           weakness PSYCHIC
@@ -887,11 +887,11 @@ public enum PokemodJungle implements LogicCardInfo {
               powerUsed()
               def choice = choose([0,1,2,3,4],["Top of your deck", "Top of your opponent's deck", "Your opponent’s hand ", "Your Prizes", "Opponent's Prizes"])
               switch (choice){
-                case 0: my.deck.subList(0,1).showToMe("Top of your deck"); break;
-                case 1: opp.deck.subList(0,1).showToMe("Top of your opponent's deck"); break;
-                case 2: opp.hand.shuffledCopy().select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break;
-                case 3: my.prizeCardSet.select(hidden: true, "Select a random card from your prizes").showToMe("Selected card"); break;
-                case 4: opp.prizeCardSet.select(hidden: true, "Select a random card from your opponent's prizes").showToMe("Selected card"); break;
+                case 0: my.deck.subList(0,1).showToMe("Top of your deck"); break
+                case 1: opp.deck.subList(0,1).showToMe("Top of your opponent's deck"); break
+                case 2: opp.hand.shuffledCopy().select(hidden: true, "Select a random card from opponent's hand").showToMe("Selected card"); break
+                case 3: my.prizeCardSet.select(hidden: true, "Select a random card from your prizes").showToMe("Selected card"); break
+                case 4: opp.prizeCardSet.select(hidden: true, "Select a random card from your opponent's prizes").showToMe("Selected card"); break
               }
             }
           }
@@ -904,7 +904,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MEOWTH_56:
         return basic (this, hp:HP050, type:COLORLESS, retreatCost:1) {
           weakness FIGHTING
@@ -919,7 +919,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case NIDORAN_FEMALE_57:
         return basic (this, hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -946,9 +946,9 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ODDISH_58:
-        return copy (Jungle.ODDISH_58, this);
+        return copy (Jungle.ODDISH_58, this)
       case PARAS_59:
         return basic (this, hp:HP040, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -969,7 +969,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PIKACHU_60:
         return basic (this, hp:HP050, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -983,11 +983,11 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case RHYHORN_61:
-        return copy (Jungle.RHYHORN_61, this);
+        return copy (Jungle.RHYHORN_61, this)
       case SPEAROW_62:
-        return copy (Jungle.SPEAROW_62, this);
+        return copy (Jungle.SPEAROW_62, this)
       case VENONAT_63:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness FIRE
@@ -1010,11 +1010,11 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case POKE_BALL_64:
-        return copy (Jungle.POKE_BALL_64, this);
+        return copy (Jungle.POKE_BALL_64, this)
       case ENERGY_RESTORE_65:
-       return copy(RubySapphire.ENERGY_RESTORE_81, this);
+       return copy(RubySapphire.ENERGY_RESTORE_81, this)
       case LEVEL_BALL_66:
        return basicTrainer(this) {
           text "Search your deck for a Pokémon with 50 HP or less, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -1024,13 +1024,13 @@ public enum PokemodJungle implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck"
           }
-        };
+        }
       case SAMURAI_67:
-       return copy(SunMoon.HAU_120, this);
+       return copy(SunMoon.HAU_120, this)
       case HEALING_FIELDS_69:
        break
       case POKEMON_POOL_PARTY_70:
-       return copy(BlackWhitePromos.TROPICAL_BEACH_BW28, this);
+       return copy(BlackWhitePromos.TROPICAL_BEACH_BW28, this)
       case MASTER_BALL_71:
        return basicTrainer (this) {
           text "Search your deck for up to 3 Basic Pokémon. Show them to your opponent, and put them into your hand. Shuffle your deck afterward"
@@ -1040,7 +1040,7 @@ public enum PokemodJungle implements LogicCardInfo {
           playRequirement{
             assert my.deck : "There are no more cards in your deck"
           }
-        };
+        }
       case SCOOP_UP_CYCLONE_72:
        return basicTrainer (this) {
           text "Put 1 of your Pokémon in play and all cards attached to it into your hand."
@@ -1052,15 +1052,15 @@ public enum PokemodJungle implements LogicCardInfo {
           playRequirement{
             confirmScoopLastPokemon()
           }
-        };
+        }
       case SCRAMBLE_SWITCH_73:
-       return copy(PlasmaStorm.SCRAMBLE_SWITCH_129, this);
+       return copy(PlasmaStorm.SCRAMBLE_SWITCH_129, this)
       case KANGASKHAN_74:
-       return copy (Jungle.KANGASKHAN_5, this);
+       return copy (Jungle.KANGASKHAN_5, this)
       case HUNGRY_SNORLAX_75:
        break
       case SCYTHER_76:
-       return copy (Jungle.SCYTHER_10, this);
+       return copy (Jungle.SCYTHER_10, this)
       case WIGGLYTUFF_EX_77:
        return evolution (this, from: "Jigglypuff", hp:100, type:COLORLESS, retreatCost:2) {
          weakness FIGHTING
@@ -1083,7 +1083,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VILEPLUME_EX_78:
        return evolution (this, from: "Gloom", hp:120, type:GRASS, retreatCost:2) {
          weakness PSYCHIC, FIRE
@@ -1110,7 +1110,7 @@ public enum PokemodJungle implements LogicCardInfo {
              }
            }
           }
-       };
+       }
       case CLEFABLE_EX_79:
        return evolution (this, from:"Clefairy", hp:HP100, type:COLORLESS, retreatCost:2) {
           weakness FIGHTING
@@ -1123,7 +1123,7 @@ public enum PokemodJungle implements LogicCardInfo {
               def moveList = []
               def labelList = []
 
-              moveList.addAll(defending.topPokemonCard.moves);
+              moveList.addAll(defending.topPokemonCard.moves)
               labelList.addAll(defending.topPokemonCard.moves.collect{it.name})
 
               def move=choose(moveList, labelList, "Which move do you want to use")
@@ -1140,7 +1140,7 @@ public enum PokemodJungle implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case FLAREON_EX_80:
        return evolution (this, from:"Eevee", hp:HP100, type:R, retreatCost:1) {
         weakness W
@@ -1169,7 +1169,7 @@ public enum PokemodJungle implements LogicCardInfo {
             damage 20, self
           }
         }
-      };
+      }
       case VAPOREON_EX_81:
        return evolution (this, from:"Eevee", hp:HP100, type:W, retreatCost:1) {
         weakness L
@@ -1198,7 +1198,7 @@ public enum PokemodJungle implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case JOLTEON_EX_82:
        return evolution (this, from:"Eevee", hp:HP100, type:L, retreatCost:1) {
         weakness F
@@ -1229,9 +1229,9 @@ public enum PokemodJungle implements LogicCardInfo {
             discardSelfEnergy L
           }
         }
-      };
+      }
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/pokemod/PokemodNeoDestiny.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodNeoDestiny.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -153,53 +153,53 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
   ROCKET_S_SNEASEL_EX_117 ("Rocket's Sneasel ex", "117", Rarity.HOLORARE, [POKEMON, BASIC, EX, OWNERS_POKEMON, _DARKNESS_]),
   ROCKET_S_SCIZOR_EX_118 ("Rocket's Scizor ex", "118", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, EX, OWNERS_POKEMON, _DARKNESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodNeoDestiny(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_NEO_DESTINY;
+    return tcgwars.logic.card.Collection.POKEMOD_NEO_DESTINY
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -221,7 +221,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DARK_CROBAT_2:
       return evolution (this, from:"Dark Golbat", hp:HP070, type:G, retreatCost:0) {
         weakness P
@@ -239,7 +239,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_DONPHAN_3:
       return evolution (this, from:"Phanpy", hp:HP060, type:F, retreatCost:3) {
         weakness G
@@ -260,7 +260,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DARK_ESPEON_4:
       return evolution (this, from:"Eevee", hp:HP060, type:P, retreatCost:0) {
         weakness P
@@ -280,7 +280,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_FERALIGATR_5:
       return evolution (this, from:"Croconaw", hp:HP080, type:W, retreatCost:3) {
         weakness G
@@ -297,7 +297,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case DARK_GENGAR_6:
       return evolution (this, from:"Haunter", hp:HP070, type:P, retreatCost:2) {
         weakness D
@@ -315,7 +315,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_HOUNDOOM_7:
       return evolution (this, from:"Houndour", hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -335,7 +335,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_PORYGON2_8:
       return evolution (this, from:"Porygon", hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -353,7 +353,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_SCIZOR_9:
       return evolution (this, from:"Scyther", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -374,7 +374,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_TYPHLOSION_10:
       return evolution (this, from:"Quilava", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -394,7 +394,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_TYRANITAR_11:
       return evolution (this, from:"Dark Pupitar", hp:HP090, type:F, retreatCost:3) {
         weakness W
@@ -415,7 +415,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LIGHT_ARCANINE_12:
       return evolution (this, from:"Growlithe", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -432,7 +432,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LIGHT_AZUMARILL_13:
       return evolution (this, from:"Marill", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -452,7 +452,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LIGHT_DRAGONITE_14:
       return evolution (this, from:"Dragonair", hp:HP100, type:C, retreatCost:2) {
         resistance F, MINUS30
@@ -469,7 +469,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LIGHT_TOGETIC_15:
       return evolution (this, from:"Togepi", hp:HP060, type:C, retreatCost:0) {
         resistance F, MINUS30
@@ -486,7 +486,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_ARIADOS_17:
       return evolution (this, from:"Spinarak", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -506,7 +506,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_MAGCARGO_18:
       return evolution (this, from:"Slugma", hp:HP060, type:R, retreatCost:3) {
         weakness W
@@ -523,7 +523,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_OMASTAR_19:
       return evolution (this, from:"Omanyte", hp:HP070, type:W, retreatCost:2) {
         weakness G
@@ -544,7 +544,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_SLOWKING_20:
       return evolution (this, from:"Slowpoke", hp:HP060, type:P, retreatCost:2) {
         weakness P
@@ -561,7 +561,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_URSARING_21:
       return evolution (this, from:"Teddiursa", hp:HP060, type:C, retreatCost:2) {
         weakness F
@@ -582,7 +582,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case LIGHT_DRAGONAIR_22:
       return evolution (this, from:"Dratini", hp:HP080, type:C, retreatCost:2) {
         resistance P, MINUS30
@@ -602,7 +602,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LIGHT_LANTURN_23:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -622,7 +622,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LIGHT_LEDIAN_24:
       return evolution (this, from:"Ledyba", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -643,7 +643,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LIGHT_MACHAMP_25:
       return evolution (this, from:"Machoke", hp:HP100, type:F, retreatCost:2) {
         weakness P
@@ -660,7 +660,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LIGHT_PILOSWINE_26:
       return evolution (this, from:"Swinub", hp:HP090, type:W, retreatCost:3) {
         weakness M
@@ -678,7 +678,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case UNOWN_G_27:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -695,7 +695,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_H_28:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -712,7 +712,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_W_29:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -729,7 +729,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_X_30:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -746,7 +746,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CHANSEY_31:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness F
@@ -767,7 +767,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case DARK_CROCONAW_32:
       return evolution (this, from:"Totodile", hp:HP060, type:W, retreatCost:2) {
         weakness G
@@ -779,7 +779,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_EXEGGUTOR_33:
       return evolution (this, from:"Exeggcute", hp:HP060, type:P, retreatCost:2) {
         weakness P
@@ -799,7 +799,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_FLAAFFY_34:
       return evolution (this, from:"Mareep", hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -819,7 +819,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DARK_FORRETRESS_35:
       return evolution (this, from:"Pineco", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -839,7 +839,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case DARK_HAUNTER_36:
       return evolution (this, from:"Gastly", hp:HP060, type:P, retreatCost:0) {
         weakness D
@@ -860,7 +860,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_OMANYTE_37:
       return evolution (this, from:"Mysterious Fossil", hp:HP040, type:W, retreatCost:1) {
         weakness G
@@ -873,7 +873,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_PUPITAR_38:
       return evolution (this, from:"Larvitar", hp:HP060, type:F, retreatCost:1) {
         weakness W
@@ -894,7 +894,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DARK_QUILAVA_39:
       return evolution (this, from:"Cyndaquil", hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -914,7 +914,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DARK_WIGGLYTUFF_40:
       return evolution (this, from:"Jigglypuff", hp:HP060, type:C, retreatCost:2) {
         weakness F
@@ -935,7 +935,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HERACROSS_41:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -955,7 +955,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HITMONLEE_42:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -975,7 +975,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HOUNDOUR_43:
       return basic (this, hp:HP040, type:D, retreatCost:1) {
         weakness F
@@ -996,7 +996,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JIGGLYPUFF_44:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1009,7 +1009,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LIGHT_DEWGONG_45:
       return evolution (this, from:"Seel", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -1029,7 +1029,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LIGHT_FLAREON_46:
       return evolution (this, from:"Eevee", hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -1049,7 +1049,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LIGHT_GOLDUCK_47:
       return evolution (this, from:"Psyduck", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1069,7 +1069,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LIGHT_JOLTEON_48:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -1089,7 +1089,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LIGHT_MACHOKE_49:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:2) {
         weakness P
@@ -1109,7 +1109,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LIGHT_NINETALES_50:
       return evolution (this, from:"Vulpix", hp:HP090, type:R, retreatCost:1) {
         weakness W
@@ -1129,7 +1129,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LIGHT_SLOWBRO_51:
       return evolution (this, from:"Slowpoke", hp:HP080, type:P, retreatCost:2) {
         weakness P
@@ -1149,7 +1149,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LIGHT_VAPOREON_52:
       return evolution (this, from:"Eevee", hp:HP080, type:W, retreatCost:1) {
         weakness L
@@ -1169,7 +1169,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LIGHT_VENOMOTH_53:
       return evolution (this, from:"Venonat", hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -1190,7 +1190,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LIGHT_WIGGLYTUFF_54:
       return evolution (this, from:"Jigglypuff", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1211,7 +1211,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SCYTHER_55:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1232,7 +1232,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case TOGEPI_56:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -1252,7 +1252,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case UNOWN_C_57:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1269,7 +1269,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_P_58:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1286,7 +1286,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_Q_59:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1303,7 +1303,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_Z_60:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1320,7 +1320,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CYNDAQUIL_61:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1332,7 +1332,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DARK_OCTILLERY_62:
       return evolution (this, from:"Remoraid", hp:HP060, type:W, retreatCost:2) {
         weakness L
@@ -1352,7 +1352,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DRATINI_63:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -1372,7 +1372,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EXEGGCUTE_64:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1392,7 +1392,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GASTLY_65:
       return basic (this, hp:HP040, type:P, retreatCost:0) {
         weakness D
@@ -1405,7 +1405,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GIRAFARIG_66:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         move "Tail Bite", {
@@ -1424,7 +1424,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GLIGAR_67:
       return basic (this, hp:HP050, type:F, retreatCost:0) {
         weakness G
@@ -1437,7 +1437,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GROWLITHE_68:
       return basic (this, hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1449,7 +1449,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HITMONCHAN_69:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness P
@@ -1469,7 +1469,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case LARVITAR_70:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -1490,7 +1490,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LEDYBA_71:
       return basic (this, hp:HP040, type:G, retreatCost:0) {
         weakness R
@@ -1503,7 +1503,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LIGHT_SUNFLORA_72:
       return evolution (this, from:"Sunkern", hp:HP080, type:G, retreatCost:1) {
         weakness R
@@ -1524,7 +1524,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MACHOP_73:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness P
@@ -1544,7 +1544,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MANTINE_74:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness L
@@ -1557,7 +1557,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MAREEP_75:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1569,7 +1569,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PHANPY_76:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1582,7 +1582,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PINECO_77:
       return basic (this, hp:HP040, type:G, retreatCost:2) {
         weakness R
@@ -1594,7 +1594,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PORYGON_78:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1607,7 +1607,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PSYDUCK_79:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1627,7 +1627,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case REMORAID_80:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -1639,7 +1639,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEEL_81:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -1651,7 +1651,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLUGMA_82:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -1663,7 +1663,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SUNKERN_83:
       return basic (this, hp:HP040, type:G, retreatCost:2) {
         weakness R
@@ -1684,7 +1684,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SWINUB_84:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1697,7 +1697,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case TOTODILE_85:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1709,7 +1709,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_L_86:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1726,7 +1726,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_S_87:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1743,7 +1743,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case UNOWN_T_88:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1760,7 +1760,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case UNOWN_V_89:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1777,7 +1777,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VENONAT_90:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1797,7 +1797,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VULPIX_91:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1809,7 +1809,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BROKEN_GROUND_GYM_92:
       return stadium (this) {
         text "All Baby Pokémon in play have their Baby Pokémon Rules disabled."
@@ -1817,7 +1817,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case EXP_ALL_93:
       return pokemonTool (this) {
         text "Attach EXP.ALL to 1 of your Pokémon that doesn't have a Pokémon Tool attached to it." +
@@ -1828,7 +1828,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DARK_CLAW_94:
       return pokemonTool (this) {
         text "If this card is attached to a [D] Pokémon, each of the attacks of that Pokémon does 10 more damage to your opponent's Active Pokémon (after applying Weakness and Resistance)."
@@ -1838,7 +1838,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case SILVER_BANGLE_95:
       return pokemonTool (this) {
         text "The attacks of the Pokémon this card is attached to (excluding Pokémon-ex) do 10 more damage to your opponent''s Active Pokémon-ex (before applying Weakness and Resistance).'"
@@ -1848,7 +1848,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case THOUGHT_WAVE_MACHINE_96:
       return basicTrainer (this) {
         text "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent's Active Pokémon to your opponent's hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent's hand. Your turn is over now (you don't get to attack)."
@@ -1856,7 +1856,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case VERMILLION_CITY_97:
       return stadium (this) {
         text "The Retreat Cost of each Basic Pokémon in play is [C] less."
@@ -1864,7 +1864,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case KURT_98:
       return supporter (this) {
         text "Search your deck for 2 Evolution cards with 90HP or more, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -1872,7 +1872,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ENERGY_STADIUM_99:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play." +
@@ -1881,7 +1881,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DEFENDER_100:
       return basicTrainer (this) {
         text "Attach Defender to 1 of your Pokémon (exluding [M] Pokémon). At the end of your opponent's next turn, discard Defender. Damage done to that Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance)."
@@ -1889,7 +1889,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PLUSPOWER_101:
       return basicTrainer (this) {
         text "Attach PlusPower to your Active Pokémon (excluding [D] Pokémon). At the end of your turn, discard PlusPower. If this Pokémon's attack does damage to the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon."
@@ -1897,7 +1897,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ULTRA_BALL_102:
       return basicTrainer (this) {
         text "Discard 2 cards from your hand. (if you can't discard 2 cards, you can't play this card.) Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -1905,7 +1905,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case POKEMON_CATCHER_103:
       return basicTrainer (this) {
         text "Flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch it with his or her Active Pokémon."
@@ -1913,7 +1913,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ROCKET_S_ENERGY_BOMB_104:
       return basicTrainer (this) {
         text "If it's your first turn, you can't play this card. Search your deck for an Energy card with Rocket's in its name and attach it to 1 of your Benched Pokémon with Dark or Rocket's in its name. Shuffle your deck afterward. Then, put 1 damage counter on that Pokémon."
@@ -1921,7 +1921,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DARK_AMPHAROS_105:
       return evolution (this, from:"Dark Flaaffy", hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -1938,7 +1938,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SHINING_CELEBI_106:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1958,7 +1958,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHINING_CHARIZARD_107:
       return basic (this, hp:HP100, type:R, retreatCost:3) {
         weakness W
@@ -1971,7 +1971,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case SHINING_KABUTOPS_108:
       return basic (this, hp:HP080, type:F, retreatCost:2) {
         weakness G
@@ -1992,7 +1992,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SHINING_MEWTWO_109:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -2012,7 +2012,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHINING_NOCTOWL_110:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -2025,7 +2025,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SHINING_RAICHU_111:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -2037,7 +2037,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SHINING_STEELIX_112:
       return basic (this, hp:HP090, type:M, retreatCost:4) {
         weakness R
@@ -2050,7 +2050,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case SHINING_TYRANITAR_113:
       return basic (this, hp:HP080, type:D, retreatCost:3) {
         weakness F
@@ -2071,7 +2071,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ROCKET_S_ENTEI_EX_114:
       return basic (this, hp:HP090, type:D, retreatCost:1) {
         weakness W
@@ -2096,7 +2096,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ROCKET_S_SUICUNE_EX_115:
       return basic (this, hp:HP090, type:D, retreatCost:1) {
         weakness L
@@ -2121,7 +2121,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ROCKET_S_RAIKOU_EX_116:
       return basic (this, hp:HP090, type:D, retreatCost:2) {
         weakness F
@@ -2138,7 +2138,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ROCKET_S_SNEASEL_EX_117:
       return basic (this, hp:HP080, type:D, retreatCost:1) {
         weakness F
@@ -2159,7 +2159,7 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ROCKET_S_SCIZOR_EX_118:
       return evolution (this, from:"Rocket's Scyther ex", hp:HP100, type:D, retreatCost:2) {
         weakness R
@@ -2177,9 +2177,9 @@ public enum PokemodNeoDestiny implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodNeoGenesis.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodNeoGenesis.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -162,53 +162,53 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
   FERALIGATR_EX_125 ("Feraligatr ex", "125", Rarity.ULTRARARE, [POKEMON, EVOLUTION, EX, STAGE2, _METAL_]),
   MEGANIUM_EX_126 ("Meganium ex", "126", Rarity.ULTRARARE, [POKEMON, EVOLUTION, EX, STAGE2, _GRASS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodNeoGenesis(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_NEO_GENESIS;
+    return tcgwars.logic.card.Collection.POKEMOD_NEO_GENESIS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -225,7 +225,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case AZUMARILL_2:
       return evolution (this, from:"Marill", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -245,7 +245,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BELLOSSOM_3:
       return evolution (this, from:"Gloom", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -266,7 +266,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FERALIGATR_4:
       return evolution (this, from:"Croconaw", hp:HP100, type:W, retreatCost:3) {
         weakness G
@@ -283,7 +283,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case FERALIGATR_5:
       return evolution (this, from:"Croconaw", hp:HP120, type:W, retreatCost:3) {
         weakness G
@@ -300,7 +300,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case HERACROSS_6:
       return basic (this, hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -317,7 +317,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case JUMPLUFF_7:
       return evolution (this, from:"Skiploom", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -338,7 +338,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case KINGDRA_8:
       return evolution (this, from:"Seadra", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -358,7 +358,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LUGIA_9:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness P
@@ -371,7 +371,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case MEGANIUM_10:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -389,7 +389,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MEGANIUM_11:
       return evolution (this, from:"Bayleef", hp:HP100, type:G, retreatCost:3) {
         weakness R
@@ -402,7 +402,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PICHU_12:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:L, retreatCost:0) {
         move "Zzzap", {
@@ -413,7 +413,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SKARMORY_13:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -434,7 +434,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLOWKING_14:
       return evolution (this, from:"Slowpoke", hp:HP080, type:P, retreatCost:3) {
         weakness P
@@ -451,7 +451,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STEELIX_15:
       return evolution (this, from:"Onix", hp:HP110, type:M, retreatCost:4) {
         weakness R
@@ -472,7 +472,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TOGETIC_16:
       return evolution (this, from:"Togepi", hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -493,7 +493,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TYPHLOSION_17:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -510,7 +510,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case TYPHLOSION_18:
       return evolution (this, from:"Quilava", hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -527,7 +527,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case METAL_ENERGY_19:
       return specialEnergy (this, [[C]]) {
         text "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon Metal Energy is attached isn't [M]. Metal Energy provides[M] Energy. (Doesn't count as a basic Energy card.)"
@@ -539,7 +539,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CLEFFA_20:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:C, retreatCost:0) {
         move "Eeeeeeek", {
@@ -550,7 +550,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DONPHAN_21:
       return evolution (this, from:"Phanpy", hp:HP070, type:F, retreatCost:3) {
         weakness G
@@ -571,7 +571,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ELEKID_22:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:L, retreatCost:0) {
         pokePower "Playful Punch", {
@@ -580,7 +580,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
           }
         }
 
-      };
+      }
       case MAGBY_23:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:R, retreatCost:0) {
         move "Sputter", {
@@ -591,7 +591,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MURKROW_24:
       return basic (this, hp:HP060, type:D, retreatCost:0) {
         weakness L
@@ -612,7 +612,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNEASEL_25:
       return basic (this, hp:HP060, type:D, retreatCost:1) {
         weakness F
@@ -633,7 +633,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case AIPOM_26:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         weakness F
@@ -654,7 +654,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ARIADOS_27:
       return evolution (this, from:"Spinarak", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -674,7 +674,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case BAYLEEF_28:
       return evolution (this, from:"Chikorita", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -695,7 +695,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case BAYLEEF_29:
       return evolution (this, from:"Chikorita", hp:HP080, type:G, retreatCost:2) {
         weakness R
@@ -716,7 +716,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case CLEFAIRY_30:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -737,7 +737,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CROCONAW_31:
       return evolution (this, from:"Totodile", hp:HP070, type:W, retreatCost:2) {
         weakness G
@@ -757,7 +757,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CROCONAW_32:
       return evolution (this, from:"Totodile", hp:HP080, type:W, retreatCost:2) {
         weakness G
@@ -777,7 +777,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case ELECTABUZZ_33:
       return basic (this, hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -797,7 +797,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FLAAFFY_34:
       return evolution (this, from:"Mareep", hp:HP060, type:L, retreatCost:1) {
         weakness F
@@ -817,7 +817,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case FURRET_35:
       return evolution (this, from:"Sentret", hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -838,7 +838,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GLOOM_36:
       return evolution (this, from:"Oddish", hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -858,7 +858,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GRANBULL_37:
       return evolution (this, from:"Snubbull", hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -879,7 +879,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LANTURN_38:
       return evolution (this, from:"Chinchou", hp:HP070, type:L, retreatCost:2) {
         weakness F
@@ -896,7 +896,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LEDIAN_39:
       return evolution (this, from:"Ledyba", hp:HP060, type:G, retreatCost:0) {
         weakness R
@@ -909,7 +909,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGMAR_40:
       return basic (this, hp:HP070, type:R, retreatCost:2) {
         weakness W
@@ -929,7 +929,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MILTANK_41:
       return basic (this, hp:HP070, type:C, retreatCost:2) {
         weakness F
@@ -950,7 +950,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case NOCTOWL_42:
       return evolution (this, from:"Hoothoot", hp:HP060, type:C, retreatCost:0) {
         weakness L
@@ -968,7 +968,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PHANPY_43:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -989,7 +989,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PILOSWINE_44:
       return evolution (this, from:"Swinub", hp:HP080, type:W, retreatCost:3) {
         weakness M
@@ -1010,7 +1010,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case QUAGSIRE_45:
       return evolution (this, from:"Wooper", hp:HP070, type:W, retreatCost:2) {
         weakness G
@@ -1031,7 +1031,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case QUILAVA_46:
       return evolution (this, from:"Cyndaquil", hp:HP060, type:R, retreatCost:1) {
         weakness W
@@ -1051,7 +1051,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QUILAVA_47:
       return evolution (this, from:"Cyndaquil", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -1071,7 +1071,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SEADRA_48:
       return evolution (this, from:"Horsea", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1091,7 +1091,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKIPLOOM_49:
       return evolution (this, from:"Hoppip", hp:HP060, type:G, retreatCost:0) {
         weakness R
@@ -1112,7 +1112,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SUNFLORA_50:
       return evolution (this, from:"Sunkern", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1125,7 +1125,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case TOGEPI_51:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         resistance P, MINUS30
@@ -1137,7 +1137,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case XATU_52:
       return evolution (this, from:"Natu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -1158,7 +1158,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CHIKORITA_53:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1179,7 +1179,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CHIKORITA_54:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1200,7 +1200,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHINCHOU_55:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1220,7 +1220,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CYNDAQUIL_56:
       return basic (this, hp:HP040, type:R, retreatCost:1) {
         weakness W
@@ -1240,7 +1240,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CYNDAQUIL_57:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1260,7 +1260,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GIRAFARIG_58:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         move "Agility", {
@@ -1279,7 +1279,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GLIGAR_59:
       return basic (this, hp:HP060, type:F, retreatCost:0) {
         weakness G
@@ -1300,7 +1300,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HOOTHOOT_60:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1321,7 +1321,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HOPPIP_61:
       return basic (this, hp:HP050, type:G, retreatCost:0) {
         weakness R
@@ -1342,7 +1342,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HORSEA_62:
       return basic (this, hp:HP050, type:W, retreatCost:0) {
         weakness L
@@ -1354,7 +1354,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LEDYBA_63:
       return basic (this, hp:HP040, type:G, retreatCost:0) {
         weakness R
@@ -1375,7 +1375,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MANTINE_64:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1388,7 +1388,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAREEP_65:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1408,7 +1408,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MARILL_66:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1428,7 +1428,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case NATU_67:
       return basic (this, hp:HP030, type:P, retreatCost:0) {
         weakness P
@@ -1449,7 +1449,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ODDISH_68:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1469,7 +1469,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ONIX_69:
       return basic (this, hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -1489,7 +1489,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PIKACHU_70:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1509,7 +1509,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SENTRET_71:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1522,7 +1522,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHUCKLE_72:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1542,7 +1542,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SLOWPOKE_73:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1562,7 +1562,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNUBBULL_74:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1583,7 +1583,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SPINARAK_75:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1603,7 +1603,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STANTLER_76:
       return basic (this, hp:HP060, type:C, retreatCost:2) {
         weakness F
@@ -1624,7 +1624,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SUDOWOODO_77:
       return basic (this, hp:HP060, type:F, retreatCost:3) {
         weakness W
@@ -1644,7 +1644,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SUNKERN_78:
       return basic (this, hp:HP040, type:G, retreatCost:2) {
         weakness R
@@ -1665,7 +1665,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SWINUB_79:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness M
@@ -1678,7 +1678,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TOTODILE_80:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness G
@@ -1698,7 +1698,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TOTODILE_81:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1718,7 +1718,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WOOPER_82:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness G
@@ -1739,7 +1739,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case Falkner_83:
       return supporter (this) {
         text "Choose 1 of your opponent's Benched Pokémonand switch it with his or her Active Pokémon."
@@ -1747,7 +1747,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ECOGYM_84:
       return stadium (this) {
         text "Whenever an attack, Poké-Power, or Trainer card discards another player's basic Energy card from a Pokémon, shuffle that Energy card into its owner's deck. (Energy cards that are discarded when that Pokémon is Knocked Out don't count.)"
@@ -1755,7 +1755,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case ENERGY_CHARGE_85:
       return basicTrainer (this) {
         text "Flip a coin. If heads, shuffle up to 2 Energy cards from your discard pile into your deck."
@@ -1763,7 +1763,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case EUSINE_86:
       return supporter (this) {
         text "Discard an Energy card from your hand. Then, draw 4 cards."
@@ -1771,7 +1771,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case KURT_87:
       return supporter (this) {
         text "Search your deck for up to 2 Evolution cards with 90HP or more, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
@@ -1779,7 +1779,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case RANDOM_RECEIVER_88:
       return basicTrainer (this) {
         text "Reveal cards for the top of your deck until you reveal a Supporter card. Put it into your hand. Shuffle the other cards back into your deck."
@@ -1787,7 +1787,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SUPER_ENERGY_RETRIEVAL_89:
       return basicTrainer (this) {
         text "Trade 2 of the other cards in your hand for 4 basic Energy cards from your discard pile. If you have fewer than 4 basic Energy cards there, take all of them."
@@ -1795,7 +1795,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case DARK_PATCH_90:
       return basicTrainer (this) {
         text "If it's your first turn, you can't play this card. Attach a basic [D] Energy from your discard pile to 1 of your Benched [D] Pokémon."
@@ -1803,7 +1803,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case METAL_PATCH_91:
       return basicTrainer (this) {
         text "If it's your first turn, you can't play this card. Attach a basic [M] Energy from your discard pile to 1 of your Benched [M] Pokémon."
@@ -1811,7 +1811,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case YOUNGSTER_JOEY_92:
       return supporter (this) {
         text "Search your deck for a Pokémon, show it to your opponent and put it into your hand. Shuffle your deck afterward."
@@ -1819,7 +1819,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SILENT_LAB_93:
       return stadium (this) {
         text "Each Basic Pokémon in play, and in each player's discard pile have their Poké-Powers Disabled."
@@ -1827,7 +1827,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case MIRACLE_BERRY_94:
       return pokemonTool (this) {
         text "At any time between turns, if the Pokémon Miracle Berry is attached to is affected by a Special Condition, you may remove all of those effects from that Pokémon and discard Miracle Berry. At the start of each turn, if the Pokémon Miracle Berry is attached to is affected by a Special Condition, remove all of those effects from that Pokémon and discard Miracle Berry."
@@ -1837,7 +1837,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case NEW_POKEDEX_95:
       return basicTrainer (this) {
         text "Shuffle your deck. Then, look at up to 5 cards from the top of your deck and rearrange them as you like."
@@ -1845,7 +1845,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case PROFESSOR_ELM_96:
       return supporter (this) {
         text "Shuffle your hand into your deck. Then, draw 7 cards. You can't play any more Trainer cards this turn."
@@ -1853,7 +1853,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SPROUT_TOWER_97:
       return stadium (this) {
         text "All damage done by [C] Pokémon's attacks is reduce by 30 (after applying Weakness and Resistance)."
@@ -1861,7 +1861,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case SUPER_SCOOP_UP_98:
       return basicTrainer (this) {
         text "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand."
@@ -1869,7 +1869,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case ITEM_FINDER_99:
       return basicTrainer (this) {
         text "You may choose to Discard 1 card from your hand in order to search your discard pile for a Supporter card. Show it to your opponent and put it into your hand. Or" +
@@ -1878,7 +1878,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BATTLE_FRONTIER_100:
       return stadium (this) {
         text "Each Player's [C] Evolved Pokémon, [D] Evolved Pokémon, and [M] Evolved Pokémon can't use any Poké-Powers."
@@ -1886,7 +1886,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case BROKEN_TIME_SPACE_101:
       return stadium (this) {
         text "Once during each player's turn, he or she may evolve a Stage 1 Pokémon that he or she just evolved during that turn."
@@ -1894,7 +1894,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case POKEMON_MARCH_102:
       return basicTrainer (this) {
         text "Your opponent may search his or her deck for 1 Basic Pokémon card and put it onto his or her Bench. Then, you may search your deck for 1 Basic Pokémon card and put it onto your Bench. Then, each player shuffles his or her deck. (A player can't do any of this if his or her Bench is full.)"
@@ -1902,7 +1902,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case BATTLE_ARENA_103:
       return stadium (this) {
         text "Once during each player's turn, if the or she evolves 1 of their Pokémon (excluding Pokémon-ex), remove 2 damage counters from that Pokémon."
@@ -1910,7 +1910,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DARKNESS_ENERGY_104:
       return specialEnergy (this, [[C]]) {
         text "If the Pokémon Darkness Energy is attached to damages the Defending Pokémon (after applying Weakness and Resistance), the attack does 10 more damage to the Defending Pokémon. At the end of every turn, put 1 damage counter on the Pokémon Darkness Energy is attached to, unless it's [D]. Darkness Energy provides [D] Energy. (Doesn't count as a basic Energy card.)"
@@ -1922,7 +1922,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case RECYCLE_ENERGY_105:
       return specialEnergy (this, [[C]]) {
         text "Recycle Energy provides 1 Energy. (Doesn't count as a basic Energy card.) If this card is put into your discard pile from play, return it to your hand."
@@ -1934,31 +1934,31 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case FIGHTING_ENERGY_106:
-      return basicEnergy (this, F);
+      return basicEnergy (this, F)
       case FIRE_ENERGY_107:
-      return basicEnergy (this, R);
+      return basicEnergy (this, R)
       case GRASS_ENERGY_108:
-      return basicEnergy (this, G);
+      return basicEnergy (this, G)
       case LIGHTNING_ENERGY_109:
-      return basicEnergy (this, L);
+      return basicEnergy (this, L)
       case PSYCHIC_ENERGY_110:
-      return basicEnergy (this, P);
+      return basicEnergy (this, P)
       case WATER_ENERGY_111:
-      return basicEnergy (this, W);
+      return basicEnergy (this, W)
       case FIGHTING_ENERGY_112:
-      return copy (FIGHTING_ENERGY_106, this);
+      return copy (FIGHTING_ENERGY_106, this)
       case FIRE_ENERGY_113:
-      return copy (FIRE_ENERGY_107, this);
+      return copy (FIRE_ENERGY_107, this)
       case GRASS_ENERGY_114:
-      return copy (GRASS_ENERGY_108, this);
+      return copy (GRASS_ENERGY_108, this)
       case LIGHTNING_ENERGY_115:
-      return copy (LIGHTNING_ENERGY_109, this);
+      return copy (LIGHTNING_ENERGY_109, this)
       case PSYCHIC_ENERGY_116:
-      return copy (PSYCHIC_ENERGY_110, this);
+      return copy (PSYCHIC_ENERGY_110, this)
       case WATER_ENERGY_117:
-      return copy (WATER_ENERGY_111, this);
+      return copy (WATER_ENERGY_111, this)
       case BLEND_ENERGY_WGR_118:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] Energy. While this card attached to a Pokémon, it provides [W], [G], and [R] Energy but provides only 1 Energy at a time."
@@ -1970,7 +1970,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case BLEND_ENERGY_FLP_119:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] Energy. While this card attached to a Pokémon, it provides [F], [L], and [P] Energy but provides only 1 Energy at a time."
@@ -1982,7 +1982,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DONPHAN_120:
       return evolution (this, from:"Phanpy", hp:HP060, type:F, retreatCost:3) {
         weakness G
@@ -2000,7 +2000,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKARMORY_EX_121:
       return basic (this, hp:HP100, type:M, retreatCost:1) {
         weakness R
@@ -2026,7 +2026,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CROBAT_EX_122:
       return evolution (this, from:"Golbat", hp:HP130, type:G, retreatCost:0) {
         weakness L
@@ -2052,7 +2052,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STEELIX_EX_123:
       return evolution (this, from:"Onix", hp:HP120, type:M, retreatCost:3) {
         weakness R
@@ -2080,7 +2080,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEW_EX_124:
       return basic (this, hp:HP090, type:P, retreatCost:1) {
         weakness P
@@ -2096,7 +2096,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case FERALIGATR_EX_125:
       return evolution (this, from:"Croconaw", hp:HP150, type:M, retreatCost:3) {
         weakness G
@@ -2122,7 +2122,7 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case MEGANIUM_EX_126:
       return evolution (this, from:"Bayleef", hp:HP150, type:G, retreatCost:2) {
         weakness G
@@ -2149,9 +2149,9 @@ public enum PokemodNeoGenesis implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodNeoRevelation.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodNeoRevelation.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -106,53 +106,53 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
   LUGIA_EX_69 ("Lugia ex", "69", Rarity.HOLORARE, [POKEMON, BASIC, EX, _COLORLESS_]),
   SCIZOR_EX ("Scizor ex", "70", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, EX, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodNeoRevelation(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_NEO_REVELATION;
+    return tcgwars.logic.card.Collection.POKEMOD_NEO_REVELATION
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -177,7 +177,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case BLISSEY_2:
       return evolution (this, from:"Chansey", hp:HP120, type:C, retreatCost:2) {
         weakness F
@@ -195,7 +195,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CELEBI_3:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -212,7 +212,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CROBAT_4:
       return evolution (this, from:"Golbat", hp:HP090, type:G, retreatCost:0) {
         weakness P
@@ -233,7 +233,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DELIBIRD_5:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness L
@@ -246,7 +246,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case ENTEI_6:
       return basic (this, hp:HP080, type:R, retreatCost:1) {
         weakness W
@@ -263,7 +263,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case HO_OH_7:
       return basic (this, hp:HP090, type:R, retreatCost:2) {
         weakness W
@@ -292,7 +292,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 90
           }
         }
-      };
+      }
       case HOUNDOOM_8:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -313,7 +313,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JUMPLUFF_9:
       return evolution (this, from:"Skiploom", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -334,7 +334,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGNETON_10:
       return evolution (this, from:"Magnemite", hp:HP080, type:M, retreatCost:2) {
         weakness R
@@ -352,7 +352,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MISDREAVUS_11:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -373,7 +373,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case PORYGON2_12:
       return evolution (this, from:"Porygon", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -391,7 +391,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case RAIKOU_13:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -408,7 +408,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case SUICUNE_14:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -425,7 +425,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case AERODACTYL_15:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -443,7 +443,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case CELEBI_16:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -455,7 +455,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ENTEI_17:
       return basic (this, hp:HP060, type:R, retreatCost:0) {
         weakness W
@@ -471,7 +471,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HO_OH_18:
       return basic (this, hp:HP090, type:C, retreatCost:2) {
         weakness W
@@ -484,7 +484,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case KINGDRA_19:
       return evolution (this, from:"Seadra", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -504,7 +504,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LUGIA_20:
       return basic (this, hp:HP090, type:P, retreatCost:2) {
         weakness P
@@ -517,7 +517,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAICHU_21:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -537,7 +537,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAIKOU_22:
       return basic (this, hp:HP060, type:L, retreatCost:0) {
         weakness F
@@ -553,7 +553,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SKARMORY_23:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -574,7 +574,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SNEASEL_24:
       return basic (this, hp:HP060, type:D, retreatCost:0) {
         weakness F
@@ -595,7 +595,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STARMIE_25:
       return evolution (this, from:"Staryu", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -615,7 +615,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SUDOWOODO_26:
       return basic (this, hp:HP060, type:F, retreatCost:3) {
         weakness W
@@ -632,7 +632,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SUICUNE_27:
       return basic (this, hp:HP060, type:W, retreatCost:0) {
         weakness L
@@ -648,7 +648,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FLAAFFY_28:
       return evolution (this, from:"Mareep", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -668,7 +668,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GOLBAT_29:
       return evolution (this, from:"Zubat", hp:HP060, type:G, retreatCost:0) {
         weakness P
@@ -689,7 +689,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GRAVELER_30:
       return evolution (this, from:"Geodude", hp:HP070, type:F, retreatCost:2) {
         weakness G
@@ -709,7 +709,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case JYNX_31:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness M
@@ -729,7 +729,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case LANTURN_32:
       return evolution (this, from:"Chinchou", hp:HP080, type:L, retreatCost:2) {
         weakness F
@@ -746,7 +746,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGCARGO_33:
       return evolution (this, from:"Slugma", hp:HP080, type:R, retreatCost:3) {
         weakness W
@@ -763,7 +763,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case OCTILLERY_34:
       return evolution (this, from:"Remoraid", hp:HP080, type:W, retreatCost:2) {
         weakness L
@@ -783,7 +783,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case PARASECT_35:
       return evolution (this, from:"Paras", hp:HP060, type:G, retreatCost:2) {
         weakness R
@@ -800,7 +800,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PILOSWINE_36:
       return evolution (this, from:"Swinub", hp:HP090, type:F, retreatCost:3) {
         weakness G
@@ -821,7 +821,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 80
           }
         }
-      };
+      }
       case SEAKING_37:
       return evolution (this, from:"Goldeen", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -841,7 +841,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STANTLER_38:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -862,7 +862,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case UNOWN_B_39:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -879,7 +879,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case UNOWN_Y_40:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -896,7 +896,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case AIPOM_41:
       return basic (this, hp:HP040, type:C, retreatCost:0) {
         weakness F
@@ -917,7 +917,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHINCHOU_42:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -937,7 +937,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FARFETCH_D_43:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -958,7 +958,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GEODUDE_44:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -970,7 +970,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLDEEN_45:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -982,7 +982,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MURKROW_46:
       return basic (this, hp:HP060, type:D, retreatCost:0) {
         weakness L
@@ -1003,7 +1003,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case PARAS_47:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1023,7 +1023,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case QUAGSIRE_48:
       return evolution (this, from:"Wooper", hp:HP070, type:W, retreatCost:2) {
         weakness G
@@ -1044,7 +1044,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case QWILFISH_49:
       return basic (this, hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1064,7 +1064,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case REMORAID_50:
       return basic (this, hp:HP040, type:W, retreatCost:0) {
         weakness L
@@ -1076,7 +1076,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SHUCKLE_51:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness W
@@ -1093,7 +1093,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SKIPLOOM_52:
       return evolution (this, from:"Hoppip", hp:HP060, type:G, retreatCost:0) {
         weakness R
@@ -1114,7 +1114,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SLUGMA_53:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -1134,7 +1134,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SMOOCHUM_54:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:P, retreatCost:0) {
         move "Psykiss", {
@@ -1145,7 +1145,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SNUBBULL_55:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1166,7 +1166,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STARYU_56:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -1186,7 +1186,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SWINUB_57:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1207,7 +1207,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case UNOWN_K_58:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1224,7 +1224,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZUBAT_59:
       return basic (this, hp:HP040, type:G, retreatCost:0) {
         weakness P
@@ -1245,7 +1245,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VIRIDIAN_FOREST_60:
       return stadium (this) {
         text "Once during each player's turn, that player may discard a card from their hand. If they do, that player searches their deck for a basic Energy card, shows it to their opponent, and puts it into their hand. Then, that player shuffles their deck."
@@ -1253,7 +1253,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case HIGH_PRESSURE_SYSTEM_61:
       return stadium (this) {
         text "Each player pays [C] less to retreat his or her [R] and [W] Pokémon."
@@ -1261,7 +1261,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case POKEMON_BREEDER_FIELDS_62:
       return basicTrainer (this) {
         text "Flip a coin for 1 or 2 of your non-Baby Pokémon that can evolve. For each heads, search your deck for a later-Stage card that matches that Pokémon. Then put that card into your hand. Shuffle your deck afterward."
@@ -1269,7 +1269,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case HEAVY_PRESSURE_SYSTEM_63:
       return stadium (this) {
         text "Any damage done by attacks from [P] Pokémon and [F] Pokémon (both yours and your opponent's) is not affected by Resistance."
@@ -1277,7 +1277,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case LOW_PRESSURE_SYSTEM_64:
       return stadium (this) {
         text "Each [G] and [L] Pokémon in play (both yours and your opponent's) gets +10 HP."
@@ -1285,7 +1285,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case SHINING_GYARADOS_65:
       return basic (this, hp:HP100, type:W, retreatCost:3) {
         weakness L
@@ -1306,7 +1306,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case SHINING_MAGIKARP_66:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1326,7 +1326,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case CELEBI_EX_67:
       return basic (this, hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -1346,7 +1346,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HO_OH_EX_68:
       return basic (this, hp:HP100, type:R, retreatCost:2) {
         weakness W
@@ -1363,7 +1363,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LUGIA_EX_69:
       return basic (this, hp:HP100, type:C, retreatCost:1) {
         weakness P
@@ -1381,7 +1381,7 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 200
           }
         }
-      };
+      }
       case SCIZOR_EX:
       return evolution (this, from:"Scyther", hp:HP100, type:C, retreatCost:1) {
         weakness R
@@ -1407,9 +1407,9 @@ public enum PokemodNeoRevelation implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodSkyridge.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodSkyridge.groovy
@@ -1,34 +1,34 @@
 package tcgwars.logic.impl.pokemod
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author lithogenn@gmail.com
@@ -226,53 +226,53 @@ public enum PokemodSkyridge implements LogicCardInfo {
   MAGCARGO_EX_190 ("Magcargo ex", "190", Rarity.HOLORARE, [POKEMON, EVOLUTION, STAGE1, EX, _FIRE_]),
   RAYQUAZA_EX_191 ("Rayquaza ex", "191", Rarity.HOLORARE, [POKEMON, BASIC, EX, _COLORLESS_]);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodSkyridge(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_SKYRIDGE;
+    return tcgwars.logic.card.Collection.POKEMOD_SKYRIDGE
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -294,7 +294,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ALAKAZAM_2:
       return evolution (this, from:"Kadabra", hp:HP100, type:P, retreatCost:2) {
         weakness P
@@ -311,7 +311,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ARCANINE_3:
       return evolution (this, from:"Growlithe", hp:HP080, type:R, retreatCost:2) {
         weakness W
@@ -336,7 +336,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case ARTICUNO_4:
       return basic (this, hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -362,7 +362,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case BEEDRILL_5:
       return evolution (this, from:"Kakuna", hp:HP080, type:G, retreatCost:0) {
         weakness R
@@ -380,7 +380,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case CROBAT_6:
       return evolution (this, from:"Golbat", hp:HP090, type:G, retreatCost:0) {
         weakness P
@@ -397,7 +397,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DEWGONG_7:
       return evolution (this, from:"Seel", hp:HP080, type:W, retreatCost:2) {
         weakness M
@@ -417,7 +417,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FLAREON_8:
       return evolution (this, from:"Eevee", hp:HP070, type:R, retreatCost:1) {
         weakness W
@@ -442,7 +442,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case FORRETRESS_9:
       return evolution (this, from:"Pineco", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -463,7 +463,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GENGAR_10:
       return evolution (this, from:"Haunter", hp:HP100, type:P, retreatCost:2) {
         weakness D
@@ -481,7 +481,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GYARADOS_11:
       return evolution (this, from:"Magikarp", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -498,7 +498,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HOUNDOOM_12:
       return evolution (this, from:"Houndour", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -519,7 +519,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case JOLTEON_13:
       return evolution (this, from:"Eevee", hp:HP070, type:L, retreatCost:0) {
         weakness F
@@ -544,7 +544,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KABUTOPS_14:
       return evolution (this, from:"Kabuto", hp:HP090, type:F, retreatCost:2) {
         weakness G
@@ -562,7 +562,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case LEDIAN_15:
       return evolution (this, from:"Ledyba", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -582,7 +582,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case MACHAMP_16:
       return evolution (this, from:"Machoke", hp:HP120, type:F, retreatCost:2) {
         weakness P
@@ -607,7 +607,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MAGCARGO_17:
       return evolution (this, from:"Slugma", hp:HP080, type:R, retreatCost:3) {
         weakness W
@@ -627,7 +627,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case MAGCARGO_18:
       return evolution (this, from:"Slugma", hp:HP080, type:F, retreatCost:3) {
         weakness W
@@ -644,7 +644,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MAGNETON_19:
       return evolution (this, from:"Magnemite", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -661,7 +661,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MAGNETON_20:
       return evolution (this, from:"Magnemite", hp:HP070, type:M, retreatCost:2) {
         weakness R
@@ -682,7 +682,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MOLTRES_21:
       return basic (this, hp:HP080, type:R, retreatCost:2) {
         resistance F, MINUS30
@@ -707,7 +707,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 60
           }
         }
-      };
+      }
       case NIDOQUEEN_22:
       return evolution (this, from:"Nidorina", hp:HP110, type:G, retreatCost:3) {
         weakness P
@@ -724,7 +724,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case OMASTAR_23:
       return evolution (this, from:"Omanyte", hp:HP090, type:W, retreatCost:2) {
         weakness L
@@ -742,7 +742,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PILOSWINE_24:
       return evolution (this, from:"Swinub", hp:HP090, type:W, retreatCost:3) {
         weakness M
@@ -762,7 +762,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case POLITOED_25:
       return evolution (this, from:"Poliwhirl", hp:HP110, type:W, retreatCost:2) {
         weakness G
@@ -790,7 +790,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 70
           }
         }
-      };
+      }
       case POLIWRATH_26:
       return evolution (this, from:"Poliwhirl", hp:HP110, type:F, retreatCost:2) {
         weakness P
@@ -807,7 +807,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAICHU_27:
       return evolution (this, from:"Pikachu", hp:HP080, type:L, retreatCost:1) {
         weakness F
@@ -828,7 +828,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             flip 1, {}, { directDamage 20, self }
           }
         }
-      };
+      }
       case RAIKOU_28:
       return basic (this, hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -845,7 +845,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RHYDON_29:
       return evolution (this, from:"Rhyhorn", hp:HP090, type:F, retreatCost:2) {
         weakness G
@@ -866,7 +866,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case STARMIE_30:
       return evolution (this, from:"Staryu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -886,7 +886,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case STEELIX_31:
       return evolution (this, from:"Onix", hp:HP100, type:M, retreatCost:4) {
         weakness R
@@ -912,7 +912,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case UMBREON_32:
       return evolution (this, from:"Eevee", hp:HP070, type:D, retreatCost:1) {
         weakness F
@@ -930,7 +930,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VAPOREON_33:
       return evolution (this, from:"Eevee", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -955,7 +955,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case WIGGLYTUFF_34:
       return evolution (this, from:"Jigglypuff", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -973,7 +973,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case XATU_35:
       return evolution (this, from:"Natu", hp:HP080, type:P, retreatCost:1) {
         weakness P
@@ -990,7 +990,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ELECTRODE_36:
       return evolution (this, from:"Voltorb", hp:HP070, type:L, retreatCost:1) {
         weakness F
@@ -1010,7 +1010,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 100
           }
         }
-      };
+      }
       case KABUTO_37:
       return evolution (this, from:"Mysterious Fossil", hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -1028,7 +1028,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MACHOKE_38:
       return evolution (this, from:"Machop", hp:HP080, type:F, retreatCost:1) {
         weakness P
@@ -1048,7 +1048,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case MISDREAVUS_39:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1069,7 +1069,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NOCTOWL_40:
       return evolution (this, from:"Hoothoot", hp:HP070, type:C, retreatCost:0) {
         weakness L
@@ -1087,7 +1087,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case OMANYTE_41:
       return evolution (this, from:"Mysterious Fossil", hp:HP060, type:W, retreatCost:1) {
         weakness L
@@ -1108,7 +1108,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PERSIAN_42:
       return evolution (this, from:"Meowth", hp:HP070, type:C, retreatCost:0) {
         weakness F
@@ -1129,7 +1129,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case PILOSWINE_43:
       return evolution (this, from:"Swinub", hp:HP080, type:F, retreatCost:3) {
         weakness G
@@ -1150,7 +1150,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case STARMIE_44:
       return evolution (this, from:"Staryu", hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -1170,7 +1170,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WOBBUFFET_45:
       return basic (this, hp:HP070, type:P, retreatCost:2) {
         weakness P
@@ -1187,7 +1187,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ABRA_46:
       return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -1204,7 +1204,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CLEFFA_48:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:C, retreatCost:0) {
         move "Energy Recycle", {
@@ -1215,7 +1215,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DELIBIRD_49:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -1235,7 +1235,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case DIGLETT_50:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -1248,7 +1248,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case DITTO_51:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1266,7 +1266,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case DUGTRIO_52:
       return evolution (this, from:"Diglett", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -1287,7 +1287,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case DUNSPARCE_53:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1305,7 +1305,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case EEVEE_54:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -1326,7 +1326,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case FARFETCH_D_55:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness L
@@ -1347,7 +1347,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case FORRETRESS_56:
       return evolution (this, from:"Pineco", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1372,7 +1372,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GASTLY_57:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness D
@@ -1385,7 +1385,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case GIRAFARIG_58:
       return basic (this, hp:HP060, type:P, retreatCost:1) {
         weakness P
@@ -1405,7 +1405,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case GLIGAR_59:
       return basic (this, hp:HP060, type:F, retreatCost:1) {
         weakness G
@@ -1425,7 +1425,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case GOLBAT_60:
       return evolution (this, from:"Zubat", hp:HP070, type:G, retreatCost:1) {
         weakness P
@@ -1445,7 +1445,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case GRANBULL_61:
       return evolution (this, from:"Snubbull", hp:HP080, type:C, retreatCost:1) {
         weakness F
@@ -1466,7 +1466,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case GROWLITHE_62:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1486,7 +1486,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case HAUNTER_63:
       return evolution (this, from:"Gastly", hp:HP070, type:P, retreatCost:1) {
         weakness D
@@ -1507,7 +1507,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HERACROSS_64:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness R
@@ -1527,7 +1527,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case HOOTHOOT_65:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness L
@@ -1548,7 +1548,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case HOUNDOUR_66:
       return basic (this, hp:HP050, type:R, retreatCost:1) {
         weakness W
@@ -1568,7 +1568,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case IGGLYBUFF_67:
       return baby (this, successors:'SUCCESSOR(S)', hp:HP030, type:C, retreatCost:0) {
         move "Energy Heal", {
@@ -1579,7 +1579,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case JIGGLYPUFF_68:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -1600,7 +1600,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case KADABRA_69:
       return evolution (this, from:"Abra", hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -1620,7 +1620,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KAKUNA_70:
       return evolution (this, from:"Weedle", hp:HP070, type:G, retreatCost:2) {
         weakness R
@@ -1637,7 +1637,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LAPRAS_71:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness M
@@ -1657,7 +1657,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case LEDYBA_72:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness L
@@ -1678,7 +1678,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case LEDYBA_73:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1698,7 +1698,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MACHOP_74:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness P
@@ -1718,7 +1718,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGIKARP_75:
       return basic (this, hp:HP030, type:W, retreatCost:1) {
         weakness L
@@ -1738,7 +1738,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MAGNEMITE_76:
       return basic (this, hp:HP040, type:L, retreatCost:1) {
         weakness F
@@ -1758,7 +1758,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MANTINE_77:
       return basic (this, hp:HP060, type:W, retreatCost:2) {
         weakness L
@@ -1779,7 +1779,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case MEOWTH_78:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -1792,7 +1792,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case MURKROW_79:
       return basic (this, hp:HP050, type:D, retreatCost:1) {
         weakness L
@@ -1813,7 +1813,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case NATU_80:
       return basic (this, hp:HP050, type:P, retreatCost:1) {
         weakness P
@@ -1833,7 +1833,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_81:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1853,7 +1853,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORAN_FEMALE_82:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -1865,7 +1865,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case NIDORINA_83:
       return evolution (this, from:"Nidoran♀", hp:HP080, type:G, retreatCost:2) {
         weakness P
@@ -1885,7 +1885,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case PIKACHU_84:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -1897,7 +1897,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINECO_85:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -1909,7 +1909,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case PINECO_86:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -1921,7 +1921,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case POLIWAG_87:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness G
@@ -1941,7 +1941,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case POLIWHIRL_88:
       return evolution (this, from:"Poliwag", hp:HP070, type:W, retreatCost:1) {
         weakness G
@@ -1961,7 +1961,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case RATICATE_89:
       return evolution (this, from:"Rattata", hp:HP070, type:C, retreatCost:1) {
         weakness F
@@ -1982,7 +1982,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RATTATA_90:
       return basic (this, hp:HP030, type:C, retreatCost:0) {
         weakness F
@@ -2003,7 +2003,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case RHYHORN_91:
       return basic (this, hp:HP060, type:F, retreatCost:2) {
         weakness G
@@ -2024,7 +2024,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSHREW_92:
       return basic (this, hp:HP040, type:F, retreatCost:1) {
         weakness G
@@ -2045,7 +2045,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SANDSLASH_93:
       return evolution (this, from:"Sandshrew", hp:HP070, type:F, retreatCost:1) {
         weakness G
@@ -2066,7 +2066,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SEEL_94:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2078,7 +2078,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SEEL_95:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2098,7 +2098,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SHUCKLE_96:
       return basic (this, hp:HP030, type:G, retreatCost:2) {
         weakness R
@@ -2115,7 +2115,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SKARMORY_97:
       return basic (this, hp:HP060, type:M, retreatCost:2) {
         weakness R
@@ -2136,7 +2136,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SLUGMA_98:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -2156,7 +2156,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SLUGMA_99:
       return basic (this, hp:HP050, type:R, retreatCost:2) {
         weakness W
@@ -2168,7 +2168,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SNORLAX_100:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness F
@@ -2186,7 +2186,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SNUBBULL_101:
       return basic (this, hp:HP050, type:C, retreatCost:1) {
         weakness F
@@ -2207,7 +2207,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case STANTLER_102:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness F
@@ -2228,7 +2228,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case STARYU_103:
       return basic (this, hp:HP040, type:W, retreatCost:1) {
         weakness L
@@ -2248,7 +2248,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case STARYU_104:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness L
@@ -2268,7 +2268,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SUNFLORA_105:
       return evolution (this, from:"Sunkern", hp:HP070, type:G, retreatCost:1) {
         weakness R
@@ -2289,7 +2289,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case SUNKERN_106:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2310,7 +2310,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case SWINUB_107:
       return basic (this, hp:HP050, type:W, retreatCost:1) {
         weakness M
@@ -2330,7 +2330,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case SWINUB_108:
       return basic (this, hp:HP050, type:F, retreatCost:1) {
         weakness G
@@ -2351,7 +2351,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case TEDDIURSA_109:
       return basic (this, hp:HP040, type:C, retreatCost:1) {
         weakness F
@@ -2372,7 +2372,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case URSARING_110:
       return evolution (this, from:"Teddiursa", hp:HP080, type:C, retreatCost:2) {
         weakness F
@@ -2393,7 +2393,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case VENOMOTH_111:
       return evolution (this, from:"Venonat", hp:HP070, type:G, retreatCost:0) {
         weakness R
@@ -2411,7 +2411,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VENONAT_112:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2431,7 +2431,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case VOLTORB_113:
       return basic (this, hp:HP050, type:L, retreatCost:1) {
         weakness F
@@ -2451,7 +2451,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case WEEDLE_114:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness R
@@ -2463,7 +2463,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case WEEDLE_115:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness R
@@ -2483,7 +2483,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
 
           }
         }
-      };
+      }
       case YANMA_116:
       return basic (this, hp:HP060, type:G, retreatCost:1) {
         weakness L
@@ -2504,7 +2504,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case ZUBAT_117:
       return basic (this, hp:HP040, type:G, retreatCost:1) {
         weakness L
@@ -2525,7 +2525,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ZUBAT_118:
       return basic (this, hp:HP050, type:G, retreatCost:1) {
         weakness P
@@ -2545,7 +2545,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 10
           }
         }
-      };
+      }
       case ANCIENT_RUINS_119:
       return stadium (this) {
         text "Once during each player's turn (before he or she attacks), if he or she has not played a Supporter card, that player may reveal his or her hand to his or her opponent. If that player reveals his or her hand and there is no Supporter card there, that player draws a card."
@@ -2553,7 +2553,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case RELIC_HUNTER_120:
       return supporter (this) {
         text "Search your discard pile for up to 2 Stadium cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2561,7 +2561,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case APRICORN_MAKER_121:
       return supporter (this) {
         text "Search your deck for up to 2 Trainer cards with Ball in their names, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
@@ -2569,7 +2569,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case CRYSTAL_SHARD_122:
       return pokemonTool (this) {
         text "As long as this card is attached to a Pokémon, that Pokémon's type (color) is [C]. If that Pokémon attacks, discard this card at the end of the turn."
@@ -2579,7 +2579,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DESERT_SHAMAN_123:
       return supporter (this) {
         text "Shuffle your hand into your deck and draw up to 4 cards. Your opponent does the same."
@@ -2587,7 +2587,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FAST_BALL_124:
       return basicTrainer (this) {
         text "Reveal cards from your deck until you reveal an Evolution card (excluding Pokémon-ex). Show that card to your opponent and put it into your hand. Shuffle the other revealed cards into your deck. (If you don't reveal an Evolution card, shuffle all the revealed cards back into your deck.)"
@@ -2595,7 +2595,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FISHERMAN_125:
       return supporter (this) {
         text "Choose 4 basic Energy cards from your discard pile (if there are fewer basic Energy cards than 4, take all of them), show them to your opponent, and put them into your hand."
@@ -2603,7 +2603,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case FRIEND_BALL_126:
       return basicTrainer (this) {
         text "Choose 1 of your opponent's Pokémon. Search your deck for a Baby Pokémon, Basic Pokémon, or Evolution card of the same type (color), show it to your opponent, and put it into your hand. Shuffle your deck afterward."
@@ -2611,7 +2611,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case SILVER_127:
       return supporter (this) {
         text "You can't have more than 1 Silver in your deck." +
@@ -2620,7 +2620,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case LURE_BALL_128:
       return basicTrainer (this) {
         text "Flip 3 coins. For each heads, choose an Evolution card from your discard pile, show it to your opponent, and put it into your hand."
@@ -2628,7 +2628,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_ALPHA_129:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Evolved [R], [L], or [F] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere Alpha." +
@@ -2637,7 +2637,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_BETA_130:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Evolved [R], [W], or [P] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere β." +
@@ -2646,7 +2646,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRACLE_SPHERE_GAMMA_131:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Evolved [G], [W], or [L] Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere γ." +
@@ -2655,7 +2655,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MIRAGE_STADIUM_132:
       return stadium (this) {
         text "Whenever a player tries to retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discard Energy normally). If tails, that Pokémon can't retreat this turn (the player doesn't discard any Energy)."
@@ -2663,7 +2663,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case MYSTERY_PLATE_ALPHA_133:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Mystery Plate Alpha." +
@@ -2672,7 +2672,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_BETA_134:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Mystery Plate Beta." +
@@ -2681,7 +2681,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_GAMMA_135:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Mystery Plate Gamma." +
@@ -2690,7 +2690,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_PLATE_DELTA_136:
       return basicTrainer (this) {
         text "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Mystery Plate Delta." +
@@ -2699,7 +2699,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case MYSTERY_ZONE_137:
       return stadium (this) {
         text "This card stays in play when you play it. Discard this card if another Stadium card comes into play." +
@@ -2708,7 +2708,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case ORACLE_138:
       return supporter (this) {
         text "Search your deck for up to 3 Basic Energy cards. Show them to your opponent and discard them. If any number of Oracle are already in your discard pile" +
@@ -2717,7 +2717,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case STAR_PIECE_139:
       return pokemonTool (this) {
         text "At any time between turns, if the Pokémon (exluding Pokémon-ex) this card is attached to is Benched and has 2 or more damage counters on it, search your deck for an Evolution card that Pokémon evolves into and put it on top of that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. Then, discard Star Piece."
@@ -2727,7 +2727,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case UNDERGROUND_EXPEDITION_140:
       return supporter (this) {
         text "Look at the bottom 4 cards of your deck. Put 2 of those cards into your hand, and then return the remaining cards to the bottom of your deck in any order."
@@ -2735,7 +2735,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         playRequirement{
         }
-      };
+      }
       case UNDERGROUND_LAKE_141:
       return stadium (this) {
         text "Once during each player's turn, that player may put an Omanyte or a Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench this way are considered Basic Pokémon.)"
@@ -2743,7 +2743,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         onRemoveFromPlay{
         }
-      };
+      }
       case DOUBLE_COLORLESS_ENERGY_142:
       return specialEnergy (this, [[C]]) {
         text "Provides [C][C] Energy."
@@ -2755,7 +2755,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CYCLONE_ENERGY_143:
       return specialEnergy (this, [[C]]) {
         text "This card provides [C] Energy." +
@@ -2768,7 +2768,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case DNA_ENERGY_144:
       return specialEnergy (this, [[C]]) {
         text "DNA Energy Provides [C] Energy." +
@@ -2781,7 +2781,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
         }
         allowAttach {to->
         }
-      };
+      }
       case CELEBI_145:
       return basic (this, hp:HP060, type:C, retreatCost:1) {
         weakness R
@@ -2806,7 +2806,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case CHARIZARD_146:
       return evolution (this, from:"Charmeleon", hp:HP110, type:C, retreatCost:4) {
         weakness W
@@ -2831,7 +2831,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case CROBAT_147:
       return evolution (this, from:"Golbat", hp:HP080, type:C, retreatCost:0) {
         weakness P
@@ -2856,7 +2856,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case GOLEM_148:
       return evolution (this, from:"Graveler", hp:HP100, type:C, retreatCost:4) {
         weakness W
@@ -2881,7 +2881,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 50
           }
         }
-      };
+      }
       case HO_OH_149:
       return basic (this, hp:HP080, type:C, retreatCost:3) {
         weakness W
@@ -2906,7 +2906,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KABUTOPS_150:
       return evolution (this, from:"Kabuto", hp:HP090, type:C, retreatCost:3) {
         weakness G
@@ -2931,71 +2931,71 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case ALAKAZAM_151:
-      return copy (ALAKAZAM_2, this);
+      return copy (ALAKAZAM_2, this)
       case ARCANINE_152:
-      return copy (ARCANINE_3, this);
+      return copy (ARCANINE_3, this)
       case ARTICUNO_153:
-      return copy (ARTICUNO_4, this);
+      return copy (ARTICUNO_4, this)
       case BEEDRILL_154:
-      return copy (BEEDRILL_5, this);
+      return copy (BEEDRILL_5, this)
       case CROBAT_155:
-      return copy (CROBAT_6, this);
+      return copy (CROBAT_6, this)
       case DEWGONG_156:
-      return copy (DEWGONG_7, this);
+      return copy (DEWGONG_7, this)
       case FLAREON_157:
-      return copy (FLAREON_8, this);
+      return copy (FLAREON_8, this)
       case FORRETRESS_158:
-      return copy (FORRETRESS_9, this);
+      return copy (FORRETRESS_9, this)
       case GENGAR_159:
-      return copy (GENGAR_10, this);
+      return copy (GENGAR_10, this)
       case GYARADOS_160:
-      return copy (GYARADOS_11, this);
+      return copy (GYARADOS_11, this)
       case HOUNDOOM_161:
-      return copy (HOUNDOOM_12, this);
+      return copy (HOUNDOOM_12, this)
       case JOLTEON_162:
-      return copy (JOLTEON_13, this);
+      return copy (JOLTEON_13, this)
       case KABUTOPS_163:
-      return copy (KABUTOPS_14, this);
+      return copy (KABUTOPS_14, this)
       case LEDIAN_164:
-      return copy (LEDIAN_15, this);
+      return copy (LEDIAN_15, this)
       case MACHAMP_165:
-      return copy (MACHAMP_16, this);
+      return copy (MACHAMP_16, this)
       case MAGCARGO_166:
-      return copy (MAGCARGO_17, this);
+      return copy (MAGCARGO_17, this)
       case MAGCARGO_167:
-      return copy (MAGCARGO_18, this);
+      return copy (MAGCARGO_18, this)
       case MAGNETON_168:
-      return copy (MAGNETON_19, this);
+      return copy (MAGNETON_19, this)
       case MAGNETON_169:
-      return copy (MAGNETON_20, this);
+      return copy (MAGNETON_20, this)
       case MOLTRES_170:
-      return copy (MOLTRES_21, this);
+      return copy (MOLTRES_21, this)
       case NIDOQUEEN_171:
-      return copy (NIDOQUEEN_22, this);
+      return copy (NIDOQUEEN_22, this)
       case PILOSWINE_172:
-      return copy (PILOSWINE_24, this);
+      return copy (PILOSWINE_24, this)
       case POLITOED_173:
-      return copy (POLITOED_25, this);
+      return copy (POLITOED_25, this)
       case POLIWRATH_174:
-      return copy (POLIWRATH_26, this);
+      return copy (POLIWRATH_26, this)
       case RAICHU_175:
-      return copy (RAICHU_27, this);
+      return copy (RAICHU_27, this)
       case RAIKOU_176:
-      return copy (RAIKOU_28, this);
+      return copy (RAIKOU_28, this)
       case RHYDON_177:
-      return copy (RHYDON_29, this);
+      return copy (RHYDON_29, this)
       case STARMIE_178:
-      return copy (STARMIE_30, this);
+      return copy (STARMIE_30, this)
       case STEELIX_179:
-      return copy (STEELIX_31, this);
+      return copy (STEELIX_31, this)
       case UMBREON_180:
-      return copy (UMBREON_32, this);
+      return copy (UMBREON_32, this)
       case VAPOREON_181:
-      return copy (VAPOREON_33, this);
+      return copy (VAPOREON_33, this)
       case XATU_182:
-      return copy (XATU_35, this);
+      return copy (XATU_35, this)
       case WOBBUFFET_183:
       return basic (this, hp:HP070, type:P, retreatCost:1) {
         weakness P
@@ -3012,7 +3012,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case SUICUNE_184:
       return basic (this, hp:HP070, type:W, retreatCost:1) {
         weakness L
@@ -3029,7 +3029,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
       case AMPHAROS_EX_185:
       return evolution (this, from:"Flaaffy", hp:HP150, type:L, retreatCost:3) {
         weakness L
@@ -3048,7 +3048,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case KINGDRA_EX_186:
       return evolution (this, from:"Seadra", hp:HP150, type:W, retreatCost:3) {
         weakness G
@@ -3069,7 +3069,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case DRAGONITE_EX_187:
       return evolution (this, from:"Dragonair", hp:HP150, type:C, retreatCost:2) {
         weakness C
@@ -3096,7 +3096,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case GOLEM_EX_188:
       return evolution (this, from:"Graveler", hp:HP150, type:F, retreatCost:3) {
         weakness G
@@ -3117,7 +3117,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 120
           }
         }
-      };
+      }
       case MUK_EX_189:
       return evolution (this, from:"Grimer", hp:HP100, type:G, retreatCost:2) {
         weakness P
@@ -3142,7 +3142,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MAGCARGO_EX_190:
       return evolution (this, from:"Slugma", hp:HP100, type:R, retreatCost:3) {
         weakness W
@@ -3162,7 +3162,7 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 40
           }
         }
-      };
+      }
       case RAYQUAZA_EX_191:
       return basic (this, hp:HP100, type:C, retreatCost:2) {
         weakness C
@@ -3184,9 +3184,9 @@ public enum PokemodSkyridge implements LogicCardInfo {
             damage 30
           }
         }
-      };
+      }
         default:
-      return null;
+      return null
     }
   }
 }

--- a/src/tcgwars/logic/impl/pokemod/PokemodTeamRocket.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodTeamRocket.groovy
@@ -2,37 +2,37 @@ package tcgwars.logic.impl.pokemod
 
 import tcgwars.logic.effect.gm.PlayCard
 import tcgwars.logic.effect.gm.PlayTrainer
-import tcgwars.logic.impl.gen1.TeamRocket;
+import tcgwars.logic.impl.gen1.TeamRocket
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 
 /**
  * @author TheAquaPiplup
@@ -151,53 +151,53 @@ public enum PokemodTeamRocket implements LogicCardInfo {
   ROCKETS_SCYTHER_EX_108 ("Rocket's Scyther ex", "108", Rarity.ULTRARARE, [BASIC, ]),
   ROCKETS_SNORLAX_EX_109 ("Rocket's Snorlax ex", "109", Rarity.ULTRARARE, [BASIC, ]);
 
-    static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+    static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   PokemodTeamRocket(String name, String collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[])
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_TEAM_ROCKET;
+    return tcgwars.logic.card.Collection.POKEMOD_TEAM_ROCKET
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
@@ -226,7 +226,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_ARBOK_2:
         return evolution (this, from:"Ekans", hp:HP060, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -265,7 +265,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_BLASTOISE_3:
         return evolution (this, from:"Dark Wartortle", hp:HP080, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -291,9 +291,9 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_CHARIZARD_4:
-        return copy (TeamRocket.DARK_CHARIZARD_4, this);
+        return copy (TeamRocket.DARK_CHARIZARD_4, this)
       case DARK_DRAGONITE_5:
         return evolution (this, from:"Dark Dragonair", hp:HP080, type:COLORLESS, retreatCost:2) {
           resistance FIGHTING, MINUS30
@@ -321,7 +321,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DUGTRIO_6:
         return evolution (this, from:"Diglett", hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness GRASS
@@ -347,9 +347,9 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GOLBAT_7:
-        return copy (TeamRocket.DARK_GOLBAT_7, this);
+        return copy (TeamRocket.DARK_GOLBAT_7, this)
       case DARK_GYARADOS_8:
         return evolution (this, from:"Magikarp", hp:HP070, type:WATER, retreatCost:2) {
           weakness LIGHTNING
@@ -380,7 +380,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_HYPNO_9:
         return evolution (this, from:"Drowzee", hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -401,7 +401,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MACHAMP_10:
         return evolution (this, from:"Dark Machoke", hp:HP080, type:FIGHTING, retreatCost:3) {
           weakness PSYCHIC
@@ -425,7 +425,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MAGNETON_11:
         return evolution (this, from:"Magnemite", hp:HP060, type:LIGHTNING, retreatCost:2) {
           weakness FIGHTING
@@ -450,7 +450,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_SLOWBRO_12:
         return evolution (this, from:"Slowpoke", hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -471,7 +471,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_VILEPLUME_13:
         return evolution (this, from:"Dark Gloom", hp:HP060, type:GRASS, retreatCost:2) {
           weakness FIRE
@@ -502,7 +502,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_WEEZING_14:
         return evolution (this, from:"Koffing", hp:HP060, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -535,9 +535,9 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case HERE_COMES_TEAM_ROCKET_15:
-        return copy (TeamRocket.HERE_COMES_TEAM_ROCKET_15, this);
+        return copy (TeamRocket.HERE_COMES_TEAM_ROCKET_15, this)
       case ROCKETS_SNEAK_ATTACK_16:
         return basicTrainer (this) {
           text "Look at your opponent’s hand. If he or she has any Trainer cards, choose 1 of them. Your opponent shuffles that card into his or her deck."
@@ -551,37 +551,37 @@ public enum PokemodTeamRocket implements LogicCardInfo {
           playRequirement{
             assert opp.hand
           }
-        };
+        }
       case RAINBOW_ENERGY_17:
-        return copy (TeamRocket.RAINBOW_ENERGY_17, this);
+        return copy (TeamRocket.RAINBOW_ENERGY_17, this)
       case DARK_ALAKAZAM_18:
-        return copy (DARK_ALAKAZAM_1, this);
+        return copy (DARK_ALAKAZAM_1, this)
       case DARK_ARBOK_19:
-        return copy (DARK_ARBOK_2, this);
+        return copy (DARK_ARBOK_2, this)
       case DARK_BLASTOISE_20:
-        return copy (DARK_BLASTOISE_3, this);
+        return copy (DARK_BLASTOISE_3, this)
       case DARK_CHARIZARD_21:
-        return copy (TeamRocket.DARK_CHARIZARD_4, this);
+        return copy (TeamRocket.DARK_CHARIZARD_4, this)
       case DARK_DRAGONITE_22:
-        return copy (DARK_DRAGONITE_5, this);
+        return copy (DARK_DRAGONITE_5, this)
       case DARK_DUGTRIO_23:
-        return copy (DARK_DUGTRIO_6, this);
+        return copy (DARK_DUGTRIO_6, this)
       case DARK_GOLBAT_24:
-        return copy (TeamRocket.DARK_GOLBAT_7, this);
+        return copy (TeamRocket.DARK_GOLBAT_7, this)
       case DARK_GYARADOS_25:
-        return copy (DARK_GYARADOS_8, this);
+        return copy (DARK_GYARADOS_8, this)
       case DARK_HYPNO_26:
-        return copy (DARK_HYPNO_9, this);
+        return copy (DARK_HYPNO_9, this)
       case DARK_MACHAMP_27:
-        return copy (DARK_MACHAMP_10, this);
+        return copy (DARK_MACHAMP_10, this)
       case DARK_MAGNETON_28:
-        return copy (DARK_MAGNETON_11, this);
+        return copy (DARK_MAGNETON_11, this)
       case DARK_SLOWBRO_29:
-        return copy (DARK_SLOWBRO_12, this);
+        return copy (DARK_SLOWBRO_12, this)
       case DARK_VILEPLUME_30:
-        return copy (DARK_VILEPLUME_13, this);
+        return copy (DARK_VILEPLUME_13, this)
       case DARK_WEEZING_31:
-        return copy (DARK_WEEZING_14, this);
+        return copy (DARK_WEEZING_14, this)
       case DARK_CHARMELEON_32:
         return evolution (this, from:"Charmander", hp:HP060, type:FIRE, retreatCost:2) {
           weakness WATER
@@ -607,9 +607,9 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_DRAGONAIR_33:
-        return copy (TeamRocket.DARK_DRAGONAIR, this);
+        return copy (TeamRocket.DARK_DRAGONAIR, this)
       case DARK_ELECTRODE_34:
         return evolution (this, from:"Voltorb", hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -638,7 +638,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_FLAREON_35:
         return evolution (this, from:"Eevee", hp:HP060, type:FIRE, retreatCost:1) {
           weakness WATER
@@ -666,11 +666,11 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_GLOOM_36:
-        return copy (TeamRocket.DARK_GLOOM, this);
+        return copy (TeamRocket.DARK_GLOOM, this)
       case DARK_GOLDUCK_37:
-        return copy (TeamRocket.DARK_GOLDUCK, this);
+        return copy (TeamRocket.DARK_GOLDUCK, this)
       case DARK_JOLTEON_38:
         return evolution (this, from:"Eevee", hp:HP060, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -693,7 +693,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_KADABRA_39:
         return evolution (this, from:"Abra", hp:HP060, type:PSYCHIC, retreatCost:2) {
           weakness PSYCHIC
@@ -719,7 +719,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MACHOKE_40:
         return evolution (this, from:"Machop", hp:HP060, type:FIGHTING, retreatCost:2) {
           weakness PSYCHIC
@@ -748,7 +748,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_MUK_41:
         return evolution (this, from:"Grimer", hp:HP060, type:GRASS, retreatCost:2) {
           weakness PSYCHIC
@@ -770,7 +770,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PERSIAN_42:
         return evolution (this, from:"Meowth", hp:HP060, type:COLORLESS, retreatCost:0) {
           weakness FIGHTING
@@ -798,7 +798,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_PRIMEAPE_43:
         return evolution (this, from:"Mankey", hp:HP060, type:FIGHTING, retreatCost:1) {
           weakness PSYCHIC
@@ -827,7 +827,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_RAPIDASH_44:
         return evolution (this, from:"Ponyta", hp:HP060, type:FIRE, retreatCost:0) {
           weakness WATER
@@ -852,7 +852,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
               }
             }
           }
-        };
+        }
       case DARK_VAPOREON_45:
         return evolution (this, from:"Eevee", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -873,7 +873,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case DARK_WARTORTLE_46:
         return evolution (this, from:"Squirtle", hp:HP060, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -917,7 +917,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MAGIKARP_47:
         return basic (this, hp:HP030, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -943,7 +943,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case PORYGON_48:
         return basic (this, hp:HP040, type:COLORLESS, retreatCost:0) {
           resistance PSYCHIC, MINUS30
@@ -988,21 +988,21 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case ABRA_49:
-        return copy (TeamRocket.ABRA, this);
+        return copy (TeamRocket.ABRA, this)
       case CHARMANDER_50:
-        return copy (TeamRocket.CHARMANDER, this);
+        return copy (TeamRocket.CHARMANDER, this)
       case DARK_RATICATE_51:
-        return copy (TeamRocket.DARK_RATICATE, this);
+        return copy (TeamRocket.DARK_RATICATE, this)
       case DIGLETT_52:
-        return copy (TeamRocket.DIGLETT, this);
+        return copy (TeamRocket.DIGLETT, this)
       case DRATINI_53:
-        return copy (TeamRocket.DRATINI, this);
+        return copy (TeamRocket.DRATINI, this)
       case DROWZEE_54:
-        return copy (TeamRocket.DROWZEE, this);
+        return copy (TeamRocket.DROWZEE, this)
       case EEVEE_55:
-        return copy (TeamRocket.EEVEE, this);
+        return copy (TeamRocket.EEVEE, this)
       case EKANS_56:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1024,7 +1024,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case GRIMER_57:
         return basic (this, hp:HP050, type:GRASS, retreatCost:1) {
           weakness PSYCHIC
@@ -1049,11 +1049,11 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case KOFFING_58:
-        return copy (TeamRocket.KOFFING, this);
+        return copy (TeamRocket.KOFFING, this)
       case MACHOP_59:
-        return copy (TeamRocket.MACHOP, this);
+        return copy (TeamRocket.MACHOP, this)
       case MAGNEMITE_60:
         return basic (this, hp:HP040, type:LIGHTNING, retreatCost:1) {
           weakness FIGHTING
@@ -1074,21 +1074,21 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case MANKEY_61:
-        return copy (TeamRocket.MANKEY, this);
+        return copy (TeamRocket.MANKEY, this)
       case MEOWTH_62:
-        return copy (TeamRocket.MEOWTH, this);
+        return copy (TeamRocket.MEOWTH, this)
       case ODDISH_63:
-        return copy (TeamRocket.ODDISH, this);
+        return copy (TeamRocket.ODDISH, this)
       case PONYTA_64:
-        return copy (TeamRocket.PONYTA, this);
+        return copy (TeamRocket.PONYTA, this)
       case PSYDUCK_65:
-        return copy (TeamRocket.PSYDUCK, this);
+        return copy (TeamRocket.PSYDUCK, this)
       case RATTATA_66:
-        return copy (TeamRocket.RATTATA, this);
+        return copy (TeamRocket.RATTATA, this)
       case SLOWPOKE_67:
-        return copy (TeamRocket.SLOWPOKE, this);
+        return copy (TeamRocket.SLOWPOKE, this)
       case SQUIRTLE_68:
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness LIGHTNING
@@ -1101,37 +1101,37 @@ public enum PokemodTeamRocket implements LogicCardInfo {
             }
           }
 
-        };
+        }
       case VOLTORB_69:
-        return copy (TeamRocket.VOLTORB, this);
+        return copy (TeamRocket.VOLTORB, this)
       case ZUBAT_70:
-        return copy (TeamRocket.ZUBAT, this);
+        return copy (TeamRocket.ZUBAT, this)
       case HERE_COMES_TEAM_ROCKET_71:
-        return copy (TeamRocket.HERE_COMES_TEAM_ROCKET_15, this);
+        return copy (TeamRocket.HERE_COMES_TEAM_ROCKET_15, this)
       case ROCKETS_SNEAK_ATTACK_72:
-        return copy (ROCKETS_SNEAK_ATTACK_16, this);
+        return copy (ROCKETS_SNEAK_ATTACK_16, this)
       case THE_BOSSS_WAY_73:
-        return copy (TeamRocket.THE_BOSSS_WAY, this);
+        return copy (TeamRocket.THE_BOSSS_WAY, this)
       case CHALLENGE_74:
         break
       case DIGGER_75:
-        return copy (TeamRocket.DIGGER, this);
+        return copy (TeamRocket.DIGGER, this)
       case IMPOSTER_OAKS_REVENGE_76:
         break
       case NIGHTLY_GARBAGE_RUN_77:
-        return copy (TeamRocket.NIGHTLY_GARBAGE_RUN, this);
+        return copy (TeamRocket.NIGHTLY_GARBAGE_RUN, this)
       case GOOP_GAS_ATTACK_78:
         break
       case SLEEP_79:
-        return copy (TeamRocket.SLEEP, this);
+        return copy (TeamRocket.SLEEP, this)
       case RAINBOW_ENERGY_80:
-        return copy (TeamRocket.RAINBOW_ENERGY_17, this);
+        return copy (TeamRocket.RAINBOW_ENERGY_17, this)
       case FULL_HEAL_ENERGY_81:
-        return copy (TeamRocket.FULL_HEAL_ENERGY, this);
+        return copy (TeamRocket.FULL_HEAL_ENERGY, this)
       case POTION_ENERGY_82:
-        return copy (TeamRocket.POTION_ENERGY, this);
+        return copy (TeamRocket.POTION_ENERGY, this)
       case DARK_RAICHU_83:
-        return copy (TeamRocket.DARK_RAICHU, this);
+        return copy (TeamRocket.DARK_RAICHU, this)
       case BOOST_ENERGY_84:
         break
       case SCRAMBLE_ENERGY_85:
@@ -1154,7 +1154,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
           playRequirement{
             assert my.deck
           }
-        };
+        }
         //make so coinflip
       case POKEMON_RETRIVER_90:
         return basicTrainer (this) {
@@ -1172,7 +1172,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
           playRequirement{
             assert my.discard.filterByType(BASIC, EVOLUTION)
           }
-        };
+        }
       case POW_HAND_EXTENTION_91:
         break
       case SURPRISE_TIME_MACHINE_92:
@@ -1212,7 +1212,7 @@ public enum PokemodTeamRocket implements LogicCardInfo {
       case ROCKETS_SNORLAX_EX_109:
         break
       default:
-        return null;
+        return null
     }
   }
 

--- a/src/tcgwars/logic/impl/pokemod/PokemodWizardsBlackStarPromos.groovy
+++ b/src/tcgwars/logic/impl/pokemod/PokemodWizardsBlackStarPromos.groovy
@@ -3,37 +3,37 @@ package tcgwars.logic.impl.pokemod
 import tcgwars.logic.impl.gen1.WizardsBlackStarPromos
 
 import tcgwars.logic.effect.gm.PlayCard
-import tcgwars.logic.effect.gm.PlayTrainer;
+import tcgwars.logic.effect.gm.PlayTrainer
 
-import static tcgwars.logic.card.HP.*;
-import static tcgwars.logic.card.Type.*;
-import static tcgwars.logic.card.CardType.*;
-import static tcgwars.logic.groovy.TcgBuilders.*;
+import static tcgwars.logic.card.HP.*
+import static tcgwars.logic.card.Type.*
+import static tcgwars.logic.card.CardType.*
+import static tcgwars.logic.groovy.TcgBuilders.*
 import static tcgwars.logic.groovy.TcgStatics.*
 import static tcgwars.logic.effect.ability.Ability.ActivationReason.*
-import static tcgwars.logic.effect.EffectType.*;
-import static tcgwars.logic.effect.Source.*;
+import static tcgwars.logic.effect.EffectType.*
+import static tcgwars.logic.effect.Source.*
 import static tcgwars.logic.effect.EffectPriority.*
 import static tcgwars.logic.effect.special.SpecialConditionType.*
 import static tcgwars.logic.card.Resistance.ResistanceType.*
 
-import java.util.*;
-import org.apache.commons.lang.WordUtils;
-import tcgwars.entity.*;
-import tcgwars.logic.*;
-import tcgwars.logic.card.*;
-import tcgwars.logic.card.energy.*;
-import tcgwars.logic.card.pokemon.*;
-import tcgwars.logic.card.trainer.*;
-import tcgwars.logic.effect.*;
-import tcgwars.logic.effect.ability.*;
-import tcgwars.logic.effect.advanced.*;
-import tcgwars.logic.effect.basic.*;
-import tcgwars.logic.effect.blocking.*;
-import tcgwars.logic.effect.event.*;
-import tcgwars.logic.effect.getter.*;
-import tcgwars.logic.effect.special.*;
-import tcgwars.logic.util.*;
+import java.util.*
+import org.apache.commons.lang.WordUtils
+import tcgwars.entity.*
+import tcgwars.logic.*
+import tcgwars.logic.card.*
+import tcgwars.logic.card.energy.*
+import tcgwars.logic.card.pokemon.*
+import tcgwars.logic.card.trainer.*
+import tcgwars.logic.effect.*
+import tcgwars.logic.effect.ability.*
+import tcgwars.logic.effect.advanced.*
+import tcgwars.logic.effect.basic.*
+import tcgwars.logic.effect.blocking.*
+import tcgwars.logic.effect.event.*
+import tcgwars.logic.effect.getter.*
+import tcgwars.logic.effect.special.*
+import tcgwars.logic.util.*
 /**
  * @author axpendix@hotmail.com
  */
@@ -93,78 +93,78 @@ public enum PokemodWizardsBlackStarPromos implements LogicCardInfo {
   HO_OH_52 ("Ho-oh", "52", Rarity.PROMO, BASIC, POKEMON, _FIRE_),
   SUICUNE_53 ("Suicune", "53", Rarity.PROMO, BASIC, POKEMON, _WATER_);
 
-  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON
 
-  protected CardTypeSet cardTypes;
-  protected String name;
-  protected Rarity rarity;
-  protected String collectionLineNo;
+  protected CardTypeSet cardTypes
+  protected String name
+  protected Rarity rarity
+  protected String collectionLineNo
 
   private WizardsBlackStarPromos(String name, String collectionLineNo, Rarity rarity, CardType... cardTypes) {
-    this.cardTypes = new CardTypeSet(cardTypes);
-    this.name = name;
-    this.rarity = rarity;
-    this.collectionLineNo = collectionLineNo;
+    this.cardTypes = new CardTypeSet(cardTypes)
+    this.name = name
+    this.rarity = rarity
+    this.collectionLineNo = collectionLineNo
   }
 
   @Override
   public CardTypeSet getCardTypes() {
-    return cardTypes;
+    return cardTypes
   }
 
   @Override
   public String getName() {
-    return name;
+    return name
   }
 
   @Override
   public Rarity getRarity() {
-    return rarity;
+    return rarity
   }
 
   @Override
   public String getNumber() {
-    return collectionLineNo;
+    return collectionLineNo
   }
 
   @Override
   public tcgwars.logic.card.Collection getCollection() {
-    return tcgwars.logic.card.Collection.POKEMOD_PROMOS;
+    return tcgwars.logic.card.Collection.POKEMOD_PROMOS
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%s", this.name(), this.getCollection().name());
+    return String.format("%s:%s", this.name(), this.getCollection().name())
   }
 
   @Override
   public String getEnumName() {
-    return this.name();
+    return this.name()
   }
 
   @Override
    public Card getImplementation() {
       switch (this) {
       case PIKACHU_1:
-       return copy (WizardsBlackStarPromos.PIKACHU_1, this);
+       return copy (WizardsBlackStarPromos.PIKACHU_1, this)
       case ELECTABUZZ_2:
        break
       case MEWTWO_3:
-       return copy (WizardsBlackStarPromos.MEWTWO_3, this);
+       return copy (WizardsBlackStarPromos.MEWTWO_3, this)
       case PIKACHU_4:
-       return copy (WizardsBlackStarPromos.PIKACHU_4, this);
+       return copy (WizardsBlackStarPromos.PIKACHU_4, this)
       case DRAGONITE_5:
-       return copy (WizardsBlackStarPromos.DRAGONITE_5, this);
+       return copy (WizardsBlackStarPromos.DRAGONITE_5, this)
       case ARCANINE_6:
-       return copy (WizardsBlackStarPromos.ARCANINE_6, this);
+       return copy (WizardsBlackStarPromos.ARCANINE_6, this)
       case JIGGLYPUFF_7:
-       return copy (WizardsBlackStarPromos.JIGGLYPUFF_7, this);
+       return copy (WizardsBlackStarPromos.JIGGLYPUFF_7, this)
       case MEW_8:
        break
       case MEW_9:
        break
       case MEOWTH_10:
-       return copy (WizardsBlackStarPromos.MEOWTH_10, this);
+       return copy (WizardsBlackStarPromos.MEOWTH_10, this)
       case EEVEE_11:
        return basic (this, hp:HP030, type:C, retreatCost:0) {
         weakness F
@@ -183,61 +183,61 @@ public enum PokemodWizardsBlackStarPromos implements LogicCardInfo {
             damage 20
           }
         }
-      };
+      }
       case MEWTWO_12:
-       return copy (WizardsBlackStarPromos.MEWTWO_12, this);
+       return copy (WizardsBlackStarPromos.MEWTWO_12, this)
       case VENUSAUR_13:
-       return copy (WizardsBlackStarPromos.VENUSAUR_13, this);
+       return copy (WizardsBlackStarPromos.VENUSAUR_13, this)
       case MEWTWO_14:
-       return copy (WizardsBlackStarPromos.MEWTWO_14, this);
+       return copy (WizardsBlackStarPromos.MEWTWO_14, this)
       case COOL_PORYGON_15:
-       return copy (WizardsBlackStarPromos.COOL_PORYGON_15, this);
+       return copy (WizardsBlackStarPromos.COOL_PORYGON_15, this)
       case COMPUTER_ERROR_16:
-       return copy (WizardsBlackStarPromos.COMPUTER_ERROR_16, this);
+       return copy (WizardsBlackStarPromos.COMPUTER_ERROR_16, this)
       case DARK_PERSIAN_17:
-       return copy (WizardsBlackStarPromos.DARK_PERSIAN_17, this);
+       return copy (WizardsBlackStarPromos.DARK_PERSIAN_17, this)
       case TEAM_ROCKET_S_MEOWTH_18:
-       return copy (WizardsBlackStarPromos.TEAM_ROCKET_S_MEOWTH_18, this);
+       return copy (WizardsBlackStarPromos.TEAM_ROCKET_S_MEOWTH_18, this)
       case SABRINA_S_ABRA_19:
-       return copy (WizardsBlackStarPromos.SABRINA_S_ABRA_19, this);
+       return copy (WizardsBlackStarPromos.SABRINA_S_ABRA_19, this)
       case PSYDUCK_20:
-       return copy (PokemodFossil.PSYDUCK_53, this);
+       return copy (PokemodFossil.PSYDUCK_53, this)
       case MOLTRES_21:
-       return copy (WizardsBlackStarPromos.MOLTRES_21, this);
+       return copy (WizardsBlackStarPromos.MOLTRES_21, this)
       case ARTICUNO_22:
-       return copy (WizardsBlackStarPromos.ARTICUNO_22, this);
+       return copy (WizardsBlackStarPromos.ARTICUNO_22, this)
       case ZAPDOS_23:
-       return copy (WizardsBlackStarPromos.ZAPDOS_23, this);
+       return copy (WizardsBlackStarPromos.ZAPDOS_23, this)
       case BIRTHDAY_PIKACHU_24:
-       return copy (WizardsBlackStarPromos.BIRTHDAY_PIKACHU_24, this);
+       return copy (WizardsBlackStarPromos.BIRTHDAY_PIKACHU_24, this)
       case FLYING_PIKACHU_25:
-       return copy (WizardsBlackStarPromos.FLYING_PIKACHU_25, this);
+       return copy (WizardsBlackStarPromos.FLYING_PIKACHU_25, this)
       case PIKACHU_26:
-       return copy (WizardsBlackStarPromos.PIKACHU_26, this);
+       return copy (WizardsBlackStarPromos.PIKACHU_26, this)
       case PIKACHU_27:
-       return copy (WizardsBlackStarPromos.PIKACHU_27, this);
+       return copy (WizardsBlackStarPromos.PIKACHU_27, this)
       case SURFING_PIKACHU_28:
-       return copy (WizardsBlackStarPromos.SURFING_PIKACHU_28, this);
+       return copy (WizardsBlackStarPromos.SURFING_PIKACHU_28, this)
       case MARILL_29:
-       return copy (WizardsBlackStarPromos.MARILL_29, this);
+       return copy (WizardsBlackStarPromos.MARILL_29, this)
       case TOGEPI_30:
-       return copy (WizardsBlackStarPromos.TOGEPI_30, this);
+       return copy (WizardsBlackStarPromos.TOGEPI_30, this)
       case CLEFFA_31:
-       return copy (WizardsBlackStarPromos.CLEFFA_31, this);
+       return copy (WizardsBlackStarPromos.CLEFFA_31, this)
       case SMEARGLE_32:
-       return copy (WizardsBlackStarPromos.SMEARGLE_32, this);
+       return copy (WizardsBlackStarPromos.SMEARGLE_32, this)
       case SCIZOR_33:
-       return copy (WizardsBlackStarPromos.SCIZOR_33, this);
+       return copy (WizardsBlackStarPromos.SCIZOR_33, this)
       case ENTEI_34:
        break
       case PICHU_35:
-       return copy (WizardsBlackStarPromos.PICHU_35, this);
+       return copy (WizardsBlackStarPromos.PICHU_35, this)
       case IGGLYBUFF_36:
-       return copy (WizardsBlackStarPromos.IGGLYBUFF_36, this);
+       return copy (WizardsBlackStarPromos.IGGLYBUFF_36, this)
       case HITMONTOP_37:
-       return copy (WizardsBlackStarPromos.HITMONTOP_37, this);
+       return copy (WizardsBlackStarPromos.HITMONTOP_37, this)
       case UNOWN_J_38:
-       return copy (WizardsBlackStarPromos.UNOWN_J_38, this);
+       return copy (WizardsBlackStarPromos.UNOWN_J_38, this)
       case MISDREAVUS_39:
        return basic (this, hp:HP050, type:P, retreatCost:1) {
          weakness DARKNESS
@@ -259,21 +259,21 @@ public enum PokemodWizardsBlackStarPromos implements LogicCardInfo {
             flip { apply CONFUSED }
           }
         }
-      };
+      }
       case POKEMON_CENTER_40:
-       return copy (WizardsBlackStarPromos.POKEMON_CENTER_40, this);
+       return copy (WizardsBlackStarPromos.POKEMON_CENTER_40, this)
       case LUCKY_STADIUM_41:
-       return copy (WizardsBlackStarPromos.LUCKY_STADIUM_41, this);
+       return copy (WizardsBlackStarPromos.LUCKY_STADIUM_41, this)
       case POKEMON_TOWER_42:
-       return copy (WizardsBlackStarPromos.POKEMON_TOWER_42, this);
+       return copy (WizardsBlackStarPromos.POKEMON_TOWER_42, this)
       case MACHAMP_43:
-       return copy (WizardsBlackStarPromos.MACHAMP_43, this);
+       return copy (WizardsBlackStarPromos.MACHAMP_43, this)
       case MAGMAR_44:
-       return copy (WizardsBlackStarPromos.MAGMAR_44, this);
+       return copy (WizardsBlackStarPromos.MAGMAR_44, this)
       case SCYTHER_45:
-       return copy (WizardsBlackStarPromos.SCYTHER_45, this);
+       return copy (WizardsBlackStarPromos.SCYTHER_45, this)
       case ELECTABUZZ_46:
-       return copy (WizardsBlackStarPromos.ELECTABUZZ_46, this);
+       return copy (WizardsBlackStarPromos.ELECTABUZZ_46, this)
       case MEW_47:
        return basic (this, hp:HP040, type:P, retreatCost:1) {
         weakness P
@@ -307,21 +307,21 @@ public enum PokemodWizardsBlackStarPromos implements LogicCardInfo {
             flip { apply CONFUSED }
           }
         }
-      };
+      }
       case ARTICUNO_48:
        break
       case SNORLAX_49:
        break
       case CELEBI_50:
-       return copy (WizardsBlackStarPromos.CELEBI_50, this);
+       return copy (WizardsBlackStarPromos.CELEBI_50, this)
       case RAPIDASH_51:
-       return copy (WizardsBlackStarPromos.RAPIDASH_51, this);
+       return copy (WizardsBlackStarPromos.RAPIDASH_51, this)
       case HO_OH_52:
-       return copy (WizardsBlackStarPromos.HO_OH_52, this);
+       return copy (WizardsBlackStarPromos.HO_OH_52, this)
       case SUICUNE_53:
-       return copy (WizardsBlackStarPromos.SUICUNE_53, this);
+       return copy (WizardsBlackStarPromos.SUICUNE_53, this)
       default:
-    return null;
+    return null
     }
   }
 }


### PR DESCRIPTION
Legacy from really old commits from years ago, that trigger over 20k warnings across multiple IDEs (could be ignored, but it's honestly unnecessary additions in these files)

No logic changes, all automatically pruned via IntelliJ.

Requires https://github.com/axpendix/tcgone/pull/220 to be merged