### PR TITLE
Kkingdra ex δ Extra Smoke fix

### DIFF
--- a/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
+++ b/src/tcgwars/logic/impl/gen3/DragonFrontiers.groovy
@@ -1994,14 +1994,11 @@ public enum DragonFrontiers implements LogicCardInfo {
         pokeBody "Extra Smoke", {
           text "Any damage done to your Stage 2 Pokémon-ex by your opponent's attacks is reduced by 10 (before applying Weakness and Resistance)."
           delayedA {
-            /* ruling
-            Q. Say I have a Kingra-EX with “Extra Smoke” on the bench and a Stage 2 Pokémon-EX Active (other than Kingdra-EX). If my opponent attacks with “Swift” does it ignore “Extra Smoke” or not?
-            A. The effect of Extra Smoke is always attached to whatever Pokémon that the opponent attacks with, not on the Defending Pokémon nor even on the benched Kingdra-EX. And since Swift only ignores effects on the Defending Pokémon (not the player or Pokémon attacking with Swift), it does NOT ignore Extra Smoke and damage is reduced by -10. (Feb 22, 2007 PUI Rules Team)
-             */
-            after PROCESS_ATTACK_EFFECTS, {
+            // Extra Smoke was mistranslated; it is supposed to be an effect on your Stage 2 ex, meaning it gets applied AFTER W&R, and Swift will ignore it.
+            before APPLY_ATTACK_DAMAGES, {
               if (ef.attacker.owner != self.owner) {
                 bg.dm().each {
-                  if (it.to.owner == self.owner && it.to.EX && it.to.stage2 && it.dmg.value) {
+                  if (it.to.owner == self.owner && it.to.EX && it.to.stage2 && it.dmg.value && it.notNoEffect) {
                     bc "Extra Smoke -10"
                     it.dmg -= hp(10)
                   }


### PR DESCRIPTION
This was brought to my attention by JP and Coconut, and confirmed by the [Double Rainbow Cup team](https://note.com/w_rainbow_cup/n/n6148131d56b7): Extra Smoke was mistranslated, and is supposed to be an effect on the defender, not the attacker. That means it should be applied after Weakness and Resistance (not before, as is written on the card), and also that Swift will ignore it (contrary to what the Compendium says).