### PR TITLE
Drag Off/Sleep Inducer-type attack fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
+++ b/src/tcgwars/logic/impl/gen3/CrystalGuardians.groovy
@@ -1938,13 +1938,16 @@ public enum CrystalGuardians implements LogicCardInfo {
         weakness P
         move "Drag Off", {
           text "30 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+          //If switch is chosen, damage is only inflicted if the switch is successful.
           energyCost F, C
           onAttack {
-            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-              switchYourOpponentsBenchedWithActive()
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                damage 30 
+              }
+            } else {
+              damage 30
             }
-
-            damage 30
           }
         }
         move "Burn Away", {

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -908,7 +908,7 @@ public enum DeltaSpecies implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
+            if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
               apply ASLEEP
             }
           }

--- a/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
+++ b/src/tcgwars/logic/impl/gen3/DeltaSpecies.groovy
@@ -905,11 +905,12 @@ public enum DeltaSpecies implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
           energyCost C
           attackRequirement{
-            assert opp.bench : "There is no Pokémon on your opponent's bench"
+            assertOppBench()
           }
           onAttack {
-            def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( sw2(target) ) { apply ASLEEP, target }
+            if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
+              apply ASLEEP
+            }
           }
         }
         move "Psyshot", {

--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -233,10 +233,13 @@ public enum Deoxys implements LogicCardInfo {
             text "20 damage. Before doing damage, you may choose 1 of your opponent’s Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
             energyCost G
             onAttack {
-              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-                switchYourOpponentsBenchedWithActive()
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 20 
+                }
+              } else {
+                damage 20
               }
-              damage 20
             }
           }
           move "Cutting Wind", {
@@ -2738,10 +2741,13 @@ public enum Deoxys implements LogicCardInfo {
             text "20 damage. Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
             energyCost C, C
             onAttack {
-              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-                switchYourOpponentsBenchedWithActive()
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 20 
+                }
+              } else {
+                damage 20
               }
-              damage 20
             }
           }
           move "Darkness Blast", {

--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -235,15 +235,16 @@ public enum DragonFrontiers implements LogicCardInfo {
         }
         move "Drag Off", {
           text "20 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
+          //If switch is chosen, damage is only inflicted if the switch is successful.
           energyCost C, C
           onAttack {
-            if(opp.bench){
-              if(confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")){
-                def target = opp.bench.select()
-                sw2(target)
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                damage 20 
               }
+            } else {
+              damage 20
             }
-            damage 20
           }
         }
         move "Sharp Fang", {

--- a/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
+++ b/src/tcgwars/logic/impl/gen3/FireRedLeafGreen.groovy
@@ -1748,11 +1748,12 @@ public enum FireRedLeafGreen implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
             energyCost C
             attackRequirement {
-              assert opp.bench : "There is no Pokémon to switch"
+              assertOppBench()
             }
             onAttack {
-              def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( sw2(target) ) { apply ASLEEP, target }
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+              }
             }
           }
           move "Quick Blow", {

--- a/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
+++ b/src/tcgwars/logic/impl/gen3/LegendMaker.groovy
@@ -949,11 +949,14 @@ public enum LegendMaker implements LogicCardInfo {
         move "Drag Off", {
           text "10 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost C
-          onAttack{
-            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-              switchYourOpponentsBenchedWithActive()
+          onAttack {
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                damage 10 
+              }
+            } else {
+              damage 10
             }
-            damage 10
           }
         }
         move "Hydro Splash", {
@@ -1540,11 +1543,12 @@ public enum LegendMaker implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Poisoned."
           energyCost C
           attackRequirement{
-            assert opp.bench : "Your opponent has no benched Pokémon"
+            assertOppBench()
           }
           onAttack {
-            def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
-            if ( sw2(target) ) { apply POISONED, target }
+            if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+              apply POISONED
+            }
           }
         }
       };
