### PR TITLE
May 2025 fixes

### DIFF
--- a/src/tcgwars/logic/impl/gen3/Deoxys.groovy
+++ b/src/tcgwars/logic/impl/gen3/Deoxys.groovy
@@ -2259,7 +2259,7 @@ public enum Deoxys implements LogicCardInfo {
               h.object.add(C)
             }
             eff2 = delayed{
-              before ATTACK_MAIN, {
+              before PROCESS_ATTACK_EFFECTS, {
                 flag = (ef.attacker == self)
               }
               before BETWEEN_TURNS, {

--- a/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
+++ b/src/tcgwars/logic/impl/gen4/DiamondPearl.groovy
@@ -1658,8 +1658,9 @@ public enum DiamondPearl implements LogicCardInfo {
                 if ( sw2(target) ) {
                   damage 40
                 }
+              } else {
+                damage 40
               }
-              damage 40
             }
           }
 

--- a/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
+++ b/src/tcgwars/logic/impl/gen4/MysteriousTreasures.groovy
@@ -328,7 +328,7 @@ public enum MysteriousTreasures implements LogicCardInfo {
               if (opp.hand.size() >= 2 && oppConfirm("Do you want to discard 2 card from your hand?\nIf you do, $thisMove will have a base damage of 10 instead of 80.")){
                 opp.hand.oppSelect(count:2, "Which card to discard?").discard()
               } else {
-                if (!opp.hand.size() >= 2) bc "The opponent has less than 2 cards in hand! $thisMove hits at full power!"
+                if (opp.hand.size() < 2) bc "The opponent has less than 2 cards in hand! $thisMove hits at full power!"
                 damage 70
               }
             }

--- a/src/tcgwars/logic/impl/gen4/Stormfront.groovy
+++ b/src/tcgwars/logic/impl/gen4/Stormfront.groovy
@@ -3124,7 +3124,7 @@ public enum Stormfront implements LogicCardInfo {
           def flag2 = false // True when a 2nd move is being used
           customAbility {
             delayedA {
-              before ATTACK_MAIN, {
+              before PROCESS_ATTACK_EFFECTS, {
                 if(ef.move.name == "Voltage Shoot" && !flag2) {
                   if(self.lastEvolved == bg.turnCount) {
                     flag = true


### PR DESCRIPTION
Changed Crystal Shard and Raichu LV.X to check before `PROCESS_ATTACK_EFFECTS` instead of `ATTACK_MAIN`, based on Memory Berry CG's implementation. This should make them work properly if an unusable attack is chosen.