### PR TITLE
Evolution Pokémon

### DIFF
--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -510,7 +510,8 @@ public enum GreatEncounters implements LogicCardInfo {
             }
           }
           move "Cotton Cloud", {
-            text "60 damage. During your opponent's nest turn, any damage done to Altaria by attacks from your opponent's Evolved Pokémon is reduced by 30"
+            text "60 damage. During your opponent's nest turn, any damage done to Altaria by attacks from your opponent's Evolution Pokémon is reduced by 30."
+            //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/card-search/details.php/card/10118/regu/all
             energyCost C, C, C
             onAttack {
               damage 60
@@ -518,7 +519,7 @@ public enum GreatEncounters implements LogicCardInfo {
                 delayed {
                   before APPLY_ATTACK_DAMAGES, {
                     bg.dm().each {
-                      if(it.from.evolution && it.from.owner == self.owner.opposite && it.notNoEffect && it.dmg.value){
+                      if(it.from.realEvolution && it.from.owner == self.owner.opposite && it.notNoEffect && it.dmg.value){
                         bc "${thisMove.name} -30"
                         it.dmg-=30
                       }

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -1704,11 +1704,12 @@ public enum MysteriousTreasures implements LogicCardInfo {
             }
           }
           move "Triple Pick", {
-            text "Choose 3 of your opponent’s Evolved Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+            text "Choose 3 of your opponent’s Evolution Pokémon. This attack does 30 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+            //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/rules/faq/search.php?freeword=トリプルピッキング
             energyCost C, C, C
             attackRequirement {}
             onAttack {
-              multiSelect(opp.all.findAll{it.evolution}, 3, text).each{
+              multiSelect(opp.all.findAll{it.realEvolution}, 3, text).each{
                 targeted(it){
                   damage 30, it
                 }

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -343,10 +343,11 @@ public enum RisingRivals implements LogicCardInfo {
             }
           }
           move "Power Swing", {
-            text "60+ damage. Does 60 damage plus 10 more damage for each Evolved Pokémon on your Bench."
+            text "60+ damage. Does 60 damage plus 10 more damage for each Evolution Pokémon on your Bench."
+            //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/rules/faq/search.php?freeword=パワースイング
             energyCost C, C, C
             onAttack {
-              damage 60 + 10 * my.bench.findAll{it.evolution}.size()
+              damage 60 + 10 * my.bench.findAll{it.realEvolution}.size()
             }
           }
 
@@ -2717,14 +2718,16 @@ public enum RisingRivals implements LogicCardInfo {
         return basic (this, hp:HP050, type:WATER, retreatCost:1) {
           weakness L, PLUS10
           move "Cosmic Draw", {
-            text "If your opponent has any Evolved Pokémon in play, draw 3 cards."
+            text "If your opponent has any Evolution Pokémon in play, draw 3 cards."
+            //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/card-search/details.php/card/22091/regu/all
             energyCost C
             attackRequirement {
-              assert my.deck : "Your deck is empty"
-              assert opp.all.find{it.evolution} : "Your opponent doesn't have any Evolved Pokémon in play"
+              assert my.deck : "Your deck is empty"              
             }
             onAttack {
-              draw 3
+              if (opp.all.find{it.realEvolution}) {
+                draw 3
+              }
             }
           }
           move "Swift", {

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -2722,14 +2722,11 @@ public enum RisingRivals implements LogicCardInfo {
             //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/card-search/details.php/card/22091/regu/all
             energyCost C
             attackRequirement {
-              assert my.deck : "Your deck is empty"              
+              assert my.deck : "Your deck is empty"
+              assert opp.all.find{it.realEvolution} : "Opponent doesn't have any Evolution Pokémon in play"
             }
             onAttack {
-              if (opp.all.find{it.realEvolution}) {
-                draw 3
-              } else {
-                bc "Opponent doesn't have any Evolution Pokémon in play"
-              }
+              draw 3
             }
           }
           move "Swift", {

--- a/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
+++ b/src/tcgwars/logic/impl/gen4/RisingRivals.groovy
@@ -2727,6 +2727,8 @@ public enum RisingRivals implements LogicCardInfo {
             onAttack {
               if (opp.all.find{it.realEvolution}) {
                 draw 3
+              } else {
+                bc "Opponent doesn't have any Evolution Pokémon in play"
               }
             }
           }

--- a/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
+++ b/src/tcgwars/logic/impl/gen4/SecretWonders.groovy
@@ -2187,11 +2187,12 @@ f
           weakness R, PLUS20
           resistance F, MINUS20
           pokeBody "Cotton Balloon", {
-            text "If Skiploom has any [G] Energy attached to it, any damage done to Skiploom by attacks from your opponent’s Evolved Pokémon is reduced by 20."
+            text "If Skiploom has any [G] Energy attached to it, any damage done to Skiploom by attacks from your opponent’s Evolution Pokémon is reduced by 20."
+            //Errata: Evolution 「進化ポケモン」, not Evolved 進化している. https://www.pokemon-card.com/card-search/details.php/card/3007/regu/all
             delayedA {
               before APPLY_ATTACK_DAMAGES, {
                 bg.dm().each{
-                  if (self.cards.energyCount(G) && it.to == self && it.from.owner != self.owner && it.from.evolution && it.notNoEffect && it.dmg.value) {
+                  if (self.cards.energyCount(G) && it.to == self && it.from.owner != self.owner && it.from.realEvolution && it.notNoEffect && it.dmg.value) {
                     bc "Cotton Balloon -20"
                     it.dmg -= hp(20)
                   }


### PR DESCRIPTION
Some Gen 4 Pokémon incorrectly use "Evolved Pokémon" to refer to Evolution Pokémon. Only a few of them received official errata (the ones that refer to Stage 2s, i.e. Alakazam MT, Glalie MT, Staraptor SF).

Two of them (Dodrio MT and Flygon RR) have rulings on the Japanese FAQ page to confirm that they refer to Evolution Pokémon. This PR fixes those two, plus any others that don't have Japanese rulings, but use identical wording.

More info [here](https://docs.google.com/document/d/1T3YmOaQ2Dhv_Lc_dRXsglv27qzsSShnJOYOwDuOKeL0/pub).