@@ -2105,7 +2109,7 @@ public enum LegendMaker implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost C
           attackRequirement {
-            assert opp.bench : "There is no Pokémon on your opponent's bench"
+            assertOppBench()
           }
           onAttack {
             switchYourOpponentsBenchedWithActive()

--- a/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
+++ b/src/tcgwars/logic/impl/gen3/PowerKeepers.groovy
@@ -391,11 +391,13 @@ public enum PowerKeepers implements LogicCardInfo {
           text "20 damage. Before doing damage, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost F, C
           onAttack {
-            if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
-              def target = opp.bench.select("Select the new Active Pokémon.")
-              sw2(target)
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                damage 20 
+              }
+            } else {
+              damage 20
             }
-            damage 20
           }
         }
         move "Blinding Scythe", {

--- a/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
+++ b/src/tcgwars/logic/impl/gen3/TeamRocketReturns.groovy
@@ -2711,10 +2711,13 @@ public enum TeamRocketReturns implements LogicCardInfo {
             text "10 damage. Before doing damage, you may switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon. If you do, this attack does 10 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
             energyCost D
             onAttack {
-              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-                switchYourOpponentsBenchedWithActive()
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 10 
+                }
+              } else {
+                damage 10
               }
-              damage 10
             }
           }
           move "Dark Ring", {

--- a/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
+++ b/src/tcgwars/logic/impl/gen3/UnseenForces.groovy
@@ -292,14 +292,14 @@ public enum UnseenForces implements LogicCardInfo {
           text "The Defending Pokémon is now Asleep and Poisoned. Before applying this effect, you may switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. If you do, the new Defending Pokémon is now Asleep and Poisoned. Your opponent chooses the Defending Pokémon to switch."
           energyCost G
           onAttack {
-            def pcs = defending
-            if(opp.bench && confirm("Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon?")){
-              def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( sw2(target) ) { pcs = target }
-            }
-            targeted(pcs) {
-              apply ASLEEP, pcs
-              apply POISONED, pcs
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+                apply POISONED
+              }
+            } else {
+              apply ASLEEP
+              apply POISONED
             }
           }
         }
@@ -820,10 +820,13 @@ public enum UnseenForces implements LogicCardInfo {
           text "20 damage. Before doing damage, you may switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. If you do, this attack does 20 damage to the new Defending Pokémon. Your opponent chooses the Defending Pokémon to switch."
           energyCost C, C
           onAttack {
-            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-              switchYourOpponentsBenchedWithActive()
+            if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                damage 20 
+              }
+            } else {
+              damage 20
             }
