### PR TITLE
fix Unown G Claydol vs Gardevior SW interaction

### DIFF
--- a/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
+++ b/src/tcgwars/logic/impl/gen4/GreatEncounters.groovy
@@ -1721,7 +1721,7 @@ public enum GreatEncounters implements LogicCardInfo {
                 onPlay {
                   eff = delayed {
                     before null, pokemon, Source.ATTACK, {
-                      if (e.sourceAttack.attacker.owner == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages)) {
+                      if (e.targetPokemon == self && bg.currentTurn == self.owner.opposite && ef.effectType != DAMAGE && !(ef instanceof ApplyDamages)) {
                         bc "GUARD prevents effect ${ef.effectType}"
                         prevent()
                       }


### PR DESCRIPTION
Unown G blocks Psychic Lock and treats it as an effect on the pokemon rather than an effect on the player so you are able to use Claydol's pokepower when it should be blocked

code taken from HOLON_ENERGY_WP_106 as in testing it did not block the effect which is also the intended effect for Unown G

https://forum.tcgone.net/t/br-gardevoir-sw-7-claydol-ge-15-unown-g-should-not-stop-psychic-lock-as-its/15769