-            damage 20
           }
         }
         move "Rock Smash", {
@@ -1145,11 +1148,12 @@ public enum UnseenForces implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Asleep."
           energyCost C
           attackRequirement{
-            assert opp.bench : "Your opponent has no Benched Pokémon."
+            assertOppBench()
           }
           onAttack {
-            def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( sw2(target) ) { apply ASLEEP, target }
+            if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+              apply ASLEEP
+            }
           }
         }
         move "Plunder", {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1649,16 +1649,17 @@ public enum DiamondPearl implements LogicCardInfo {
           move "Magnetic Ray", {
             text "40 damage. Before doing damage, you may choose 1 of your opponent’s Benched Pokémon that has any Energy attached to it and switch that Pokémon with 1 of the Defending Pokémon."
             energyCost M, C, C
-            attackRequirement {}
             onAttack {
               //TODO: Generalize on Statics, with "may" and "filter" params. See "Drag Off" (BLAZIKEN_EX_90 in CG) as a similar attack for base.
               def target = defending
               def tar = opp.bench.findAll{ it.cards.energyCount() }
               if (tar && confirm("Before doing damage, you may choose 1 of your opponent’s Benched Pokémon that has any Energy attached to it and switch that Pokémon with 1 of the Defending Pokémon.")) {
-                target = tar.select("Select the new active")
-                sw defending, target
+                target = tar.select("Select the new Defending Pokémon.")
+                if ( sw2(target) ) {
+                  damage 40
+                }
               }
-              damage 40, target
+              damage 40
             }
           }
 
@@ -2279,11 +2280,12 @@ public enum DiamondPearl implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
             energyCost G
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon."
+              assertOppBench()
             }
             onAttack {
-              def target = opp.bench.select("Select the new Active Pokémon.")
-              if ( sw2(target) ) { apply ASLEEP, target }
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+              }
             }
           }
           move "Gust", {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearlPromos.groovy
@@ -458,15 +458,13 @@ public enum DiamondPearlPromos implements LogicCardInfo {
             energyCost C, C, C
             attackRequirement {}
             onAttack {
-              def pcs = defending
-              if (opp.bench) {
-                if (confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-                  pcs = opp.bench.select()
-                  sw defending, pcs
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 30 
                 }
+              } else {
+                damage 30
               }
-
-              damage 30, pcs
             }
           }
           move "Giga Hammer", {

--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1208,10 +1208,10 @@ public enum GreatEncounters implements LogicCardInfo {
             text "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This attack does 10 damage to the new Defending Pokémon."
             energyCost ()
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assertOppBench()
             }
             onAttack {
-              if (sw2(opp.bench.select("Choose the new Active Pokémon"))) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) {
                 damage 10
               }
             }

--- a/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
+++ b/src/tcgwars/logic/impl/gen4/HeartgoldSoulsilver.groovy
@@ -1607,13 +1607,13 @@ public enum HeartgoldSoulsilver implements LogicCardInfo {
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Asleep."
             energyCost P
             attackRequirement {
-              assert opp.bench
+              assertOppBench()
             }
             onAttack {
-              sw opp.active, opp.bench.select()
-              apply ASLEEP, opp.active
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+              }
             }
-
           }
           move "Gentle Slap", {
             text "20 damage. "

--- a/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
+++ b/src/tcgwars/logic/impl/gen4/LegendsAwakened.groovy
@@ -840,14 +840,7 @@ public enum LegendsAwakened implements LogicCardInfo {
           move "Drain Down", {
             text "30 damage. Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. If you do, this attack does 30 damage to the new Defending Pokémon. If the Defending Pokémon would be Knocked Out by this attack, you may remove all damage counters from Cradily."
             energyCost G
-            attackRequirement {}
             onAttack {
-              def pcs = defending
-              if (opp.bench && confirm("Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon?")) {
-                pcs = opp.bench.select("New Defending Pokémon")
-                sw2 pcs
-              }
-
               delayed {
                 before KNOCKOUT, pcs, {
                   if (self.numberOfDamageCounters && confirm("Remove all damage counters from Cradily?")) {
@@ -857,7 +850,13 @@ public enum LegendsAwakened implements LogicCardInfo {
                 }
                 unregisterAfter 1
               }
-              damage 30
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 30 
+                }
+              } else {
+                damage 30
+              }
             }
           }
           move "Acid", {
@@ -1535,14 +1534,16 @@ public enum LegendsAwakened implements LogicCardInfo {
           weakness R, '+30'
           move "Burning Scent", {
             text "The Defending Pokémon is now Burned and Poisoned. Before applying these effects, you may switch 1 of the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Burned and Poisoned."
-            attackRequirement {}
             onAttack {
-              if (opp.bench && confirm("Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon?")) {
-                sw2 opp.bench.select("New Defending Pokémon")
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  apply BURNED
+                  apply POISONED
+                }
+              } else {
+                apply BURNED
+                apply POISONED
               }
-
-              apply BURNED
-              apply POISONED
             }
           }
           move "Energy Dissolve", {

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -3055,14 +3055,14 @@ public enum MysteriousTreasures implements LogicCardInfo {
             text "Switch 1 of your opponent’s Benched Pokémon with 1 of the Defending Pokémon. The new Defending Pokémon is now Asleep."
             energyCost G
             attackRequirement {
-              assert opp.bench
+              assertOppBench()
             }
             onAttack {
-              sw opp.active, opp.bench.select()
-              apply ASLEEP, opp.active
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+              }
             }
           }
-
         };
       case TEDDIURSA_105:
         return basic (this, hp:HP060, type:COLORLESS, retreatCost:1) {

--- a/src/tcgwars/logic/impl/gen4/Platinum.groovy
+++ b/src/tcgwars/logic/impl/gen4/Platinum.groovy
@@ -2263,7 +2263,7 @@ public enum Platinum implements LogicCardInfo {
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. This attack does 20 damage to the new Defending Pokémon."
             energyCost C
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assertOppBench()
             }
             onAttack {
               def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
@@ -2498,12 +2498,12 @@ public enum Platinum implements LogicCardInfo {
           move "Hospitality", {
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon."
             energyCost ()
-            attackRequirement {}
+            attackRequirement {
+              assertOppBench()
+            }
             onAttack {
-              def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
-              if (sw2(target)) {
-                heal 20, target
-              }
+              def target = opp.bench.select("Select the new Defending Pokémon.")
+              if ( sw2(target) ) { heal 20, target }
             }
           }
         };

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -358,11 +358,12 @@ public enum RisingRivals implements LogicCardInfo {
             text "Switch the Defending Pokémon with one of your opponent’s Benched Pokémon. The new Defending Pokémon is now Asleep."
             energyCost C
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assertOppBench()
             }
             onAttack {
-              def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
-              if ( sw2(target) ) { apply ASLEEP, target }
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply ASLEEP
+              }
             }
           }
           move "Wake-Up Slap", {

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -633,14 +633,16 @@ public enum SecretWonders implements LogicCardInfo {
           weakness F, PLUS30
           move "Tongue Reel", {
             text "Choose 1 of your opponent’s Pokémon. If you choose a Benched Pokémon, switch the Defending Pokémon with that Pokémon. This attack does 20 damage to the Pokémon you chose. Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+            //Japanese text says flip to paralyze the chosen Pokémon, not the Defending.
             energyCost C, C
             onAttack {
-              def tar = opp.all.select("Choose 1 of your opponent's Pokémon")
-              if(tar.benched) {
-                sw2(tar) // The way I read this, even if the benched Pokémon is not successfully pulled into the active, 20 damage is still done to the selected Pokémon, then the defending Pokémon might be paralyzed.
-              }
+              def tar = opp.all.select("Choose 1 of your opponent's Pokémon.")
               damage 20, tar
-              flip {applyAfterDamage PARALYZED}
+              if (!tar.benched) {
+                flip {applyAfterDamage PARALYZED}
+              } else if (sw2(tar)) {
+                flip {applyAfterDamage PARALYZED}
+              }
             }
           }
           move "Boundless Power", {
@@ -1352,11 +1354,15 @@ f
             text "20 damage. The Defending Pokémon is now Poisoned. Before doing damage, you may switch 1 of the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Poisoned."
             energyCost C, C
             onAttack {
-              if(opp.bench && confirm("Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon?")) {
-                sw2 opp.bench.select("New Defending Pokémon")
+              if(opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 20
+                  applyAfterDamage POISONED
+                }
+              } else {
+                damage 20
+                applyAfterDamage POISONED
               }
-              damage 20
-              applyAfterDamage POISONED
             }
           }
           move "Pride Attack", {

--- a/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
+++ b/src/tcgwars/logic/impl/gen4/SupremeVictors.groovy
@@ -283,11 +283,12 @@ public enum SupremeVictors implements LogicCardInfo {
             text "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. The new Defending Pokémon is now Burned."
             energyCost R
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assertOppBench()
             }
             onAttack {
-              def target = opp.bench.select("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon.")
-              if ( sw2(target) ) { apply BURNED, target }
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                apply BURNED
+              }
             }
           }
           move "Vapor Kick", {
@@ -598,12 +599,14 @@ public enum SupremeVictors implements LogicCardInfo {
           move "Drag Off", {
             text "30 damage. Before doing damage, you may switch your opponent's Active Pokémon with 1 of his or her Benched Pokémon."
             energyCost W, C, C
-            attackRequirement {}
             onAttack {
-              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon before doing damage?")) {
-                switchYourOpponentsBenchedWithActive()
+              if (opp.bench && confirm("Switch 1 of your opponent’s Benched Pokémon with the Defending Pokémon?")) {
+                if (sw2(opp.bench.select("Select the new Defending Pokémon."))) { 
+                  damage 30 
+                }
+              } else {
+                damage 30
               }
-              damage 30
             }
           }
           move "Push Over", {

--- a/src/tcgwars/logic/impl/gen4/Undaunted.groovy
+++ b/src/tcgwars/logic/impl/gen4/Undaunted.groovy
@@ -955,10 +955,10 @@ public enum Undaunted implements LogicCardInfo {
             text "Switch the Defending Pokémon with 1 of your opponent’s Benched Pokémon. The new Defending Pokémon is now Confused and Poisoned."
             energyCost P
             attackRequirement {
-              assert opp.bench : "Your opponent has no Benched Pokémon"
+              assertOppBench()
             }
             onAttack {
-              if(sw2(opp.bench.select("Choose the new Active Pokémon"))) {
+              if (sw2(opp.bench.select("Select the new Defending Pokémon."))) {
                 apply CONFUSED
                 apply POISONED
               }

--- a/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
+++ b/src/tcgwars/logic/impl/gen8/DarknessAblaze.groovy
@@ -3313,8 +3313,9 @@ public enum DarknessAblaze implements LogicCardInfo {
             assert opp.bench : "Opponent has no Benched Pokémon."
           }
           onAttack {
-            def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( sw2(target) ) { apply CONFUSED, target }
+            if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
+              apply CONFUSED
+            }
           }
         }
         move "Moon Impact", {

--- a/src/tcgwars/logic/impl/gen8/RebelClash.groovy
+++ b/src/tcgwars/logic/impl/gen8/RebelClash.groovy
@@ -2737,8 +2737,9 @@ public enum RebelClash implements LogicCardInfo {
             assertOppBench()
           }
           onAttack {
-            def target = opp.bench.select("Select the new Active Pokémon.")
-            if ( sw2(target) ) { damage 30, target }
+            if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
+              damage 30
+            }
           }
         }
         move "Brain Shake", {

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -842,12 +842,12 @@ public enum SwordShieldPromos implements LogicCardInfo {
           text "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Confused."
           energyCost P, C
           attackRequirement {
-            assert opp.bench : "Opponent's Bench is empty"
+            assertOppBench()
           }
           onAttack {
-            if (!opp.bench) return
-            switchYourOpponentsBenchedWithActive()
-            applyAfterDamage CONFUSED
+            if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
+              apply ASLEEP
+            }
           }
         }
         move "Mental Crush", {

--- a/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
+++ b/src/tcgwars/logic/impl/gen8/SwordShieldPromos.groovy
@@ -846,7 +846,7 @@ public enum SwordShieldPromos implements LogicCardInfo {
           }
           onAttack {
             if (sw2(opp.bench.select("Select the new Active Pokémon."))) { 
-              apply ASLEEP
+              apply CONFUSED
             }
           }
         }


### PR DESCRIPTION
Main functional change is to wrap damage/other effects inside an `if` statement, so they are prevented if the switch fails.

Some attacks (e.g. Surskit MT's Sleep Inducer) used `sw` instead of `sw2`, which let them gust in Benched Pokémon with protection from effects. That has also been fixed.

Happiny PL got an attack requirement to prevent Game Engine Errors.

Cosmetic changes:
- Assert for attack requirements
- Message displayed when choosing the new Defending (Gen 3/4)/Active (Gen 8) Pokémon.
- `if` statement phrasing